### PR TITLE
fix(timeline-web): preserve NVTX cache across GPU switches

### DIFF
--- a/src/nsys_ai/templates/timeline.html
+++ b/src/nsys_ai/templates/timeline.html
@@ -545,12 +545,17 @@
                 const k = this.key(startS, endS);
                 const entry = this.tiles.get(k);
                 if (!entry || !entry.data || !entry.data.gpus || !nvtxData || !nvtxData.gpus) return;
+                let mergedTargetGpu = false;
                 for (const ng of nvtxData.gpus) {
+                    if (ng.id !== gpuId) continue;
                     const eg = entry.data.gpus.find(g => g.id === ng.id);
                     if (!eg) continue;
                     if (Array.isArray(ng.nvtx_spans)) eg.nvtx_spans = ng.nvtx_spans;
+                    mergedTargetGpu = true;
                 }
-                this.markNvtx(startS, endS, gpuId);
+                if (mergedTargetGpu) {
+                    this.markNvtx(startS, endS, gpuId);
+                }
             }
             // Get all cached data merged
             allData() {


### PR DESCRIPTION
## Summary
Fix a timeline-web NVTX cache regression when switching GPUs.

### Root cause
When requesting NVTX for a single GPU (`gpu=<id>`), the backend response still includes all GPUs, with non-target GPUs often carrying empty `nvtx_spans`.
The frontend merge logic previously wrote these empty arrays back to cache for every GPU in the response, which could erase already-loaded NVTX data for other GPUs.

### Fix
In `TileCache.mergeNvtx(...)`:
- Merge NVTX spans only for the requested `gpuId`.
- Mark NVTX-ready only if the target GPU was actually merged.

This preserves previously loaded NVTX for other GPUs during GPU switching.

## Validation
- `node --check` on timeline template script
- `pytest -q tests/test_timeline_web_data.py tests/test_timeline_web_distca_profile.py`
