### PR TITLE
fix: ModuleNotFoundError: No module named 'rich'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,9 @@ description = "Terminal UI for NVIDIA Nsight Systems profiles — timeline viewe
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.10"
+dependencies = [
+    "rich>=13.0.0",
+]
 authors = [
     {name = "GindaChen"},
 ]


### PR DESCRIPTION
as title