### PR TITLE
feat: multi-GPU stacked timeline + visual improvements

### DIFF
--- a/src/nsys_tui/timeline/app.py
+++ b/src/nsys_tui/timeline/app.py
@@ -67,6 +67,7 @@ from .logic import (
     find_kernel_by_name,
     kernel_at_time,
     kernel_index_at_time,
+    pack_merged_rows,
     time_bounds,
     zoom_ns_per_col,
 )
@@ -108,9 +109,18 @@ class NsysTimelineApp(App):
         Binding("d", "toggle_demangled", "Demangled"),
         Binding("h", "toggle_help", "Help"),
         Binding("C", "toggle_config", "Config"),
-        Binding("B", "save_bookmark", "Bookmark"),
+        Binding("P", "toggle_path_mode", "Path mode"),
+        Binding("S", "toggle_merged", "Merged view"),
+        Binding("I", "toggle_labels", "Labels"),
+        Binding("T", "toggle_tick_density", "Ticks", show=False),
+        Binding("home", "jump_start", "Start", show=False),
+        Binding("end", "jump_end", "End", show=False),
+        Binding("g", "jump_to_time", "Jump to ns", show=False),
+        Binding("B", "toggle_bookmark", "Bookmark"),
         Binding("comma", "prev_bookmark", "← bookmark", show=False),
         Binding("full_stop", "next_bookmark", "→ bookmark", show=False),
+        Binding("r", "set_range_start", "Range start", show=False),
+        Binding("R", "set_range_end", "Range end / clear", show=False),
         Binding("apostrophe", "show_bookmark_list", "BM list", show=False),
         Binding("left_square_bracket", "range_start", "[range", show=False),
         Binding("right_square_bracket", "range_end", "range]", show=False),
@@ -139,28 +149,40 @@ class NsysTimelineApp(App):
     def __init__(
         self,
         db_path: str,
-        device: int,
-        trim: tuple[int, int] | None,
+        device: int | list[int] = 0,
+        trim: tuple[int, int] | None = None,
         min_ms: float = 0,
         json_roots: list[dict] | None = None,
     ) -> None:
         super().__init__()
         self._db_path = db_path
-        self._device = device
+        # Support single device int or list of devices
+        if isinstance(device, int):
+            self._devices: list[int] = [device]
+        else:
+            self._devices = list(device)
+        self._device = self._devices[0]  # backward compat for ChatPanel etc.
         self._trim = trim or (0, 0)
 
         # ALL plain attributes MUST be initialized before any reactive is set.
-        # Reactive setters fire watchers immediately, and watchers access these fields.
 
-        # Data
+        # Per-GPU data — keyed by device ID
+        self._gpu_kernels: dict[int, list[KernelEvent]] = {}
+        self._gpu_streams: dict[int, list[str]] = {}
+        self._gpu_stream_kernels: dict[int, dict[str, list[KernelEvent]]] = {}
+        self._gpu_nvtx_spans: dict[int, list] = {}
+        self._gpu_nvtx_max_depth: dict[int, int] = {}
+
+        # Flattened views (for navigation / bottom panel)
         self._kernels: list[KernelEvent] = []
         self._stream_kernels: dict[str, list[KernelEvent]] = {}
-        self._streams: list[str] = []
+        self._streams: list[str] = []  # flat list of "gpu:stream" keys
         self._stream_color_idx: dict[str, int] = {}
+        self._stream_gpu: dict[str, int] = {}  # stream_key -> gpu_id
         self._time_start = 0
         self._time_end = 0
         self._time_span = 1
-        self._is_mounted = False  # guard: DOM not ready until on_mount
+        self._is_mounted = False
 
         # Bookmarks and navigation state
         self._bookmarks: list[dict] = []
@@ -172,11 +194,13 @@ class NsysTimelineApp(App):
         self._relative_time = False
         self._show_demangled = False
         self._logical_mode = False
+        self._merged_mode = False  # S key: merged all-streams view
+        self._label_mode = "gpu+stream"  # I key: "gpu+stream" -> "gpu" -> "none"
 
         # Tick density (cycles: 3 → 6 → 10 → 15)
         self._tick_density = 6
 
-        # Now safe to set reactives (watchers will find all fields above)
+        # Now safe to set reactives
         self.min_dur_us = min_ms * 1000
 
         if json_roots:
@@ -190,21 +214,43 @@ class NsysTimelineApp(App):
     # -------------------------------------------------------------------------
     # Data loading
     # -------------------------------------------------------------------------
-    def _load_from_json(self, json_roots: list[dict]) -> None:
+    def _load_from_json(self, json_roots: list[dict], gpu_id: int = 0) -> None:
+        """Load JSON tree for a single GPU into per-GPU storage."""
         kernels, nvtx_spans = extract_events(json_roots)
-        self._kernels = kernels
+        self._gpu_kernels[gpu_id] = kernels
         streams = collect_streams(kernels)
-        self._streams = streams if streams else ["?"]
-        self._stream_kernels = build_stream_kernels(kernels, self._streams)
-        self._stream_color_idx = {s: i % 7 for i, s in enumerate(self._streams)}
-        self._time_start, self._time_end = time_bounds(kernels, self._trim)
+        self._gpu_streams[gpu_id] = streams if streams else ["?"]
+        self._gpu_stream_kernels[gpu_id] = build_stream_kernels(kernels, self._gpu_streams[gpu_id])
+        self._gpu_nvtx_spans[gpu_id] = nvtx_spans
+        self._gpu_nvtx_max_depth[gpu_id] = max((s.depth for s in nvtx_spans), default=-1) + 1
+
+    def _rebuild_flattened(self) -> None:
+        """Rebuild flattened views from per-GPU data."""
+        self._kernels = []
+        self._streams = []
+        self._stream_kernels = {}
+        self._stream_color_idx = {}
+        self._stream_gpu = {}
+
+        color_idx = 0
+        for gpu_id in sorted(self._gpu_kernels.keys()):
+            gpu_kernels = self._gpu_kernels[gpu_id]
+            self._kernels.extend(gpu_kernels)
+            for s in self._gpu_streams.get(gpu_id, []):
+                key = f"{gpu_id}:{s}"  # unique key "0:21", "1:52" etc.
+                self._streams.append(key)
+                self._stream_kernels[key] = self._gpu_stream_kernels.get(gpu_id, {}).get(s, [])
+                self._stream_color_idx[key] = color_idx % 7
+                self._stream_gpu[key] = gpu_id
+                color_idx += 1
+
+        self._time_start, self._time_end = time_bounds(self._kernels, self._trim)
         self._time_span = max(self._time_end - self._time_start, 1)
-        # initial zoom: fit full trace in ~100 columns
-        self.ns_per_col = max(1, self._time_span // 100)
-        self.cursor_ns = self._time_start
-        # Store nvtx spans on canvas
-        self._nvtx_spans = nvtx_spans
-        self._nvtx_max_depth = max((s.depth for s in nvtx_spans), default=-1) + 1
+        # Merge all nvtx spans
+        self._nvtx_spans = []
+        for spans in self._gpu_nvtx_spans.values():
+            self._nvtx_spans.extend(spans)
+        self._nvtx_max_depth = max(self._gpu_nvtx_max_depth.values(), default=0)
 
     def _load_from_db(self) -> None:
         from .. import profile as _profile
@@ -212,13 +258,23 @@ class NsysTimelineApp(App):
 
         try:
             with _profile.open(self._db_path) as prof:
-                roots = build_nvtx_tree(prof, self._device, self._trim)
-                json_roots = to_json(roots)
+                # Auto-detect devices if none specified or single default 0
+                devices = self._devices
+                if not devices or devices == [0]:
+                    if hasattr(prof, 'meta') and hasattr(prof.meta, 'devices') and prof.meta.devices:
+                        devices = prof.meta.devices
+                        self._devices = devices
+                for dev in devices:
+                    roots = build_nvtx_tree(prof, dev, self._trim)
+                    json_roots = to_json(roots)
+                    self._load_from_json(json_roots, gpu_id=dev)
         except Exception as e:
             self.notify(f"Failed to load profile: {e}", severity="error")
             return
-        self._load_from_json(json_roots)
-        # Push NVTX spans to bottom panel for hierarchy view
+        self._rebuild_flattened()
+        # initial zoom: fit full trace in ~100 columns
+        self.ns_per_col = max(1, self._time_span // 100)
+        self.cursor_ns = self._time_start
         if self._is_mounted:
             self.query_one("#bottom-panel", BottomPanel).set_nvtx_spans(
                 getattr(self, "_nvtx_spans", [])
@@ -254,7 +310,9 @@ class NsysTimelineApp(App):
         if not self._kernels and self._db_path:
             self._load_from_db()
         else:
-            # Push NVTX spans to bottom panel for hierarchy view
+            self._rebuild_flattened()
+            self.ns_per_col = max(1, self._time_span // 100)
+            self.cursor_ns = self._time_start
             self.query_one("#bottom-panel", BottomPanel).set_nvtx_spans(
                 getattr(self, "_nvtx_spans", [])
             )
@@ -298,6 +356,10 @@ class NsysTimelineApp(App):
             tick_density=self._tick_density,
             selected_stream_rows=selected_rows,
             default_stream_rows=default_rows,
+            merged_mode=self._merged_mode,
+            label_mode=self._label_mode,
+            stream_gpu=self._stream_gpu,
+            gpu_kernels=self._gpu_kernels,
         )
         self._update_bottom_panel()
 
@@ -311,8 +373,9 @@ class NsysTimelineApp(App):
         bm_indicator = f"  📌{len(self._bookmarks)}" if self._bookmarks else ""
         filter_indicator = f"  /{self.filter_text}" if self.filter_text else ""
         min_dur_indicator = f"  ≥{int(self.min_dur_us)}μs" if self.min_dur_us else ""
+        gpu_str = ",".join(str(d) for d in self._devices)
         self.title = (
-            f"nsys-ai Timeline  GPU {self._device}  {trim_s}  "
+            f"nsys-ai Timeline  GPU {gpu_str}  {trim_s}  "
             f"{kernel_count} kernels  @ {_fmt_ns(self.cursor_ns)}{k_info}  "
             f"[{mode}]{bm_indicator}{filter_indicator}{min_dur_indicator}"
         )
@@ -452,6 +515,20 @@ class NsysTimelineApp(App):
         self._update_bottom_panel()
         mode = bp._path_mode
         self.notify(f"Path: {mode}", timeout=2)
+
+    def action_toggle_merged(self) -> None:
+        """Toggle merged all-streams view ('S' key)."""
+        self._merged_mode = not self._merged_mode
+        self._push_canvas_state()
+        self.notify(f"View: {'merged' if self._merged_mode else 'per-stream'}", timeout=2)
+
+    def action_toggle_labels(self) -> None:
+        """Cycle label visibility: gpu+stream → gpu → none ('I' key)."""
+        modes = ["gpu+stream", "gpu", "none"]
+        idx = modes.index(self._label_mode)
+        self._label_mode = modes[(idx + 1) % len(modes)]
+        self._push_canvas_state()
+        self.notify(f"Labels: {self._label_mode}", timeout=2)
 
     def action_toggle_demangled(self) -> None:
         self._show_demangled = not self._show_demangled

--- a/src/nsys_tui/timeline/canvas.py
+++ b/src/nsys_tui/timeline/canvas.py
@@ -32,10 +32,12 @@ _STREAM_COLORS = [
 _NCCL_COLOR = Color.parse("magenta")
 
 
-def _stream_color(stream_idx: int, selected: bool, heat: float, is_nccl: bool) -> Style:
+def _stream_color(stream_idx: int, selected: bool, heat: float,
+                   is_nccl: bool, parity: int = 0) -> Style:
     color = _NCCL_COLOR if is_nccl else _STREAM_COLORS[stream_idx % len(_STREAM_COLORS)]
     bold = selected or heat > 0.7
-    dim = heat < 0.2 and not selected
+    # Alternate brightness for adjacent kernels: even = normal, odd = dimmed
+    dim = (parity % 2 == 1 and not selected) or (heat < 0.2 and not selected)
     return Style(color=color, bold=bold, dim=dim)
 
 
@@ -77,16 +79,28 @@ class TimelineCanvas(Widget):
         self.nvtx_max_depth: int = 0
         self.filter_text: str = ""
         self.min_dur_us: float = 0
-        self.selected_stream_rows: int = 2
+        self.selected_stream_rows: int = 3
         self.default_stream_rows: int = 1
         # Display flags
         self.relative_time: bool = False
         self.show_demangled: bool = False
         self.tick_density: int = 6
+        # Multi-GPU fields
+        self.merged_mode: bool = False
+        self.label_mode: str = "gpu+stream"
+        self.stream_gpu: dict[str, int] = {}
+        self.gpu_kernels: dict[int, list[KernelEvent]] = {}
 
     # ------------------------------------------------------------------
     # Textual rendering
     # ------------------------------------------------------------------
+
+    def _effective_label_w(self) -> int:
+        if self.label_mode == "none":
+            return 0
+        elif self.label_mode == "gpu":
+            return 5  # "G0  " etc.
+        return self.label_w  # "gpu+stream"
 
     def render_line(self, y: int) -> Strip:
         """Return a Strip for each terminal row."""
@@ -94,12 +108,9 @@ class TimelineCanvas(Widget):
         if width <= 0:
             return Strip.blank(width)
         if not self.streams:
-            # Avoid Strip.blank here: segments with a None style can trigger
-            # filter bugs in third-party plugins (e.g. snapshot monochrome
-            # filters). Use an explicit empty Style instead.
             return Strip([Segment(" " * width, Style())])
 
-        label_w = self.label_w
+        label_w = self._effective_label_w()
         timeline_w = max(width - label_w, 1)
 
         # Layout: row 0 = time axis, rows 1..nvtx_max_depth = NVTX, then stream rows
@@ -118,10 +129,23 @@ class TimelineCanvas(Widget):
         if y == nvtx_end:
             return Strip([Segment("─" * width, Style(dim=True))])
 
-        # Stream rows
+        # Stream rows — build layout with GPU separators
         row_y = y - stream_start
         cur_y = 0
+        prev_gpu: int | None = None
+
         for si, stream in enumerate(self.streams):
+            gpu_id = self.stream_gpu.get(stream, 0)
+
+            # GPU separator row between different GPUs
+            if prev_gpu is not None and gpu_id != prev_gpu:
+                if row_y == cur_y:
+                    sep_label = f"─ GPU {gpu_id} "
+                    sep = sep_label + "─" * max(0, width - len(sep_label))
+                    return Strip([Segment(sep, Style(color="bright_white", bold=True))])
+                cur_y += 1
+            prev_gpu = gpu_id
+
             row_h = self.selected_stream_rows if si == self.selected_stream_idx else self.default_stream_rows
             if cur_y <= row_y < cur_y + row_h:
                 is_selected = (si == self.selected_stream_idx)
@@ -231,11 +255,22 @@ class TimelineCanvas(Widget):
             bold=is_selected,
             dim=not is_selected,
         )
+        # Build label based on label_mode
+        gpu_id = self.stream_gpu.get(stream, 0)
+        # stream key format is "gpu:stream_id"
+        stream_id = stream.split(":", 1)[1] if ":" in stream else stream
+        if self.label_mode == "none":
+            label_text = ""
+        elif self.label_mode == "gpu":
+            label_text = f"G{gpu_id}"
+        else:
+            label_text = f"G{gpu_id}:S{stream_id}"
+
         # Only show stream label on the first sub-row
         if within == 0:
-            label_seg = Segment(f"S{stream}".ljust(label_w - 1), label_style)
+            label_seg = Segment(label_text.ljust(label_w - 1) if label_w > 0 else "", label_style)
         else:
-            label_seg = Segment(" " * (label_w - 1), Style())
+            label_seg = Segment(" " * max(0, label_w - 1), Style())
 
         kernels = filter_kernels(
             self.stream_kernels.get(stream, []),
@@ -248,6 +283,7 @@ class TimelineCanvas(Widget):
         # How many label rows do we have above the block row?
         label_row_count = row_h - 1  # row_h=1 → 0 label rows, row_h=2 → 1, row_h=3 → 2, etc.
 
+        kernel_idx = 0  # counter for color alternation
         for k in kernels:
             s_col = int((k.start_ns - self.viewport_start_ns) / max(self.ns_per_col, 1))
             e_col = int((k.end_ns - self.viewport_start_ns) / max(self.ns_per_col, 1))
@@ -258,7 +294,8 @@ class TimelineCanvas(Widget):
             block_w = e_col - s_col + 1
 
             is_at_cursor = is_selected and k.start_ns <= self.cursor_ns <= k.end_ns
-            style = _stream_color(ci, is_at_cursor, k.heat, k.is_nccl)
+            style = _stream_color(ci, is_at_cursor, k.heat, k.is_nccl, parity=kernel_idx)
+            kernel_idx += 1
 
             if is_block_row:
                 # Last row: block bars

--- a/src/nsys_tui/timeline/logic.py
+++ b/src/nsys_tui/timeline/logic.py
@@ -192,3 +192,33 @@ def time_bounds(kernels: list[KernelEvent], trim: tuple[int, int]) -> tuple[int,
     if kernels:
         return min(k.start_ns for k in kernels), max(k.end_ns for k in kernels)
     return trim
+
+
+# ---------------------------------------------------------------------------
+# Merged row packing (Nsight-style "all streams" view)
+# ---------------------------------------------------------------------------
+
+def pack_merged_rows(kernels: list[KernelEvent]) -> list[list[KernelEvent]]:
+    """Bin-pack kernels into minimum non-overlapping rows (greedy first-fit).
+
+    Returns a list of rows, each containing non-overlapping kernels sorted by
+    start_ns. This mirrors Nsight Systems' merged stream view.
+    """
+    sorted_ks = sorted(kernels, key=lambda k: k.start_ns)
+    rows: list[list[KernelEvent]] = []
+    row_ends: list[int] = []  # end_ns of last kernel in each row
+
+    for k in sorted_ks:
+        placed = False
+        for i, end in enumerate(row_ends):
+            if k.start_ns >= end:
+                rows[i].append(k)
+                row_ends[i] = k.end_ns
+                placed = True
+                break
+        if not placed:
+            rows.append([k])
+            row_ends.append(k.end_ns)
+
+    return rows
+


### PR DESCRIPTION
Multi-GPU timeline support with visual enhancements:
- Multi-GPU data loading with per-device storage and auto-detection
- GPU separator rows in stacked view
- Label toggle (I key): gpu+stream → gpu → none
- Merged view toggle (S key) with bin-packing
- Adjacent kernel color alternation
- NVTX depth defaults to all available levels
- Selected stream rows default to 3