### PR TITLE
Make nsys-ai schema/version aware for Nsight 2026 SQLite exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 dist/
 .pytest_cache/
 .DS_Store
+.venv/


### PR DESCRIPTION
Add an NsightSchema helper to detect available SQLite tables and (heuristically) infer Nsight Systems version from META_DATA_* tables.
Route all kernel-related queries through schema.kernel_table, keeping behavior identical for existing profiles while making the code resilient to future schema changes.
Improve CLI UX by:
Catching RuntimeError in nsys-ai so schema/validation issues show as a single Error: ... line instead of a full traceback.
Optionally printing Nsight version (heuristic) in the info command when version metadata is available.