### PR TITLE
fix: address PR #33 timeline review comments

### DIFF
--- a/src/nsys_tui/timeline/app.py
+++ b/src/nsys_tui/timeline/app.py
@@ -99,8 +99,8 @@ class NsysTimelineApp(App):
         Binding("shift+right", "page_right", "⇒", show=False),
         Binding("up,k", "prev_stream", "↑ stream", show=False),
         Binding("down,j", "next_stream", "↓ stream", show=False),
-        Binding("tab", "next_kernel", "Next kernel"),
-        Binding("shift+tab", "prev_kernel", "Prev kernel"),
+        Binding("tab", "next_kernel", "Next kernel", priority=True),
+        Binding("shift+tab", "prev_kernel", "Prev kernel", priority=True),
         Binding("plus,equals_sign", "zoom_in", "Zoom in"),
         Binding("minus,underscore", "zoom_out", "Zoom out"),
         Binding("a", "toggle_time_mode", "Abs/rel time"),
@@ -118,6 +118,7 @@ class NsysTimelineApp(App):
         Binding("/", "open_filter", "Filter"),
         Binding("n", "clear_filter", "Clear filter"),
         Binding("m", "open_min_dur", "Min dur"),
+        Binding("P", "toggle_path_mode", "Path mode"),
         Binding("T", "toggle_tick_density", "Ticks", show=False),
         Binding("home", "jump_start", "Start", show=False),
         Binding("end", "jump_end", "End", show=False),
@@ -217,6 +218,11 @@ class NsysTimelineApp(App):
             self.notify(f"Failed to load profile: {e}", severity="error")
             return
         self._load_from_json(json_roots)
+        # Push NVTX spans to bottom panel for hierarchy view
+        if self._is_mounted:
+            self.query_one("#bottom-panel", BottomPanel).set_nvtx_spans(
+                getattr(self, "_nvtx_spans", [])
+            )
         self._push_canvas_state()
         self._update_title()
 
@@ -248,6 +254,10 @@ class NsysTimelineApp(App):
         if not self._kernels and self._db_path:
             self._load_from_db()
         else:
+            # Push NVTX spans to bottom panel for hierarchy view
+            self.query_one("#bottom-panel", BottomPanel).set_nvtx_spans(
+                getattr(self, "_nvtx_spans", [])
+            )
             self._push_canvas_state()
             self._update_title()
         # Focus the canvas so App-level key bindings work.
@@ -370,16 +380,40 @@ class NsysTimelineApp(App):
     def action_next_kernel(self) -> None:
         stream = self._streams[self.selected_stream_idx] if self._streams else "?"
         ks = self._stream_kernels.get(stream, [])
+        if not ks:
+            return
         ki = kernel_index_at_time(ks, self.cursor_ns)
-        if ki >= 0 and ki + 1 < len(ks):
-            self.cursor_ns = ks[ki + 1].start_ns
+        if ki < 0:
+            return
+        # If cursor is already on this kernel, go to next; otherwise snap to it first
+        if ks[ki].start_ns <= self.cursor_ns <= ks[ki].end_ns:
+            if ki + 1 < len(ks):
+                self.cursor_ns = ks[ki + 1].start_ns
+        else:
+            # Cursor is between kernels — snap to the nearest one ahead
+            if self.cursor_ns < ks[ki].start_ns:
+                self.cursor_ns = ks[ki].start_ns
+            elif ki + 1 < len(ks):
+                self.cursor_ns = ks[ki + 1].start_ns
 
     def action_prev_kernel(self) -> None:
         stream = self._streams[self.selected_stream_idx] if self._streams else "?"
         ks = self._stream_kernels.get(stream, [])
+        if not ks:
+            return
         ki = kernel_index_at_time(ks, self.cursor_ns)
-        if ki > 0:
-            self.cursor_ns = ks[ki - 1].start_ns
+        if ki < 0:
+            return
+        # If cursor is on this kernel, go to previous; otherwise snap to it first
+        if ks[ki].start_ns <= self.cursor_ns <= ks[ki].end_ns:
+            if ki > 0:
+                self.cursor_ns = ks[ki - 1].start_ns
+        else:
+            # Cursor is between kernels — snap to the nearest one behind
+            if self.cursor_ns > ks[ki].end_ns:
+                self.cursor_ns = ks[ki].start_ns
+            elif ki > 0:
+                self.cursor_ns = ks[ki - 1].start_ns
 
     def action_zoom_in(self) -> None:
         self.ns_per_col = zoom_ns_per_col(self.ns_per_col, -1, self._time_span)
@@ -410,6 +444,14 @@ class NsysTimelineApp(App):
         self._push_canvas_state()
         self._update_title()
         self.notify(f"Mode: {'LOGICAL (NVTX hidden)' if self._logical_mode else 'TIME'}", timeout=2)
+
+    def action_toggle_path_mode(self) -> None:
+        """Toggle NVTX path display between breadcrumb and hierarchy ('P' key)."""
+        bp = self.query_one("#bottom-panel", BottomPanel)
+        bp.toggle_path_mode()
+        self._update_bottom_panel()
+        mode = bp._path_mode
+        self.notify(f"Path: {mode}", timeout=2)
 
     def action_toggle_demangled(self) -> None:
         self._show_demangled = not self._show_demangled

--- a/src/nsys_tui/timeline/canvas.py
+++ b/src/nsys_tui/timeline/canvas.py
@@ -192,7 +192,16 @@ class TimelineCanvas(Widget):
             s_col = max(0, int((span.start_ns - self.viewport_start_ns) / max(self.ns_per_col, 1)))
             e_col = min(timeline_w - 1, int((span.end_ns - self.viewport_start_ns) / max(self.ns_per_col, 1)))
             span_w = max(1, e_col - s_col + 1)
-            content = f"[{span.name}]" if span_w >= len(span.name) + 2 else "█" * span_w
+            if span_w >= len(span.name) + 2:
+                content = f"[{span.name}]"
+            elif span_w >= 5:
+                # Truncated name with ellipsis: [na…]
+                inner = span_w - 3  # room for [ … ]
+                content = f"[{span.name[:inner]}…]"
+            elif span_w >= 2:
+                content = f"[{']' if span_w == 2 else span.name[:span_w - 2] + ']'}"
+            else:
+                content = "│"  # thin marker instead of fat block
             for ci, ch in enumerate(content[:span_w]):
                 if s_col + ci < timeline_w:
                     cells[s_col + ci] = ch
@@ -212,21 +221,32 @@ class TimelineCanvas(Widget):
     ) -> Strip:
         from ..tui_models import short_kernel_name as _short_name
 
-        is_block_row = (within == row_h - 1)
         ci = self.stream_color_idx.get(stream, stream_idx % len(_STREAM_COLORS))
+        # Check if this stream is predominantly NCCL — match label color to kernel color
+        all_kernels = self.stream_kernels.get(stream, [])
+        is_nccl_stream = all_kernels and all_kernels[0].is_nccl
+        label_color = _NCCL_COLOR if is_nccl_stream else _STREAM_COLORS[ci % len(_STREAM_COLORS)]
         label_style = Style(
-            color=_STREAM_COLORS[ci % len(_STREAM_COLORS)],
+            color=label_color,
             bold=is_selected,
             dim=not is_selected,
         )
-        label_seg = Segment(f"S{stream}".ljust(label_w - 1), label_style)
+        # Only show stream label on the first sub-row
+        if within == 0:
+            label_seg = Segment(f"S{stream}".ljust(label_w - 1), label_style)
+        else:
+            label_seg = Segment(" " * (label_w - 1), Style())
 
         kernels = filter_kernels(
             self.stream_kernels.get(stream, []),
             self.filter_text,
             self.min_dur_us,
         )
-        cells = [(" ", Style())] * timeline_w  # (char, style)
+        cells = [(" ", Style())] * timeline_w
+
+        is_block_row = (within == row_h - 1)
+        # How many label rows do we have above the block row?
+        label_row_count = row_h - 1  # row_h=1 → 0 label rows, row_h=2 → 1, row_h=3 → 2, etc.
 
         for k in kernels:
             s_col = int((k.start_ns - self.viewport_start_ns) / max(self.ns_per_col, 1))
@@ -241,31 +261,56 @@ class TimelineCanvas(Widget):
             style = _stream_color(ci, is_at_cursor, k.heat, k.is_nccl)
 
             if is_block_row:
+                # Last row: block bars
                 char = "█"
                 for col in range(s_col, s_col + block_w):
                     if col < timeline_w:
                         cells[col] = (char, style)
-            else:
-                # Label row: kernel name + duration, respecting show_demangled
+            elif label_row_count > 0:
+                # Determine which label row this kernel belongs to.
+                # Row 0 (within=0): ONLY the focused/cursor kernel
+                # Rows 1+ (within=1..): other kernels distributed to minimize overlap
+                if is_at_cursor:
+                    target_row = 0
+                elif label_row_count >= 2:
+                    # Distribute non-focused kernels across rows 1..label_row_count-1
+                    # Use position-based assignment to spread them out
+                    target_row = 1 + (s_col % max(1, label_row_count - 1))
+                else:
+                    # Only 1 label row total — everything shares row 0
+                    target_row = 0
+
+                if within != target_row:
+                    continue
+
+                # Render kernel label with overflow
                 name_to_use = (k.demangled if self.show_demangled and k.demangled else k.name)
                 short = _short_name(name_to_use)
                 dur = _fmt_dur(k.duration_ms)
-                if block_w >= len(short) + len(dur) + 2:
+                if len(short) + len(dur) + 1 <= 40:
                     text = f"{short} {dur}"
-                elif block_w >= len(short):
-                    text = short[:block_w]
-                elif block_w >= 2:
-                    text = dur[:block_w]
                 else:
-                    text = ""
-                for ci2, ch in enumerate(text[:block_w]):
+                    text = short
+
+                # Calculate available space: extend rightward into empty cells
+                avail = block_w
+                for probe in range(s_col + block_w, min(s_col + len(text), timeline_w)):
+                    if cells[probe][0] == " ":
+                        avail += 1
+                    else:
+                        break
+
+                label_text = text[:avail] if avail >= 2 else ""
+                for ci2, ch in enumerate(label_text):
                     if s_col + ci2 < timeline_w:
                         cells[s_col + ci2] = (ch, style)
 
-        # Cursor line
+        # Cursor highlight — preserve the existing character, just change its style
         cursor_col = int((self.cursor_ns - self.viewport_start_ns) / max(self.ns_per_col, 1))
         if 0 <= cursor_col < timeline_w:
-            cells[cursor_col] = ("│", Style(color="yellow", bold=True))
+            existing_ch, _ = cells[cursor_col]
+            ch = existing_ch if existing_ch.strip() else "│"
+            cells[cursor_col] = (ch, Style(color="black", bgcolor="yellow", bold=True))
 
         segments: list[Segment] = [label_seg]
         # Compress runs of same style

--- a/src/nsys_tui/timeline/widgets.py
+++ b/src/nsys_tui/timeline/widgets.py
@@ -27,17 +27,30 @@ class BottomPanel(Widget):
 
     DEFAULT_CSS = """
     BottomPanel {
-        height: 4;
+        height: auto;
+        min-height: 4;
+        max-height: 12;
         dock: bottom;
         background: $surface-darken-2;
         border-top: solid $primary-darken-2;
     }
     """
 
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)
+        self._path_mode: str = "breadcrumb"  # "breadcrumb" or "hierarchy"
+        self._nvtx_spans: list = []
+
     def compose(self) -> ComposeResult:
         yield Static("", id="bp-kernel")
         yield Static("", id="bp-nvtx")
         yield Static("", id="bp-stats")
+
+    def toggle_path_mode(self) -> None:
+        self._path_mode = "hierarchy" if self._path_mode == "breadcrumb" else "breadcrumb"
+
+    def set_nvtx_spans(self, spans: list) -> None:
+        self._nvtx_spans = spans
 
     def update(  # type: ignore[override]
         self,
@@ -68,7 +81,10 @@ class BottomPanel(Widget):
         k_w.update(k_info)
 
         if kernel.nvtx_path:
-            n_w.update(Text(f" ⌂ {kernel.nvtx_path}", style="blue dim"))
+            if self._path_mode == "hierarchy":
+                n_w.update(self._render_hierarchy(kernel.nvtx_path))
+            else:
+                n_w.update(Text(f" ⌂ {kernel.nvtx_path}", style="bright_cyan"))
         else:
             n_w.update("")
 
@@ -79,6 +95,21 @@ class BottomPanel(Widget):
         e_pos = min(bar_w, max(s_pos + 1, int((kernel.end_ns - time_start) / span * bar_w)))
         bar = "─" * s_pos + "█" * (e_pos - s_pos) + "─" * (bar_w - e_pos)
         s_w.update(Text(f" [{_fmt_ns(time_start)}] {bar} [{_fmt_ns(time_end)}]", style="yellow dim"))
+
+    def _render_hierarchy(self, nvtx_path: str) -> Text:
+        """Render NVTX path as indented hierarchy with timing from spans."""
+        parts = [p.strip() for p in nvtx_path.split(" > ") if p.strip()]
+        lines: list[str] = []
+        for i, part in enumerate(parts):
+            indent = "  " * (i + 1)
+            # Try to find matching NVTX span for timing info
+            timing = ""
+            for s in self._nvtx_spans:
+                if s.name == part and s.depth == i:
+                    timing = f"  {_fmt_dur((s.end_ns - s.start_ns) / 1e6)}  [{_fmt_ns(s.start_ns)}→{_fmt_ns(s.end_ns)}]"
+                    break
+            lines.append(f"{indent}📂 {part}{timing}")
+        return Text("\n".join(lines), style="bright_cyan") if lines else Text("")
 
 
 class ConfigPanel(Widget):
@@ -114,14 +145,14 @@ class ConfigPanel(Widget):
     _ITEMS = [
         ("selected_rows", "Selected stream rows", 1, 5),
         ("default_rows", "Other stream rows", 1, 3),
-        ("nvtx_depth", "NVTX depth", 0, 8),
+        ("nvtx_depth", "NVTX depth (0=hide)", 0, 99),
     ]
 
     def __init__(self, **kwargs: object) -> None:
         super().__init__(**kwargs)
-        self.selected_rows = 2
+        self.selected_rows = 3
         self.default_rows = 1
-        self.nvtx_depth = 4
+        self.nvtx_depth = 99  # 99 = show all available levels
         self._cursor = 0
 
     def compose(self) -> ComposeResult:

--- a/src/nsys_tui/tree/app.py
+++ b/src/nsys_tui/tree/app.py
@@ -215,10 +215,25 @@ class NsysTreeApp(App):
             bubble_threshold_us=self.bubble_threshold_us,
         )
 
-    def _refresh_table(self) -> None:
+    def _refresh_table(self, preserve_cursor: bool = True) -> None:
+        # Remember the currently selected node so we can restore position.
+        prev_node: TreeNode | None = None
+        if preserve_cursor and self._visible:
+            table = self.query_one("#tree-table", TreeTable)
+            row = table.cursor_row
+            if 0 <= row < len(self._visible):
+                prev_node = self._visible[row]
+
         self._visible = self._get_visible()
         table = self.query_one("#tree-table", TreeTable)
         table.populate(self._visible, self.view_mode, self.show_demangled)
+
+        # Restore cursor to the same node (or closest position).
+        if prev_node is not None:
+            new_idx = node_index_in_visible(self._visible, prev_node)
+            if new_idx is not None:
+                self.query_one(DataTable).move_cursor(row=new_idx)
+
         self._update_detail_bar()
 
     def _update_title(self) -> None:

--- a/src/nsys_tui/tree/chat.py
+++ b/src/nsys_tui/tree/chat.py
@@ -134,8 +134,10 @@ class ChatPanel(Widget):
 
     def _on_text_chunk(self, chunk: str) -> None:
         stream_label = self.query_one("#chat-stream", Static)
-        current = str(stream_label.renderable)
-        stream_label.update(current + chunk)
+        if not hasattr(self, "_stream_buffer"):
+            self._stream_buffer = ""
+        self._stream_buffer += chunk
+        stream_label.update(self._stream_buffer)
 
     def _on_system_event(self, content: str) -> None:
         self.query_one("#chat-log", RichLog).write(
@@ -148,6 +150,7 @@ class ChatPanel(Widget):
         if final_content:
             log.write(f"[bold green]AI:[/bold green] {final_content}")
         stream_label.update("")
+        self._stream_buffer = ""
         with self._lock:
             if final_content:
                 self._history.append({"role": "assistant", "content": final_content})


### PR DESCRIPTION
Fixes raised in PR #33 review:

- **NVTX rendering**: thin markers (│, [n…]) instead of opaque █ blocks for narrow spans
- **Tab/Shift+Tab**: priority bindings + better between-kernel jump logic
- **Breadcrumb color**: blue dim → bright_cyan for readability
- **Multi-row layout**: focused kernel gets dedicated row; other labels distributed
- **Cursor**: yellow background highlight instead of overwriting text with │
- **Hierarchy path toggle**: P key cycles breadcrumb ↔ directory-style with per-level timing
- **NCCL stream labels**: match magenta kernel color
- **AI chat crash**: replace Static.renderable (Textual 8 compat) with buffer string
- **Tree scroll fix**: preserve cursor position on expand/collapse
- **Config defaults**: selected_rows=3, nvtx_depth=all