### PR TITLE
feat ai: refine Brain & Navigator UX across web + TUI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,10 +30,11 @@ nsys-ai = "nsys_tui.__main__:main"
 nsys-tui = "nsys_tui.__main__:main"
 
 [project.optional-dependencies]
-agent = ["anthropic>=0.20.0"]
-ai = ["anthropic>=0.20.0"]  # backward compat alias
+agent = ["anthropic>=0.20.0", "litellm>=1.0.0"]
+ai = ["anthropic>=0.20.0", "litellm>=1.0.0"]  # backward compat alias
+chat = ["litellm>=1.0.0", "textual>=0.80.0"]  # Textual AI chat TUI
 dev = ["pytest>=7.0"]
-all = ["nsys-ai[agent]"]
+all = ["nsys-ai[agent,chat]"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/nsys_tui/__main__.py
+++ b/src/nsys_tui/__main__.py
@@ -158,15 +158,19 @@ def main():
     p.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
 
     # ── tui ──
-    p = sub.add_parser("tui", help="Terminal tree view (rich)")
+    p = sub.add_parser("tui", help="Terminal tree view; press A for AI chat")
     _add_gpu_trim(p)
     p.add_argument("--depth", type=int, default=-1, help="Max tree depth (-1=all)")
     p.add_argument("--min-ms", type=float, default=0, help="Min duration to show (ms)")
 
     # ── timeline ──
-    p = sub.add_parser("timeline", help="Horizontal timeline view (Perfetto-style)")
+    p = sub.add_parser("timeline", help="Horizontal timeline; press A for AI chat")
     _add_gpu_trim(p)
     p.add_argument("--min-ms", type=float, default=0, help="Min duration to show (ms)")
+
+    # ── chat ──
+    p = sub.add_parser("chat", help="AI chat TUI with top-kernel navigator (requires litellm + textual)")
+    p.add_argument("profile", help="Path to profile (.sqlite or .nsys-rep)")
 
     # ── skill ──
     p = sub.add_parser("skill", help="List or run analysis skills")
@@ -411,6 +415,14 @@ def main():
             from .tui_timeline import run_timeline
             run_timeline(args.profile, args.gpu, _parse_trim(args),
                          min_ms=args.min_ms)
+
+        elif args.command == "chat":
+            try:
+                from .tui_textual import run_chat_tui
+            except ImportError:
+                print("Error: 'textual' package is required. Install with: pip install 'textual>=0.80.0'")
+                return
+            run_chat_tui(args.profile)
 
         elif args.command == "skill":
             from .skills.registry import list_skills, all_skills, run_skill as _run_skill

--- a/src/nsys_tui/chat.py
+++ b/src/nsys_tui/chat.py
@@ -1,0 +1,767 @@
+"""
+chat.py - LLM chat for AI Profiler (Brain + Navigator).
+
+Uses LiteLLM for model-agnostic completion with OpenAI-style tool calling.
+Returns { "content": "...", "actions": [...] }; actions are executed by the frontend.
+Model can be selected via NSYS_AI_MODEL (env), or per-request "model" in payload.
+Text-to-SQL: query_profile_db tool (see tools_profile.py) is registered for agent use.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from typing import Callable
+
+_log = logging.getLogger(__name__)
+_telemetry_log = logging.getLogger("nsys_tui.telemetry")
+
+from .tools_profile import (
+    TOOL_QUERY_PROFILE_DB,
+    open_profile_readonly,
+    get_profile_schema_cached,
+    query_profile_db,
+)
+
+# Cap total messages sent to the LLM per request; keeps token budget bounded.
+MAX_AGENT_MESSAGES = 100
+# Warn when prompt tokens exceed this threshold.
+PROMPT_TOKEN_WARNING_THRESHOLD = 30_000
+# Consecutive DB errors before injecting a break-cycle hint.
+MAX_CONSECUTIVE_DB_ERRORS = 2
+
+# Model options for UI and resolution. Anthropic 4.x, OpenAI 5.x, Gemini 2.5+ and 3.x only.
+MODEL_OPTIONS = [
+    # Anthropic (Claude 4.x)
+    {"id": "anthropic/claude-opus-4-6-20260205", "label": "Claude Opus 4.6"},
+    {"id": "anthropic/claude-sonnet-4-6", "label": "Claude Sonnet 4.6"},
+    {"id": "anthropic/claude-sonnet-4-5-20250929", "label": "Claude Sonnet 4.5"},
+    {"id": "anthropic/claude-opus-4-5-20251101", "label": "Claude Opus 4.5"},
+    {"id": "anthropic/claude-haiku-4-5-20251001", "label": "Claude Haiku 4.5"},
+    # OpenAI (GPT-5.x)
+    {"id": "gpt-5.2", "label": "GPT-5.2"},
+    {"id": "gpt-5.2-pro", "label": "GPT-5.2 Pro"},
+    {"id": "gpt-5-mini", "label": "GPT-5 Mini"},
+    {"id": "gpt-5.3-codex", "label": "GPT-5.3 Codex"},
+    {"id": "gpt-4o", "label": "GPT-4o"},
+    # Gemini (2.5+ and 3.x). LiteLLM/API may use -preview for some regions.
+    {"id": "gemini/gemini-2.5-pro", "label": "Gemini 2.5 Pro"},
+    {"id": "gemini/gemini-2.5-pro-preview-05-20", "label": "Gemini 2.5 Pro (preview)"},
+    {"id": "gemini/gemini-2.5-flash", "label": "Gemini 2.5 Flash"},
+    {"id": "gemini/gemini-2.5-flash-lite", "label": "Gemini 2.5 Flash Lite"},
+    {"id": "gemini/gemini-2.0-flash", "label": "Gemini 2.0 Flash"},
+    {"id": "gemini/gemini-3.1-pro-preview", "label": "Gemini 3.1 Pro"},
+    {"id": "gemini/gemini-3-pro-preview", "label": "Gemini 3 Pro"},
+    {"id": "gemini/gemini-3-flash-preview", "label": "Gemini 3 Flash"},
+]
+
+# Map model id (or prefix) to env var for API key.
+def _model_to_key(model_id: str) -> str | None:
+    """Return the env var name for the given model id, or None if unknown."""
+    if not model_id:
+        return None
+    if model_id.startswith("anthropic/"):
+        return "ANTHROPIC_API_KEY"
+    if model_id.startswith("openai/") or model_id.startswith("gpt-"):
+        return "OPENAI_API_KEY"
+    if model_id.startswith("gemini/"):
+        return "GEMINI_API_KEY"
+    return None
+
+
+def _get_model_and_key(preferred_model: str | None = None) -> tuple[str | None, str | None]:
+    """
+    Return (model, api_key) for a configured provider, or (None, None).
+    preferred_model: optional model id from request or NSYS_AI_MODEL env.
+    """
+    preferred = preferred_model or os.environ.get("NSYS_AI_MODEL")
+    if preferred:
+        key_name = _model_to_key(preferred)
+        if key_name and os.environ.get(key_name):
+            return preferred, os.environ[key_name]
+    if os.environ.get("ANTHROPIC_API_KEY"):
+        return "anthropic/claude-sonnet-4-5-20250929", os.environ["ANTHROPIC_API_KEY"]
+    if os.environ.get("OPENAI_API_KEY"):
+        return "gpt-5.2", os.environ["OPENAI_API_KEY"]
+    if os.environ.get("GEMINI_API_KEY"):
+        return "gemini/gemini-2.5-pro", os.environ["GEMINI_API_KEY"]
+    return None, None
+
+
+def get_available_models() -> list[dict]:
+    """Return list of { id, label } for models that have an API key set."""
+    out = []
+    for opt in MODEL_OPTIONS:
+        key_name = _model_to_key(opt["id"])
+        if key_name and os.environ.get(key_name):
+            out.append({"id": opt["id"], "label": opt["label"]})
+    return out
+
+
+def get_default_model() -> str | None:
+    """Return the default model id (from NSYS_AI_MODEL or first available)."""
+    if os.environ.get("NSYS_AI_MODEL"):
+        key_name = _model_to_key(os.environ["NSYS_AI_MODEL"])
+        if key_name and os.environ.get(key_name):
+            return os.environ["NSYS_AI_MODEL"]
+    models = get_available_models()
+    return models[0]["id"] if models else None
+
+
+def _tools_openai():
+    """OpenAI-style tool definitions: navigate, zoom, and query_profile_db (,)."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "navigate_to_kernel",
+                "description": "Navigate the UI to a specific kernel. Match by EXACT kernel name from visible_kernels_summary or global_top_kernels. The frontend will resolve the exact occurrence.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "target_name": {"type": "string", "description": "The exact name of the kernel to navigate to."},
+                        "occurrence_index": {"type": "integer", "description": "Which occurrence to jump to (1-based). Default is 1.", "default": 1},
+                        "reason": {"type": "string", "description": "A short, 1-sentence reason why this kernel was chosen, to show the user."},
+                    },
+                    "required": ["target_name"],
+                },
+            },
+        },
+        {
+            "type": "function",
+            "function": {
+                "name": "zoom_to_time_range",
+                "description": "Zoom the UI to a specific time range in seconds.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "start_s": {"type": "number", "description": "Start time in seconds"},
+                        "end_s": {"type": "number", "description": "End time in seconds"},
+                    },
+                    "required": ["start_s", "end_s"],
+                },
+            },
+        },
+        TOOL_QUERY_PROFILE_DB,
+    ]
+
+
+def _build_system_prompt(ui_context: dict, profile_schema: str | None = None) -> str:
+    """System prompt with ui_context; optional profile_schema for query_profile_db (,)."""
+    ctx_json = json.dumps(ui_context, separators=(",", ":"))
+    schema_block = ""
+    if profile_schema:
+        schema_block = f"""
+=== PROFILE DATABASE SCHEMA (for query_profile_db) ===
+{profile_schema}
+NOTE: Write strict SQLite3 SQL only (use strftime() not DATE_TRUNC/EXTRACT; use || for concatenation not CONCAT()).
+=====================================================
+
+"""
+    return f"""You are an expert GPU performance analyst and UI navigator for an Nsight Systems viewer.
+Your goal is to explain CUDA/GPU bottlenecks clearly and help users navigate the timeline.
+{schema_block}=== CURRENT UI CONTEXT ===
+```json
+{ctx_json}
+```
+==========================
+
+INSTRUCTIONS:
+1. When asked to explain a kernel or bottleneck, use the provided context. Be concise, professional, and use Markdown for formatting.
+2. If the user asks to go to, find, or locate a specific kernel or time range, YOU MUST use the provided tools (`navigate_to_kernel` or `zoom_to_time_range`).
+3. When a PROFILE DATABASE SCHEMA is provided above, you MUST use the `query_profile_db` tool to answer whole-profile questions (e.g. first kernel, slowest kernel, counts, total GPU time, total kernel count). Run a SELECT; the backend returns the result and you answer from it. Never use `SELECT *`; always select only the columns you need. For total GPU time use SUM(duration_ns)/1e6; for kernel count use COUNT(*). Kernel names are stored as IDs referencing StringIds: join with StringIds (e.g. k.shortName = StringIds.id) and use StringIds.value for human-readable names. IMPORTANT: stats.total_gpu_ms, stats.total_kernel_count, and global_top_kernels are intentionally OMITTED from ui_context when the DB agent is enabled. You MUST use `query_profile_db` to answer any whole-profile questions - do NOT guess or say the data is missing.
+4. TOOL USE RULES:
+   - Match kernel names exactly from `visible_kernels_summary` or `global_top_kernels`.
+   - Do NOT explain what you are about to do before calling a tool. Just call the tool.
+   - For `navigate_to_kernel` and `zoom_to_time_range`: execution is immediate on the client; you do not wait for a result. For `query_profile_db`: the backend runs the query and returns rows; use them in your answer.
+   - Do NOT output code blocks or JSON for navigation - use the actual tool call mechanism only.
+5. If a requested kernel is not in the context, politely say it is not visible or does not exist."""
+
+
+def _parse_tool_call(name: str, arguments: str) -> dict | None:
+    """Graceful parsing: extract only needed fields. Return action dict or None."""
+    try:
+        args = json.loads(arguments) if isinstance(arguments, str) else arguments
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if name == "navigate_to_kernel":
+        target = args.get("target_name")
+        if not target:
+            return None
+        return {
+            "type": "navigate_to_kernel",
+            "target_name": target,
+            "occurrence_index": args.get("occurrence_index", 1),
+            "reason": args.get("reason"),
+        }
+    if name == "zoom_to_time_range":
+        start_s = args.get("start_s")
+        end_s = args.get("end_s")
+        if start_s is None or end_s is None:
+            return None
+        return {"type": "zoom_to_time_range", "start_s": float(start_s), "end_s": float(end_s)}
+    return None
+
+
+def _compact_old_tool_results(api_messages: list) -> None:
+    """
+    Replace large tool-result content from previous agent turns with compact summaries.
+
+    Reduces prompt size when the model makes multiple DB queries per response. Tool results
+    from all-but-the-last tool turn are replaced with "[Summary: DB query returned results.]"
+    if they exceed 200 chars. The most recent turn's results are left intact so the model can
+    use them for its final answer.
+    """
+    tool_turn_indices = [
+        i for i, m in enumerate(api_messages)
+        if m.get("role") == "assistant" and m.get("tool_calls")
+    ]
+    if len(tool_turn_indices) < 2:
+        return  # Only one tool turn; nothing old yet.
+    cutoff = tool_turn_indices[-1]
+    for m in api_messages[:cutoff]:
+        if m.get("role") == "tool" and len(m.get("content", "")) > 200:
+            m["content"] = "[Summary: DB query returned results.]"
+
+
+def distill_history(messages: list) -> list:
+    """
+    Compress intermediate tool call/result pairs from previous conversation turns
+    into short summary messages, keeping final user/assistant messages intact.
+
+    Strategy:
+    - Keep system messages (role=system).
+    - Keep all user messages.
+    - Keep final assistant messages (those without tool_calls, i.e. the actual answers).
+    - For each assistant message that has tool_calls + its following tool result messages:
+      replace the entire sequence with a single system summary.
+
+    Returns a new list (does not mutate the input).
+    """
+    if not messages:
+        return messages
+
+    result = []
+    i = 0
+    while i < len(messages):
+        m = messages[i]
+        role = m.get("role", "")
+
+        # Keep system and user messages as-is.
+        if role in ("system", "user"):
+            result.append(m)
+            i += 1
+            continue
+
+        # Assistant message with tool_calls = intermediate turn → compress.
+        if role == "assistant" and m.get("tool_calls"):
+            tool_names = []
+            for tc in m["tool_calls"]:
+                fn = tc.get("function") or {}
+                name = fn.get("name", "unknown")
+                tool_names.append(name)
+            # Skip over all following 'tool' role messages belonging to this turn.
+            i += 1
+            tool_count = 0
+            while i < len(messages) and messages[i].get("role") == "tool":
+                tool_count += 1
+                i += 1
+            # Replace with summary.
+            summary = f"[Agent called {', '.join(tool_names)} ({tool_count} result(s) consumed)]"
+            result.append({"role": "system", "content": summary})
+            continue
+
+        # Regular assistant message (final answer) - keep it.
+        result.append(m)
+        i += 1
+
+    return result
+
+
+def run_agent_loop(
+    model: str,
+    api_messages: list,
+    tools: list | None = None,
+    query_runner: Callable[[str], str] | None = None,
+    max_turns: int = 5,
+) -> tuple[str, list]:
+    """
+    Run multi-turn agent loop until the model returns no tool_calls or max_turns is reached.
+    Used by test_agent.py, Web, and TUI (,).
+    query_runner(sql_query: str) -> str is used for query_profile_db; pass None to treat DB calls as no-op.
+    Returns (final_content, actions) where actions are parsed navigate_to_kernel / zoom_to_time_range dicts.
+    """
+    try:
+        import litellm
+    except ImportError:
+        return ("LLM not available (install litellm).", [])
+
+    tools = tools if tools is not None else _tools_openai()
+    actions: list = []
+    consecutive_db_errors = 0
+
+    for _ in range(max_turns):
+        _compact_old_tool_results(api_messages)
+        if len(api_messages) > MAX_AGENT_MESSAGES:
+            api_messages[:] = [api_messages[0]] + api_messages[-(MAX_AGENT_MESSAGES - 1) :]
+        response = litellm.completion(
+            model=model,
+            messages=api_messages,
+            tools=tools,
+            tool_choice="auto",
+        )
+        choice = response.choices[0] if response.choices else None
+        if not choice:
+            return ("", actions)
+        message = choice.message
+        if isinstance(message, dict):
+            content = (message.get("content") or "").strip()
+            tool_calls = message.get("tool_calls") or []
+        else:
+            content = (getattr(message, "content", None) or "").strip()
+            tool_calls = getattr(message, "tool_calls", None) or []
+
+        if not tool_calls:
+            return (content, actions)
+
+        tc_list = []
+        for tc in tool_calls:
+            fn = getattr(tc, "function", None) if not isinstance(tc, dict) else tc.get("function") or {}
+            tc_id = getattr(tc, "id", None) if not isinstance(tc, dict) else tc.get("id")
+            name = getattr(fn, "name", None) if not isinstance(fn, dict) else fn.get("name")
+            args_str = getattr(fn, "arguments", None) if not isinstance(fn, dict) else fn.get("arguments") or "{}"
+            tc_list.append((tc_id, name, args_str))
+
+        assistant_msg = {
+            "role": "assistant",
+            "content": content or None,
+            "tool_calls": [
+                {"id": tid, "type": "function", "function": {"name": n, "arguments": a}}
+                for tid, n, a in tc_list
+            ],
+        }
+        api_messages.append(assistant_msg)
+
+        has_external = False
+        for tc_id, name, args_str in tc_list:
+            if not name or not tc_id:
+                continue
+            action = _parse_tool_call(name, args_str)
+            if action:
+                # External navigation tool: collect action, exit after all tools processed.
+                has_external = True
+                actions.append(action)
+            elif name == "query_profile_db":
+                # DB tool: run if runner available, else report; continue loop so model sees result.
+                if query_runner is not None:
+                    try:
+                        sql = json.loads(args_str).get("sql_query", "")
+                        result = query_runner(sql)
+                    except Exception as e:
+                        result = f"Error: {e}"
+                    if result.startswith("Error:"):
+                        consecutive_db_errors += 1
+                        if consecutive_db_errors >= MAX_CONSECUTIVE_DB_ERRORS:
+                            result += "\n[System: Repeated SQL errors. Please answer from available context without further queries.]"
+                    else:
+                        consecutive_db_errors = 0
+                else:
+                    result = "Not executed (no profile loaded)."
+                api_messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc_id,
+                    "name": name,
+                    "content": result,
+                })
+            else:
+                api_messages.append({
+                    "role": "tool",
+                    "tool_call_id": tc_id,
+                    "name": name,
+                    "content": "Not executed.",
+                })
+
+        if has_external:
+            return (content, actions)
+
+    return ("Max turns reached.", actions)
+
+
+def chat_completion(body_bytes: bytes) -> dict | None:
+    """
+    Handle POST /api/chat body. Returns { "content": str, "actions": list } or None for 501.
+    """
+    try:
+        import litellm
+    except ImportError:
+        return None
+
+    try:
+        payload = json.loads(body_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {"content": "Invalid request body.", "actions": []}
+
+    preferred_model = payload.get("model")
+    model, _ = _get_model_and_key(preferred_model)
+    if not model:
+        return None
+
+    messages = payload.get("messages") or []
+    ui_context = payload.get("ui_context") or {}
+    profile_path = payload.get("profile_path")
+
+    # Feature flag: NSYS_AI_DB_AGENT controls whether the Web path uses the DB-backed
+    # agent loop when profile_path is present (,).
+    db_agent_flag = os.environ.get("NSYS_AI_DB_AGENT", "").strip().lower()
+    db_agent_enabled = bool(db_agent_flag) and db_agent_flag not in ("0", "false", "no", "off")
+
+    # When profile_path is provided AND DB agent is enabled, run full agent loop with
+    # query_profile_db (,). Otherwise fall back to v1 behavior using only ui_context.
+    if profile_path and db_agent_enabled:
+        try:
+            from .profile import resolve_profile_path
+            sqlite_path = resolve_profile_path(profile_path)
+        except RuntimeError as e:
+            return {"content": f"Profile error: {e}", "actions": []}
+        conn = open_profile_readonly(sqlite_path)
+        try:
+            schema_str = get_profile_schema_cached(conn, sqlite_path)
+            system_prompt = _build_system_prompt(ui_context, profile_schema=schema_str)
+            api_messages = [{"role": "system", "content": system_prompt}]
+            for m in messages:
+                role = m.get("role")
+                content = m.get("content")
+                if role and content is not None:
+                    api_messages.append({"role": role, "content": content})
+            query_runner = lambda sql: query_profile_db(conn, sql)
+            try:
+                content, actions = run_agent_loop(
+                    model=model,
+                    api_messages=api_messages,
+                    tools=_tools_openai(),
+                    query_runner=query_runner,
+                    max_turns=5,
+                )
+                return {"content": content, "actions": actions}
+            except Exception as e:
+                err_msg = str(e)
+                print(f"[nsys-tui] Agent loop error (model={model!r}): {err_msg}", file=sys.stderr)
+                if "429" in err_msg or "RateLimitError" in type(e).__name__ or "quota" in err_msg.lower():
+                    friendly = "Quota exceeded (429). Try a different model or check API billing."
+                else:
+                    friendly = err_msg
+                return {"content": f"LLM error: {friendly}", "actions": []}
+        finally:
+            conn.close()
+
+    system_prompt = _build_system_prompt(ui_context)
+    api_messages = [{"role": "system", "content": system_prompt}]
+    for m in messages:
+        role = m.get("role")
+        content = m.get("content")
+        if role and content is not None:
+            api_messages.append({"role": role, "content": content})
+
+    try:
+        response = litellm.completion(
+            model=model,
+            messages=api_messages,
+            tools=_tools_openai(),
+            tool_choice="auto",
+        )
+    except Exception as e:
+        err_msg = str(e)
+        print(f"[nsys-tui] LiteLLM error (model={model!r}): {err_msg}", file=sys.stderr)
+        if "429" in err_msg or "RateLimitError" in type(e).__name__ or "quota" in err_msg.lower():
+            friendly = "Quota exceeded (429). Try a different model (e.g. Gemini 2.5 Flash) or check billing: https://ai.google.dev/gemini-api/docs/rate-limits"
+        else:
+            friendly = err_msg
+        return {"content": f"LLM error: {friendly}", "actions": []}
+
+    choice = response.choices[0] if response.choices else None
+    if not choice:
+        return {"content": "", "actions": []}
+    message = choice.message
+    # Support both object and dict (e.g. different LiteLLM/provider shapes)
+    if isinstance(message, dict):
+        content = (message.get("content") or "").strip()
+        tool_calls = message.get("tool_calls") or []
+    else:
+        content = (getattr(message, "content", None) or "").strip()
+        tool_calls = getattr(message, "tool_calls", None) or []
+    actions = []
+    for tc in tool_calls:
+        fn = getattr(tc, "function", None) if not isinstance(tc, dict) else tc.get("function")
+        fn = fn or {}
+        name = getattr(fn, "name", None) if not isinstance(fn, dict) else fn.get("name")
+        args_str = getattr(fn, "arguments", None) if not isinstance(fn, dict) else fn.get("arguments")
+        args_str = args_str or "{}"
+        if name:
+            action = _parse_tool_call(name, args_str)
+            if action:
+                actions.append(action)
+    return {"content": content, "actions": actions}
+
+
+def _sse_event(evt: str, data: dict) -> bytes:
+    return f"event: {evt}\ndata: {json.dumps(data)}\n\n".encode("utf-8")
+
+
+def stream_agent_loop(
+    model: str,
+    messages: list,
+    ui_context: dict,
+    tools: list | None = None,
+    profile_path: str | None = None,
+    max_turns: int = 5,
+):
+    """
+    UI-agnostic streaming agent loop. Yields events: text, system, action, done.
+
+    - Internal tool query_profile_db: runs in-loop when profile_path is set; appends
+      tool messages and continues to next turn.
+    - External tools (navigate_to_kernel, zoom_to_time_range): yields action then done.
+    - Connection is opened inside this generator (same thread as caller), respecting (worker-owned connection when called from TUI worker).
+    """
+    try:
+        import litellm
+    except ImportError:
+        yield {"type": "text", "content": "LLM not available (install litellm)."}
+        yield {"type": "done", "usage": {}}
+        return
+
+    tools = tools if tools is not None else _tools_openai()
+    conn = None
+    query_runner = None
+    if profile_path:
+        try:
+            from .profile import resolve_profile_path
+            sqlite_path = resolve_profile_path(profile_path)
+        except RuntimeError as e:
+            yield {"type": "text", "content": f"Profile error: {e}"}
+            yield {"type": "done", "usage": {}}
+            return
+        conn = open_profile_readonly(sqlite_path)
+        try:
+            schema_str = get_profile_schema_cached(conn, sqlite_path)
+            query_runner = lambda sql: query_profile_db(conn, sql)
+        except Exception:
+            if conn:
+                conn.close()
+            raise
+    else:
+        schema_str = None
+
+    system_prompt = _build_system_prompt(ui_context, profile_schema=schema_str)
+    api_messages = [{"role": "system", "content": system_prompt}]
+    for m in messages:
+        role = m.get("role")
+        content = m.get("content")
+        if role and content is not None:
+            api_messages.append({"role": role, "content": content})
+
+    try:
+        usage = {}
+        consecutive_db_errors = 0
+        turn_count = 0
+        for _ in range(max_turns):
+            turn_count += 1
+            _compact_old_tool_results(api_messages)
+            if len(api_messages) > MAX_AGENT_MESSAGES:
+                api_messages[:] = [api_messages[0]] + api_messages[-(MAX_AGENT_MESSAGES - 1) :]
+            try:
+                stream = litellm.completion(
+                    model=model,
+                    messages=api_messages,
+                    tools=tools,
+                    tool_choice="auto",
+                    stream=True,
+                )
+            except Exception as e:
+                err_msg = str(e)
+                print(f"[nsys-tui] LiteLLM stream error (model={model!r}): {err_msg}", file=sys.stderr)
+                friendly = "Quota exceeded (429). Try a different model or check billing." if "429" in err_msg or "quota" in err_msg.lower() else err_msg
+                yield {"type": "text", "content": f"LLM error: {friendly}"}
+                yield {"type": "done", "usage": usage}
+                return
+
+            content_parts = []
+            tool_calls_by_index = {}
+
+            for chunk in stream:
+                choice = chunk.choices[0] if chunk.choices else None
+                if not choice:
+                    continue
+                delta = getattr(choice, "delta", None) or (choice.get("delta") if isinstance(choice, dict) else None)
+                if not delta:
+                    continue
+                c = getattr(delta, "content", None) if not isinstance(delta, dict) else delta.get("content")
+                if c:
+                    content_parts.append(c)
+                    yield {"type": "text", "content": c}
+                tcs = getattr(delta, "tool_calls", None) if not isinstance(delta, dict) else delta.get("tool_calls")
+                tcs = tcs or []
+                for tc in tcs:
+                    idx = getattr(tc, "index", 0) if not isinstance(tc, dict) else tc.get("index", 0)
+                    tc_id = getattr(tc, "id", None) if not isinstance(tc, dict) else tc.get("id")
+                    fn = getattr(tc, "function", None) if not isinstance(tc, dict) else tc.get("function") or {}
+                    if isinstance(fn, dict):
+                        name, args = fn.get("name"), fn.get("arguments") or ""
+                    else:
+                        name, args = getattr(fn, "name", None), getattr(fn, "arguments", None) or ""
+                    if idx not in tool_calls_by_index:
+                        tool_calls_by_index[idx] = {"id": None, "name": None, "arguments": ""}
+                    if tc_id:
+                        tool_calls_by_index[idx]["id"] = tc_id
+                    if name:
+                        tool_calls_by_index[idx]["name"] = name
+                    tool_calls_by_index[idx]["arguments"] = tool_calls_by_index[idx]["arguments"] + args
+                u = getattr(chunk, "usage", None) or (chunk.get("usage") if isinstance(chunk, dict) else None)
+                if u:
+                    usage = u if isinstance(u, dict) else {"prompt_tokens": getattr(u, "prompt_tokens", 0), "completion_tokens": getattr(u, "completion_tokens", 0)}
+
+            full_content = "".join(content_parts).strip() if content_parts else ""
+            tc_list = []
+            for idx in sorted(tool_calls_by_index):
+                t = tool_calls_by_index[idx]
+                tid = t.get("id") or f"call_{idx}"
+                name = t.get("name")
+                args_str = t.get("arguments") or "{}"
+                tc_list.append((tid, name, args_str))
+
+            if usage:
+                pt = usage.get("prompt_tokens", 0) if isinstance(usage, dict) else getattr(usage, "prompt_tokens", 0)
+                if isinstance(pt, int) and pt > PROMPT_TOKEN_WARNING_THRESHOLD:
+                    _log.warning(
+                        "stream_agent_loop: high prompt token usage (%d). model=%s", pt, model
+                    )
+                    yield {"type": "system", "content": f"⚠ Large context ({pt:,} tokens). Consider starting a new chat to reduce cost."}
+
+            if not tc_list:
+                yield {"type": "done", "usage": usage}
+                return
+
+            assistant_msg = {
+                "role": "assistant",
+                "content": full_content or None,
+                "tool_calls": [
+                    {"id": tid, "type": "function", "function": {"name": n, "arguments": a}}
+                    for tid, n, a in tc_list
+                ],
+            }
+            api_messages.append(assistant_msg)
+
+            has_external = False
+            for tid, name, args_str in tc_list:
+                if not name or not tid:
+                    continue
+                if name == "query_profile_db" and query_runner is not None:
+                    yield {"type": "system", "content": "Running DB query..."}
+                    try:
+                        args = json.loads(args_str)
+                        sql = args.get("sql_query", "")
+                        result = query_runner(sql)
+                    except Exception as e:
+                        result = f"Error: {e}"
+                    if result.startswith("Error:"):
+                        consecutive_db_errors += 1
+                        if consecutive_db_errors >= MAX_CONSECUTIVE_DB_ERRORS:
+                            result += "\n[System: Repeated SQL errors. Please answer from available context without further queries.]"
+                    else:
+                        consecutive_db_errors = 0
+                    api_messages.append({
+                        "role": "tool",
+                        "tool_call_id": tid,
+                        "name": name,
+                        "content": result,
+                    })
+                else:
+                    if name == "query_profile_db":
+                        api_messages.append({
+                            "role": "tool",
+                            "tool_call_id": tid,
+                            "name": name,
+                            "content": "Not executed (no profile loaded).",
+                        })
+                    action = _parse_tool_call(name, args_str)
+                    if action:
+                        has_external = True
+                        yield {"type": "action", "action": action}
+
+            if has_external:
+                yield {"type": "done", "usage": usage}
+                return
+        yield {"type": "done", "usage": usage}
+    finally:
+        # Telemetry: log usage data for cost analysis and future rate-limiting.
+        if usage:
+            _telemetry_log.info(
+                "agent_usage model=%s prompt_tokens=%s completion_tokens=%s turns=%d",
+                model,
+                usage.get("prompt_tokens", "?") if isinstance(usage, dict) else getattr(usage, "prompt_tokens", "?"),
+                usage.get("completion_tokens", "?") if isinstance(usage, dict) else getattr(usage, "completion_tokens", "?"),
+                turn_count,
+            )
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def chat_completion_stream(body_bytes: bytes):
+    """
+    Generator yielding SSE bytes for streaming mode (,).
+    Always delegates to stream_agent_loop; uses profile_path when NSYS_AI_DB_AGENT is set.
+    """
+    try:
+        payload = json.loads(body_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        yield _sse_event("text", {"chunk": "Invalid request body."})
+        yield _sse_event("done", {})
+        return
+
+    preferred_model = payload.get("model")
+    model, _ = _get_model_and_key(preferred_model)
+    if not model:
+        yield _sse_event("done", {"error": "LLM not configured"})
+        return
+
+    messages = payload.get("messages") or []
+    ui_context = payload.get("ui_context") or {}
+    profile_path = payload.get("profile_path")
+    db_agent_flag = os.environ.get("NSYS_AI_DB_AGENT", "").strip().lower()
+    db_agent_enabled = bool(db_agent_flag) and db_agent_flag not in ("0", "false", "no", "off")
+
+    # Use DB-backed agent when profile_path is present and NSYS_AI_DB_AGENT is set.
+    effective_profile = profile_path if (profile_path and db_agent_enabled) else None
+
+    try:
+        for ev in stream_agent_loop(
+            model=model,
+            messages=messages,
+            ui_context=ui_context,
+            tools=_tools_openai(),
+            profile_path=effective_profile,
+            max_turns=5,
+        ):
+            t = ev.get("type")
+            if t == "text":
+                yield _sse_event("text", {"chunk": ev.get("content", "")})
+            elif t == "system":
+                yield _sse_event("system", {"content": ev.get("content", "")})
+            elif t == "action":
+                yield _sse_event("action", ev.get("action", {}))
+            elif t == "done":
+                yield _sse_event("done", ev.get("usage") or {})
+    except (BrokenPipeError, ConnectionResetError, OSError):
+        pass
+    except Exception as e:
+        err_msg = str(e)
+        print(f"[nsys-tui] stream_agent_loop error (model={model!r}): {err_msg}", file=sys.stderr)
+        try:
+            yield _sse_event("text", {"chunk": f"Stream error: {err_msg}"})
+            yield _sse_event("done", {"error": err_msg})
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass

--- a/src/nsys_tui/templates/nvtx_tree.html
+++ b/src/nsys_tui/templates/nvtx_tree.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>NVTX Stack Trace — $GPU_LABEL</title>
+    <title>NVTX Stack Trace - $GPU_LABEL</title>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js"></script>
     <style>
         :root {
             --bg: #0d1117;
@@ -154,7 +156,7 @@
             display: block
         }
 
-        /* Focus mode — hide all chrome, maximize tab panel */
+        /* Focus mode - hide all chrome, maximize tab panel */
         body.focused>h1,
         body.focused>.subtitle,
         body.focused>.stats,
@@ -421,6 +423,32 @@
             background: var(--surface)
         }
 
+        .kernel-table tr.selected {
+            background: color-mix(in srgb, var(--accent) 18%, var(--surface));
+            border-left: 3px solid var(--accent);
+        }
+
+        .kernel-table .explain-btn {
+            opacity: 0;
+            border: none;
+            background: var(--accent);
+            color: #fff;
+            padding: 2px 8px;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 10px;
+            white-space: nowrap;
+            transition: opacity .15s;
+        }
+
+        .kernel-table tr:hover .explain-btn {
+            opacity: 1;
+        }
+
+        .kernel-table .explain-btn:hover {
+            filter: brightness(1.15);
+        }
+
         .kernel-table .stream-badge {
             padding: 1px 6px;
             border-radius: 3px;
@@ -492,6 +520,14 @@
             border: 1px dashed rgba(248, 81, 73, .3)
         }
 
+        .scan-block-wrap { position: relative; display: inline-flex; margin: 0 1px; }
+        .scan-block-wrap .scan-block { padding-right: 28px; box-sizing: border-box; }
+        .scan-block-wrap .explain-btn-scan { position: absolute; right: 2px; top: 50%; transform: translateY(-50%); opacity: 0; border: 1px solid var(--border); background: var(--surface); color: var(--accent); padding: 2px 5px; border-radius: 3px; cursor: pointer; font-size: 9px; z-index: 2; }
+        .scan-block-wrap:hover .explain-btn-scan { opacity: 1; }
+        .scan-block-wrap .explain-btn-scan:hover { background: var(--accent); color: #fff; border-color: var(--accent); }
+        .scanv2-kernel-cell .explain-btn-scan { display: block; margin-top: 4px; width: 100%; border: 1px solid var(--border); background: var(--surface); color: var(--accent); padding: 2px 6px; border-radius: 3px; cursor: pointer; font-size: 10px; opacity: 0; transition: opacity .15s; }
+        .scanv2-kernel-cell:hover .explain-btn-scan { opacity: 1; }
+        .scanv2-kernel-cell .explain-btn-scan:hover { background: var(--accent); color: #fff; border-color: var(--accent); }
         .scan-crossing {
             position: absolute;
             width: 1px;
@@ -620,16 +656,19 @@
             right: 0;
             top: 0;
             width: 380px;
+            min-width: 0;
             height: 100%;
+            box-sizing: border-box;
             background: var(--surface);
             border-left: 1px solid var(--border);
             z-index: 100;
             display: none;
-            flex-direction: column
+            flex-direction: column;
+            overflow: hidden;
         }
 
         .ai-sidebar.open {
-            display: flex
+            display: flex;
         }
 
         .ai-header {
@@ -648,8 +687,10 @@
 
         .ai-messages {
             flex: 1;
+            min-width: 0;
             overflow-y: auto;
-            padding: 12px 16px
+            overflow-x: hidden;
+            padding: 12px 16px;
         }
 
         .ai-msg {
@@ -657,46 +698,178 @@
             padding: 8px 12px;
             border-radius: 6px;
             font-size: 12px;
-            line-height: 1.5
+            line-height: 1.5;
+            min-width: 0;
+            overflow-wrap: break-word;
+            word-break: break-word;
+            word-wrap: break-word;
         }
 
         .ai-msg.user {
             background: #1a2332;
-            border: 1px solid var(--border)
+            border: 1px solid var(--border);
         }
 
         .ai-msg.assistant {
             background: #0d3117;
-            border: 1px solid #238636
+            border: 1px solid #238636;
+        }
+
+        /* Markdown display in chat bubbles (see docs/chat-markdown-display.md) */
+        .ai-msg p { margin: 0 0 0.6em 0; }
+        .ai-msg p:last-child { margin-bottom: 0; }
+        .ai-msg h1, .ai-msg h2, .ai-msg h3, .ai-msg h4, .ai-msg h5, .ai-msg h6 {
+            margin: 0.85em 0 0.4em 0;
+            font-weight: 600;
+            line-height: 1.3;
+        }
+        .ai-msg h1 { font-size: 1.25em; }
+        .ai-msg h2 { font-size: 1.15em; border-bottom: 1px solid rgba(255,255,255,0.15); padding-bottom: 2px; }
+        .ai-msg h3, .ai-msg h4, .ai-msg h5, .ai-msg h6 { font-size: 1.05em; }
+        .ai-msg ul, .ai-msg ol { margin: 0.4em 0 0.6em 0; padding-left: 1.4em; }
+        .ai-msg li { margin-bottom: 0.25em; line-height: 1.5; }
+        .ai-msg pre {
+            margin: 0.5em 0;
+            padding: 10px 12px;
+            background: rgba(0,0,0,0.25);
+            border-radius: 6px;
+            overflow-x: auto;
+            font-size: 11px;
+            line-height: 1.4;
+        }
+        .ai-msg pre code { background: none; padding: 0; font-size: inherit; }
+        .ai-msg code { font-size: 0.95em; padding: 2px 4px; background: rgba(0,0,0,0.2); border-radius: 4px; }
+        .ai-msg strong { font-weight: 600; }
+        .ai-msg a { color: #58a6ff; text-decoration: none; }
+        .ai-msg a:hover { text-decoration: underline; }
+
+        .ai-loading {
+            color: var(--text-dim);
+            display: inline-block;
+        }
+        .ai-loading-dots {
+            display: inline-block;
+            animation: ai-loading-pulse 1s ease-in-out infinite;
+        }
+        @keyframes ai-loading-pulse {
+            0%, 100% { opacity: 0.4; }
+            50% { opacity: 1; }
         }
 
         .ai-input-area {
             padding: 12px 16px;
             border-top: 1px solid var(--border);
             display: flex;
-            gap: 8px
+            flex-direction: column;
+            gap: 10px;
+            min-width: 0
         }
 
-        .ai-input-area input {
+        .ai-model-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            min-width: 0
+        }
+
+        .ai-model-row label {
+            font-size: 11px;
+            color: var(--text-dim);
+            white-space: nowrap;
+            flex-shrink: 0
+        }
+
+        .ai-model-row select {
             flex: 1;
+            min-width: 0;
+            font-size: 12px;
+            padding: 6px 24px 6px 8px;
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            color: var(--text);
+            cursor: pointer;
+            font-family: inherit;
+            appearance: none;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23888' d='M2.5 4.5L6 8l3.5-3.5'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 8px center
+        }
+
+        .ai-model-row select:hover {
+            border-color: var(--accent);
+        }
+
+        .ai-model-row select:focus {
+            outline: none;
+            border-color: var(--accent);
+            box-shadow: 0 0 0 2px rgba(56, 189, 248, 0.25);
+        }
+
+        .ai-input-row {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            min-width: 0
+        }
+
+        .ai-input-area .ai-input-row input {
+            flex: 1;
+            min-width: 0;
             background: var(--bg);
             border: 1px solid var(--border);
             color: var(--text);
             padding: 8px 12px;
-            border-radius: 4px;
+            border-radius: 6px;
             font-family: inherit;
             font-size: 12px
         }
 
-        .ai-input-area button {
+        .ai-input-area .ai-input-row input:focus {
+            outline: none;
+            border-color: var(--accent);
+        }
+
+        .ai-input-area .ai-input-row button {
+            flex-shrink: 0;
             background: var(--accent);
             border: none;
             color: #fff;
             padding: 8px 14px;
-            border-radius: 4px;
+            border-radius: 6px;
             cursor: pointer;
-            font-size: 12px
+            font-size: 12px;
+            font-family: inherit;
         }
+
+        .ai-input-area .ai-input-row button:hover {
+            filter: brightness(1.1);
+        }
+
+        .ai-input-area .ai-input-row button:disabled {
+            opacity: 0.6;
+            cursor: not-allowed;
+        }
+
+        .ai-apikey-hint {
+            font-size: 11px;
+            color: var(--text-dim);
+            padding: 10px 12px;
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            line-height: 1.5;
+        }
+
+        .ai-apikey-hint p { margin: 0 0 6px 0; }
+        .ai-apikey-hint p:last-child { margin-bottom: 0; }
+        .ai-apikey-hint code {
+            font-size: 10px;
+            padding: 1px 4px;
+            background: rgba(255,255,255,0.06);
+            border-radius: 3px;
+        }
+        .ai-apikey-hint ul { margin: 4px 0; padding-left: 18px; }
 
         /* Pattern badges */
         .pattern-badge {
@@ -829,21 +1002,38 @@
     <!-- Context menu -->
     <div class="ctx-menu" id="ctxMenu" style="display:none"></div>
 
-    <!-- AI sidebar -->
+    <!-- AI sidebar (Issue #6: chat + context + Explain this + history) -->
     <div class="ai-sidebar" id="aiSidebar">
         <div class="ai-header">
-            <h2>🤖 AI Profiler</h2><button onclick="toggleAI()"
-                style="background:transparent;border:none;color:var(--text);cursor:pointer;font-size:16px">✕</button>
+            <h2>🤖 AI Profiler</h2>
+            <span>
+                <button type="button" onclick="clearChatHistory()" title="Clear conversation" style="background:transparent;border:1px solid var(--border);color:var(--text-dim);cursor:pointer;font-size:11px;padding:2px 8px;border-radius:4px;margin-right:6px">Clear</button>
+                <button onclick="toggleAI()" style="background:transparent;border:none;color:var(--text);cursor:pointer;font-size:16px">✕</button>
+            </span>
         </div>
-        <div class="ai-messages" id="aiMessages">
-            <div class="ai-msg assistant">I can analyze your GPU profile. Try asking:<br>• "What's the bottleneck?"<br>•
-                "Why is kernel X slow?"<br>• "Compare streams 21 and 56"<br><br><em
-                    style="color:var(--text-dim)">Configure LLM endpoint in settings to enable.</em></div>
-        </div>
+        <div class="ai-messages" id="aiMessages"></div>
         <div class="ai-input-area">
-            <input type="text" id="aiInput" placeholder="Ask about this profile..."
-                onkeydown="if(event.key==='Enter')sendAI()">
-            <button onclick="sendAI()">Send</button>
+            <div class="ai-model-row">
+                <label for="chatModelSelect">Model</label>
+                <select id="chatModelSelect" onchange="saveChatModelChoice()" title="Select AI model (requires corresponding API key)"></select>
+            </div>
+            <div class="ai-apikey-hint" id="aiApiKeyHint" style="display:none">
+                <p><strong>How to set API key</strong></p>
+                <p>Set the API key as an <strong>environment variable before starting the server</strong>, then restart <code>nsys-ai web</code>.</p>
+                <p>Set one of:</p>
+                <ul>
+                    <li><code>ANTHROPIC_API_KEY</code> (Claude)</li>
+                    <li><code>OPENAI_API_KEY</code> (GPT-4o)</li>
+                    <li><code>GEMINI_API_KEY</code> (Gemini)</li>
+                </ul>
+                <p>Example: <code>export ANTHROPIC_API_KEY=sk-ant-...</code></p>
+            </div>
+            <div class="ai-input-row">
+                <input type="text" id="aiInput" placeholder="Ask about this profile..."
+                    onkeydown="if(event.key==='Enter')sendAI()">
+                <button type="button" id="chatStopBtn" onclick="if(window._chatAbortController)window._chatAbortController.abort()" style="display:none;background:var(--bubble)">⏹ Stop</button>
+                <button type="button" id="chatSendBtn" onclick="sendAI()">Send</button>
+            </div>
         </div>
     </div>
 
@@ -852,19 +1042,28 @@
 
     <script>
         const DATA = $DATA;
+        const PROFILE_PATH = "$PROFILE_PATH";
+        const DB_AGENT_ENABLED = "$DB_AGENT_ENABLED" === "1";
         let heatEnabled = false, demangledMode = false, searchMode = 'path', currentTab = 'tree', scopeActive = false, scopedData = null, scopePath = null;
-        // Tree expand state: null (mixed/initial), 'all', 'none', 2, 4 — used to show active button
+        // Tree expand state: null (mixed/initial), 'all', 'none', 2, 4 - used to show active button
         let treeExpandState = null;
         // searchMode: 'name' (substring), 'regex' (JS regex), 'path' (glob on NVTX path)
+        // Issue #6: AI chat - selected kernel and conversation history (profile-bound)
+        let selectedKernel = null;
+        const PROFILE_ID = "$PROFILE_ID";
+        const CHAT_STORAGE_KEY = 'nsys_chat_history_' + (PROFILE_ID || 'default');
+        const CHAT_MODEL_STORAGE_KEY = 'nsys_chat_model';
+        let chatHistory = (function() { try { return JSON.parse(localStorage.getItem(CHAT_STORAGE_KEY) || '[]'); } catch (_) { return []; } })();
 
-        // ══════════════ Utilities ══════════════
-        function escHtml(s) { return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') }
+        // = Utilities =
+        function escHtml(s) { if (s == null) return ''; return String(s).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;') }
+        function escAttr(s) { return escHtml(s).replace(/"/g, '&quot;') }
         function fmtDur(ms) { return ms >= 1 ? ms.toFixed(1) + 'ms' : (ms * 1000).toFixed(0) + 'μs' }
         function fmtNs(ns) { return (ns / 1e6).toFixed(3) + 'ms' }
         function heatColor(h) { if (h <= .25) return 'var(--heat-0)'; if (h <= .5) return 'var(--heat-25)'; if (h <= .75) return 'var(--heat-50)'; if (h <= .9) return 'var(--heat-75)'; return 'var(--heat-100)' }
         function streamClass(s) { if (s === undefined) return ''; const n = String(s); return n.includes('nccl') ? 'stream-nccl' : 'stream-compute' }
 
-        // ══════════════ Data extraction ══════════════
+        // = Data extraction =
         function collectAll(nodes, arr) { arr = arr || []; nodes.forEach(n => { arr.push(n); if (n.children) collectAll(n.children, arr) }); return arr }
         function collectKernels(nodes) { return collectAll(nodes).filter(n => n.type === 'kernel') }
         function collectNVTX(nodes) { return collectAll(nodes).filter(n => n.type === 'nvtx') }
@@ -874,7 +1073,140 @@
 
         function activeData() { return scopedData || DATA }
 
-        // ══════════════ Tab switching ══════════════
+        // = Profile context (Issue #6) =
+        function getTimeRangeFromData(nodes) {
+            let minNs = Infinity, maxNs = -Infinity;
+            function walk(n) {
+                const s = n.start_ns != null ? n.start_ns : n.start;
+                const e = n.end_ns != null ? n.end_ns : n.end;
+                if (s != null && e != null) { minNs = Math.min(minNs, s); maxNs = Math.max(maxNs, e); }
+                (n.children || []).forEach(walk);
+            }
+            (nodes || []).forEach(walk);
+            return { min_ns: minNs === Infinity ? 0 : minNs, max_ns: maxNs === -Infinity ? 0 : maxNs };
+        }
+        function getProfileContext() {
+            const data = activeData();
+            const tr = getTimeRangeFromData(data);
+            const trimLabel = (tr.min_ns / 1e9).toFixed(1) + 's - ' + (tr.max_ns / 1e9).toFixed(1) + 's';
+            const scopeLabel = scopeActive && scopePath ? scopePath : 'All regions';
+            let ctx = 'Current view: ' + trimLabel + ', scope: ' + scopeLabel + '.';
+            if (selectedKernel) {
+                const streamStr = selectedKernel.stream !== undefined ? String(selectedKernel.stream) : 'N/A (NVTX range)';
+                ctx += ' Selected kernel: ' + selectedKernel.name + ' (path: ' + (selectedKernel.path || ' - ') + '), ' + fmtDur(selectedKernel.duration_ms) + ', stream ' + streamStr + '.';
+            }
+            return ctx;
+        }
+        // Build payload for POST /api/chat: rolling window last 10 messages, capped context
+        function buildChatPayload(stream) {
+            var MAX_MESSAGE_CHARS = 16000;
+            function truncateForApi(s) {
+                if (s == null || s === undefined) return '';
+                try { var str = typeof s === 'string' ? s : String(s); } catch (_) { return ''; }
+                return str.length <= MAX_MESSAGE_CHARS ? str : str.slice(0, MAX_MESSAGE_CHARS) + '\n\n[... truncated for context]';
+            }
+            var messages;
+            try {
+                messages = chatHistory.slice(-10).filter(function(m) { return m && m.content !== AI_LOADING_PLACEHOLDER; }).map(function(m) { return { role: m.role, content: truncateForApi(m.content) }; });
+            } catch (e) {
+                if (console) console.warn('[SSE] buildChatPayload messages failed:', e);
+                messages = [];
+            }
+            var ui_context;
+            try {
+                const data = activeData();
+                const tr = getTimeRangeFromData(data);
+                const globalStats = countNodes(DATA);
+                const visibleKernels = collectKernels(data);
+                const globalKernels = collectKernels(DATA);
+                const totalGpuMs = globalStats.totalMs;
+                const globalAgg = {};
+                globalKernels.forEach(function(k) { if (!globalAgg[k.name]) globalAgg[k.name] = 0; globalAgg[k.name] += k.duration_ms; });
+                const globalTopKernelsFull = Object.entries(globalAgg).map(function(e) { return { name: e[0], total_ms: Math.round(e[1] * 100) / 100 }; }).sort(function(a, b) { return b.total_ms - a.total_ms; });
+                // When DB-backed agent is enabled (NSYS_AI_DB_AGENT=1) and profile_path is present,
+                // rely on query_profile_db for whole-profile facts and omit global_top_kernels to save tokens (,).
+                const useDbAgent = DB_AGENT_ENABLED && typeof PROFILE_PATH === 'string' && PROFILE_PATH;
+                const globalTopKernels = useDbAgent
+                    ? []
+                    : globalTopKernelsFull.slice(0, 8).map(function(x) {
+                        return {
+                            name: x.name,
+                            total_ms: x.total_ms,
+                            percentage: totalGpuMs > 0 ? Math.round(x.total_ms / totalGpuMs * 10000) / 100 : 0
+                        };
+                    });
+                const visibleAgg = {};
+                visibleKernels.forEach(function(k) {
+                    if (!visibleAgg[k.name]) visibleAgg[k.name] = { count: 0, total_ms: 0 };
+                    visibleAgg[k.name].count++;
+                    visibleAgg[k.name].total_ms += k.duration_ms;
+                });
+                // When DB agent is active, send fewer visible kernels (20 vs 50) since the agent can query the DB for details.
+                const visibleSummaryCap = useDbAgent ? 20 : 50;
+                const visibleKernelsSummary = Object.entries(visibleAgg).map(function(e) {
+                    return { name: e[0], count: e[1].count, total_ms: Math.round(e[1].total_ms * 100) / 100 };
+                }).sort(function(a, b) { return b.total_ms - a.total_ms; }).slice(0, visibleSummaryCap);
+                const viewState = { time_range: { min_ns: tr.min_ns, max_ns: tr.max_ns }, scope: scopeActive && scopePath ? scopePath : 'All regions' };
+                const selK = selectedKernel ? { name: selectedKernel.name, duration_ms: selectedKernel.duration_ms, stream: selectedKernel.stream !== undefined ? selectedKernel.stream : null } : null;
+                // When DB agent is enabled, omit global stats; agent uses query_profile_db instead.
+                const stats = useDbAgent
+                    ? { nvtx_count: globalStats.nvtx }
+                    : { total_gpu_ms: Math.round(totalGpuMs * 100) / 100, kernel_count: globalStats.kern, nvtx_count: globalStats.nvtx, total_kernel_count: globalStats.kern };
+                ui_context = { view_state: viewState, selected_kernel: selK, stats: stats, global_top_kernels: globalTopKernels, visible_kernels_summary: visibleKernelsSummary };
+            } catch (e) {
+                if (console) console.warn('[SSE] buildChatPayload ui_context failed:', e);
+                ui_context = { view_state: {}, selected_kernel: null, stats: {}, global_top_kernels: [], visible_kernels_summary: [] };
+            }
+            var payload = { messages: messages, ui_context: ui_context };
+            if (typeof PROFILE_PATH === 'string' && PROFILE_PATH) {
+                payload.profile_path = PROFILE_PATH;
+            }
+            if (stream) payload.stream = true;
+            var sel = document.getElementById('chatModelSelect');
+            if (sel && sel.value) payload.model = sel.value;
+            return payload;
+        }
+        function loadChatModels() {
+            var sel = document.getElementById('chatModelSelect');
+            var hint = document.getElementById('aiApiKeyHint');
+            if (!sel) return Promise.resolve();
+            return fetch('/api/models').then(function(r) { return r.json(); }).then(function(data) {
+                sel.innerHTML = '';
+                var options = data.options || [];
+                var defaultId = data.default || (options.length ? options[0].id : null);
+                var saved = null;
+                try { saved = localStorage.getItem(CHAT_MODEL_STORAGE_KEY); } catch (_) {}
+                var chosen = saved || defaultId;
+                if (options.length === 0) {
+                    var opt = document.createElement('option');
+                    opt.value = '';
+                    opt.textContent = 'No API key set';
+                    sel.appendChild(opt);
+                    if (hint) hint.style.display = 'block';
+                } else {
+                    if (hint) hint.style.display = 'none';
+                    var ids = options.map(function(o) { return o.id; });
+                    options.forEach(function(o) {
+                        var opt = document.createElement('option');
+                        opt.value = o.id;
+                        opt.textContent = o.label;
+                        if (o.id === chosen) opt.selected = true;
+                        sel.appendChild(opt);
+                    });
+                    if (options.length && (chosen == null || ids.indexOf(chosen) === -1)) sel.value = options[0].id;
+                }
+            }).catch(function() {
+                sel.innerHTML = '<option value="">Failed to load models</option>';
+                if (hint) hint.style.display = 'block';
+                return Promise.resolve();
+            });
+        }
+        function saveChatModelChoice() {
+            var sel = document.getElementById('chatModelSelect');
+            if (sel && sel.value) try { localStorage.setItem(CHAT_MODEL_STORAGE_KEY, sel.value); } catch (_) {}
+        }
+
+        // = Tab switching =
         function switchTab(tab) {
             currentTab = tab;
             // Activate only the tab button whose data-tab matches.
@@ -893,7 +1225,7 @@
             if (tab === 'patterns') renderPatternView();
         }
 
-        // ══════════════ Tree view ══════════════
+        // = Tree view =
         function renderNode(node, depth) {
             const hasC = node.children && node.children.length > 0, isK = node.type === 'kernel', cls = isK ? 'kernel' : 'nvtx';
             const icon = isK ? '⚡' : '📦', toggle = hasC ? '▶' : ' ';
@@ -904,7 +1236,10 @@
             const barW = Math.max(3, Math.min(120, relPct * 1.2)), barC = heatColor(heat);
             const heatBar = '<span class="heat-bar" style="width:' + barW + 'px;background:' + barC + ';display:' + (heatEnabled ? 'inline-block' : 'none') + '" title="' + relPct.toFixed(1) + '% of parent"></span>';
             const pctLabel = '<span class="pct-label" style="display:' + (heatEnabled ? 'inline' : 'none') + '">' + relPct.toFixed(0) + '%</span>';
-            let h = '<div class="node ' + cls + '" data-depth="' + depth + '" data-name="' + escHtml(node.name) + '" data-demangled="' + escHtml(node.demangled || '') + '" data-path="' + escHtml(node.path || '') + '" data-dur="' + node.duration_ms + '" data-stream="' + (node.stream || '') + '" oncontextmenu="showCtx(event,this)">';
+            const startNs = node.start_ns != null ? node.start_ns : node.start;
+            const endNs = node.end_ns != null ? node.end_ns : node.end;
+            const streamVal = (node.stream !== undefined && node.stream !== null) ? String(node.stream) : '';
+            let h = '<div class="node ' + cls + '" data-depth="' + depth + '" data-name="' + escAttr(node.name) + '" data-demangled="' + escAttr(node.demangled || '') + '" data-path="' + escAttr(node.path || '') + '" data-dur="' + node.duration_ms + '" data-stream="' + streamVal + '" data-start-ns="' + (startNs ?? '') + '" data-end-ns="' + (endNs ?? '') + '" oncontextmenu="showCtx(event,this)">';
             h += '<div class="node-header" onclick="toggleNode(this)">';
             h += '<span class="toggle">' + toggle + '</span><span class="icon">' + icon + '</span>';
             h += '<span class="name">' + escHtml(displayName) + '</span>' + stream + dur + ' ' + heatBar + pctLabel + '</div>';
@@ -933,7 +1268,7 @@
             });
         }
 
-        // ══════════════ Search modes: name / regex / path ══════════════
+        // = Search modes: name / regex / path =
         function cycleSearchMode() {
             const modes = ['name', 'regex', 'path'];
             const hints = { name: 'substring match', regex: 'JavaScript regex', path: 'glob path: sample_0/**/flash*' };
@@ -984,22 +1319,46 @@
             });
         }
 
-        // ══════════════ Context menu ══════════════
+        // = Context menu =
+        let lastCtxNodeEl = null;
+        let lastCtxExplainKernel = null;
+        function streamFromNodeEl(el) {
+            var attr = el.getAttribute('data-stream');
+            if (attr != null && attr !== '') { var n = parseInt(attr, 10); if (!isNaN(n)) return n; }
+            var span = el.querySelector('.node-header .stream');
+            if (span) { var m = /\[stream\s+(\d+)\]/.exec(span.textContent); if (m) return parseInt(m[1], 10); }
+            return undefined;
+        }
+        function getKernelFromNodeEl(el) {
+            if (!el) return null;
+            var d = el.dataset;
+            return { name: d.name, path: d.path || '', start_ns: parseInt(d.startNs, 10) || 0, end_ns: parseInt(d.endNs, 10) || 0, duration_ms: parseFloat(d.dur) || 0, stream: streamFromNodeEl(el) };
+        }
+        function positionCtxMenu(menu, x, y) {
+            menu.style.display = 'block';
+            menu.style.left = x + 'px';
+            menu.style.top = y + 'px';
+            var r = menu.getBoundingClientRect();
+            if (r.right > window.innerWidth) menu.style.left = (window.innerWidth - r.width - 8) + 'px';
+            if (r.bottom > window.innerHeight) menu.style.top = (window.innerHeight - r.height - 8) + 'px';
+        }
         function showCtx(ev, nodeEl) {
-            ev.preventDefault(); const menu = document.getElementById('ctxMenu');
-            const name = nodeEl.dataset.name, path = nodeEl.dataset.path, dur = nodeEl.dataset.dur, stream = nodeEl.dataset.stream;
-            const isK = nodeEl.classList.contains('kernel');
-            let h = '';
-            h += '<div class="ctx-menu-item" onclick="copyText(\'' + escHtml(name) + '\')">📋 Copy name</div>';
-            if (path) h += '<div class="ctx-menu-item" onclick="copyText(\'' + escHtml(path) + '\')">📋 Copy NVTX path</div>';
-            h += '<div class="ctx-menu-item" onclick="copyText(\'' + name + ' | ' + fmtDur(parseFloat(dur)) + (stream ? ' | stream ' + stream : '') + '\')">📋 Copy info</div>';
-            h += '<div class="ctx-menu-sep"></div>';
-            if (isK) { h += '<div class="ctx-menu-item" onclick="findAllInvocations(\'' + escHtml(name) + '\')">🔍 Find all invocations</div>' }
-            h += '<div class="ctx-menu-item" onclick="filterByName(\'' + escHtml(name) + '\')">🔎 Filter to this</div>';
-            if (isK) h += '<div class="ctx-menu-item" onclick="showInKernelView(\'' + escHtml(name) + '\')">⚡ Show in kernel view</div>';
-            menu.innerHTML = h; menu.style.display = 'block'; menu.style.left = ev.clientX + 'px'; menu.style.top = ev.clientY + 'px';
-            const rect = menu.getBoundingClientRect(); if (rect.right > window.innerWidth) menu.style.left = (window.innerWidth - rect.width - 8) + 'px';
-            if (rect.bottom > window.innerHeight) menu.style.top = (window.innerHeight - rect.height - 8) + 'px';
+            ev.preventDefault();
+            var resolved = (ev.target && ev.target.closest && ev.target.closest('.node')) || nodeEl || null;
+            if (!resolved) return;
+            lastCtxNodeEl = resolved;
+            lastCtxExplainKernel = getKernelFromNodeEl(resolved);
+            var menu = document.getElementById('ctxMenu');
+            var path = resolved.dataset.path, isK = resolved.classList.contains('kernel');
+            var h = '<div class="ctx-menu-item" onclick="copyText(lastCtxNodeEl.dataset.name)">Copy name</div>';
+            if (path) h += '<div class="ctx-menu-item" onclick="copyText(lastCtxNodeEl.dataset.path)">Copy NVTX path</div>';
+            h += '<div class="ctx-menu-item" onclick="copyText(lastCtxNodeEl.dataset.name + \' | \' + fmtDur(parseFloat(lastCtxNodeEl.dataset.dur)) + (lastCtxNodeEl.dataset.stream ? \' | stream \' + lastCtxNodeEl.dataset.stream : \'\'))">Copy info</div><div class="ctx-menu-sep"></div>';
+            if (isK) h += '<div class="ctx-menu-item" onclick="findAllInvocations(lastCtxNodeEl.dataset.name)">Find all invocations</div>';
+            h += '<div class="ctx-menu-item" onclick="filterByName(lastCtxNodeEl.dataset.name)">Filter to this</div>';
+            if (isK) h += '<div class="ctx-menu-item" onclick="showInKernelView(lastCtxNodeEl.dataset.name)">Show in kernel view</div>';
+            h += '<div class="ctx-menu-sep"></div><div class="ctx-menu-item" onclick="if(lastCtxExplainKernel)explainThisKernel(lastCtxExplainKernel)">Explain this</div>';
+            menu.innerHTML = h;
+            positionCtxMenu(menu, ev.clientX, ev.clientY);
         }
         document.addEventListener('click', () => document.getElementById('ctxMenu').style.display = 'none');
         function copyText(t) { navigator.clipboard.writeText(t).catch(() => { }) }
@@ -1007,7 +1366,7 @@
         function findAllInvocations(n) { switchTab('kernels'); setTimeout(() => { document.getElementById('search').value = n; renderKernelView() }, 50) }
         function showInKernelView(n) { switchTab('kernels'); setTimeout(() => { document.getElementById('search').value = n; renderKernelView() }, 50) }
 
-        // ══════════════ NVTX Scoping ══════════════
+        // = NVTX Scoping =
         function toggleScopeBar() { const bar = document.getElementById('scopeBar'); const show = bar.style.display === 'none'; bar.style.display = show ? 'flex' : 'none'; document.getElementById('scopeToggle').classList.toggle('active', show); if (show) populateScope(); updateScopeUI() }
         function populateScope() {
             const sel = document.getElementById('scopeSelect');
@@ -1040,7 +1399,7 @@
         function findSubtree(nodes, path) { for (const n of nodes) { if (n.path === path) return n.children || [n]; if (n.children) { const r = findSubtree(n.children, path); if (r) return r } } return null }
         function refreshCurrentView() { if (currentTab === 'tree') { const s = countNodes(activeData()); document.getElementById('stats').innerHTML = '<span>NVTX: <strong>' + s.nvtx + '</strong></span><span>Kernels: <strong>' + s.kern + '</strong></span><span>Total GPU: <strong>' + s.totalMs.toFixed(1) + 'ms</strong></span>'; let h = ''; activeData().forEach(n => h += renderNode(n, 0)); document.getElementById('tree').innerHTML = h } else switchTab(currentTab) }
 
-        // ══════════════ Kernel-only view ══════════════
+        // = Kernel-only view =
         let kernelSort = { col: 'start_ns', dir: 'asc' };
         function renderKernelView() {
             const kernels = collectKernels(activeData()); const q = document.getElementById('search').value.trim().toLowerCase();
@@ -1049,26 +1408,62 @@
             let h = '<table class="kernel-table"><thead><tr>';
             ['name', 'start_ns', 'end_ns', 'duration_ms', 'stream', 'path'].forEach(c => {
                 const cls = kernelSort.col === c ? (kernelSort.dir === 'asc' ? 'sorted-asc' : 'sorted-desc') : '';
-                h += '<th class="' + cls + '" onclick="sortKernels(\'' + c + '\')">' + { name: 'Kernel', start_ns: 'Start', end_ns: 'End', duration_ms: 'Duration', stream: 'Stream', path: 'NVTX Path' }[c] + '</th>'
+                h += '<th class="' + cls + '" onclick="sortKernels(\'' + c + '\')">' + { name: 'Kernel', start_ns: 'Start', end_ns: 'End', duration_ms: 'Duration', stream: 'Stream', path: 'NVTX Path' }[c] + '</th>';
             });
-            h += '</tr></thead><tbody>';
+            h += '<th style="width:90px;text-align:center">Actions</th></tr></thead><tbody>';
             filtered.slice(0, 500).forEach(k => {
                 const sc = k.stream !== undefined ? (String(k.name).toLowerCase().includes('nccl') ? 'stream-nccl' : 'stream-compute') : '';
-                h += '<tr oncontextmenu="showKernelCtx(event,this)" data-name="' + escHtml(k.name) + '" data-path="' + escHtml(k.path || '') + '">';
+                const sel = isSelectedKernel(k) ? ' selected' : '';
+                h += '<tr class="kernel-row' + sel + '" oncontextmenu="showKernelCtx(event,this)" onclick="selectKernelRow(this)" data-name="' + escAttr(k.name) + '" data-path="' + escAttr(k.path || '') + '" data-start-ns="' + (k.start_ns ?? '') + '" data-end-ns="' + (k.end_ns ?? '') + '" data-duration-ms="' + (k.duration_ms ?? '') + '" data-stream="' + (k.stream !== undefined ? k.stream : '') + '">';
                 h += '<td style="color:#7ee787">' + escHtml(k.name) + '</td>';
                 h += '<td>' + fmtNs(k.start_ns) + '</td><td>' + fmtNs(k.end_ns) + '</td>';
                 h += '<td>' + fmtDur(k.duration_ms) + '</td>';
                 h += '<td><span class="stream-badge ' + sc + '">' + (k.stream !== undefined ? k.stream : '?') + '</span></td>';
-                h += '<td style="color:var(--text-dim);font-size:11px">' + escHtml(k.path || '') + '</td></tr>'
+                h += '<td style="color:var(--text-dim);font-size:11px">' + escHtml(k.path || '') + '</td>';
+                h += '<td style="text-align:center"><button type="button" class="explain-btn" onclick="event.stopPropagation();explainThisKernelFromRow(this)">Explain this</button></td></tr>';
             });
             h += '</tbody></table>';
-            h += '<div style="margin-top:8px;color:var(--text-dim);font-size:11px">Showing ' + Math.min(filtered.length, 500) + ' of ' + filtered.length + ' kernels</div>';
+            h += '<div style="margin-top:8px;color:var(--text-dim);font-size:11px">Showing ' + Math.min(filtered.length, 500) + ' of ' + filtered.length + ' kernels. Click row to select; use Explain this to ask.</div>';
             document.getElementById('kernelView').innerHTML = h;
         }
         function sortKernels(col) { if (kernelSort.col === col) kernelSort.dir = kernelSort.dir === 'asc' ? 'desc' : 'asc'; else { kernelSort.col = col; kernelSort.dir = 'asc' } renderKernelView() }
-        function showKernelCtx(ev, tr) { ev.preventDefault(); const menu = document.getElementById('ctxMenu'); const name = tr.dataset.name, path = tr.dataset.path; menu.innerHTML = '<div class="ctx-menu-item" onclick="copyText(\'' + escHtml(name) + '\')">📋 Copy name</div><div class="ctx-menu-item" onclick="copyText(\'' + escHtml(path) + '\')">📋 Copy path</div><div class="ctx-menu-sep"></div><div class="ctx-menu-item" onclick="findAllInvocations(\'' + escHtml(name) + '\')">🔍 Find all invocations</div>'; menu.style.display = 'block'; menu.style.left = ev.clientX + 'px'; menu.style.top = ev.clientY + 'px' }
+        function isSelectedKernel(k) { return selectedKernel && k.name === selectedKernel.name && k.start_ns === selectedKernel.start_ns; }
+        function selectKernel(k) { selectedKernel = k; renderKernelView(); }
+        function kernelFromDataset(d) {
+            if (!d || d.name == null) return null;
+            var stream = (d.stream !== '' && d.stream != null) ? parseInt(d.stream, 10) : undefined;
+            return { name: d.name, path: d.path || '', start_ns: parseInt(d.startNs, 10) || 0, end_ns: parseInt(d.endNs, 10) || 0, duration_ms: parseFloat(d.durationMs) || 0, stream: isNaN(stream) ? undefined : stream };
+        }
+        function ensureAISidebarOpen() {
+            var sb = document.getElementById('aiSidebar');
+            if (sb.classList.contains('open')) return Promise.resolve();
+            sb.classList.add('open');
+            document.body.classList.add('ai-open');
+            document.getElementById('aiToggleBtn').classList.add('active');
+            return loadChatModels() || Promise.resolve();
+        }
+        function explainThisKernel(k) {
+            selectedKernel = k;
+            renderKernelView();
+            var msg = 'Explain this kernel: ' + k.name;
+            ensureAISidebarOpen().then(function() { sendAIWithMessage(msg); });
+        }
+        let lastKernelCtxTr = null;
+        function explainThisKernelFromTr(tr) { var k = kernelFromDataset(tr && tr.dataset); if (k) explainThisKernel(k); }
+        function explainThisKernelFromRow(btn) { explainThisKernelFromTr(btn.closest('tr')); }
+        function explainThisKernelFromNodeEl(el) { var k = getKernelFromNodeEl(el); if (k) explainThisKernel(k); }
+        function explainThisKernelFromScanBlock(btn) { var w = btn.closest('.scan-block-wrap'); if (w) { var k = kernelFromDataset(w.dataset); if (k) explainThisKernel(k); } }
+        function explainThisKernelFromScanV2Cell(btn) { var td = btn.closest('td'); if (td) { var k = kernelFromDataset(td.dataset); if (k) explainThisKernel(k); } }
+        function selectKernelRow(tr) { var k = kernelFromDataset(tr && tr.dataset); if (k) selectKernel(k); }
+        function showKernelCtx(ev, tr) {
+            ev.preventDefault(); lastKernelCtxTr = tr;
+            const menu = document.getElementById('ctxMenu');
+            const name = tr.dataset.name, path = tr.dataset.path;
+            menu.innerHTML = '<div class="ctx-menu-item" onclick="copyText(lastKernelCtxTr.dataset.name)">Copy name</div><div class="ctx-menu-item" onclick="copyText(lastKernelCtxTr.dataset.path)">Copy path</div><div class="ctx-menu-sep"></div><div class="ctx-menu-item" onclick="findAllInvocations(lastKernelCtxTr.dataset.name)">Find all invocations</div><div class="ctx-menu-sep"></div><div class="ctx-menu-item" onclick="explainThisKernelFromTr(lastKernelCtxTr)">Explain this</div>';
+            menu.style.display = 'block'; menu.style.left = ev.clientX + 'px'; menu.style.top = ev.clientY + 'px';
+        }
 
-        // ══════════════ Scan view (logical event sequence) ══════════════
+        // = Scan view (logical event sequence) =
         function renderScanView() {
             const streams = collectStreams(activeData()); const sids = Object.keys(streams).sort((a, b) => a - b);
             if (!sids.length) { document.getElementById('scanView').innerHTML = '<div style="color:var(--text-dim)">No kernel data for scan view</div>'; return }
@@ -1087,7 +1482,7 @@
                 h += '<div class="scan-row"><div class="scan-label">Stream ' + s + (isNccl ? ' (NCCL)' : '') + '</div>';
                 events.forEach(e => {
                     if (e.gap) { const intensity = Math.min(1, e.duration_ms / maxDur); const r = Math.round(200 + 55 * intensity); h += '<div class="scan-block bubble" style="opacity:' + (.3 + .7 * intensity) + '" title="Bubble: ' + fmtDur(e.duration_ms) + '"></div>' }
-                    else { const intensity = Math.min(1, e.duration_ms / maxDur); const color = isNccl ? 'var(--nccl)' : 'var(--kernel)'; const alpha = .3 + .7 * intensity; h += '<div class="scan-block" style="background:' + color + ';opacity:' + alpha + '" title="' + escHtml(e.name) + ' ' + fmtDur(e.duration_ms) + '" onclick="filterByName(\'' + escHtml(e.name) + '\')">' + escHtml(e.name.slice(0, 12)) + '</div>' }
+                    else { const intensity = Math.min(1, e.duration_ms / maxDur); const color = isNccl ? 'var(--nccl)' : 'var(--kernel)'; const alpha = .3 + .7 * intensity; h += '<span class="scan-block-wrap" data-name="' + escAttr(e.name) + '" data-path="' + escAttr(e.path || '') + '" data-start-ns="' + (e.start_ns || '') + '" data-end-ns="' + (e.end_ns || '') + '" data-duration-ms="' + (e.duration_ms || '') + '" data-stream="' + (e.stream !== undefined ? e.stream : s) + '"><div class="scan-block" style="background:' + color + ';opacity:' + alpha + '" title="' + escHtml(e.name) + ' ' + fmtDur(e.duration_ms) + '" onclick="filterByName(this.parentElement.dataset.name)">' + escHtml(e.name.slice(0, 12)) + '</div><button type="button" class="explain-btn-scan" onclick="event.stopPropagation();explainThisKernelFromScanBlock(this)">Explain</button></span>'; }
                 });
                 h += '</div>'
             });
@@ -1096,7 +1491,7 @@
             document.getElementById('scanView').innerHTML = h;
         }
 
-        // ══════════════ ScanV2 — Vertical logical event grid ══════════════
+        // = ScanV2 - Vertical logical event grid =
         // Config persists across re-renders
         const sv2 = {
             colWidth: 180, heightScale: 5, heightMode: 'log',
@@ -1104,7 +1499,7 @@
             inited: false
         };
 
-        // Height: logistic curve — short kernels get minimum, longer grow then plateau
+        // Height: logistic curve - short kernels get minimum, longer grow then plateau
         function sv2Height(dur_ms) {
             if (sv2.heightMode === 'uniform') return 28;
             const dur_us = dur_ms * 1000;
@@ -1268,9 +1663,11 @@
                         const bg = isNccl[col] ? 'rgba(210,168,255,' + (.15 + .6 * durI) + ')' : 'rgba(35,134,54,' + (.15 + .6 * durI) + ')';
                         const brc = isNccl[col] ? 'rgba(210,168,255,0.4)' : 'rgba(126,231,135,0.4)';
                         const tc = isNccl[col] ? 'var(--nccl)' : '#7ee787';
-                        h += '<td rowspan="' + span + '" style="border:1px solid ' + brc + ';background:' + bg + ';padding:2px 5px;vertical-align:top;cursor:pointer;max-width:' + cw + 'px;overflow:hidden;height:' + totalH + 'px" ';
-                        h += 'title="' + escHtml(k.name) + '\n' + fmtDur(k.duration_ms) + '" onclick="filterByName(\'' + escHtml(k.name) + '\')">';
-                        h += '<div style="display:flex;gap:4px;align-items:baseline;line-height:1.2"><span style="color:var(--text-dim);font-size:9px;white-space:nowrap;min-width:42px;text-align:right;flex-shrink:0">' + fmtDur(k.duration_ms) + '</span><span style="color:' + tc + ';font-weight:500;overflow:hidden;text-overflow:ellipsis">' + escHtml(k.name) + '</span></div></td>';
+                        h += '<td class="scanv2-kernel-cell" rowspan="' + span + '" style="border:1px solid ' + brc + ';background:' + bg + ';padding:4px 6px;vertical-align:top;cursor:pointer;max-width:' + cw + 'px;overflow:hidden;height:' + totalH + 'px" ';
+                        h += 'data-name="' + escAttr(k.name) + '" data-path="' + escAttr(k.path || '') + '" data-start-ns="' + (k.start_ns || '') + '" data-end-ns="' + (k.end_ns || '') + '" data-duration-ms="' + (k.duration_ms || '') + '" data-stream="' + (k.stream !== undefined ? k.stream : '') + '" ';
+                        h += 'title="' + escHtml(k.name) + '\n' + fmtDur(k.duration_ms) + '" onclick="filterByName(this.dataset.name)">';
+                        h += '<div style="display:flex;gap:4px;align-items:baseline;line-height:1.2"><span style="color:var(--text-dim);font-size:9px;white-space:nowrap;min-width:42px;text-align:right;flex-shrink:0">' + fmtDur(k.duration_ms) + '</span><span style="color:' + tc + ';font-weight:500;overflow:hidden;text-overflow:ellipsis">' + escHtml(k.name) + '</span></div>';
+                        h += '<button type="button" class="explain-btn-scan" onclick="event.stopPropagation();explainThisKernelFromScanV2Cell(this)">Explain</button></td>';
                     } else if (cell.type === 'bubble') {
                         const alpha = Math.min(0.8, 0.15 + 0.65 * Math.min(1, cell.duration_ms / (maxSlotDur / 1e6)));
                         h += '<td rowspan="' + span + '" style="border:1px dashed rgba(248,81,73,0.3);background:rgba(248,81,73,' + alpha.toFixed(2) + ');padding:2px 5px;vertical-align:middle;text-align:center;max-width:' + cw + 'px;height:' + totalH + 'px"><span style="color:var(--memcpy);font-size:9px">\ud83d\udca8 ' + fmtDur(cell.duration_ms) + '</span></td>';
@@ -1284,7 +1681,7 @@
             document.getElementById('scanV2View').innerHTML = h;
         }
 
-        // ══════════════ Multi-stream comparison ══════════════
+        // = Multi-stream comparison =
         function renderStreamView() {
             const streams = collectStreams(activeData()); const sids = Object.keys(streams).sort((a, b) => a - b);
             if (sids.length < 1) { document.getElementById('streamView').innerHTML = '<div style="color:var(--text-dim)">No streams found</div>'; return }
@@ -1311,7 +1708,7 @@
             document.getElementById('streamView').innerHTML = h;
         }
 
-        // ══════════════ Kernel aggregation dashboard ══════════════
+        // = Kernel aggregation dashboard =
         function renderAggView() {
             const kernels = collectKernels(activeData()); if (!kernels.length) { document.getElementById('aggView').innerHTML = '<div style="color:var(--text-dim)">No kernels</div>'; return }
             const grouped = {}; kernels.forEach(k => { if (!grouped[k.name]) grouped[k.name] = { count: 0, total: 0, min: Infinity, max: 0, streams: new Set() }; const g = grouped[k.name]; g.count++; g.total += k.duration_ms; g.min = Math.min(g.min, k.duration_ms); g.max = Math.max(g.max, k.duration_ms); if (k.stream !== undefined) g.streams.add(k.stream) });
@@ -1328,7 +1725,7 @@
             document.getElementById('aggView').innerHTML = h;
         }
 
-        // ══════════════ Pattern detection engine ══════════════
+        // = Pattern detection engine =
         function renderPatternView() {
             const kernels = collectKernels(activeData()); const streams = collectStreams(activeData());
             if (!kernels.length) { document.getElementById('patternView').innerHTML = '<div style="color:var(--text-dim)">No data for pattern detection</div>'; return }
@@ -1367,29 +1764,352 @@
             document.getElementById('patternView').innerHTML = h;
         }
 
-        // ══════════════ AI sidebar ══════════════
+        // = AI sidebar =
         function toggleFocus() { document.body.classList.toggle('focused') }
         document.addEventListener('keydown', e => { if (e.key === 'f' && !e.ctrlKey && !e.metaKey && !e.altKey && !['INPUT', 'TEXTAREA', 'SELECT'].includes(e.target.tagName)) { e.preventDefault(); toggleFocus() } });
-        function toggleAI() { const sb = document.getElementById('aiSidebar'); const open = !sb.classList.contains('open'); sb.classList.toggle('open', open); document.body.classList.toggle('ai-open', open); document.getElementById('aiToggleBtn').classList.toggle('active', open); }
+        document.addEventListener('keydown', e => { if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'j') && !['INPUT', 'TEXTAREA'].includes(e.target.tagName)) { e.preventDefault(); toggleAI(); } });
+        function toggleAI() { const sb = document.getElementById('aiSidebar'); const open = !sb.classList.contains('open'); sb.classList.toggle('open', open); document.body.classList.toggle('ai-open', open); document.getElementById('aiToggleBtn').classList.toggle('active', open); if (open) loadChatModels(); }
+        function renderChatHistory() {
+            const msgs = document.getElementById('aiMessages');
+            if (chatHistory.length === 0) {
+                msgs.innerHTML = '<div class="ai-msg assistant">I can analyze your GPU profile. Ask about bottlenecks, streams, or click <strong>Explain this</strong> on a kernel (hover on Scan/ScanV2 blocks).<br><br><em style="color:var(--text-dim)">Context is included automatically. Chat is saved (LocalStorage).</em><br><span style="font-size:10px;color:var(--text-dim)">Shortcut: Cmd/Ctrl+J or Cmd/Ctrl+K to open.</span></div>';
+                return;
+            }
+            let h = '';
+            chatHistory.forEach(function(m) {
+                var html;
+                try {
+                    if (m.role === 'user') html = escHtml(m.content);
+                    else if (m.content === AI_LOADING_PLACEHOLDER) html = '<span class="ai-loading"><span class="ai-loading-dots">...</span></span>';
+                    else html = (typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined' ? (function() { var p = marked.parse(m.content || ''); return typeof p === 'string' ? DOMPurify.sanitize(p) : escHtml(m.content); })() : escHtml(m.content));
+                } catch (e) {
+                    if (console) console.warn('[SSE] renderChatHistory message render failed:', e);
+                    html = escHtml(typeof m.content === 'string' ? m.content : '');
+                }
+                h += '<div class="ai-msg ' + m.role + '">' + html + '</div>';
+            });
+            msgs.innerHTML = h;
+            msgs.scrollTop = msgs.scrollHeight;
+        }
+        let isGenerating = false;
+        const AI_LOADING_PLACEHOLDER = '\u200bLOADING\u200b';
+        const CHAT_STREAM_TIMEOUT_MS = 120000;
+        function setLastAssistantContent(content, orPush) {
+            var last = chatHistory[chatHistory.length - 1];
+            if (last && last.role === 'assistant' && last.content === AI_LOADING_PLACEHOLDER) last.content = content;
+            else if (orPush !== false) chatHistory.push({ role: 'assistant', content: content });
+            saveChatHistoryToStorage();
+            renderChatHistory();
+        }
+        function sendAIWithMessage(q) {
+            if (console) console.log('[SSE] sendAIWithMessage called, qLen=', (q && q.length) || 0, 'isGenerating=', isGenerating);
+            if (!q || !q.trim()) { if (console) console.log('[SSE] sendAIWithMessage early return: empty q'); return; }
+            if (isGenerating) { if (console) console.log('[SSE] sendAIWithMessage early return: isGenerating=true'); return; }
+            chatHistory.push({ role: 'user', content: q.trim() });
+            saveChatHistoryToStorage();
+            renderChatHistory();
+            document.getElementById('aiInput').value = '';
+            isGenerating = true;
+            var inputEl = document.getElementById('aiInput');
+            var sendBtn = document.getElementById('chatSendBtn');
+            var stopBtn = document.getElementById('chatStopBtn');
+            if (inputEl) inputEl.disabled = true;
+            if (sendBtn) sendBtn.disabled = true;
+            if (stopBtn) stopBtn.style.display = '';
+            chatHistory.push({ role: 'assistant', content: AI_LOADING_PLACEHOLDER });
+            saveChatHistoryToStorage();
+            renderChatHistory();
+            document.getElementById('aiMessages').scrollTop = document.getElementById('aiMessages').scrollHeight;
+            window._chatClearGenerating = function() {
+                isGenerating = false;
+                if (inputEl) inputEl.disabled = false;
+                if (sendBtn) sendBtn.disabled = false;
+                var sb = document.getElementById('chatStopBtn');
+                if (sb) sb.style.display = 'none';
+                document.getElementById('aiMessages').scrollTop = document.getElementById('aiMessages').scrollHeight;
+            };
+            window._chatTimeoutFired = false;
+            var timeoutId = setTimeout(function() {
+                window._chatTimeoutFired = true;
+                if (window._chatAbortController) window._chatAbortController.abort();
+            }, CHAT_STREAM_TIMEOUT_MS);
+            try {
+                var payload = buildChatPayload(true);
+                if (console) console.log('[SSE] fetch /api/chat starting, historyLength=', chatHistory.length);
+                fetch('/api/chat', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload), signal: (window._chatAbortController = new AbortController()).signal })
+                    .then(function(r) {
+                        if (console) console.log('[SSE] fetch response ok=', r.ok, 'Content-Type=', r.headers.get('Content-Type'));
+                        if (!r.ok) throw new Error(r.status === 501 ? 'LLM not configured' : 'HTTP ' + r.status);
+                        return (r.headers.get('Content-Type') || '').indexOf('text/event-stream') !== -1 ? processSSE(r.body) : r.json();
+                    })
+                    .then(function(data) {
+                        if (data && data._sse) return;
+                        var content = data.content || (data.error ? data.error : 'No response.');
+                        content = parseAndExecuteActions(content);
+                        var trimmed = (content && String(content).trim()) || '';
+                        var navLine = null;
+                        if (data.actions && data.actions.length) {
+                            navLine = executeActionsFromAPI(data.actions);
+                            // If there is text content, append the navigation note as a system message in history.
+                            // If there is no text (navigation only), let the green AI bubble carry the navigation message.
+                            if (navLine && trimmed) {
+                                chatHistory.push({ role: 'system', content: navLine });
+                                saveChatHistoryToStorage();
+                                renderChatHistory();
+                            } else if (navLine && !trimmed) {
+                                content = navLine;
+                                trimmed = navLine;
+                            }
+                        }
+                        setLastAssistantContent(content);
+                    })
+                    .catch(function(err) {
+                        if (console) console.log('[SSE] fetch request failed:', err.name, err.message || err);
+                        if (err.name !== 'AbortError') {
+                            var msg = (err.message || '').indexOf('fetch') !== -1 || err.name === 'TypeError' ? 'Connection lost, AI response incomplete.' : 'Request failed: ' + (err.message || 'Check console.');
+                            setLastAssistantContent(msg);
+                        } else {
+                            var last = chatHistory[chatHistory.length - 1];
+                            if (last && last.role === 'assistant' && last.content === AI_LOADING_PLACEHOLDER) {
+                                if (window._chatTimeoutFired) last.content = 'Response timed out after 2 minutes. Try again or choose a smaller context.';
+                                else chatHistory.pop();
+                            }
+                            saveChatHistoryToStorage();
+                            renderChatHistory();
+                        }
+                    })
+                    .finally(function() {
+                        clearTimeout(timeoutId);
+                        window._chatTimeoutFired = false;
+                        if (window._chatClearGenerating) window._chatClearGenerating();
+                    });
+            } catch (e) {
+                if (console) console.error('[SSE] send request threw:', e);
+                clearTimeout(timeoutId);
+                window._chatTimeoutFired = false;
+                setLastAssistantContent('Failed to send: ' + (e.message || String(e)));
+                saveChatHistoryToStorage();
+                renderChatHistory();
+                if (window._chatClearGenerating) window._chatClearGenerating();
+            }
+        }
+        function parseSSEBlock(block) {
+            var ev = '', dat = '', lines = block.split('\n');
+            for (var j = 0; j < lines.length; j++) {
+                if (lines[j].indexOf('event:') === 0) ev = lines[j].slice(6).trim();
+                else if (lines[j].indexOf('data:') === 0) dat = lines[j].slice(5).trim();
+            }
+            return { ev: ev, dat: dat };
+        }
+        function renderStreamedHtml(txt) {
+            return (typeof DOMPurify !== 'undefined' && typeof marked !== 'undefined') ? DOMPurify.sanitize(marked.parse(txt)) : escHtml(txt);
+        }
+        function processSSE(body) {
+            var reader = body.getReader(), decoder = new TextDecoder(), buf = '';
+            var last = chatHistory[chatHistory.length - 1];
+            if (!(last && last.role === 'assistant' && last.content === AI_LOADING_PLACEHOLDER)) chatHistory.push({ role: 'assistant', content: AI_LOADING_PLACEHOLDER });
+            saveChatHistoryToStorage();
+            renderChatHistory();
+            if (console) console.log('[SSE] processSSE started, historyLength=', chatHistory.length);
+            var streamedContent = '';
+            function getStreamingBubble() {
+                var list = document.querySelectorAll('#aiMessages .ai-msg.assistant');
+                for (var i = list.length - 1; i >= 0; i--) {
+                    if (list[i].querySelector('.ai-loading')) {
+                        if (console) console.log('[SSE] getStreamingBubble: found by .ai-loading, index=', i, 'of', list.length);
+                        return list[i];
+                    }
+                }
+                var fallback = document.querySelector('#aiMessages .ai-msg.assistant:last-child');
+                if (console) console.log('[SSE] getStreamingBubble: using last-child, found=', !!fallback);
+                return fallback;
+            }
+            function setAssistantFinalContent(html) {
+                var idx = -1;
+                for (var i = chatHistory.length - 1; i >= 0; i--) {
+                    if (chatHistory[i].role === 'assistant' && chatHistory[i].content === AI_LOADING_PLACEHOLDER) {
+                        idx = i;
+                        break;
+                    }
+                }
+                if (console) console.log('[SSE] setAssistantFinalContent idx=', idx >= 0 ? idx : 'last', 'contentLen=', (html && html.length) || 0);
+                if (idx >= 0) {
+                    chatHistory[idx].content = html;
+                } else {
+                    var lastMsg = chatHistory[chatHistory.length - 1];
+                    if (lastMsg && lastMsg.role === 'assistant') lastMsg.content = html;
+                }
+                saveChatHistoryToStorage();
+                renderChatHistory();
+                if (window._chatClearGenerating) window._chatClearGenerating();
+            }
+            function processOneEvent(ev, dat) {
+                try {
+                    var data = JSON.parse(dat);
+                    if (ev === 'text' && data.chunk) {
+                        streamedContent += data.chunk;
+                        var bubble = getStreamingBubble();
+                        if (console) console.log('[SSE] event: text, bubble=', bubble ? 'found' : 'NULL', 'streamedLen=', streamedContent.length);
+                        if (bubble) bubble.innerHTML = renderStreamedHtml(streamedContent);
+                        document.getElementById('aiMessages').scrollTop = document.getElementById('aiMessages').scrollHeight;
+                        return 'text';
+                    }
+                    if (ev === 'action' && data.type) {
+                        if (console) console.log('[SSE] event: action', data.type);
+                        var navLine = executeActionsFromAPI([data]);
+                        if (navLine) {
+                            // If text is already streaming, append the navigation note as a system message.
+                            // Otherwise (navigation only), fill the current green AI bubble with this message.
+                            if (streamedContent && streamedContent.trim()) {
+                                chatHistory.push({ role: 'system', content: navLine });
+                                saveChatHistoryToStorage();
+                                renderChatHistory();
+                            } else {
+                                streamedContent = navLine;
+                                var bubble = getStreamingBubble();
+                                if (bubble) bubble.innerHTML = renderStreamedHtml(streamedContent);
+                            }
+                        }
+                        return 'action';
+                    }
+                    if (ev === 'done') {
+                        if (console) console.log('[SSE] event: done, streamedLen=', streamedContent.length);
+                        if (data.usage && console) console.log('Token usage:', data.usage);
+                        if (data.error) {
+                            streamedContent += (streamedContent ? '\n\n' : '') + 'Error: ' + data.error;
+                            var bubble = getStreamingBubble();
+                            if (bubble) bubble.innerHTML = (typeof DOMPurify !== 'undefined' ? DOMPurify.sanitize(streamedContent) : escHtml(streamedContent));
+                        }
+                        // If the entire turn had no text output (e.g. model only produced tool calls, or nothing at all),
+                        // show the user at least one clear message instead of an empty green bubble.
+                        if (!streamedContent || !String(streamedContent).trim()) {
+                            streamedContent = 'No response from model. Try rephrasing the question or ask for an explanation instead of navigation.';
+                        }
+                        setAssistantFinalContent(renderStreamedHtml(streamedContent));
+                        return 'done';
+                    }
+                } catch (_) {}
+                return null;
+            }
+            function drainBuf() {
+                var parts = buf.split('\n\n');
+                if (parts.length < 1) return null;
+                buf = parts.pop();
+                for (var i = 0; i < parts.length; i++) {
+                    var p = parseSSEBlock(parts[i]);
+                    var out = processOneEvent(p.ev, p.dat);
+                    if (out === 'done') return 'done';
+                    if (out === 'text' && (i < parts.length - 1 || buf) && typeof requestAnimationFrame !== 'undefined') {
+                        buf = parts.slice(i + 1).join('\n\n') + (buf ? '\n\n' + buf : '');
+                        return 'yield';
+                    }
+                }
+                if (buf.indexOf('event:') !== -1 && buf.indexOf('data:') !== -1) {
+                    var p = parseSSEBlock(buf);
+                    var out = processOneEvent(p.ev, p.dat);
+                    if (out === 'done' || out === 'text' || out === 'action') {
+                        buf = '';
+                        if (out === 'done') return 'done';
+                        if (out === 'text' && typeof requestAnimationFrame !== 'undefined') return 'yield';
+                    }
+                }
+                return null;
+            }
+            function pump() {
+                var drained = drainBuf();
+                if (drained === 'done') return Promise.resolve({ _sse: true });
+                if (drained === 'yield') return new Promise(function(resolve) { requestAnimationFrame(function() { pump().then(resolve); }); });
+                return reader.read().then(function(result) {
+                    if (result.done) {
+                        if (console) console.log('[SSE] stream end (result.done), bufLen=', buf.length, 'streamedLen=', streamedContent.length);
+                        var partsLeft = buf.split('\n\n');
+                        for (var pi = 0; pi < partsLeft.length; pi++) {
+                            var p = parseSSEBlock(partsLeft[pi]);
+                            try {
+                                var d = JSON.parse(p.dat);
+                                if (p.ev === 'text' && d.chunk) streamedContent += d.chunk;
+                            } catch (_) {}
+                        }
+                        setAssistantFinalContent(renderStreamedHtml(streamedContent));
+                        return { _sse: true };
+                    }
+                    buf += decoder.decode(result.value, { stream: true });
+                    var again = drainBuf();
+                    if (again === 'done') return Promise.resolve({ _sse: true });
+                    if (again === 'yield') return new Promise(function(resolve) { requestAnimationFrame(function() { pump().then(resolve); }); });
+                    return pump();
+                });
+            }
+            return pump();
+        }
+        var viewHistoryStack = [];
+        function pushViewHistory() {
+            var tr = getTimeRangeFromData(activeData());
+            viewHistoryStack.push({ min_s: tr.min_ns / 1e9, max_s: tr.max_ns / 1e9 });
+        }
+        function popViewHistoryAndRestore() {
+            if (viewHistoryStack.length === 0) return;
+            var prev = viewHistoryStack.pop();
+            zoom_to_time_range(prev.min_s, prev.max_s);
+        }
+        function executeActionsFromAPI(actions) {
+            if (actions && actions.length) pushViewHistory();
+            var allKernels = collectKernels(DATA);
+            allKernels.sort(function(a, b) { return (a.start_ns || 0) - (b.start_ns || 0); });
+            var lines = [];
+            for (var i = 0; i < actions.length; i++) {
+                var a = actions[i];
+                if (a.type === 'zoom_to_time_range' && typeof a.start_s === 'number' && typeof a.end_s === 'number') {
+                    zoom_to_time_range(a.start_s, a.end_s);
+                } else if (a.type === 'navigate_to_kernel' && a.target_name) {
+                    var matched = allKernels.filter(function(k) { return k.name === a.target_name; });
+                    if (matched.length === 0) matched = allKernels.filter(function(k) { return k.name.toLowerCase().indexOf(a.target_name.toLowerCase()) !== -1; });
+                    if (matched.length === 0) { lines.push('Cannot find kernel: ' + escHtml(a.target_name)); continue; }
+                    var idx = Math.min(Math.max(0, (a.occurrence_index || 1) - 1), matched.length - 1);
+                    var target = matched[idx];
+                    var startS = target.start_ns / 1e9, endS = target.end_ns / 1e9;
+                    var dur = endS - startS, pad = dur * 0.1;
+                    // Try to zoom the view when the viewer provides a time-range API; otherwise,
+                    // we still want navigation to have a visible effect for the user.
+                    zoom_to_time_range(startS - pad, endS + pad);
+                    // Always switch to the Kernels tab and filter by the kernel name so that the
+                    // target kernel is visible even when the viewer has no zoom API implemented.
+                    goto_kernel(target.name);
+                    var reasonPart = a.reason ? ' - ' + escHtml(a.reason) : '';
+                    lines.push('🚀 Navigated to ' + escHtml(a.target_name) + ' (' + (idx + 1) + ' of ' + matched.length + ')' + reasonPart);
+                }
+            }
+            if (lines.length === 0) return null;
+            // Temporarily omit the Undo link until a full zoom/navigation history
+            // API is available for the web viewer.
+            return lines.join('<br>');
+        }
         function sendAI() {
-            const input = document.getElementById('aiInput'); const q = input.value.trim(); if (!q) return;
-            const msgs = document.getElementById('aiMessages'); msgs.innerHTML += '<div class="ai-msg user">' + escHtml(q) + '</div>'; input.value = '';
-            // Build context
-            const stats = countNodes(activeData()); const kernels = collectKernels(activeData());
-            const topK = {}; kernels.forEach(k => { if (!topK[k.name]) topK[k.name] = 0; topK[k.name] += k.duration_ms });
-            const top5 = Object.entries(topK).sort((a, b) => b[1] - a[1]).slice(0, 5).map(([n, ms]) => n + ': ' + ms.toFixed(1) + 'ms').join(', ');
-            // Local analysis (no LLM needed)
-            let response = '';
-            if (q.toLowerCase().includes('bottleneck')) { response = 'Based on this profile:<br>• <strong>' + stats.kern + '</strong> kernels, <strong>' + stats.totalMs.toFixed(1) + 'ms</strong> total GPU time<br>• Top kernels: ' + top5 + '<br><br>The top kernel accounts for <strong>' + ((Object.values(topK).sort((a, b) => b - a)[0] || 0) / stats.totalMs * 100).toFixed(0) + '%</strong> of GPU time.' }
-            else if (q.toLowerCase().includes('stream')) { const st = collectStreams(activeData()); const info = Object.entries(st).map(([s, ks]) => 'Stream ' + s + ': ' + ks.length + ' kernels, ' + ks.reduce((a, k) => a + k.duration_ms, 0).toFixed(1) + 'ms').join('<br>'); response = 'Stream breakdown:<br>' + info }
-            else { response = 'Profile summary:<br>• ' + stats.nvtx + ' NVTX regions, ' + stats.kern + ' kernels<br>• Total GPU: ' + stats.totalMs.toFixed(1) + 'ms<br>• Top kernels: ' + top5 + '<br><br><em>For deeper analysis, configure an LLM endpoint.</em>' }
-            msgs.innerHTML += '<div class="ai-msg assistant">' + response + '</div>'; msgs.scrollTop = msgs.scrollHeight;
+            const q = document.getElementById('aiInput').value.trim();
+            if (!q) return;
+            sendAIWithMessage(q);
+        }
+        function saveChatHistoryToStorage() { try { localStorage.setItem(CHAT_STORAGE_KEY, JSON.stringify(chatHistory)); } catch (_) {} }
+        function clearChatHistory() { chatHistory = []; try { localStorage.removeItem(CHAT_STORAGE_KEY); } catch (_) {} renderChatHistory(); }
+        function goto_kernel(kernelName) { switchTab('kernels'); document.getElementById('search').value = kernelName; renderKernelView(); }
+        function zoom_to_time_range(startS, endS) { if (typeof window.zoomToTimeRange === 'function') window.zoomToTimeRange(startS, endS); else console.log('Time range ' + startS + 's\u2013' + endS + 's (viewer has no zoom API)'); }
+        function parseAndExecuteActions(text) {
+            var out = text;
+            var re = new RegExp('<!--\\s*action:\\s*(goto_kernel|zoom_to_time_range)\\s+(.+?)\\s*-->', 'g');
+            var m;
+            while ((m = re.exec(text)) !== null) {
+                if (m[1] === 'goto_kernel') goto_kernel(m[2].trim());
+                if (m[1] === 'zoom_to_time_range') { var parts = m[2].trim().split(/\s+/); if (parts.length >= 2) zoom_to_time_range(parseFloat(parts[0]), parseFloat(parts[1])); }
+                out = out.replace(m[0], '');
+            }
+            return out.replace(/\n{2,}/g, '\n').trim();
         }
 
-        // ══════════════ Initial render ══════════════
+        // = Initial render =
         const stats = countNodes(DATA);
         document.getElementById('stats').innerHTML = '<span>NVTX: <strong>' + stats.nvtx + '</strong></span><span>Kernels: <strong>' + stats.kern + '</strong></span><span>Total GPU: <strong>' + stats.totalMs.toFixed(1) + 'ms</strong></span>';
         let html = ''; DATA.forEach(n => html += renderNode(n, 0)); document.getElementById('tree').innerHTML = html;
+        renderChatHistory();
     </script>
 </body>
 

--- a/src/nsys_tui/tools_profile.py
+++ b/src/nsys_tui/tools_profile.py
@@ -1,0 +1,254 @@
+"""
+tools_profile.py - Safe read-only SQL tool and schema for the Text-to-SQL agent (v2).
+
+Exposes query_profile_db(conn, sql_query) and get_profile_schema(conn) for use by
+chat.py and test_agent.py. See docs/plan-brain-navigator.md
+"""
+import json
+import logging
+import re
+import sqlite3
+import threading
+
+_log = logging.getLogger(__name__)
+
+# Default max rows to prevent token explosion.
+DEFAULT_MAX_LIMIT = 50
+# Default maximum JSON length (characters) returned to the model.
+DEFAULT_MAX_JSON_CHARS = 8000
+
+# NVTX table name is stable; kernel table is detected by NsightSchema.
+NVTX_TABLE = "NVTX_EVENTS"
+# StringIds maps id -> value for kernel names (shortName, demangledName reference it).
+STRING_IDS_TABLE = "StringIds"
+
+# Regex: reject any mutating SQL.
+_READ_ONLY_BLOCK = re.compile(
+    r"(?i)\b(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|REPLACE|TRUNCATE)\b"
+)
+
+
+def _adaptive_limit(sql_upper: str, base_limit: int) -> int:
+    """
+    Return a LIMIT adjusted by the projected column count.
+
+    Narrow queries (1 column, e.g. SELECT name) get up to 2x the base limit;
+    wide queries (4+ columns) get half the base limit (min 20) to keep JSON small.
+    """
+    select_idx = sql_upper.find("SELECT")
+    if select_idx < 0:
+        return base_limit
+    from_idx = sql_upper.find(" FROM ", select_idx + 6)
+    end = from_idx if from_idx > 0 else len(sql_upper)
+    projection = sql_upper[select_idx + 6:end].strip()
+    # Count top-level comma separators (commas inside function args don't split columns).
+    depth, col_count = 0, 1
+    for ch in projection:
+        if ch in "([":
+            depth += 1
+        elif ch in ")]":
+            depth -= 1
+        elif ch == "," and depth == 0:
+            col_count += 1
+    if col_count <= 1:
+        return min(100, base_limit * 2)
+    if col_count <= 3:
+        return base_limit
+    return max(20, base_limit // 2)
+
+
+def query_profile_db(
+    conn: sqlite3.Connection,
+    sql_query: str,
+    *,
+    max_limit: int = DEFAULT_MAX_LIMIT,
+) -> str:
+    """
+    Execute a read-only SELECT on the profile DB and return rows as a JSON string.
+
+    - Guardrail 1: Rejects any query containing INSERT/UPDATE/DELETE/DROP/ALTER/CREATE/etc.
+    - Guardrail 2: If no LIMIT or LIMIT > max_limit, enforces LIMIT max_limit.
+    - Guardrail 3: Rejects broad SELECT * queries to avoid token explosion.
+    - Returns: "[{\"col\": \"val\"}, ...]" or an error string for the model.
+    """
+    if not (sql_query or "").strip():
+        return "Error: Empty query."
+
+    if _READ_ONLY_BLOCK.search(sql_query):
+        return "Error: Read-only. Only SELECT queries are allowed."
+
+    q = sql_query.strip().rstrip(";")
+    upper = q.upper()
+
+    # Reject broad SELECT * to keep responses small and focused.
+    # This is conservative and applies to all tables; the model should learn
+    # to select only the columns it needs instead of dumping entire rows.
+    star_match = re.search(r"\bSELECT\s+\*", upper)
+    if star_match:
+        return (
+            "Error: SELECT * is not allowed - it returns too many columns and wastes tokens. "
+            "Please select only the columns you need, for example: "
+            "SELECT start, [end], shortName FROM <table> WHERE ... LIMIT 20")
+
+    # Adaptive LIMIT: narrow projections allow more rows; wide ones get fewer.
+    effective_limit = _adaptive_limit(upper, max_limit)
+
+    # Enforce LIMIT: if no LIMIT append; if LIMIT > effective_limit rewrite.
+    limit_match = re.search(r"\bLIMIT\s+(\d+)", upper, re.IGNORECASE)
+    if limit_match:
+        n = int(limit_match.group(1))
+        if n > effective_limit:
+            q = re.sub(r"\bLIMIT\s+" + str(n) + r"\b", f"LIMIT {effective_limit}", q, count=1, flags=re.IGNORECASE)
+    else:
+        q = q + f" LIMIT {effective_limit}"
+
+    try:
+        cur = conn.execute(q)
+        rows = cur.fetchall()
+        if conn.row_factory is sqlite3.Row:
+            out = [dict(r) for r in rows]
+        else:
+            names = [d[0] for d in cur.description] if cur.description else []
+            out = [dict(zip(names, r)) for r in rows]
+        # JSON-serializable values (sqlite3 can return bytes etc.)
+        def _serialize(obj):
+            if isinstance(obj, (bytes, bytearray)):
+                return obj.decode("utf-8", errors="replace")
+            if isinstance(obj, (int, float, str, type(None))):
+                return obj
+            return str(obj)
+
+        for row in out:
+            for k, v in list(row.items()):
+                row[k] = _serialize(v)
+        json_str = json.dumps(out, ensure_ascii=False)
+        if len(json_str) > DEFAULT_MAX_JSON_CHARS:
+            _log.info(
+                "query_profile_db: result truncated (size=%d, max=%d)",
+                len(json_str),
+                DEFAULT_MAX_JSON_CHARS,
+            )
+            json_str = json_str[: DEFAULT_MAX_JSON_CHARS] + (
+                "...[Truncated - result exceeds %d chars] "
+                "Please refine your query: SELECT only essential columns "
+                "(e.g. start, [end], shortName) or reduce the LIMIT." % DEFAULT_MAX_JSON_CHARS
+            )
+        return json_str
+    except sqlite3.Error as e:
+        return f"Error: Database error: {e}"
+
+
+def get_profile_schema(
+    conn: sqlite3.Connection,
+    table_names: tuple[str, ...] | None = None,
+) -> str:
+    """
+    Return a short schema description for injection into the system prompt.
+
+    Uses NsightSchema to get the kernel table name, then fetches DDL from
+    sqlite_master for that table and NVTX_EVENTS (if present).
+    """
+    try:
+        from .profile import NsightSchema
+        ns = NsightSchema(conn)
+        kernel_table = ns.kernel_table
+    except Exception:
+        kernel_table = None
+
+    want = list(table_names) if table_names else []
+    if kernel_table and kernel_table not in want:
+        want.append(kernel_table)
+    if NVTX_TABLE not in want:
+        want.append(NVTX_TABLE)
+    if STRING_IDS_TABLE not in want:
+        want.append(STRING_IDS_TABLE)
+
+    if not want:
+        return "(No tables specified.)"
+
+    placeholders = ",".join("?" * len(want))
+    try:
+        cur = conn.execute(
+            f"SELECT name, sql FROM sqlite_master WHERE type='table' AND name IN ({placeholders})",
+            want,
+        )
+        rows = cur.fetchall()
+    except sqlite3.Error:
+        return "(Could not read schema.)"
+
+    parts = []
+    for name, ddl in rows:
+        if ddl:
+            parts.append(ddl.strip())
+    return "\n\n".join(parts) if parts else "(Empty schema.)"
+
+
+# Optional schema cache by profile path. Max entries to avoid unbounded growth.
+_SCHEMA_CACHE_MAX = 16
+_schema_cache: dict[str, str] = {}
+_schema_cache_lock = threading.Lock()
+
+
+def get_profile_schema_cached(conn: sqlite3.Connection, path: str | None = None) -> str:
+    """
+    Return schema for the given connection, using a cache keyed by path when provided.
+    If path is None, always calls get_profile_schema(conn). Call with path when the
+    same profile may be used repeatedly (e.g. Web/TUI per-session). Thread-safe.
+    """
+    if path is None:
+        return get_profile_schema(conn)
+    with _schema_cache_lock:
+        if path in _schema_cache:
+            return _schema_cache[path]
+        schema = get_profile_schema(conn)
+        if len(_schema_cache) >= _SCHEMA_CACHE_MAX:
+            first = next(iter(_schema_cache))
+            del _schema_cache[first]
+        _schema_cache[path] = schema
+    return schema
+
+
+def open_profile_readonly(path: str) -> sqlite3.Connection:
+    """Open a profile SQLite file in read-only mode (URI mode=ro)."""
+    uri = f"file:{path}?mode=ro"
+    conn = sqlite3.connect(uri, uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def open_profile_readonly_for_worker(path: str) -> sqlite3.Connection:
+    """
+    Open a read-only profile connection for use from a worker thread.
+
+    Each worker (e.g. TUI chat worker) must open and close its own connection;
+    do not share a connection across threads. This helper is equivalent to
+    open_profile_readonly(path); use it when calling from a background thread
+    to make the pattern explicit. stream_agent_loop opens the connection
+    inside the same thread that runs the loop (worker or request handler).
+    """
+    return open_profile_readonly(path)
+
+
+# OpenAI-style tool definition for query_profile_db.
+TOOL_QUERY_PROFILE_DB = {
+    "type": "function",
+    "function": {
+        "name": "query_profile_db",
+        "description": (
+            "Execute a read-only SELECT query on the Nsight Systems profile SQLite database. "
+            "Use this to answer whole-profile questions (e.g. first kernel, slowest kernel, counts). "
+            "Only SELECT is allowed. LIMIT is enforced (max 50 rows) if missing or too large. "
+            "Use the table and column names from the schema provided in the system prompt."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "sql_query": {
+                    "type": "string",
+                    "description": "A single SELECT SQL statement (no INSERT/UPDATE/DELETE/DROP).",
+                },
+            },
+            "required": ["sql_query"],
+        },
+    },
+}

--- a/src/nsys_tui/tui.py
+++ b/src/nsys_tui/tui.py
@@ -1,5 +1,5 @@
 """
-tui.py — Interactive Terminal UI for NVTX tree view.
+tui.py - Interactive Terminal UI for NVTX tree view.
 
 Renders the NVTX tree in an interactive curses-based terminal UI.
 Designed for use over SSH on remote servers where opening a browser is
@@ -22,12 +22,16 @@ Keybindings:
     0               Unlimited depth
     d               Toggle demangled kernel names
     t               Toggle start/end timestamps
+    A               Toggle AI chat panel (ask questions, navigate to kernel/zoom)
     q               Quit
 """
 import curses
 import os
+import threading
 from typing import Optional
 
+from . import chat as chat_mod
+from . import tui_actions
 
 def _fmt_dur(ms: float) -> str:
     if ms >= 1000:
@@ -107,7 +111,16 @@ class InteractiveTUI:
         self.bookmarks = []           # list of {name, start_ns, end_ns, cursor_path}
         self.show_bookmarks = False   # toggle right panel
 
-        # Build all nodes in DFS order — this is the source of truth
+        # Chat pane (AI Brain & Navigator)
+        self.chat_enabled = False
+        self.chat_messages: list[dict] = []  # {"role": "user"|"assistant"|"system", "content": str}
+        self.chat_input = ""
+        self.chat_input_mode = False
+        self.chat_is_running = False
+        self.chat_status_msg = ""
+        self._chat_lock = threading.Lock()
+
+        # Build all nodes in DFS order - this is the source of truth
         self.all_nodes: list[TreeNode] = []
         self._build_nodes(json_roots, 0)
 
@@ -213,7 +226,7 @@ class InteractiveTUI:
             # Text filter: if filter is active, check if this node or descendants match
             if ft:
                 if not self._node_matches_filter(node, ft):
-                    # Don't skip children — they might match
+                    # Don't skip children - they might match
                     continue
 
             visible.append(node)
@@ -375,14 +388,16 @@ class InteractiveTUI:
             stdscr.addnstr(1, 0, bar, width - 1, curses.color_pair(7))
 
             # Help line
-            help_text = " ↑↓jk:nav ←→:expand e/c:this E/C:all /:filter m:min S:save p:panel h:help q:quit"
+            help_text = " ↑↓jk:nav ←→:expand e/c:this E/C:all /:filter m:min S:save p:panel A:chat h:help q:quit"
             stdscr.addnstr(height - 1, 0, help_text[:width - 1], width - 1, curses.A_DIM)
 
             # Visible rows
             visible = self._visible_rows()
             display_height = height - 7  # header(1) + status(1) + breadcrumb(1) + tree area + detail(2) + help(1) + gap
+            if self.chat_enabled:
+                display_height -= 6  # reserve space for chat panel so tree does not overlap
 
-            # Breadcrumb hierarchy — show NVTX path of cursor's position
+            # Breadcrumb hierarchy - show NVTX path of cursor's position
             breadcrumb = ""
             if visible and 0 <= self.cursor < len(visible):
                 cur_node = visible[self.cursor]
@@ -497,7 +512,7 @@ class InteractiveTUI:
                     except curses.error:
                         pass
 
-            # ── Bookmarks panel (right side) ──
+            # -- Bookmarks panel (right side) --
             if self.show_bookmarks and self.bookmarks:
                 panel_w = min(35, width // 3)
                 panel_x = width - panel_w
@@ -521,50 +536,53 @@ class InteractiveTUI:
                     except curses.error:
                         pass
 
-            # ── Detail bar: selected node info + mini timeline ──
-            detail_y = height - 3
-            if visible and 0 <= self.cursor < len(visible):
-                sel = visible[self.cursor]
-                # Line 1: fixed-width columns — time │ dur stream │ name
-                # Col 1: time range (fixed 22 chars)
-                if sel.start_ns is not None and sel.end_ns is not None:
-                    time_col = f"{_fmt_ns(sel.start_ns)}→{_fmt_ns(sel.end_ns)}"
-                else:
-                    time_col = "?"
-                time_col = time_col.ljust(22)
-                # Col 2: duration + stream (fixed 20 chars)
-                dur_col = _fmt_dur(sel.duration_ms)
-                if sel.type == 'kernel':
-                    dur_col += f" [S{sel.stream}]"
-                if sel.relative_pct < 100:
-                    dur_col += f" {sel.relative_pct:.0f}%"
-                dur_col = dur_col.ljust(20)
-                # Col 3: name (fills rest)
-                info = f" {time_col} │ {dur_col} │ {sel.name}"
-                try:
-                    stdscr.addnstr(detail_y, 0, info[:width - 1], width - 1,
-                                   curses.A_BOLD | curses.color_pair(7))
-                except curses.error:
-                    pass
-
-                # Line 2: mini timeline bar
-                trim_start, trim_end = self.trim
-                trim_span = max(trim_end - trim_start, 1)
-                bar_width = min(width - 6, 60)
-                if bar_width > 10 and sel.start_ns is not None and sel.end_ns is not None:
-                    # Compute positions
-                    s_pos = max(0, min(bar_width - 1, int((sel.start_ns - trim_start) / trim_span * bar_width)))
-                    e_pos = max(s_pos + 1, min(bar_width, int((sel.end_ns - trim_start) / trim_span * bar_width)))
-                    bar_chars = ['─'] * bar_width
-                    for i in range(s_pos, e_pos):
-                        if i < bar_width:
-                            bar_chars[i] = '█'
-                    timeline = f" [{_fmt_ns(trim_start)}] {''.join(bar_chars)} [{_fmt_ns(trim_end)}]"
+            # -- Detail bar or chat panel --
+            if self.chat_enabled:
+                self._draw_chat_panel(stdscr, height, width)
+            else:
+                detail_y = height - 3
+                if visible and 0 <= self.cursor < len(visible):
+                    sel = visible[self.cursor]
+                    # Line 1: fixed-width columns - time │ dur stream │ name
+                    # Col 1: time range (fixed 22 chars)
+                    if sel.start_ns is not None and sel.end_ns is not None:
+                        time_col = f"{_fmt_ns(sel.start_ns)}→{_fmt_ns(sel.end_ns)}"
+                    else:
+                        time_col = "?"
+                    time_col = time_col.ljust(22)
+                    # Col 2: duration + stream (fixed 20 chars)
+                    dur_col = _fmt_dur(sel.duration_ms)
+                    if sel.type == 'kernel':
+                        dur_col += f" [S{sel.stream}]"
+                    if sel.relative_pct < 100:
+                        dur_col += f" {sel.relative_pct:.0f}%"
+                    dur_col = dur_col.ljust(20)
+                    # Col 3: name (fills rest)
+                    info = f" {time_col} │ {dur_col} │ {sel.name}"
                     try:
-                        stdscr.addnstr(detail_y + 1, 0, timeline[:width - 1], width - 1,
-                                       curses.color_pair(9))
+                        stdscr.addnstr(detail_y, 0, info[:width - 1], width - 1,
+                                       curses.A_BOLD | curses.color_pair(7))
                     except curses.error:
                         pass
+
+                    # Line 2: mini timeline bar
+                    trim_start, trim_end = self.trim
+                    trim_span = max(trim_end - trim_start, 1)
+                    bar_width = min(width - 6, 60)
+                    if bar_width > 10 and sel.start_ns is not None and sel.end_ns is not None:
+                        # Compute positions
+                        s_pos = max(0, min(bar_width - 1, int((sel.start_ns - trim_start) / trim_span * bar_width)))
+                        e_pos = max(s_pos + 1, min(bar_width, int((sel.end_ns - trim_start) / trim_span * bar_width)))
+                        bar_chars = ['─'] * bar_width
+                        for i in range(s_pos, e_pos):
+                            if i < bar_width:
+                                bar_chars[i] = '█'
+                        timeline = f" [{_fmt_ns(trim_start)}] {''.join(bar_chars)} [{_fmt_ns(trim_end)}]"
+                        try:
+                            stdscr.addnstr(detail_y + 1, 0, timeline[:width - 1], width - 1,
+                                           curses.color_pair(9))
+                        except curses.error:
+                            pass
 
             # Filter input mode
             if self.filter_mode:
@@ -592,6 +610,23 @@ class InteractiveTUI:
 
             # Handle input
             key = stdscr.getch()
+
+            # Chat input mode: intercept keys before normal handling
+            if self.chat_input_mode:
+                if key == 27:  # Esc
+                    self.chat_input_mode = False
+                    self.status_msg = 'Chat input cancelled'
+                elif key in (10, 13):  # Enter
+                    text = self.chat_input.strip()
+                    if text and not self.chat_is_running:
+                        self._start_chat_request(text)
+                        self.chat_input = ''
+                elif key in (8, 127, 263):  # Backspace
+                    self.chat_input = self.chat_input[:-1]
+                elif 32 <= key <= 126:
+                    if len(self.chat_input) < 200:
+                        self.chat_input += chr(key)
+                continue
 
             if self.threshold_mode:
                 if key == 27:  # Esc
@@ -679,6 +714,14 @@ class InteractiveTUI:
 
             if key == ord('q'):
                 break
+            elif key == ord('A'):
+                # Toggle chat pane; when opening, focus input box.
+                self.chat_enabled = not self.chat_enabled
+                self.chat_input_mode = self.chat_enabled
+                if self.chat_enabled:
+                    self.status_msg = 'Chat: ON (type your question)'
+                else:
+                    self.status_msg = 'Chat: OFF'
             elif key in (curses.KEY_UP, ord('k')):
                 self.cursor = max(0, self.cursor - 1)
                 self.selection_anchor = -1  # clear selection on normal nav
@@ -761,7 +804,7 @@ class InteractiveTUI:
             elif key == ord('C'):
                 self._collapse_all()
             elif key == ord('h'):
-                # Toggle help — just show a status message with key summary
+                # Toggle help - just show a status message with key summary
                 self.status_msg = 'e/c:expand/collapse E/C:all ←→:nav /:filter m:min S:bookmark p:panel v:view'
             elif key == ord('/'):
                 self.filter_mode = True
@@ -805,7 +848,7 @@ class InteractiveTUI:
                 self.show_bookmarks = not self.show_bookmarks
                 self.status_msg = f"Bookmarks: {'ON' if self.show_bookmarks else 'OFF'}"
             elif key == ord('G'):
-                # Jump to bookmark — show list and prompt
+                # Jump to bookmark - show list and prompt
                 if self.bookmarks:
                     self.threshold_mode = True
                     self.threshold_target = 'bookmark'
@@ -861,6 +904,257 @@ class InteractiveTUI:
                 self.threshold_target = 'trim'
                 self.threshold_input = f"{self.trim[0]/1e9:.1f} {self.trim[1]/1e9:.1f}"
                 self.status_msg = 'Enter trim: START_S END_S'
+        # End of input loop
+
+    def _draw_chat_panel(self, stdscr, height: int, width: int):
+        """Draw a simple chat panel at the bottom of the screen."""
+        panel_height = 6
+        top = max(3, height - panel_height - 3)
+        title = " AI Chat (A toggle, Enter send, Esc exit input) "
+        try:
+            stdscr.addnstr(top, 0, title.ljust(width - 1), width - 1,
+                           curses.A_BOLD | curses.color_pair(7))
+        except curses.error:
+            return
+
+        msg_area_lines = panel_height - 3
+        with self._chat_lock:
+            msgs = self.chat_messages[-msg_area_lines:]
+            is_running = self.chat_is_running
+            status = self.chat_status_msg
+            input_text = self.chat_input
+        start_y = top + 1
+        for i in range(msg_area_lines):
+            y = start_y + i
+            if y >= height - 2:
+                break
+            line = ""
+            if i < len(msgs):
+                m = msgs[i]
+                role = m.get("role", "user")
+                prefix = "U:" if role == "user" else ("A:" if role == "assistant" else "S:")
+                line = f"{prefix} {m.get('content', '')}"
+            try:
+                stdscr.addnstr(y, 0, line[: width - 1].ljust(width - 1), width - 1,
+                               curses.A_NORMAL)
+            except curses.error:
+                break
+
+        input_y = top + panel_height - 2
+        prompt = "> " + input_text
+        if self.chat_input_mode:
+            prompt += "█"
+        try:
+            stdscr.addnstr(input_y, 0, prompt[: width - 1].ljust(width - 1), width - 1,
+                           curses.A_BOLD | curses.color_pair(10))
+        except curses.error:
+            pass
+
+        status_y = input_y + 1
+        if status or is_running:
+            label = status or ""
+            if is_running:
+                if label:
+                    label += " | "
+                label += "AI thinking..."
+            try:
+                stdscr.addnstr(status_y, 0, label[: width - 1].ljust(width - 1), width - 1,
+                               curses.A_DIM | curses.color_pair(9))
+            except curses.error:
+                pass
+
+    def _start_chat_request(self, user_text: str):
+        """Append user message and launch background worker for the agent."""
+        with self._chat_lock:
+            self.chat_messages.append({"role": "user", "content": user_text})
+            if len(self.chat_messages) > 50:
+                self.chat_messages = self.chat_messages[-50:]
+            if self.chat_is_running:
+                return
+            self.chat_is_running = True
+            self.chat_status_msg = ""
+
+        worker = threading.Thread(target=self._chat_worker, args=(user_text,), daemon=True)
+        worker.start()
+
+    def _build_ui_context_for_chat(self) -> dict:
+        """Build a minimal ui_context snapshot for the agent."""
+        ctx: dict = {}
+        visible = self._visible_rows()
+
+        selected_kernel = None
+        if visible and 0 <= self.cursor < len(visible):
+            n = visible[self.cursor]
+            if n.type == "kernel":
+                selected_kernel = {
+                    "name": n.name,
+                    "duration_ms": n.duration_ms,
+                    "stream": n.stream,
+                }
+        ctx["selected_kernel"] = selected_kernel
+
+        trim_start, trim_end = self.trim
+        view_state = {
+            "time_range_s": [trim_start / 1e9, trim_end / 1e9],
+        }
+        if visible and 0 <= self.cursor < len(visible):
+            view_state["scope"] = visible[self.cursor].path or ""
+        ctx["view_state"] = view_state
+
+        ctx["stats"] = {
+            "total_gpu_ms": self.total_gpu_ms,
+            "kernel_count": self.total_kernels,
+            "nvtx_count": self.total_nvtx,
+        }
+        return ctx
+
+    def _chat_worker(self, user_text: str):
+        """Background worker: call the shared agent and update chat messages."""
+        try:
+            model = chat_mod.get_default_model()
+        except Exception:
+            model = None
+
+        if not model:
+            with self._chat_lock:
+                self.chat_messages.append(
+                    {"role": "system", "content": "LLM is not configured (no API key)."}
+                )
+                self.chat_is_running = False
+                self.chat_status_msg = ""
+            try:
+                curses.ungetch(0)
+            except curses.error:
+                pass
+            return
+
+        with self._chat_lock:
+            history = [
+                {"role": m.get("role", "user"), "content": m.get("content", "")}
+                for m in self.chat_messages[-10:]
+            ]
+
+        ui_context = self._build_ui_context_for_chat()
+
+        content = ""
+        actions = []
+        assistant_idx = None
+        try:
+            stream = chat_mod.stream_agent_loop(
+                model=model,
+                messages=history,
+                ui_context=ui_context,
+                tools=chat_mod._tools_openai(),
+                profile_path=self.db_path,
+                max_turns=5,
+            )
+            for ev in stream:
+                t = ev.get("type")
+                if t == "text":
+                    with self._chat_lock:
+                        if assistant_idx is None:
+                            self.chat_messages.append({"role": "assistant", "content": ""})
+                            assistant_idx = len(self.chat_messages) - 1
+                        content += ev.get("content", "")
+                        if assistant_idx is not None and assistant_idx < len(self.chat_messages):
+                            self.chat_messages[assistant_idx]["content"] = content
+                    try:
+                        curses.ungetch(0)
+                    except curses.error:
+                        pass
+                elif t == "system":
+                    with self._chat_lock:
+                        self.chat_status_msg = (ev.get("content", "") or "")[:60]
+                    try:
+                        curses.ungetch(0)
+                    except curses.error:
+                        pass
+                elif t == "action":
+                    act = ev.get("action")
+                    if act:
+                        actions.append(act)
+                elif t == "done":
+                    break
+        except Exception as e:
+            content = f"LLM error: {e}"
+            actions = []
+
+        with self._chat_lock:
+            if content and assistant_idx is not None and assistant_idx < len(self.chat_messages):
+                self.chat_messages[assistant_idx]["content"] = content
+            elif content and (assistant_idx is None or assistant_idx >= len(self.chat_messages)):
+                self.chat_messages.append({"role": "assistant", "content": content})
+            # Distill history to compress tool call/result sequences for lean context.
+            try:
+                self.chat_messages[:] = chat_mod.distill_history(self.chat_messages)
+            except Exception:
+                pass  # Non-critical
+            if len(self.chat_messages) > 50:
+                self.chat_messages = self.chat_messages[-50:]
+            self.chat_is_running = False
+            self.chat_status_msg = ""
+
+        for action in actions or []:
+            try:
+                tui_actions.execute_tui_action(action, self)
+            except Exception:
+                continue
+
+        try:
+            curses.ungetch(0)
+        except curses.error:
+            pass
+
+    # TUI-side navigation APIs for AI actions
+    def scroll_to_kernel(self, target_name: str, occurrence_index: int = 1):
+        """Scroll to the Nth kernel with the given name."""
+        # Ensure scopes are expanded so kernels are visible.
+        self._expand_all()
+        matches = []
+        for idx, node in enumerate(self.all_nodes):
+            if node.type == "kernel" and node.name == target_name:
+                matches.append((idx, node))
+        if not matches:
+            self.status_msg = f'AI: kernel not found: {target_name}'
+            return
+        occ = max(1, occurrence_index)
+        if occ > len(matches):
+            occ = len(matches)
+        _, target_node = matches[occ - 1]
+
+        visible = self._visible_rows()
+        target_visible_idx = None
+        for i, n in enumerate(visible):
+            if n is target_node:
+                target_visible_idx = i
+                break
+        if target_visible_idx is None:
+            self.status_msg = f'AI: kernel not visible: {target_name}'
+            return
+
+        self.cursor = target_visible_idx
+        self.status_msg = f'AI: navigated to {target_name} ({occ}/{len(matches)})'
+
+    def zoom_to_time_range(self, start_s: float, end_s: float):
+        """Zoom tree view to a specific time range (seconds)."""
+        if end_s <= start_s:
+            return
+        start_ns = int(start_s * 1e9)
+        end_ns = int(end_s * 1e9)
+        self.trim = (start_ns, end_ns)
+        self._reload()
+        visible = self._visible_rows()
+        if not visible:
+            return
+        # Move cursor to first kernel inside the range, if any.
+        best_idx = 0
+        for i, n in enumerate(visible):
+            if n.type == "kernel" and n.start_ns is not None:
+                if start_ns <= n.start_ns <= end_ns:
+                    best_idx = i
+                    break
+        self.cursor = best_idx
+        self.status_msg = f'AI: zoom {start_s:.3f}s-{end_s:.3f}s'
 
 
 def render_tree(roots: list[dict], title: str = "NVTX Tree",
@@ -967,7 +1261,7 @@ def run_tui(db_path: str, device: int, trim: tuple[int, int],
     except Exception:
         pass
 
-    trim_label = f"{trim[0] / 1e9:.1f}s – {trim[1] / 1e9:.1f}s"
+    trim_label = f"{trim[0] / 1e9:.1f}s - {trim[1] / 1e9:.1f}s"
     title = f"{gpu_name}  |  {trim_label}"
 
     # If not a terminal (piped), fall back to static rich rendering

--- a/src/nsys_tui/tui_actions.py
+++ b/src/nsys_tui/tui_actions.py
@@ -1,0 +1,45 @@
+"""
+tui_actions.py - Map parsed tool-call actions to TUI Python APIs (,).
+
+When the agent returns navigate_to_kernel or zoom_to_time_range, the TUI (curses/Textual)
+calls execute_tui_action(action_dict, app) so the same tool schema drives both Web (JS)
+and TUI (Python). The app object should implement the methods below; missing methods
+are no-ops.
+"""
+from typing import Any
+
+
+def execute_tui_action(action_dict: dict, app: Any) -> bool:
+    """
+    Execute a single parsed action (navigate_to_kernel or zoom_to_time_range) on the TUI app.
+
+    The app is expected to provide:
+      - scroll_to_kernel(target_name: str, occurrence_index: int = 1) for navigate_to_kernel
+      - zoom_to_time_range(start_s: float, end_s: float) for zoom_to_time_range
+
+    Returns True if the action was handled, False if unknown or app has no handler.
+    """
+    if not action_dict or not isinstance(action_dict, dict):
+        return False
+    action_type = action_dict.get("type")
+    if action_type == "navigate_to_kernel":
+        target = action_dict.get("target_name")
+        if not target:
+            return False
+        occurrence = action_dict.get("occurrence_index", 1)
+        handler = getattr(app, "scroll_to_kernel", None)
+        if callable(handler):
+            handler(target, occurrence)
+            return True
+        return False
+    if action_type == "zoom_to_time_range":
+        start_s = action_dict.get("start_s")
+        end_s = action_dict.get("end_s")
+        if start_s is None or end_s is None:
+            return False
+        handler = getattr(app, "zoom_to_time_range", None)
+        if callable(handler):
+            handler(float(start_s), float(end_s))
+            return True
+        return False
+    return False

--- a/src/nsys_tui/tui_textual.py
+++ b/src/nsys_tui/tui_textual.py
@@ -1,0 +1,499 @@
+"""
+tui_textual.py — Textual AI chat TUI for nsys-ai (§11.3, §11.8).
+
+Usage (registered as CLI command):
+    nsys-ai chat <profile>
+
+Layout:
+    Left panel:  DataTable of top kernels by GPU time.
+    Right panel: RichLog (chat history) + Static (streaming) + Input.
+
+Threading:
+    stream_agent_loop runs in a @work(thread=True) worker.
+    UI updates are dispatched via self.call_from_thread().
+"""
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from textual import work
+from textual.app import App, ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.message import Message
+from textual.widgets import DataTable, Footer, Header, Input, Label, RichLog, Static
+
+
+# ---------------------------------------------------------------------------
+# Profile helper — load top kernels without importing the full Profile class.
+# ---------------------------------------------------------------------------
+
+def _load_top_kernels(sqlite_path: str, limit: int = 30) -> list[dict]:
+    """Return top kernels by total GPU duration as a list of dicts.
+
+    Each dict has: name, count, total_ms, avg_ms.
+    Opens the file in read-only URI mode; returns [] on any error.
+    """
+    try:
+        conn = sqlite3.connect(f"file:{sqlite_path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+    except Exception:
+        return []
+    try:
+        tables = {
+            r[0] for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        kernel_table = next(
+            (
+                t for t in (
+                    "CUPTI_ACTIVITY_KIND_KERNEL",
+                    "CUPTI_ACTIVITY_KIND_KERNEL_V2",
+                    "CUPTI_ACTIVITY_KIND_KERNEL_V3",
+                )
+                if t in tables
+            ),
+            None,
+        )
+        if not kernel_table:
+            return []
+        rows = conn.execute(
+            f"""
+            SELECT s.value AS name,
+                   COUNT(*) AS count,
+                   SUM(k.[end] - k.start) / 1e6 AS total_ms,
+                   AVG(k.[end] - k.start) / 1e6 AS avg_ms
+            FROM {kernel_table} k
+            JOIN StringIds s ON k.shortName = s.id
+            GROUP BY k.shortName
+            ORDER BY total_ms DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:
+        return []
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Textual App
+# ---------------------------------------------------------------------------
+
+class NsysChatApp(App):
+    """Textual AI chat TUI for Nsight Systems profiles.
+
+    Left panel : DataTable of top kernels (navigate_to_kernel lands here).
+    Right panel: RichLog (completed turns) + Static (streaming) + Input.
+    """
+
+    # ── Textual Messages ─────────────────────────────────────────────────────
+
+    class NavigateToKernel(Message):
+        """Posted when the agent calls navigate_to_kernel."""
+        def __init__(self, target_name: str, reason: str | None = None) -> None:
+            super().__init__()
+            self.target_name = target_name
+            self.reason = reason
+
+    class ZoomToTimeRange(Message):
+        """Posted when the agent calls zoom_to_time_range."""
+        def __init__(self, start_s: float, end_s: float) -> None:
+            super().__init__()
+            self.start_s = start_s
+            self.end_s = end_s
+
+    CSS = """
+    Screen {
+        layout: vertical;
+        background: $surface;
+    }
+
+    #main-area {
+        layout: horizontal;
+        height: 1fr;
+    }
+
+    #left-panel {
+        width: 46;
+        min-width: 30;
+        border-right: tall $primary-darken-2;
+        padding: 0 1;
+        layout: vertical;
+    }
+
+    #left-panel Label {
+        text-style: bold;
+        color: $accent;
+        width: 100%;
+        margin-bottom: 1;
+    }
+
+    DataTable {
+        height: 1fr;
+    }
+
+    #right-panel {
+        width: 1fr;
+        layout: vertical;
+        padding: 0 1;
+    }
+
+    #chat-log {
+        height: 1fr;
+        border: round $surface-lighten-2;
+        padding: 0 1;
+    }
+
+    #streaming-area {
+        height: auto;
+        max-height: 12;
+        padding: 0 1;
+        color: $accent;
+    }
+
+    #chat-input {
+        margin-top: 1;
+    }
+
+    #chat-input:focus {
+        border: tall $accent;
+    }
+
+    #kernel-info-bar {
+        height: auto;
+        max-height: 4;
+        padding: 0 2;
+        color: $accent;
+        background: $surface-darken-2;
+        border-bottom: tall $accent;
+        text-style: bold;
+    }
+    """
+
+    BINDINGS = [
+        Binding("ctrl+l", "clear_chat", "Clear Chat", show=True),
+        Binding("ctrl+c", "cancel_generation", "Cancel", show=False),
+        Binding("escape", "quit", "Quit", show=True),
+    ]
+
+    def __init__(self, profile_path: str) -> None:
+        super().__init__()
+        self.profile_path = profile_path
+        self.profile_name = Path(profile_path).name
+        # LLM conversation history (user + assistant turns only; system is built internally).
+        self._chat_messages: list[dict] = []
+        # Top kernels loaded from the profile DB.
+        self._kernels: list[dict] = []
+        # Maps lowercase kernel name → DataTable row index for navigation.
+        self._kernel_name_to_row: dict[str, int] = {}
+        # Protects against overlapping stream workers.
+        self._is_generating: bool = False
+        # Accumulates chunks for the current streaming response.
+        self._streaming_buffer: list[str] = []
+        # Last navigation message (set by _on_action_navigate, consumed by _on_stream_done).
+        self._last_nav_message: str = ""
+
+    # ── Compose ──────────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        yield Header(show_clock=False)
+        with Horizontal(id="main-area"):
+            with Vertical(id="left-panel"):
+                yield Label("Top Kernels (by GPU time)")
+                yield DataTable(id="kernel-table", cursor_type="row", show_cursor=True)
+            with Vertical(id="right-panel"):
+                yield Static("", id="kernel-info-bar")
+                yield RichLog(id="chat-log", markup=True, highlight=False, wrap=True)
+                yield Static("", id="streaming-area")
+                yield Input(
+                    placeholder="Ask about this profile… (Enter to send)",
+                    id="chat-input",
+                )
+        yield Footer()
+
+    # ── Lifecycle ─────────────────────────────────────────────────────────────
+
+    def on_mount(self) -> None:
+        self.title = f"nsys-ai chat — {self.profile_name}"
+        self._setup_table_columns()
+        self._load_and_populate_kernels()
+        log = self.query_one("#chat-log", RichLog)
+        log.write(f"[bold cyan]Profile:[/bold cyan] {self.profile_path}")
+        if self._kernels:
+            log.write(
+                f"[bold cyan]{len(self._kernels)} kernels loaded.[/bold cyan] "
+                "Ask anything about this GPU profile."
+            )
+        else:
+            log.write("[yellow]No kernels found. Profile may be empty or incompatible.[/yellow]")
+        log.write("[dim]─────────────────────────────────────────[/dim]")
+
+    # ── Setup helpers ─────────────────────────────────────────────────────────
+
+    def _setup_table_columns(self) -> None:
+        table = self.query_one("#kernel-table", DataTable)
+        table.add_columns("#", "Kernel", "ms (total)", "Calls")
+
+    def _load_and_populate_kernels(self) -> None:
+        """Synchronously load kernels from the profile DB and fill the DataTable."""
+        try:
+            from .profile import resolve_profile_path
+            sqlite_path = resolve_profile_path(self.profile_path)
+            self._kernels = _load_top_kernels(sqlite_path)
+        except Exception as e:
+            self.query_one("#chat-log", RichLog).write(
+                f"[bold red]Error loading profile:[/bold red] {e}"
+            )
+            return
+
+        table = self.query_one("#kernel-table", DataTable)
+        self._kernel_name_to_row = {}
+        for i, k in enumerate(self._kernels):
+            name = k.get("name", "")
+            display = name[:28] + "…" if len(name) > 29 else name
+            table.add_row(
+                str(i + 1),
+                display,
+                f"{k.get('total_ms', 0):.1f}",
+                str(k.get("count", 0)),
+            )
+            self._kernel_name_to_row[name.lower()] = i
+
+    # ── Input handler ─────────────────────────────────────────────────────────
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        user_msg = event.value.strip()
+        if not user_msg or self._is_generating:
+            return
+        event.input.value = ""
+        self._add_user_turn(user_msg)
+        self._is_generating = True
+        self._streaming_buffer = []
+        self._last_nav_message = ""
+        # Show "AI: " prefix in RichLog; streaming chunks go to #streaming-area.
+        self.query_one("#streaming-area", Static).update("[bold green]AI:[/bold green] …")
+        self._run_stream_worker(user_msg)
+
+    # ── Main-thread UI callbacks (called via call_from_thread) ────────────────
+
+    def _add_user_turn(self, text: str) -> None:
+        """Write user message to RichLog and append to history."""
+        log = self.query_one("#chat-log", RichLog)
+        log.write(f"[bold yellow]You:[/bold yellow] {text}")
+        self._chat_messages.append({"role": "user", "content": text})
+
+    def _on_text_chunk(self, chunk: str) -> None:
+        """Append streaming text chunk to the Static display area."""
+        self._streaming_buffer.append(chunk)
+        current = "".join(self._streaming_buffer)
+        self.query_one("#streaming-area", Static).update(
+            f"[bold green]AI:[/bold green] {current}"
+        )
+
+    def _on_system_event(self, content: str) -> None:
+        """Display a system/status message in the chat log."""
+        self.query_one("#chat-log", RichLog).write(f"[dim]{content}[/dim]")
+
+    def _on_action_navigate(self, target_name: str, reason: str | None) -> None:
+        """Move DataTable cursor to the kernel matching target_name.
+
+        Does NOT write to the chat log directly — the message is stored in
+        _last_nav_message and displayed by _on_stream_done to avoid duplication.
+        """
+        table = self.query_one("#kernel-table", DataTable)
+        target_lower = target_name.lower()
+        # Substring match — LLM names may differ slightly from short names.
+        matched_row = next(
+            (
+                row
+                for name, row in self._kernel_name_to_row.items()
+                if target_lower in name or name in target_lower
+            ),
+            None,
+        )
+        if matched_row is not None:
+            table.move_cursor(row=matched_row, animate=False)
+            table.scroll_visible()
+            kernel_info = self._kernels[matched_row] if matched_row < len(self._kernels) else {}
+            gpu_ms = kernel_info.get("total_ms", 0)
+            calls = kernel_info.get("count", 0)
+            avg_ms = gpu_ms / calls if calls else 0
+            msg = f"⚡ → [bold]{target_name}[/bold] (row {matched_row + 1}, {gpu_ms:.1f}ms, {calls} calls)"
+            # Update the info bar with kernel details.
+            self._update_kernel_info_bar(target_name, gpu_ms, calls, avg_ms)
+        else:
+            msg = f"⚠ Kernel not found: {target_name}"
+        if reason:
+            msg += f" — {reason}"
+        self._last_nav_message = msg
+        self.post_message(self.NavigateToKernel(target_name, reason))
+
+    def _update_kernel_info_bar(self, name: str, total_ms: float, calls: int, avg_ms: float) -> None:
+        """Update the selected kernel info bar below the DataTable."""
+        bar = self.query_one("#kernel-info-bar", Static)
+        bar.update(
+            f"▶ [bold]{name}[/bold]  │  [magenta]{total_ms:,.1f}ms total[/magenta]  │  "
+            f"[cyan]{calls} calls[/cyan]  │  avg [yellow]{avg_ms:.2f}ms[/yellow]"
+        )
+
+    def on_data_table_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
+        """Update the info bar when the user manually selects a DataTable row."""
+        row_idx = event.cursor_row
+        if 0 <= row_idx < len(self._kernels):
+            k = self._kernels[row_idx]
+            name = k.get("name", "")
+            total_ms = k.get("total_ms", 0)
+            calls = k.get("count", 0)
+            avg_ms = total_ms / calls if calls else 0
+            self._update_kernel_info_bar(name, total_ms, calls, avg_ms)
+
+    def _on_stream_done(self, final_content: str) -> None:
+        """Finalize the streaming response: move to RichLog, unlock input.
+
+        Display logic (mirrors web frontend):
+        - text + nav  → AI bubble = text, plus a dim nav note below
+        - nav only    → AI bubble = nav message
+        - text only   → AI bubble = text
+        """
+        log = self.query_one("#chat-log", RichLog)
+        if final_content and self._last_nav_message:
+            # Both text and navigation
+            log.write(f"[bold green]AI:[/bold green] {final_content}")
+            log.write(f"[dim]{self._last_nav_message}[/dim]")
+            self._chat_messages.append({"role": "assistant", "content": final_content})
+        elif final_content:
+            # Text only (e.g. "tell me the slowest kernel")
+            log.write(f"[bold green]AI:[/bold green] {final_content}")
+            self._chat_messages.append({"role": "assistant", "content": final_content})
+        elif self._last_nav_message:
+            # Pure navigation, no text — nav message becomes the response
+            log.write(f"[bold green]AI:[/bold green] {self._last_nav_message}")
+            self._chat_messages.append({"role": "assistant", "content": self._last_nav_message})
+        # else: truly empty (rare edge case)
+        log.write("")
+        self.query_one("#streaming-area", Static).update("")
+        self._streaming_buffer = []
+        self._last_nav_message = ""
+        self._is_generating = False
+
+    # ── Background worker ─────────────────────────────────────────────────────
+
+    @work(thread=True, exclusive=True)
+    def _run_stream_worker(self, user_msg: str) -> None:
+        """Background thread: calls stream_agent_loop, posts UI updates via call_from_thread.
+
+        Imports chat module lazily so the rest of the app works without litellm installed.
+        """
+        try:
+            from .chat import _get_model_and_key, stream_agent_loop, distill_history
+        except ImportError as e:
+            self.call_from_thread(
+                self._on_system_event, f"chat module unavailable: {e}"
+            )
+            self.call_from_thread(self._on_stream_done, "")
+            return
+
+        model, _ = _get_model_and_key()
+        if not model:
+            self.call_from_thread(
+                self._on_system_event,
+                "No LLM configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY.",
+            )
+            self.call_from_thread(self._on_stream_done, "")
+            return
+
+        # Build a lightweight ui_context so the model knows which profile it's analyzing.
+        ui_context: dict = {
+            "profile": self.profile_path,
+            "global_top_kernels": [
+                {
+                    "name": k.get("name", ""),
+                    "total_ms": round(k.get("total_ms", 0), 2),
+                    "count": k.get("count", 0),
+                }
+                for k in self._kernels[:10]
+            ],
+        }
+
+        # Snapshot history so the worker sees a consistent view (read-only copy).
+        messages = list(self._chat_messages)
+        accumulated: list[str] = []
+
+        try:
+            for event in stream_agent_loop(
+                model=model,
+                messages=messages,
+                ui_context=ui_context,
+                profile_path=self.profile_path,
+                max_turns=5,
+            ):
+                etype = event.get("type")
+                if etype == "text":
+                    chunk = event.get("content", "")
+                    if chunk:
+                        accumulated.append(chunk)
+                        self.call_from_thread(self._on_text_chunk, chunk)
+                elif etype == "system":
+                    self.call_from_thread(
+                        self._on_system_event, event.get("content", "")
+                    )
+                elif etype == "action":
+                    action = event.get("action", {})
+                    atype = action.get("type")
+                    if atype == "navigate_to_kernel":
+                        self.call_from_thread(
+                            self._on_action_navigate,
+                            action.get("target_name", ""),
+                            action.get("reason"),
+                        )
+                    elif atype == "zoom_to_time_range":
+                        start_s = action.get("start_s", 0)
+                        end_s = action.get("end_s", 0)
+                        self.call_from_thread(
+                            self._on_system_event,
+                            f"🔍 Zoom: {start_s:.3f}s – {end_s:.3f}s",
+                        )
+                # "done" type is handled by loop termination.
+        except Exception as e:
+            self.call_from_thread(self._on_system_event, f"Stream error: {e}")
+
+        final_content = "".join(accumulated)
+        self.call_from_thread(self._on_stream_done, final_content)
+
+        # Distill history to compress tool call/result sequences for lean context (§11.7).
+        try:
+            self._chat_messages[:] = distill_history(self._chat_messages)
+        except Exception:
+            pass  # Non-critical; don't break the UI if distillation fails.
+
+    # ── Actions ───────────────────────────────────────────────────────────────
+
+    def action_clear_chat(self) -> None:
+        """Clear the chat history and the log display."""
+        self._chat_messages.clear()
+        self.query_one("#chat-log", RichLog).clear()
+        self.query_one("#streaming-area", Static).update("")
+        self._on_system_event("Chat cleared.")
+
+    def action_cancel_generation(self) -> None:
+        """Cancel the current AI generation if running (Ctrl+C)."""
+        if self._is_generating:
+            self.workers.cancel_all()
+            self._is_generating = False
+            self._streaming_buffer = []
+            self.query_one("#streaming-area", Static).update("")
+            self._on_system_event("⚠ Generation cancelled.")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def run_chat_tui(profile_path: str) -> None:
+    """Launch the Textual AI chat TUI for the given profile path."""
+    NsysChatApp(profile_path).run()

--- a/src/nsys_tui/tui_timeline.py
+++ b/src/nsys_tui/tui_timeline.py
@@ -1,5 +1,5 @@
 """
-tui_timeline.py — Horizontal timeline TUI v2 (Perfetto-style).
+tui_timeline.py - Horizontal timeline TUI v2 (Perfetto-style).
 
 TIME-CURSOR driven: ←/→ pans through time, ↑/↓ selects stream.
 The cursor is a nanosecond timestamp; viewport auto-centers on it.
@@ -24,13 +24,17 @@ Keybindings:
     [            Set range bookmark start
     ]            Set range bookmark end (saves range)
     Home / End   Jump to start / end of trace
+    A            Toggle AI chat panel (ask questions, navigate to kernel/zoom)
     q            Quit
     Ctrl+C       Exit cleanly
 """
 import curses
 import os
+import threading
 from typing import Optional
 
+from . import chat as chat_mod
+from . import tui_actions
 
 def _fmt_dur(ms: float) -> str:
     if ms >= 1000:
@@ -95,7 +99,7 @@ class NvtxSpan:
 
 
 class TimelineTUI:
-    """Horizontal timeline viewer — time-cursor driven."""
+    """Horizontal timeline viewer - time-cursor driven."""
 
     def __init__(self, json_roots: list[dict], title: str = "Timeline",
                  db_path: str = '', device: int = 0,
@@ -141,13 +145,13 @@ class TimelineTUI:
         # NVTX depth
         self.nvtx_max_depth = min(4, max((s.depth for s in self.nvtx_spans), default=0) + 1)
 
-        # ── Cursor state ──
+        # -- Cursor state --
         self.cursor_ns = self.time_start  # time position of cursor
         self.selected_stream = 0
         self.ns_per_col = max(1, self.time_span // 100)
         self.view_start = self.time_start
 
-        # ── Options ──
+        # -- Options --
         self.logical_mode = False
         self.relative_time = False
         self.show_demangled = False
@@ -166,7 +170,7 @@ class TimelineTUI:
         self.selected_stream_rows = 2   # rows for selected stream
         self.default_stream_rows = 1    # rows for other streams
 
-        # ── Bookmarks ──
+        # -- Bookmarks --
         self.bookmarks: list[dict] = []
         self.bookmark_idx = -1
         self.range_start_ns: Optional[int] = None
@@ -181,6 +185,16 @@ class TimelineTUI:
             'tick_density', 'nvtx_max_depth', 'min_dur_us',
         ]
         self.config_cursor = 0
+        self._last_timeline_w = 80  # updated each frame for chat context
+
+        # Chat pane (shared Brain & Navigator)
+        self.chat_enabled = False
+        self.chat_messages: list[dict] = []
+        self.chat_input = ""
+        self.chat_input_mode = False
+        self.chat_is_running = False
+        self.chat_status_msg = ""
+        self._chat_lock = threading.Lock()
 
     def _extract_events(self, nodes: list[dict], path: str, depth: int):
         for node in nodes:
@@ -275,6 +289,7 @@ class TimelineTUI:
             stdscr.clear()
             height, width = stdscr.getmaxyx()
             timeline_w = max(width - label_w - 1, 20)
+            self._last_timeline_w = timeline_w
 
             stream = self.streams[self.selected_stream] if self.streams else '?'
             sk = self._get_stream_kernels(stream)
@@ -287,7 +302,7 @@ class TimelineTUI:
             # Cursor column
             cursor_col = int((self.cursor_ns - self.view_start) / max(self.ns_per_col, 1))
 
-            # ── Header ──
+            # -- Header --
             mode_label = "LOGICAL" if self.logical_mode else "TIME"
             sel_k = self._kernel_at_time(stream, self.cursor_ns)
             k_info = f"  [{_short_kernel_name(sel_k.name)} {_fmt_dur(sel_k.duration_ms)}]" if sel_k else ""
@@ -300,10 +315,10 @@ class TimelineTUI:
                 header += f"  📌{len(self.bookmarks)}"
             stdscr.addnstr(0, 0, header, width - 1, curses.A_BOLD)
 
-            # ── Time axis (row 1) ──
+            # -- Time axis (row 1) --
             self._draw_time_axis(stdscr, 1, label_w, timeline_w, width)
 
-            # ── NVTX rows (fixed height) ──
+            # -- NVTX rows (fixed height) --
             nvtx_y = 2
             if not self.logical_mode and self.ns_per_col > 0:
                 for depth in range(self.nvtx_max_depth):
@@ -349,7 +364,7 @@ class TimelineTUI:
                         except curses.error:
                             pass
 
-            # ── Separator + streams ──
+            # -- Separator + streams --
             sep_y = nvtx_y + self.nvtx_max_depth
             try:
                 stdscr.addnstr(sep_y, 0, '─' * width, width - 1, curses.A_DIM)
@@ -357,8 +372,10 @@ class TimelineTUI:
                 pass
             swim_y = sep_y + 1
 
-            # Stream rows — variable height per stream
+            # Stream rows - variable height per stream
             available = height - swim_y - 6
+            if self.chat_enabled:
+                available -= 6  # reserve space for chat panel
             # Calculate total rows needed
             stream_y_map: list[tuple[int, int, int]] = []  # (start_y, row_h, stream_idx)
             cur_y = swim_y
@@ -390,7 +407,7 @@ class TimelineTUI:
                 self._draw_stream_row(stdscr, name_y, block_y, label_w, timeline_w,
                                      s_kernels, is_sel, ci, width)
 
-            # ── Cursor line through all stream rows ──
+            # -- Cursor line through all stream rows --
             total_stream_h = sum(rh for _, rh, _ in stream_y_map)
             if 0 <= cursor_col < timeline_w:
                 cursor_x = label_w + cursor_col
@@ -403,21 +420,24 @@ class TimelineTUI:
                     except curses.error:
                         pass
 
-            # ── Bottom panel ──
+            # -- Bottom panel or chat panel --
             panel_y = swim_y + total_stream_h + 1
-            self._draw_bottom_panel(stdscr, panel_y, width, height, stream, sel_k)
+            if self.chat_enabled:
+                self._draw_chat_panel(stdscr, height, width)
+            else:
+                self._draw_bottom_panel(stdscr, panel_y, width, height, stream, sel_k)
 
-            # ── Config panel ──
+            # -- Config panel --
             if self.show_config:
                 self._draw_config_panel(stdscr, height, width)
 
-            # ── Help overlay ──
+            # -- Help overlay --
             if self.show_help:
                 self._draw_help(stdscr, height, width)
 
-            # ── Bookmark list overlay ──
+            # -- Bookmark list overlay --
             if self.bookmark_list_mode and self.bookmarks:
-                bm_lines = ["─── Bookmarks (1-9 to jump, Esc to cancel) ───"]
+                bm_lines = ["--─ Bookmarks (1-9 to jump, Esc to cancel) --─"]
                 for bi, bm in enumerate(self.bookmarks[:9]):
                     num = bi + 1
                     name = bm['name']
@@ -440,7 +460,7 @@ class TimelineTUI:
                     except curses.error:
                         pass
 
-            # ── Input prompts ──
+            # -- Input prompts --
             if self.filter_mode:
                 try:
                     stdscr.addnstr(height - 2, 0, f" Filter: {self.filter_input}█",
@@ -468,7 +488,7 @@ class TimelineTUI:
                 self.status_msg = ''
 
             # Help line
-            help_short = " ←→:time ↑↓:stream Tab:kernel +/-:zoom B:bookmark a:axis h:help q:quit"
+            help_short = " ←→:time ↑↓:stream Tab:kernel +/-:zoom B:bookmark a:axis A:chat h:help q:quit"
             try:
                 stdscr.addnstr(height - 1, 0, help_short[:width - 1], width - 1, curses.A_DIM)
             except curses.error:
@@ -476,8 +496,25 @@ class TimelineTUI:
 
             stdscr.refresh()
 
-            # ── Input ──
+            # -- Input --
             key = stdscr.getch()
+
+            # Chat input mode: intercept keys before normal handling
+            if self.chat_input_mode:
+                if key == 27:  # Esc
+                    self.chat_input_mode = False
+                    self.status_msg = 'Chat input cancelled'
+                elif key in (10, 13):  # Enter
+                    text = self.chat_input.strip()
+                    if text and not self.chat_is_running:
+                        self._start_chat_request(text)
+                        self.chat_input = ''
+                elif key in (8, 127, 263):  # Backspace
+                    self.chat_input = self.chat_input[:-1]
+                elif 32 <= key <= 126:
+                    if len(self.chat_input) < 200:
+                        self.chat_input += chr(key)
+                continue
 
             if self.filter_mode:
                 if key == 27:
@@ -537,7 +574,7 @@ class TimelineTUI:
                     self.bookmark_input += chr(key)
                 continue
 
-            # ── Bookmark list mode ──
+            # -- Bookmark list mode --
             if self.bookmark_list_mode:
                 if key == 27:
                     self.bookmark_list_mode = False
@@ -553,7 +590,7 @@ class TimelineTUI:
                     self.bookmark_list_mode = False
                 continue
 
-            # ── Config panel mode ──
+            # -- Config panel mode --
             if self.show_config:
                 if key == 27 or key == ord('C'):
                     self.show_config = False
@@ -574,11 +611,19 @@ class TimelineTUI:
                     break
                 continue
 
-            # ── Navigation ──
+            # -- Navigation --
             step = self.ns_per_col  # 1 column
 
             if key == ord('q'):
                 break
+            elif key == ord('A'):
+                # Toggle chat pane; when opening, focus input box.
+                self.chat_enabled = not self.chat_enabled
+                self.chat_input_mode = self.chat_enabled
+                if self.chat_enabled:
+                    self.status_msg = 'Chat: ON (type your question)'
+                else:
+                    self.status_msg = 'Chat: OFF'
             elif key in (curses.KEY_LEFT,):
                 self.cursor_ns -= step
                 self.cursor_ns = max(self.time_start, self.cursor_ns)
@@ -870,7 +915,7 @@ class TimelineTUI:
                     except curses.error:
                         pass
         else:
-            # No kernel at cursor — show cursor time
+            # No kernel at cursor - show cursor time
             try:
                 stdscr.addnstr(panel_y, 0,
                                f" Cursor: {_fmt_ns(self.cursor_ns)}  (no kernel on S{stream})",
@@ -881,7 +926,7 @@ class TimelineTUI:
     def _draw_help(self, stdscr, height: int, width: int):
         """Draw help overlay at bottom."""
         help_lines = [
-            "─── Keybindings ───",
+            "--─ Keybindings --─",
             "←/→         Pan through time (1 column)",
             "Shift+←/→   Page pan (1/4 viewport)",
             "PgUp/PgDn   Page pan",
@@ -929,7 +974,7 @@ class TimelineTUI:
             'min_dur_us': 'Min kernel dur (μs)',
         }
 
-        header = "─── Config (C or Esc to close) ───"
+        header = "--─ Config (C or Esc to close) --─"
         try:
             stdscr.addnstr(panel_y, panel_x, header, panel_w, curses.color_pair(8) | curses.A_BOLD)
         except curses.error:
@@ -984,6 +1029,234 @@ class TimelineTUI:
                 return nice
         return max(raw, 1)
 
+    def _draw_chat_panel(self, stdscr, height: int, width: int):
+        """Draw chat panel at the bottom of the screen."""
+        panel_height = 6
+        top = max(3, height - panel_height - 3)
+        title = " AI Chat (A toggle, Enter send, Esc exit input) "
+        try:
+            stdscr.addnstr(top, 0, title.ljust(width - 1), width - 1,
+                           curses.A_BOLD | curses.color_pair(9))
+        except curses.error:
+            return
+
+        msg_area_lines = panel_height - 3
+        with self._chat_lock:
+            msgs = self.chat_messages[-msg_area_lines:]
+            is_running = self.chat_is_running
+            status = self.chat_status_msg
+            input_text = self.chat_input
+        start_y = top + 1
+        for i in range(msg_area_lines):
+            y = start_y + i
+            if y >= height - 2:
+                break
+            line = ""
+            if i < len(msgs):
+                m = msgs[i]
+                role = m.get("role", "user")
+                prefix = "U:" if role == "user" else ("A:" if role == "assistant" else "S:")
+                line = f"{prefix} {m.get('content', '')}"
+            try:
+                stdscr.addnstr(y, 0, line[: width - 1].ljust(width - 1), width - 1,
+                               curses.A_NORMAL)
+            except curses.error:
+                break
+
+        input_y = top + panel_height - 2
+        prompt = "> " + input_text
+        if self.chat_input_mode:
+            prompt += "█"
+        try:
+            stdscr.addnstr(input_y, 0, prompt[: width - 1].ljust(width - 1), width - 1,
+                           curses.A_BOLD | curses.color_pair(7))
+        except curses.error:
+            pass
+
+        status_y = input_y + 1
+        if status or is_running:
+            label = status or ""
+            if is_running:
+                if label:
+                    label += " | "
+                label += "AI thinking..."
+            try:
+                stdscr.addnstr(status_y, 0, label[: width - 1].ljust(width - 1), width - 1,
+                               curses.A_DIM | curses.color_pair(8))
+            except curses.error:
+                pass
+
+    def _build_ui_context_for_chat(self) -> dict:
+        """Minimal ui_context snapshot for the agent."""
+        ctx: dict = {}
+        stream = self.streams[self.selected_stream] if self.streams else "0"
+        sel_k = self._kernel_at_time(stream, self.cursor_ns)
+        if sel_k:
+            ctx["selected_kernel"] = {
+                "name": sel_k.name,
+                "duration_ms": sel_k.duration_ms,
+                "stream": sel_k.stream,
+            }
+        else:
+            ctx["selected_kernel"] = None
+
+        view_state = {
+            "time_range_s": [
+                self.view_start / 1e9,
+                (self.view_start + self.ns_per_col * max(self._last_timeline_w, 1)) / 1e9,
+            ],
+            "scope": f"Timeline stream S{stream}",
+        }
+        ctx["view_state"] = view_state
+
+        ctx["stats"] = {
+            "total_gpu_ms": sum(k.duration_ms for k in self.kernels),
+            "kernel_count": len(self.kernels),
+            "nvtx_count": len(self.nvtx_spans),
+        }
+        return ctx
+
+    def _start_chat_request(self, user_text: str):
+        """Append user message and launch background worker."""
+        with self._chat_lock:
+            self.chat_messages.append({"role": "user", "content": user_text})
+            if len(self.chat_messages) > 50:
+                self.chat_messages = self.chat_messages[-50:]
+            if self.chat_is_running:
+                return
+            self.chat_is_running = True
+            self.chat_status_msg = ""
+
+        worker = threading.Thread(target=self._chat_worker, args=(user_text,), daemon=True)
+        worker.start()
+
+    def _chat_worker(self, user_text: str):
+        """Background worker: call shared agent and update chat messages."""
+        try:
+            model = chat_mod.get_default_model()
+        except Exception:
+            model = None
+
+        if not model:
+            with self._chat_lock:
+                self.chat_messages.append(
+                    {"role": "system", "content": "LLM is not configured (no API key)."}
+                )
+                self.chat_is_running = False
+                self.chat_status_msg = ""
+            try:
+                curses.ungetch(0)
+            except curses.error:
+                pass
+            return
+
+        with self._chat_lock:
+            history = [
+                {"role": m.get("role", "user"), "content": m.get("content", "")}
+                for m in self.chat_messages[-10:]
+            ]
+
+        ui_context = self._build_ui_context_for_chat()
+
+        content = ""
+        actions = []
+        assistant_idx = None
+        try:
+            stream = chat_mod.stream_agent_loop(
+                model=model,
+                messages=history,
+                ui_context=ui_context,
+                tools=chat_mod._tools_openai(),
+                profile_path=self.db_path,
+                max_turns=5,
+            )
+            for ev in stream:
+                t = ev.get("type")
+                if t == "text":
+                    with self._chat_lock:
+                        if assistant_idx is None:
+                            self.chat_messages.append({"role": "assistant", "content": ""})
+                            assistant_idx = len(self.chat_messages) - 1
+                        content += ev.get("content", "")
+                        if assistant_idx is not None and assistant_idx < len(self.chat_messages):
+                            self.chat_messages[assistant_idx]["content"] = content
+                    try:
+                        curses.ungetch(0)
+                    except curses.error:
+                        pass
+                elif t == "system":
+                    with self._chat_lock:
+                        self.chat_status_msg = (ev.get("content", "") or "")[:60]
+                    try:
+                        curses.ungetch(0)
+                    except curses.error:
+                        pass
+                elif t == "action":
+                    act = ev.get("action")
+                    if act:
+                        actions.append(act)
+                elif t == "done":
+                    break
+        except Exception as e:
+            content = f"LLM error: {e}"
+            actions = []
+
+        with self._chat_lock:
+            if content and assistant_idx is not None and assistant_idx < len(self.chat_messages):
+                self.chat_messages[assistant_idx]["content"] = content
+            elif content and (assistant_idx is None or assistant_idx >= len(self.chat_messages)):
+                self.chat_messages.append({"role": "assistant", "content": content})
+            if len(self.chat_messages) > 50:
+                self.chat_messages = self.chat_messages[-50:]
+            self.chat_is_running = False
+            self.chat_status_msg = ""
+
+        for action in actions or []:
+            try:
+                tui_actions.execute_tui_action(action, self)
+            except Exception:
+                continue
+
+        try:
+            curses.ungetch(0)
+        except curses.error:
+            pass
+
+    # TUI-side navigation APIs for AI actions
+    def scroll_to_kernel(self, target_name: str, occurrence_index: int = 1):
+        """Scroll timeline to the Nth kernel with the given name."""
+        matches = [k for k in self.kernels if k.name == target_name]
+        if not matches:
+            self.status_msg = f'AI: kernel not found: {target_name}'
+            return
+        occ = max(1, occurrence_index)
+        if occ > len(matches):
+            occ = len(matches)
+        k = matches[occ - 1]
+        self.cursor_ns = k.start_ns
+        # Move to its stream
+        try:
+            self.selected_stream = self.streams.index(k.stream)
+        except ValueError:
+            self.selected_stream = 0
+        self.status_msg = f'AI: navigated to {target_name} ({occ}/{len(matches)})'
+
+    def zoom_to_time_range(self, start_s: float, end_s: float):
+        """Zoom timeline to a specific time range (seconds)."""
+        if end_s <= start_s:
+            return
+        start_ns = int(start_s * 1e9)
+        end_ns = int(end_s * 1e9)
+        span = max(end_ns - start_ns, 1)
+        # Approximate ns_per_col using current terminal width on next loop;
+        # here we set a conservative value so that viewport covers the range.
+        self.ns_per_col = max(1, span // 100)
+        self.cursor_ns = (start_ns + end_ns) // 2
+        self.time_start = min(self.time_start, start_ns)
+        self.time_end = max(self.time_end, end_ns)
+        self.time_span = max(self.time_end - self.time_start, 1)
+        self.status_msg = f'AI: zoom {start_s:.3f}s-{end_s:.3f}s'
+
 
 def run_timeline(db_path: str, device: int, trim: tuple[int, int],
                  max_depth: int = -1, min_ms: float = 0):
@@ -1005,7 +1278,7 @@ def run_timeline(db_path: str, device: int, trim: tuple[int, int],
     except Exception:
         pass
 
-    trim_label = f"{trim[0] / 1e9:.1f}s – {trim[1] / 1e9:.1f}s"
+    trim_label = f"{trim[0] / 1e9:.1f}s - {trim[1] / 1e9:.1f}s"
     title = f"{gpu_name}  |  {trim_label}"
 
     if not os.isatty(1):

--- a/src/nsys_tui/viewer.py
+++ b/src/nsys_tui/viewer.py
@@ -1,5 +1,5 @@
 """
-viewer.py — Generate interactive HTML visualizations for Nsight profiles.
+viewer.py - Generate interactive HTML visualizations for Nsight profiles.
 
 Uses string.Template with HTML template files for clean separation between
 Python logic and HTML/CSS/JS presentation.
@@ -28,14 +28,23 @@ def generate_html(prof, device: int, trim: tuple[int, int]) -> str:
     gpu_info = prof.meta.gpu_info.get(device)
     gpu_label = f"GPU {device}"
     if gpu_info:
-        gpu_label += (f" — {gpu_info.name} ({gpu_info.pci_bus}), "
+        gpu_label += (f" - {gpu_info.name} ({gpu_info.pci_bus}), "
                       f"{gpu_info.sm_count} SMs, {gpu_info.memory_bytes/1e9:.0f}GB")
 
+    # Stable id for this profile view (device + time window) for profile-bound chat history
+    trim_sec = (trim[0] / 1e9, trim[1] / 1e9)
+    profile_id = f"{device}_{trim_sec[0]:.1f}_{trim_sec[1]:.1f}"
+
     tmpl = _load_template("nvtx_tree.html")
+    db_agent_flag = os.environ.get("NSYS_AI_DB_AGENT", "").strip().lower()
+    db_agent_enabled = bool(db_agent_flag) and db_agent_flag not in ("0", "false", "no", "off")
     return tmpl.safe_substitute(
         DATA=json.dumps(tree_json),
         GPU_LABEL=gpu_label,
-        TRIM_LABEL=f"{trim[0]/1e9:.1f}s – {trim[1]/1e9:.1f}s",
+        TRIM_LABEL=f"{trim[0]/1e9:.1f}s - {trim[1]/1e9:.1f}s",
+        PROFILE_ID=profile_id,
+        PROFILE_PATH=prof.path,
+        DB_AGENT_ENABLED="1" if db_agent_enabled else "",
     )
 
 
@@ -53,14 +62,14 @@ def generate_timeline_html(prof, device: int, trim: tuple[int, int]) -> str:
     gpu_info = prof.meta.gpu_info.get(device)
     gpu_label = f"GPU {device}"
     if gpu_info:
-        gpu_label += (f" — {gpu_info.name} ({gpu_info.pci_bus}), "
+        gpu_label += (f" - {gpu_info.name} ({gpu_info.pci_bus}), "
                       f"{gpu_info.sm_count} SMs, {gpu_info.memory_bytes/1e9:.0f}GB")
 
     tmpl = _load_template("timeline.html")
     return tmpl.safe_substitute(
         DATA=json.dumps(tree_json),
         GPU_LABEL=gpu_label,
-        TRIM_LABEL=f"{trim[0]/1e9:.1f}s – {trim[1]/1e9:.1f}s",
+        TRIM_LABEL=f"{trim[0]/1e9:.1f}s - {trim[1]/1e9:.1f}s",
     )
 
 

--- a/src/nsys_tui/web.py
+++ b/src/nsys_tui/web.py
@@ -11,10 +11,58 @@ Usage:
 """
 import json
 import os
+import queue
+import socketserver
 import threading
 import webbrowser
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import quote
+
+# Bounded thread pool: fixed worker count, request queue with max size.
+# Workers are released when each request finishes (finish_request + shutdown_request).
+# See docs/chat-thread-pool.md.
+CHAT_SERVER_POOL_SIZE = 8
+CHAT_SERVER_QUEUE_SIZE = 16
+
+
+class _ThreadPoolMixIn(socketserver.ThreadingMixIn):
+    """Use a fixed-size thread pool instead of one thread per request. Prevents thread exhaustion."""
+
+    daemon_threads = True
+    _pool_size = CHAT_SERVER_POOL_SIZE
+    _queue_maxsize = CHAT_SERVER_QUEUE_SIZE
+
+    def process_request(self, request, client_address):
+        """Enqueue request for a pool worker instead of spawning a new thread."""
+        if not getattr(self, "_pool_ready", False):
+            self._request_queue = queue.Queue(maxsize=self._queue_maxsize)
+            for _ in range(self._pool_size):
+                t = threading.Thread(target=self._pool_worker, daemon=True)
+                t.start()
+            self._pool_ready = True
+        try:
+            self._request_queue.put((request, client_address), block=True, timeout=30)
+        except queue.Full:
+            self.handle_error(request, client_address)
+
+    def _pool_worker(self):
+        """Worker loop: take (request, client_address) from queue and handle; thread is released when done."""
+        while True:
+            try:
+                request, client_address = self._request_queue.get()
+                if request is None:
+                    break
+                try:
+                    self.process_request_thread(request, client_address)
+                except Exception:
+                    self.handle_error(request, client_address)
+            except Exception:
+                pass
+
+
+class _ThreadedHTTPServer(_ThreadPoolMixIn, socketserver.ThreadingMixIn, HTTPServer):
+    """Concurrent chat requests via bounded thread pool; workers released after each request."""
+    daemon_threads = True
 
 from .viewer import generate_html, generate_timeline_html
 from .export import gpu_trace
@@ -27,6 +75,9 @@ def _run_server(server, open_url, prof):
     actual_port = server.server_address[1]
     actual_url = f"http://127.0.0.1:{actual_port}"
     print(f"Serving at {actual_url}")
+    pool_size = getattr(server, "_pool_size", None)
+    if pool_size is not None:
+        print(f"  (thread pool: {pool_size} workers, queue max {getattr(server, '_queue_maxsize', '?')})")
     if os.environ.get("SSH_CONNECTION"):
         print(f"  Remote/SSH: on your local machine run:  ssh -L {actual_port}:127.0.0.1:{actual_port} <host>  then open the URL in your local browser.")
     print("Press Ctrl-C to stop.")
@@ -45,16 +96,107 @@ def _run_server(server, open_url, prof):
 
 # ── Mode 1: Built-in HTML viewer ────────────────────────────────
 
+def _handle_chat_request(body_bytes: bytes) -> dict | None:
+    """Handle POST /api/chat. Returns JSON-serializable dict or None for 501."""
+    try:
+        from . import chat
+        return chat.chat_completion(body_bytes)
+    except ImportError:
+        pass
+    # Phase 0 mock: no chat module or LLM not configured
+    return {"content": "Mock reply. Configure an LLM endpoint (e.g. pip install nsys-ai[ai], set ANTHROPIC_API_KEY) for real analysis.", "actions": []}
+
+
+def _handle_chat_stream(body_bytes: bytes):
+    """Return generator yielding SSE bytes for stream=true, or None for 501."""
+    try:
+        from . import chat
+        if hasattr(chat, "chat_completion_stream"):
+            return chat.chat_completion_stream(body_bytes)
+    except ImportError:
+        pass
+    return None
+
+
 class _ViewerHandler(BaseHTTPRequestHandler):
-    """Serve the pre-rendered HTML on every GET request."""
+    """Serve the pre-rendered HTML on GET; GET /api/models for model list; POST /api/chat for AI chat."""
     html_bytes: bytes = b""
 
     def do_GET(self):
+        path = self.path.split("?")[0]
+        if path == "/api/models":
+            try:
+                import nsys_tui.chat as chat_mod
+                options = chat_mod.get_available_models()
+                default = chat_mod.get_default_model()
+            except Exception:
+                options = []
+                default = None
+            body = json.dumps({"default": default, "options": options}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
         self.send_response(200)
         self.send_header("Content-Type", "text/html; charset=utf-8")
         self.send_header("Content-Length", str(len(self.html_bytes)))
         self.end_headers()
         self.wfile.write(self.html_bytes)
+
+    def do_POST(self):
+        if self.path.split("?")[0] != "/api/chat":
+            self.send_error(404)
+            return
+        content_length = int(self.headers.get("Content-Length", 0))
+        body = self.rfile.read(content_length) if content_length else b"{}"
+        stream_requested = False
+        try:
+            payload = json.loads(body.decode("utf-8"))
+            stream_requested = payload.get("stream") is True
+        except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+            pass
+        try:
+            if stream_requested:
+                print("[chat] stream request received", flush=True)
+                gen = _handle_chat_stream(body)
+                if gen is None:
+                    self.send_response(501)
+                    self.send_header("Content-Type", "application/json; charset=utf-8")
+                    self.end_headers()
+                    self.wfile.write(b'{"error":"LLM not configured"}')
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Cache-Control", "no-cache")
+                self.send_header("Connection", "keep-alive")
+                self.send_header("X-Accel-Buffering", "no")
+                self.end_headers()
+                for chunk in gen:
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+                return
+            out = _handle_chat_request(body)
+            if out is None:
+                self.send_response(501)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(b'{"error":"LLM not configured"}')
+                return
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            resp = json.dumps(out).encode("utf-8")
+            self.send_header("Content-Length", str(len(resp)))
+            self.end_headers()
+            self.wfile.write(resp)
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
+        except Exception as e:
+            self.send_response(500)
+            self.send_header("Content-Type", "application/json; charset=utf-8")
+            self.end_headers()
+            self.wfile.write(json.dumps({"error": str(e)}).encode("utf-8"))
 
     def log_message(self, format, *args):
         pass
@@ -62,11 +204,19 @@ class _ViewerHandler(BaseHTTPRequestHandler):
 
 def serve(prof, device: int, trim: tuple[int, int], *,
           port: int = 8142, open_browser: bool = True):
-    """Start a local HTTP server serving the interactive HTML viewer."""
+    """Start a local HTTP server serving the interactive HTML viewer.
+    If the requested port is in use, tries port 0 (system assigns a free port) and opens that URL.
+    """
     html = generate_html(prof, device, trim)
     _ViewerHandler.html_bytes = html.encode("utf-8")
 
-    server = HTTPServer(("127.0.0.1", port), _ViewerHandler)
+    try:
+        server = _ThreadedHTTPServer(("127.0.0.1", port), _ViewerHandler)
+    except OSError:
+        if port == 0:
+            raise
+        server = _ThreadedHTTPServer(("127.0.0.1", 0), _ViewerHandler)
+        print(f"Port {port} in use, using port {server.server_address[1]} instead.")
     open_url = f"http://127.0.0.1:{server.server_address[1]}" if open_browser else None
     _run_server(server, open_url, prof)
 
@@ -79,7 +229,7 @@ def serve_timeline(prof, device: int, trim: tuple[int, int], *,
     html = generate_timeline_html(prof, device, trim)
     _ViewerHandler.html_bytes = html.encode("utf-8")
 
-    server = HTTPServer(("127.0.0.1", port), _ViewerHandler)
+    server = _ThreadedHTTPServer(("127.0.0.1", port), _ViewerHandler)
     actual_url = f"http://127.0.0.1:{server.server_address[1]}"
     print(f"Timeline viewer at {actual_url}")
     _run_server(server, actual_url if open_browser else None, prof)

--- a/test_agent.py
+++ b/test_agent.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""
+test_agent.py — CLI to run the Text-to-SQL agent loop against a profile DB (§11.5).
+
+Usage:
+  python test_agent.py [--model MODEL] <profile.sqlite|profile.nsys-rep> [question]
+  python test_agent.py -m gemini/gemini-2.5-flash profile.sqlite "What is the first kernel?"
+  echo "What is the first kernel?" | python test_agent.py <profile.sqlite>
+
+Model selection:
+  - CLI: --model / -m  (e.g. -m gemini/gemini-2.5-flash, -m anthropic/claude-sonnet-4-5-20250929)
+  - Global: set NSYS_AI_MODEL in the environment (same model id as above)
+
+Accepts .sqlite or .nsys-rep (resolved to .sqlite via nsys export when needed).
+Requires: model (via -m/--model or NSYS_AI_MODEL) and one of GEMINI_API_KEY / ANTHROPIC_API_KEY / OPENAI_API_KEY.
+"""
+import argparse
+import sys
+import threading
+
+
+def _resolve_profile(path: str) -> str:
+    """Return .sqlite path; convert .nsys-rep via resolve_profile_path when needed."""
+    from nsys_tui.profile import resolve_profile_path
+    return resolve_profile_path(path)
+
+
+def _spinner(stop_event: threading.Event, message: str = "Thinking") -> None:
+    """Run a terminal spinner on stderr until stop_event is set."""
+    chars = "|/-\\"
+    idx = 0
+    while not stop_event.is_set():
+        print(f"\r{message} {chars[idx % len(chars)]}  ", end="", file=sys.stderr, flush=True)
+        idx += 1
+        stop_event.wait(0.12)
+    print("\r" + " " * (len(message) + 4) + "\r", end="", file=sys.stderr, flush=True)
+
+
+def _main():
+    parser = argparse.ArgumentParser(
+        description="Run Text-to-SQL agent loop against a profile DB (§11.5).",
+        epilog="Model: use --model/NSYS_AI_MODEL (e.g. gemini/gemini-2.5-flash). API key: GEMINI_API_KEY, ANTHROPIC_API_KEY, or OPENAI_API_KEY.",
+    )
+    parser.add_argument(
+        "-m", "--model",
+        metavar="MODEL",
+        default=None,
+        help="Model id (e.g. gemini/gemini-2.5-flash). Overrides NSYS_AI_MODEL if set.",
+    )
+    parser.add_argument("profile", help="Path to profile (.sqlite or .nsys-rep)")
+    parser.add_argument("question", nargs="?", default=None, help="Question to ask (or read from stdin)")
+    args = parser.parse_args()
+
+    profile_path = args.profile
+    question = args.question
+    if not question:
+        question = sys.stdin.read().strip()
+    if not question:
+        print("No question provided (argument or stdin).", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        from nsys_tui.tools_profile import (
+            open_profile_readonly,
+            get_profile_schema,
+            query_profile_db,
+        )
+        from nsys_tui.chat import (
+            _tools_openai,
+            _build_system_prompt,
+            _get_model_and_key,
+            run_agent_loop,
+        )
+    except ImportError as e:
+        print(f"Import error: {e}. Install: pip install -e '.[ai]'", file=sys.stderr)
+        sys.exit(1)
+
+    model, _ = _get_model_and_key(args.model)
+    if not model:
+        print("No LLM configured. Use --model MODEL or set NSYS_AI_MODEL and the corresponding API key.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        sqlite_path = _resolve_profile(profile_path)
+    except RuntimeError as e:
+        print(f"Profile resolve error: {e}", file=sys.stderr)
+        sys.exit(1)
+    conn = open_profile_readonly(sqlite_path)
+    try:
+        schema_str = get_profile_schema(conn)
+        system_prompt = _build_system_prompt(ui_context={}, profile_schema=schema_str)
+        api_messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": question},
+        ]
+
+        def query_runner(sql_query: str):
+            return query_profile_db(conn, sql_query)
+
+        stop = threading.Event()
+        spinner = threading.Thread(target=_spinner, args=(stop, "Thinking"), daemon=True)
+        spinner.start()
+        try:
+            content, _actions = run_agent_loop(
+                model=model,
+                api_messages=api_messages,
+                tools=_tools_openai(),
+                query_runner=query_runner,
+                max_turns=5,
+            )
+        finally:
+            stop.set()
+            spinner.join(timeout=0.5)
+        print(content)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    _main()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,0 +1,613 @@
+"""Unit tests for nsys_tui.chat (AI Brain + Navigator)."""
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nsys_tui import chat as chat_mod
+
+
+def test_get_model_and_key_none(monkeypatch):
+    """With no API keys set, returns (None, None)."""
+    for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    model, key = chat_mod._get_model_and_key()
+    assert model is None
+    assert key is None
+
+
+def test_get_model_and_key_anthropic(monkeypatch):
+    """ANTHROPIC_API_KEY is preferred."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-x")
+    model, key = chat_mod._get_model_and_key()
+    assert "anthropic" in model
+    assert key == "sk-ant-x"
+
+
+def test_get_model_and_key_openai(monkeypatch):
+    """OPENAI_API_KEY used when Anthropic not set."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-openai")
+    model, key = chat_mod._get_model_and_key()
+    assert "gpt" in model
+    assert key == "sk-openai"
+
+
+def test_get_model_and_key_gemini(monkeypatch):
+    """GEMINI_API_KEY used when others not set."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    model, key = chat_mod._get_model_and_key()
+    assert "gemini" in model
+    assert key == "gemini-key"
+
+
+def test_get_model_and_key_priority(monkeypatch):
+    """Order: Anthropic > OpenAI > Gemini."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "a")
+    monkeypatch.setenv("OPENAI_API_KEY", "b")
+    monkeypatch.setenv("GEMINI_API_KEY", "c")
+    model, _ = chat_mod._get_model_and_key()
+    assert "anthropic" in model
+
+
+def test_get_model_and_key_preferred(monkeypatch):
+    """preferred_model (or NSYS_AI_MODEL) overrides default."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-o")
+    monkeypatch.setenv("GEMINI_API_KEY", "sk-g")
+    model, key = chat_mod._get_model_and_key("gemini/gemini-1.5-flash")
+    assert "gemini" in model
+    assert key == "sk-g"
+    model2, _ = chat_mod._get_model_and_key("gpt-4o-mini")
+    assert "gpt" in model2
+    assert model2 == "gpt-4o-mini"
+
+
+def test_model_to_key():
+    """_model_to_key maps model id to env var name."""
+    assert chat_mod._model_to_key("anthropic/claude-3") == "ANTHROPIC_API_KEY"
+    assert chat_mod._model_to_key("gpt-4o") == "OPENAI_API_KEY"
+    assert chat_mod._model_to_key("gemini/gemini-1.5-pro") == "GEMINI_API_KEY"
+    assert chat_mod._model_to_key("") is None
+
+
+def test_get_available_models(monkeypatch):
+    """get_available_models returns only models with API key set."""
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    assert chat_mod.get_available_models() == []
+    monkeypatch.setenv("OPENAI_API_KEY", "x")
+    opts = chat_mod.get_available_models()
+    assert any(o["id"] == "gpt-4o" for o in opts)
+
+
+def test_build_system_prompt():
+    """System prompt contains ui_context as JSON code block."""
+    ctx = {"view_state": {"scope": "all"}, "global_top_kernels": []}
+    out = chat_mod._build_system_prompt(ctx)
+    assert "```json" in out
+    assert "view_state" in out
+    assert "global_top_kernels" in out
+    assert "CURRENT UI CONTEXT" in out
+
+
+def test_tools_openai():
+    """Three tools defined: navigate_to_kernel, zoom_to_time_range, query_profile_db."""
+    tools = chat_mod._tools_openai()
+    assert len(tools) == 3
+    names = {t["function"]["name"] for t in tools}
+    assert names == {"navigate_to_kernel", "zoom_to_time_range", "query_profile_db"}
+    nav = next(t for t in tools if t["function"]["name"] == "navigate_to_kernel")
+    assert "target_name" in nav["function"]["parameters"]["properties"]
+    zoom = next(t for t in tools if t["function"]["name"] == "zoom_to_time_range")
+    assert "start_s" in zoom["function"]["parameters"]["properties"]
+    assert "end_s" in zoom["function"]["parameters"]["properties"]
+
+
+def test_parse_tool_call_navigate():
+    """navigate_to_kernel with required and optional args."""
+    action = chat_mod._parse_tool_call(
+        "navigate_to_kernel",
+        '{"target_name": "my_kernel", "occurrence_index": 2, "reason": "bottleneck"}',
+    )
+    assert action == {
+        "type": "navigate_to_kernel",
+        "target_name": "my_kernel",
+        "occurrence_index": 2,
+        "reason": "bottleneck",
+    }
+
+
+def test_parse_tool_call_navigate_minimal():
+    """navigate_to_kernel defaults occurrence_index to 1."""
+    action = chat_mod._parse_tool_call("navigate_to_kernel", '{"target_name": "k"}')
+    assert action["target_name"] == "k"
+    assert action["occurrence_index"] == 1
+
+
+def test_parse_tool_call_navigate_missing_target():
+    """navigate_to_kernel without target_name returns None."""
+    assert chat_mod._parse_tool_call("navigate_to_kernel", "{}") is None
+
+
+def test_parse_tool_call_zoom():
+    """zoom_to_time_range parses start_s and end_s."""
+    action = chat_mod._parse_tool_call(
+        "zoom_to_time_range", '{"start_s": 1.5, "end_s": 2.5}'
+    )
+    assert action == {
+        "type": "zoom_to_time_range",
+        "start_s": 1.5,
+        "end_s": 2.5,
+    }
+
+
+def test_parse_tool_call_zoom_missing():
+    """zoom_to_time_range missing start_s or end_s returns None."""
+    assert chat_mod._parse_tool_call("zoom_to_time_range", '{"start_s": 1}') is None
+    assert chat_mod._parse_tool_call("zoom_to_time_range", '{"end_s": 1}') is None
+
+
+def test_parse_tool_call_invalid_json():
+    """Invalid JSON arguments return None."""
+    assert chat_mod._parse_tool_call("navigate_to_kernel", "not json") is None
+    assert chat_mod._parse_tool_call("navigate_to_kernel", "") is None
+
+
+def test_parse_tool_call_unknown():
+    """Unknown tool name returns None."""
+    assert chat_mod._parse_tool_call("other_tool", '{"x": 1}') is None
+
+
+def test_chat_completion_invalid_body(monkeypatch):
+    """Invalid JSON body returns error content and empty actions."""
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+    out = chat_mod.chat_completion(b"not json")
+    assert out is not None
+    assert "content" in out
+    assert "Invalid" in out["content"]
+    assert out["actions"] == []
+
+
+def test_chat_completion_no_model(monkeypatch):
+    """When no LLM is configured, returns None (501)."""
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: (None, None))
+    out = chat_mod.chat_completion(b'{"messages": [{"role": "user", "content": "hi"}]}')
+    assert out is None
+
+
+def test_chat_completion_success_mock(monkeypatch):
+    """With mocked litellm, returns content and actions from completion."""
+    fake_message = MagicMock(content="Hello.", tool_calls=[])
+    fake_choice = MagicMock(message=fake_message)
+    fake_response = MagicMock(choices=[fake_choice])
+
+    mock_lt = MagicMock()
+    mock_lt.completion.return_value = fake_response
+
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        # Clear cached litellm in chat module so next import uses our mock
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        body = json.dumps({"messages": [{"role": "user", "content": "hi"}]}).encode("utf-8")
+        out = chat_mod.chat_completion(body)
+    assert out is not None
+    assert out["content"] == "Hello."
+    assert out["actions"] == []
+
+
+def test_chat_completion_tool_calls_mock(monkeypatch):
+    """Mock response with tool_calls produces actions."""
+    fn = MagicMock()
+    fn.name = "navigate_to_kernel"
+    fn.arguments = '{"target_name": "kernel_a", "reason": "test"}'
+    tc = MagicMock(function=fn)
+    fake_message = MagicMock(content="Going there.", tool_calls=[tc])
+    fake_choice = MagicMock(message=fake_message)
+    fake_response = MagicMock(choices=[fake_choice])
+
+    mock_lt = MagicMock()
+    mock_lt.completion.return_value = fake_response
+
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        body = json.dumps({"messages": [{"role": "user", "content": "go to kernel_a"}]}).encode("utf-8")
+        out = chat_mod.chat_completion(body)
+    assert out is not None
+    assert out["content"] == "Going there."
+    assert len(out["actions"]) == 1
+    assert out["actions"][0]["type"] == "navigate_to_kernel"
+    assert out["actions"][0]["target_name"] == "kernel_a"
+
+
+def test_sse_event():
+    """_sse_event produces valid SSE line format."""
+    raw = chat_mod._sse_event("text", {"chunk": "hi"})
+    assert raw.startswith(b"event: text\n")
+    assert b"data: " in raw
+    assert "hi" in raw.decode("utf-8")
+
+
+# --- 11.8.4 Stage 1: stream_agent_loop headless integration tests ---
+
+
+def test_stream_agent_loop_yields_text_and_done(monkeypatch):
+    """stream_agent_loop with mocked stream yields at least one text event and a done event."""
+    chunk1 = MagicMock()
+    chunk1.choices = [MagicMock(delta=MagicMock(content="Hi", tool_calls=[]))]
+    chunk1.usage = None
+    chunk2 = MagicMock()
+    chunk2.choices = []
+    chunk2.usage = MagicMock(prompt_tokens=5, completion_tokens=2)
+
+    mock_lt = MagicMock()
+    mock_lt.completion.return_value = iter([chunk1, chunk2])
+
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        events = list(
+            chat_mod.stream_agent_loop(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                ui_context={},
+                profile_path=None,
+                max_turns=2,
+            )
+        )
+    types = [e.get("type") for e in events]
+    assert "text" in types
+    assert "done" in types
+    text_events = [e for e in events if e.get("type") == "text"]
+    assert any("Hi" in (e.get("content") or "") for e in text_events)
+    done_events = [e for e in events if e.get("type") == "done"]
+    assert len(done_events) >= 1
+
+
+def test_stream_agent_loop_terminates_with_done(monkeypatch):
+    """stream_agent_loop always ends with a done event (§11.8.4 Stage 1)."""
+    mock_lt = MagicMock()
+    mock_lt.completion.return_value = iter([])  # empty stream -> no tool_calls, exit with done
+
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        events = list(
+            chat_mod.stream_agent_loop(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "x"}],
+                ui_context={},
+                profile_path=None,
+                max_turns=1,
+            )
+        )
+    assert events
+    assert events[-1].get("type") == "done"
+
+
+# --- 11.8.4 Stage 2: tool error feedback in run_agent_loop (§11.7.1) ---
+
+
+def test_run_agent_loop_appends_tool_error_to_messages(monkeypatch):
+    """When query_profile_db returns an error string, it is appended as role: tool (§11.7.1)."""
+    # Turn 1: model returns a query_profile_db tool call
+    fn1 = MagicMock()
+    fn1.name = "query_profile_db"
+    fn1.arguments = '{"sql_query": "SELECT bad FROM t"}'
+    tc1 = MagicMock()
+    tc1.id = "call_1"
+    tc1.function = fn1
+    msg1 = MagicMock(content="", tool_calls=[tc1])
+    resp1 = MagicMock(choices=[MagicMock(message=msg1)])
+
+    # Turn 2: model returns plain text (no tool calls)
+    msg2 = MagicMock(content="I see, that column does not exist.", tool_calls=[])
+    resp2 = MagicMock(choices=[MagicMock(message=msg2)])
+
+    mock_lt = MagicMock()
+    mock_lt.completion.side_effect = [resp1, resp2]
+
+    def query_runner(sql):
+        return "Error: no such column: bad"
+
+    api_messages = [
+        {"role": "system", "content": "You are a test."},
+        {"role": "user", "content": "What is in table t?"},
+    ]
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        content, actions = chat_mod.run_agent_loop(
+            model="gpt-4o",
+            api_messages=api_messages,
+            tools=chat_mod._tools_openai(),
+            query_runner=query_runner,
+            max_turns=5,
+        )
+    assert "does not exist" in content or "I see" in content
+    tool_msgs = [m for m in api_messages if m.get("role") == "tool"]
+    assert any("Error" in (m.get("content") or "") for m in tool_msgs)
+    assert any("no such column" in (m.get("content") or "") for m in tool_msgs)
+
+
+def test_run_agent_loop_exits_after_navigate(monkeypatch):
+    """run_agent_loop exits immediately after navigate_to_kernel (no extra LLM turn)."""
+    fn1 = MagicMock()
+    fn1.name = "navigate_to_kernel"
+    fn1.arguments = '{"target_name": "fast_kernel", "reason": "bottleneck"}'
+    tc1 = MagicMock()
+    tc1.id = "call_nav"
+    tc1.function = fn1
+    msg1 = MagicMock(content="Navigating.", tool_calls=[tc1])
+    resp1 = MagicMock(choices=[MagicMock(message=msg1)])
+
+    mock_lt = MagicMock()
+    mock_lt.completion.return_value = resp1
+
+    api_messages = [
+        {"role": "system", "content": "You are a test."},
+        {"role": "user", "content": "Go to fast_kernel"},
+    ]
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        content, actions = chat_mod.run_agent_loop(
+            model="gpt-4o",
+            api_messages=api_messages,
+            tools=chat_mod._tools_openai(),
+            query_runner=None,
+            max_turns=5,
+        )
+    # Must exit after 1 LLM call, not loop again
+    assert mock_lt.completion.call_count == 1
+    assert len(actions) == 1
+    assert actions[0]["type"] == "navigate_to_kernel"
+    assert actions[0]["target_name"] == "fast_kernel"
+    # No orphaned tool messages for navigation tools
+    tool_msgs = [m for m in api_messages if m.get("role") == "tool"]
+    assert not tool_msgs
+
+
+def test_stream_agent_loop_yields_action_and_done(monkeypatch):
+    """stream_agent_loop with navigate_to_kernel yields action event then done (§11.8.4)."""
+    # Chunk 1: text delta
+    chunk_text = MagicMock()
+    chunk_text.choices = [MagicMock(delta=MagicMock(
+        content="Going there.",
+        tool_calls=[],
+    ))]
+    chunk_text.usage = None
+    # Chunk 2: tool_call delta
+    fn_delta = MagicMock()
+    fn_delta.name = "navigate_to_kernel"
+    fn_delta.arguments = '{"target_name": "k1"}'
+    tc_delta = MagicMock()
+    tc_delta.index = 0
+    tc_delta.id = "call_1"
+    tc_delta.function = fn_delta
+    chunk_tc = MagicMock()
+    chunk_tc.choices = [MagicMock(delta=MagicMock(content=None, tool_calls=[tc_delta]))]
+    chunk_tc.usage = None
+
+    mock_lt = MagicMock()
+    mock_lt.completion.return_value = iter([chunk_text, chunk_tc])
+
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        events = list(
+            chat_mod.stream_agent_loop(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "go"}],
+                ui_context={},
+                profile_path=None,
+                max_turns=3,
+            )
+        )
+
+    types = [e.get("type") for e in events]
+    assert "text" in types
+    assert "action" in types
+    assert types[-1] == "done"
+    # Only one LLM call (exits after external tool)
+    assert mock_lt.completion.call_count == 1
+    action_ev = next(e for e in events if e.get("type") == "action")
+    assert action_ev["action"]["type"] == "navigate_to_kernel"
+    assert action_ev["action"]["target_name"] == "k1"
+
+
+def test_compact_old_tool_results_compacts_previous_turns():
+    """_compact_old_tool_results replaces large old tool content (§11.9 Phase 2.2)."""
+    api_messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "c1", "type": "function", "function": {"name": "query_profile_db", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c1", "name": "query_profile_db", "content": "x" * 300},
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "c2", "type": "function", "function": {"name": "query_profile_db", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "c2", "name": "query_profile_db", "content": "y" * 300},
+    ]
+    chat_mod._compact_old_tool_results(api_messages)
+    # Tool message from turn 1 (before last assistant) should be compacted.
+    assert api_messages[3]["content"] == "[Summary: DB query returned results.]"
+    # Tool message from turn 2 (most recent) should be unchanged.
+    assert api_messages[5]["content"] == "y" * 300
+
+
+def test_compact_old_tool_results_noop_first_turn():
+    """_compact_old_tool_results is a no-op when only one tool turn exists."""
+    api_messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "assistant", "content": None, "tool_calls": [{"id": "c1"}]},
+        {"role": "tool", "tool_call_id": "c1", "content": "z" * 300},
+    ]
+    import copy
+    original = copy.deepcopy(api_messages)
+    chat_mod._compact_old_tool_results(api_messages)
+    assert api_messages == original
+
+
+def test_run_agent_loop_consecutive_errors_add_hint(monkeypatch):
+    """After 2 consecutive DB errors, hint is appended to tool message (§11.9 Pitfall 2)."""
+    # Turn 1: query_profile_db → error
+    fn1 = MagicMock(name_attr="query_profile_db", arguments='{"sql_query": "bad"}')
+    fn1.name = "query_profile_db"
+    fn1.arguments = '{"sql_query": "bad1"}'
+    tc1 = MagicMock()
+    tc1.id = "c1"
+    tc1.function = fn1
+    msg1 = MagicMock(content="", tool_calls=[tc1])
+    resp1 = MagicMock(choices=[MagicMock(message=msg1)])
+
+    # Turn 2: query_profile_db → error again (2nd consecutive)
+    fn2 = MagicMock()
+    fn2.name = "query_profile_db"
+    fn2.arguments = '{"sql_query": "bad2"}'
+    tc2 = MagicMock()
+    tc2.id = "c2"
+    tc2.function = fn2
+    msg2 = MagicMock(content="", tool_calls=[tc2])
+    resp2 = MagicMock(choices=[MagicMock(message=msg2)])
+
+    # Turn 3: model gives up and answers in text
+    msg3 = MagicMock(content="I cannot retrieve this data.", tool_calls=[])
+    resp3 = MagicMock(choices=[MagicMock(message=msg3)])
+
+    mock_lt = MagicMock()
+    mock_lt.completion.side_effect = [resp1, resp2, resp3]
+
+    api_messages = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "q"},
+    ]
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        content, _ = chat_mod.run_agent_loop(
+            model="gpt-4o",
+            api_messages=api_messages,
+            tools=chat_mod._tools_openai(),
+            query_runner=lambda sql: "Error: no such table",
+            max_turns=5,
+        )
+    tool_msgs = [m for m in api_messages if m.get("role") == "tool"]
+    # Second error message should contain the hint
+    assert any("Repeated SQL errors" in (m.get("content") or "") for m in tool_msgs)
+    assert "cannot retrieve" in content
+
+
+def test_stream_agent_loop_token_warning(monkeypatch):
+    """stream_agent_loop yields a system warning when prompt_tokens exceeds threshold (§11.9 Phase 4.1)."""
+    chunk = MagicMock()
+    chunk.choices = [MagicMock(delta=MagicMock(content="Answer.", tool_calls=[]))]
+    chunk.usage = MagicMock(prompt_tokens=35_000, completion_tokens=100)
+
+    mock_lt = MagicMock()
+    mock_lt.completion.return_value = iter([chunk])
+
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        events = list(
+            chat_mod.stream_agent_loop(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": "hi"}],
+                ui_context={},
+                profile_path=None,
+                max_turns=1,
+            )
+        )
+    system_events = [e for e in events if e.get("type") == "system"]
+    # Should contain a token budget warning
+    assert any("tokens" in (e.get("content") or "").lower() for e in system_events)
+
+
+def test_build_system_prompt_with_schema_includes_sqlite_note():
+    """System prompt with schema includes SQLite3 dialect note (§11.9 Pitfall 1)."""
+    out = chat_mod._build_system_prompt({}, profile_schema="CREATE TABLE k(id INT)")
+    assert "SQLite3" in out or "sqlite" in out.lower()
+    assert "strftime" in out
+
+
+def test_chat_completion_stream_no_db_agent(monkeypatch):
+    """chat_completion_stream without DB agent uses stream_agent_loop (no profile)."""
+    chunk = MagicMock()
+    chunk.choices = [MagicMock(delta=MagicMock(content="Hello", tool_calls=[]))]
+    chunk.usage = None
+
+    mock_lt = MagicMock()
+    mock_lt.completion.return_value = iter([chunk])
+
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+    monkeypatch.delenv("NSYS_AI_DB_AGENT", raising=False)
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        body = json.dumps({"messages": [{"role": "user", "content": "hi"}]}).encode()
+        raw = b"".join(chat_mod.chat_completion_stream(body))
+    assert b"Hello" in raw
+    assert b"event: done" in raw
+
+
+# --- History distillation tests (§11.7) ---
+
+
+def test_distill_history_compresses_tool_turns():
+    """distill_history replaces intermediate tool call/result sequences with summaries."""
+    messages = [
+        {"role": "system", "content": "You are a test."},
+        {"role": "user", "content": "What is the slowest kernel?"},
+        # Intermediate: assistant with tool_calls + tool result
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {"id": "c1", "type": "function", "function": {"name": "query_profile_db", "arguments": "{}"}}
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "name": "query_profile_db", "content": '[{"name": "axpy", "total_ms": 42}]'},
+        # Final assistant answer (no tool_calls)
+        {"role": "assistant", "content": "The slowest kernel is axpy at 42ms."},
+    ]
+    result = chat_mod.distill_history(messages)
+    # System and user messages preserved
+    assert result[0]["role"] == "system"
+    assert result[1]["role"] == "user"
+    # Intermediate tool turn compressed into a single summary
+    assert result[2]["role"] == "system"
+    assert "query_profile_db" in result[2]["content"]
+    assert "1 result" in result[2]["content"]
+    # Final assistant answer preserved
+    assert result[3]["role"] == "assistant"
+    assert "axpy" in result[3]["content"]
+    # Total messages: 4 (system, user, summary, assistant) instead of 5
+    assert len(result) == 4
+
+
+def test_distill_history_preserves_simple_conversation():
+    """distill_history does not modify conversations without tool calls."""
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there!"},
+        {"role": "user", "content": "Explain this kernel"},
+        {"role": "assistant", "content": "This kernel is..."},
+    ]
+    result = chat_mod.distill_history(messages)
+    assert result == messages
+    assert len(result) == 4
+
+
+def test_distill_history_empty():
+    """distill_history returns empty list for empty input."""
+    assert chat_mod.distill_history([]) == []

--- a/tests/test_chat_gemini.py
+++ b/tests/test_chat_gemini.py
@@ -1,0 +1,70 @@
+"""
+Backend integration tests for AI chat using Gemini 2.5 Flash.
+Run with: GEMINI_API_KEY=<your-key> pytest tests/test_chat_gemini.py -v
+Skips all tests if GEMINI_API_KEY is not set.
+"""
+import json
+import os
+
+import pytest
+
+from nsys_tui import chat as chat_mod
+
+GEMINI_KEY = os.environ.get("GEMINI_API_KEY")
+MODEL_25_FLASH = "gemini/gemini-2.5-flash"
+
+
+@pytest.mark.skipif(not GEMINI_KEY, reason="GEMINI_API_KEY not set")
+def test_chat_completion_gemini_25_flash():
+    """Stage 1: Non-stream chat_completion with Gemini 2.5 Flash returns content."""
+    payload = {
+        "model": MODEL_25_FLASH,
+        "messages": [{"role": "user", "content": "Reply with exactly the word OK and nothing else."}],
+        "ui_context": {"view_state": {}, "stats": {}, "global_top_kernels": [], "visible_kernels_summary": []},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    out = chat_mod.chat_completion(body)
+    assert out is not None, "chat_completion should not return None when GEMINI_API_KEY is set"
+    assert "content" in out
+    assert isinstance(out["content"], str)
+    assert len(out["content"].strip()) > 0
+    assert "actions" in out
+    assert isinstance(out["actions"], list)
+
+
+@pytest.mark.skipif(not GEMINI_KEY, reason="GEMINI_API_KEY not set")
+def test_chat_completion_stream_gemini_25_flash():
+    """Stage 2: Stream chat_completion_stream with Gemini 2.5 Flash yields text then done."""
+    payload = {
+        "model": MODEL_25_FLASH,
+        "messages": [{"role": "user", "content": "Say hello in one short word."}],
+        "ui_context": {"view_state": {}, "stats": {}, "global_top_kernels": [], "visible_kernels_summary": []},
+        "stream": True,
+    }
+    body = json.dumps(payload).encode("utf-8")
+    gen = chat_mod.chat_completion_stream(body)
+    events = []
+    for chunk in gen:
+        assert isinstance(chunk, bytes)
+        s = chunk.decode("utf-8")
+        if s.startswith("event:"):
+            ev = s.split("\n")[0].replace("event:", "").strip()
+            events.append(ev)
+    assert "text" in events, "Expected at least one event: text"
+    assert "done" in events, "Expected event: done"
+
+
+@pytest.mark.skipif(not GEMINI_KEY, reason="GEMINI_API_KEY not set")
+def test_get_model_and_key_preferred_25_flash():
+    """Stage 3: _get_model_and_key with preferred_model=2.5-flash returns that model and key."""
+    model, key = chat_mod._get_model_and_key(MODEL_25_FLASH)
+    assert model == MODEL_25_FLASH
+    assert key == GEMINI_KEY
+
+
+@pytest.mark.skipif(not GEMINI_KEY, reason="GEMINI_API_KEY not set")
+def test_get_available_models_includes_gemini():
+    """Stage 4: get_available_models() includes Gemini 2.5 Flash when key is set."""
+    opts = chat_mod.get_available_models()
+    ids = [o["id"] for o in opts]
+    assert MODEL_25_FLASH in ids

--- a/tests/test_chat_two_requests_backend.py
+++ b/tests/test_chat_two_requests_backend.py
@@ -1,0 +1,123 @@
+"""
+Backend-only test: call chat_completion_stream twice in sequence (like first + second user message).
+Use this to see if the second reply fails on the server side or only in the frontend.
+
+Run from repo root with GEMINI_API_KEY set and Gemini Flash available:
+  python -m pytest tests/test_chat_two_requests_backend.py -v -s
+  or:  GEMINI_API_KEY=xxx python tests/test_chat_two_requests_backend.py
+"""
+import json
+import os
+import sys
+
+# Minimal ui_context similar to what the frontend sends
+MINIMAL_UI_CONTEXT = {
+    "view_state": {"time_range": {"min_ns": 0, "max_ns": 1e9}, "scope": "All regions"},
+    "selected_kernel": None,
+    "stats": {"total_gpu_ms": 100.0, "kernel_count": 10, "nvtx_count": 5, "total_kernel_count": 10},
+    "global_top_kernels": [],
+    "visible_kernels_summary": [],
+}
+
+
+def _build_payload(messages: list, model: str = "gemini/gemini-2.5-flash") -> bytes:
+    payload = {
+        "messages": messages,
+        "ui_context": MINIMAL_UI_CONTEXT,
+        "stream": True,
+        "model": model,
+    }
+    return json.dumps(payload).encode("utf-8")
+
+
+def _consume_sse_stream(gen):
+    """Consume generator of SSE bytes; return (full_text, got_done, error_from_done)."""
+    buf = b""
+    full_text = ""
+    got_done = False
+    error_from_done = None
+    for chunk in gen:
+        buf += chunk
+        while b"\n\n" in buf:
+            block, buf = buf.split(b"\n\n", 1)
+            block = block.decode("utf-8", errors="replace")
+            ev = ""
+            dat = ""
+            for line in block.split("\n"):
+                if line.startswith("event:"):
+                    ev = line[6:].strip()
+                elif line.startswith("data:"):
+                    dat = line[5:].strip()
+            if ev == "text" and dat:
+                try:
+                    d = json.loads(dat)
+                    full_text += d.get("chunk") or ""
+                except json.JSONDecodeError:
+                    pass
+            elif ev == "done" and dat:
+                got_done = True
+                try:
+                    d = json.loads(dat)
+                    error_from_done = d.get("error")
+                except json.JSONDecodeError:
+                    pass
+    return full_text.strip(), got_done, error_from_done
+
+
+def run_two_requests():
+    if not os.environ.get("GEMINI_API_KEY"):
+        print("Set GEMINI_API_KEY to run this test.", file=sys.stderr)
+        return 2
+
+    from nsys_tui import chat
+
+    model = "gemini/gemini-2.5-flash"
+
+    # Request 1: single user message
+    messages_1 = [{"role": "user", "content": "Explain this kernel: nvjet_tst_192x192_64x4_2x1_v_bz_coopB_TNN"}]
+    body_1 = _build_payload(messages_1, model=model)
+    print("--- Request 1 (first message) ---")
+    gen_1 = chat.chat_completion_stream(body_1)
+    text_1, done_1, err_1 = _consume_sse_stream(gen_1)
+    if err_1:
+        print(f"Request 1 error: {err_1}")
+        return 1
+    if not done_1:
+        print("Request 1: stream ended without event:done")
+        return 1
+    print(f"Request 1: got_done=OK, response length={len(text_1)} chars")
+    print(f"Request 1 reply (first 200 chars): {text_1[:200]}...")
+
+    # Request 2: user, assistant (first reply), user (second question) — simulates "second turn"
+    messages_2 = [
+        {"role": "user", "content": "Explain this kernel: nvjet_tst_192x192_64x4_2x1_v_bz_coopB_TNN"},
+        {"role": "assistant", "content": text_1[:8000] if len(text_1) > 8000 else text_1},
+        {"role": "user", "content": "Explain this kernel: ncclDevKernel_ReduceScatter_Sum_bf16_RING_LL"},
+    ]
+    body_2 = _build_payload(messages_2, model=model)
+    print("\n--- Request 2 (second message, with history) ---")
+    gen_2 = chat.chat_completion_stream(body_2)
+    text_2, done_2, err_2 = _consume_sse_stream(gen_2)
+    if err_2:
+        print(f"Request 2 error: {err_2}")
+        return 1
+    if not done_2:
+        print("Request 2: stream ended without event:done")
+        return 1
+    print(f"Request 2: got_done=OK, response length={len(text_2)} chars")
+    print(f"Request 2 reply (first 200 chars): {text_2[:200]}...")
+
+    print("\n--- Both requests completed successfully from backend. ---")
+    return 0
+
+
+def test_two_requests_backend():
+    """Pytest: run two stream requests in sequence. Skip if no GEMINI_API_KEY."""
+    if not os.environ.get("GEMINI_API_KEY"):
+        import pytest
+        pytest.skip("GEMINI_API_KEY not set")
+    assert run_two_requests() == 0
+
+
+if __name__ == "__main__":
+    sys.exit(run_two_requests())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,6 @@
 """Basic smoke tests for nsys-ai package."""
+import json
+import sqlite3
 import subprocess
 import sys
 
@@ -25,5 +27,14 @@ def test_subcommands():
         capture_output=True, text=True)
     for cmd in ['info', 'analyze', 'open', 'summary', 'overlap', 'nccl', 'iters', 'tree', 'markdown',
                 'search', 'export-csv', 'export-json', 'export', 'viewer', 'timeline-html',
-                'web', 'perfetto', 'timeline-web', 'tui', 'timeline']:
+                'web', 'perfetto', 'timeline-web', 'tui', 'timeline', 'chat']:
         assert cmd in result.stdout, f"Missing subcommand: {cmd}"
+
+
+def test_chat_subcommand_help():
+    """chat subcommand should have --help and accept a profile argument."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_tui", "chat", "--help"],
+        capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "profile" in result.stdout

--- a/tests/test_tools_profile.py
+++ b/tests/test_tools_profile.py
@@ -1,0 +1,170 @@
+"""Tests for tools_profile (query_profile_db guardrails, get_profile_schema)."""
+import json
+import sqlite3
+
+import pytest
+
+
+def test_query_profile_db_readonly_guardrail():
+    """query_profile_db rejects INSERT/UPDATE/DELETE/DROP/ALTER/CREATE."""
+    from nsys_tui.tools_profile import query_profile_db
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t(id INT)")
+    for bad in ("INSERT INTO t VALUES(1)", "UPDATE t SET id=1", "DELETE FROM t",
+                "DROP TABLE t", "ALTER TABLE t RENAME TO x", "CREATE TABLE x(y INT)"):
+        out = query_profile_db(conn, bad)
+        assert "Error" in out
+    conn.close()
+
+
+def test_query_profile_db_limit_enforced():
+    """query_profile_db enforces LIMIT; adaptive limit applies based on column count."""
+    from nsys_tui.tools_profile import query_profile_db, DEFAULT_MAX_LIMIT
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t(id INT, name TEXT, val REAL, extra TEXT)")
+    conn.executemany("INSERT INTO t VALUES(?,?,?,?)", [(i, f"k{i}", float(i), "x") for i in range(200)])
+    # Multi-column (4 cols → adaptive limit = max(20, 50//2) = 25): never return all 200 rows.
+    out = query_profile_db(conn, "SELECT id, name, val, extra FROM t")
+    rows = json.loads(out)
+    assert len(rows) <= max(20, DEFAULT_MAX_LIMIT // 2)
+    # Explicit LIMIT 200 on multi-column query is capped to adaptive limit.
+    out2 = query_profile_db(conn, "SELECT id, name, val, extra FROM t LIMIT 200")
+    rows2 = json.loads(out2)
+    assert len(rows2) <= max(20, DEFAULT_MAX_LIMIT // 2)
+    conn.close()
+
+
+def test_query_profile_db_rejects_select_star():
+    """query_profile_db rejects SELECT * with a clear error (§11.7.3, §11.8.4 Stage 2)."""
+    from nsys_tui.tools_profile import query_profile_db
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t(a INT, b INT)")
+    out = query_profile_db(conn, "SELECT * FROM t LIMIT 10")
+    assert "Error" in out
+    assert "SELECT *" in out or "select only the columns" in out.lower()
+    conn.close()
+
+
+def test_query_profile_db_valid_select():
+    """query_profile_db returns JSON array of rows for valid SELECT."""
+    from nsys_tui.tools_profile import query_profile_db
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.execute("CREATE TABLE k(name TEXT, start INT)")
+    conn.execute("INSERT INTO k VALUES('axpy', 100)")
+    out = query_profile_db(conn, "SELECT name, start FROM k LIMIT 10")
+    rows = json.loads(out)
+    assert rows == [{"name": "axpy", "start": 100}]
+    conn.close()
+
+
+def test_get_profile_schema_in_memory():
+    """get_profile_schema returns DDL for requested tables."""
+    from nsys_tui.tools_profile import get_profile_schema
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL(start INT, name TEXT)")
+    conn.execute("CREATE TABLE NVTX_EVENTS(text TEXT)")
+    schema = get_profile_schema(conn, table_names=("CUPTI_ACTIVITY_KIND_KERNEL", "NVTX_EVENTS"))
+    assert "CUPTI_ACTIVITY_KIND_KERNEL" in schema
+    assert "NVTX_EVENTS" in schema
+    conn.close()
+
+
+def test_get_profile_schema_cached_reuses_cache():
+    """get_profile_schema_cached returns same result without querying DB again (§11.7.7)."""
+    from nsys_tui.tools_profile import get_profile_schema_cached, _schema_cache
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE NVTX_EVENTS(text TEXT)")
+    path = "/tmp/test_cache_path_unique_12345.sqlite"
+    # Clear any stale cache entry
+    _schema_cache.pop(path, None)
+
+    schema1 = get_profile_schema_cached(conn, path)
+    # Close the connection; a second call must use the cache, not the closed conn
+    conn.close()
+    schema2 = get_profile_schema_cached(None, path)  # conn unused when cache hits
+    assert schema1 == schema2
+
+    # Cleanup
+    _schema_cache.pop(path, None)
+
+
+def test_get_profile_schema_cached_no_path():
+    """get_profile_schema_cached with path=None always calls get_profile_schema."""
+    from nsys_tui.tools_profile import get_profile_schema_cached
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE NVTX_EVENTS(col INT)")
+    schema = get_profile_schema_cached(conn, None)
+    assert "NVTX_EVENTS" in schema
+    conn.close()
+
+
+def test_open_profile_readonly_for_worker_returns_connection(tmp_path):
+    """open_profile_readonly_for_worker returns a usable read-only connection (§11.7.5)."""
+    from nsys_tui.tools_profile import open_profile_readonly_for_worker
+    db = tmp_path / "test.sqlite"
+    # Create a DB with one table
+    setup = sqlite3.connect(str(db))
+    setup.execute("CREATE TABLE t(v INT)")
+    setup.execute("INSERT INTO t VALUES(42)")
+    setup.commit()
+    setup.close()
+
+    conn = open_profile_readonly_for_worker(str(db))
+    rows = conn.execute("SELECT v FROM t").fetchall()
+    assert rows[0][0] == 42
+    conn.close()
+
+
+def test_query_profile_db_empty_query():
+    """query_profile_db rejects empty or whitespace-only queries."""
+    from nsys_tui.tools_profile import query_profile_db
+    conn = sqlite3.connect(":memory:")
+    assert "Error" in query_profile_db(conn, "")
+    assert "Error" in query_profile_db(conn, "   ")
+    conn.close()
+
+
+def test_adaptive_limit_narrow_query():
+    """Single-column queries get up to 2× base limit (§11.9 Phase 2.1)."""
+    from nsys_tui.tools_profile import query_profile_db, DEFAULT_MAX_LIMIT
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t(name TEXT)")
+    for i in range(200):
+        conn.execute("INSERT INTO t VALUES(?)", (f"k{i}",))
+    out = query_profile_db(conn, "SELECT name FROM t")
+    rows = json.loads(out)
+    # Single-column → effective limit = min(100, DEFAULT_MAX_LIMIT * 2)
+    assert len(rows) <= min(100, DEFAULT_MAX_LIMIT * 2)
+    assert len(rows) > DEFAULT_MAX_LIMIT  # must be higher than the default limit
+    conn.close()
+
+
+def test_adaptive_limit_wide_query():
+    """Queries with 4+ columns get a reduced limit (§11.9 Phase 2.1)."""
+    from nsys_tui.tools_profile import query_profile_db, DEFAULT_MAX_LIMIT
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE t(a TEXT, b TEXT, c TEXT, d TEXT, e TEXT)")
+    for i in range(100):
+        conn.execute("INSERT INTO t VALUES(?,?,?,?,?)", (f"v{i}",)*5)
+    out = query_profile_db(conn, "SELECT a, b, c, d, e FROM t")
+    rows = json.loads(out)
+    # 5 columns → effective limit = max(20, DEFAULT_MAX_LIMIT // 2) = 25
+    expected_max = max(20, DEFAULT_MAX_LIMIT // 2)
+    assert len(rows) <= expected_max
+    conn.close()
+
+
+def test_query_profile_db_truncates_large_results():
+    """query_profile_db truncates JSON output beyond DEFAULT_MAX_JSON_CHARS (§11.7.6)."""
+    from nsys_tui.tools_profile import query_profile_db, DEFAULT_MAX_JSON_CHARS
+    conn = sqlite3.connect(":memory:")
+    # Create rows with long string values to exceed the JSON char limit
+    conn.execute("CREATE TABLE t(v TEXT)")
+    long_val = "x" * 500
+    conn.executemany("INSERT INTO t VALUES(?)", [(long_val,)] * 50)
+    out = query_profile_db(conn, "SELECT v FROM t", max_limit=50)
+    # Should be truncated with actionable hint
+    assert "Truncated" in out
+    assert "refine your query" in out.lower() or "reduce the LIMIT" in out
+    conn.close()


### PR DESCRIPTION
### PR Title

**feat ai: refine Brain & Navigator UX across web + TUI**


### PR Description (brief)

- **Web AI Profiler**
  - Slims `ui_context` when `NSYS_AI_DB_AGENT=1` by removing remaining global stats that should be answered via `query_profile_db`.
  - Improves navigation UX: `navigate_to_kernel` now always drives the Kernels tab (filter + focus), and navigation confirmations are rendered as lightweight system messages instead of full assistant bubbles.
  - Adds sensible fallbacks for edge cases where the model returns only tools or even no text/tool at all, so the AI bubble is never visually “empty”.

- **Textual Chat TUI**
  - Introduces a dedicated kernel info card in the right panel, showing the currently selected / navigated kernel with total time, call count, and average duration.
  - Removes visual noise in the streaming area and tweaks styling to make the layout clearer while keeping all key information visible.
  - Aligns TUI navigation messaging with the web behavior (text + nav vs nav-only handling).

- **Agent / DB Tooling**
  - Tightens `query_profile_db` guardrails and messaging so oversized or badly scoped queries produce more helpful errors.
  - Adds token‑/history‑related helpers and tests to keep the Text‑to‑SQL agent safer and more predictable over long conversations.

- **Tests**
  - Extends `tests/test_tools_profile.py` and `tests/test_chat.py` to cover new DB guards, history compaction hooks, and streaming agent behavior.
  - Keeps existing Gemini/backend tests as optional (skipped) so the suite remains green without provider credentials.


### Usage Notes (how to try it)

- **CLI Text‑to‑SQL agent**

  ```bash
  export GEMINI_API_KEY=...        # or ANTHROPIC_API_KEY / OPENAI_API_KEY
  export NSYS_AI_MODEL=gemini/gemini-2.5-flash

  python3 test_agent.py <sqlite files> \
    "What is the very first kernel in this profile?"
  ```

- **Web Brain & Navigator**

  ```bash
  export GEMINI_API_KEY=...
  export NSYS_AI_MODEL=gemini/gemini-2.5-flash
  export NSYS_AI_DB_AGENT=1

  nsys-ai web data/nsys-hero/distca-0/baseline.t128k.host-fs-mbz-gpu-899.sqlite \
    --gpu 4 --trim 30 50
  ```

  In the browser:

  - Use **AI Profiler** on the right.
  - Ask things like:
    - “Explain this kernel: \<name\>”
    - “Navigate to the last Flash Attention kernel in the profile.”
  - The Kernels tab should automatically jump + filter when navigation tools fire, and the green bubble will show a short navigation explanation if there is no other text.

- **Textual Chat TUI**

  ```bash
  python3 -m nsys_tui chat data/nsys-hero/distca-0/baseline.t128k.host-fs-mbz-gpu-899.sqlite
  ```

  - Left panel: top‑k kernels by GPU time.
  - Right top: kernel info card (selected / navigated kernel summary).
  - Right middle: chat log; bottom input: “Ask about this profile…”.
  - Type questions or navigation requests (e.g. “Take me to the slowest kernel overall”) and watch both the info card and table selection update accordingly.

example question: #21 