### PR TITLE
fix: include memcpy/memset in timeline-web payload

### DIFF
--- a/src/nsys_ai/viewer.py
+++ b/src/nsys_ai/viewer.py
@@ -11,6 +11,12 @@ from string import Template
 from .tree import build_nvtx_tree, to_json
 
 _TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
+_CUDA_MEMCPY_KIND_LABELS = {
+    1: "H2D",
+    2: "D2H",
+    8: "D2D",
+    10: "P2P",
+}
 
 
 def _load_template(name: str) -> Template:
@@ -118,7 +124,7 @@ def build_timeline_gpu_data(
         kernels = []
         if include_kernels:
             # 1) Kernel-first: authoritative source for timeline rows.
-            sql = f"""
+            kernel_sql = f"""
                 SELECT k.start AS start_ns, k.[end] AS end_ns, k.streamId AS stream,
                        s.value AS name
                 FROM {prof.schema.kernel_table} k
@@ -127,7 +133,7 @@ def build_timeline_gpu_data(
                 ORDER BY k.start
             """
             with prof._lock:
-                rows = prof.conn.execute(sql, (dev, trim[0], trim[1])).fetchall()
+                rows = prof.conn.execute(kernel_sql, (dev, trim[0], trim[1])).fetchall()
 
             for r in rows:
                 start_ns = int(r["start_ns"])
@@ -141,6 +147,67 @@ def build_timeline_gpu_data(
                     "stream": r["stream"],
                     "path": "",
                 })
+
+            if "CUPTI_ACTIVITY_KIND_MEMCPY" in prof.schema.tables:
+                memcpy_sql = """
+                    SELECT m.start AS start_ns,
+                           m.[end] AS end_ns,
+                           m.streamId AS stream,
+                           m.copyKind AS copy_kind
+                    FROM CUPTI_ACTIVITY_KIND_MEMCPY m
+                    WHERE m.deviceId = ? AND m.[end] >= ? AND m.start <= ?
+                    ORDER BY m.start
+                """
+                with prof._lock:
+                    memcpy_rows = prof.conn.execute(
+                        memcpy_sql, (dev, trim[0], trim[1])
+                    ).fetchall()
+
+                for r in memcpy_rows:
+                    start_ns = int(r["start_ns"])
+                    end_ns = int(r["end_ns"])
+                    copy_kind = int(r["copy_kind"])
+                    copy_kind_label = _CUDA_MEMCPY_KIND_LABELS.get(
+                        copy_kind, f"kind={copy_kind}"
+                    )
+                    kernels.append({
+                        "type": "memcpy",
+                        "name": f"[CUDA memcpy {copy_kind_label}]",
+                        "start_ns": start_ns,
+                        "end_ns": end_ns,
+                        "duration_ms": round((end_ns - start_ns) / 1e6, 3),
+                        "stream": r["stream"],
+                        "path": "",
+                    })
+
+            if "CUPTI_ACTIVITY_KIND_MEMSET" in prof.schema.tables:
+                memset_sql = """
+                    SELECT m.start AS start_ns,
+                           m.[end] AS end_ns,
+                           m.streamId AS stream
+                    FROM CUPTI_ACTIVITY_KIND_MEMSET m
+                    WHERE m.deviceId = ? AND m.[end] >= ? AND m.start <= ?
+                    ORDER BY m.start
+                """
+                with prof._lock:
+                    memset_rows = prof.conn.execute(
+                        memset_sql, (dev, trim[0], trim[1])
+                    ).fetchall()
+
+                for r in memset_rows:
+                    start_ns = int(r["start_ns"])
+                    end_ns = int(r["end_ns"])
+                    kernels.append({
+                        "type": "memset",
+                        "name": "[CUDA memset]",
+                        "start_ns": start_ns,
+                        "end_ns": end_ns,
+                        "duration_ms": round((end_ns - start_ns) / 1e6, 3),
+                        "stream": r["stream"],
+                        "path": "",
+                    })
+
+            kernels.sort(key=lambda k: (k["start_ns"], k["end_ns"]))
 
         # 2) NVTX-only annotations + kernel->path labels.
         #    NVTX is advisory metadata; missing mapping must not drop kernels.
@@ -156,6 +223,9 @@ def build_timeline_gpu_data(
 
         if include_kernels:
             for k in kernels:
+                if k.get("type") != "kernel":
+                    k["path"] = k["name"]
+                    continue
                 key = (k["start_ns"], k["end_ns"], k["stream"], k["name"])
                 k["path"] = kernel_paths.get(key, k["name"])
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,28 @@ CREATE TABLE IF NOT EXISTS CUPTI_ACTIVITY_KIND_KERNEL (
     blockZ          INTEGER DEFAULT 1
 );
 
+CREATE TABLE IF NOT EXISTS CUPTI_ACTIVITY_KIND_MEMCPY (
+    globalPid       INTEGER DEFAULT 0,
+    deviceId        INTEGER DEFAULT 0,
+    streamId        INTEGER DEFAULT 0,
+    copyKind        INTEGER DEFAULT 0,
+    bytes           INTEGER DEFAULT 0,
+    srcKind         INTEGER DEFAULT 0,
+    dstKind         INTEGER DEFAULT 0,
+    start           INTEGER NOT NULL,
+    end             INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS CUPTI_ACTIVITY_KIND_MEMSET (
+    globalPid       INTEGER DEFAULT 0,
+    deviceId        INTEGER DEFAULT 0,
+    streamId        INTEGER DEFAULT 0,
+    bytes           INTEGER DEFAULT 0,
+    value           INTEGER DEFAULT 0,
+    start           INTEGER NOT NULL,
+    end             INTEGER NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS CUPTI_ACTIVITY_KIND_RUNTIME (
     globalTid       INTEGER DEFAULT 0,
     correlationId   INTEGER DEFAULT 0,

--- a/tests/test_timeline_web_data.py
+++ b/tests/test_timeline_web_data.py
@@ -79,6 +79,41 @@ def test_timeline_web_can_build_nvtx_without_kernels(minimal_nsys_db_path):
         assert "thread" in entry["nvtx_spans"][0]
 
 
+def test_timeline_web_includes_memcpy_and_memset_events(minimal_nsys_db_path):
+    conn = sqlite3.connect(minimal_nsys_db_path)
+    conn.execute(
+        """
+        INSERT INTO CUPTI_ACTIVITY_KIND_MEMCPY
+        (globalPid, deviceId, streamId, copyKind, bytes, srcKind, dstKind, start, end)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (100, 0, 11, 1, 4096, 1, 3, 1_200_000, 1_350_000),
+    )
+    conn.execute(
+        """
+        INSERT INTO CUPTI_ACTIVITY_KIND_MEMSET
+        (globalPid, deviceId, streamId, bytes, value, start, end)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (100, 0, 12, 8192, 0, 3_200_000, 3_450_000),
+    )
+    conn.commit()
+    conn.close()
+
+    with Profile(minimal_nsys_db_path) as prof:
+        gpu_data = build_timeline_gpu_data(prof, 0, (1_000_000, 4_000_000))
+        events = gpu_data[0]["kernels"]
+        memcpy_events = [e for e in events if e["type"] == "memcpy"]
+        memset_events = [e for e in events if e["type"] == "memset"]
+
+    assert len(memcpy_events) == 1
+    assert len(memset_events) == 1
+    assert memcpy_events[0]["name"] == "[CUDA memcpy H2D]"
+    assert memcpy_events[0]["path"] == "[CUDA memcpy H2D]"
+    assert memset_events[0]["name"] == "[CUDA memset]"
+    assert memset_events[0]["path"] == "[CUDA memset]"
+
+
 def test_timeline_web_template_uses_external_assets(minimal_nsys_db_path):
     with Profile(minimal_nsys_db_path) as prof:
         html = generate_timeline_html(prof, [0], None)

--- a/tests/test_timeline_web_distca_profile.py
+++ b/tests/test_timeline_web_distca_profile.py
@@ -23,7 +23,8 @@ def test_distca_timeline_web_contains_flash_backward_on_gpu3():
 
     with Profile(str(DISTCA_SQLITE)) as prof:
         gpu_payload = build_timeline_gpu_data(prof, gpu, trim)[0]
-        kernels = gpu_payload["kernels"]
+        events = gpu_payload["kernels"]
+        kernels = [e for e in events if e.get("type") == "kernel"]
 
     hit = [
         k for k in kernels
@@ -46,3 +47,49 @@ def test_distca_timeline_web_contains_flash_backward_on_gpu3():
         conn.close()
 
     assert len(kernels) == db_overlap_count
+
+
+@pytest.mark.skipif(not DISTCA_SQLITE.exists(), reason="distca example sqlite not found")
+def test_distca_timeline_web_includes_memcpy_memset_23s_to_24s():
+    trim = (int(23.0 * 1e9), int(24.0 * 1e9))
+
+    with Profile(str(DISTCA_SQLITE)) as prof:
+        devices = list(prof.meta.devices)
+        payload_by_gpu = {
+            gpu: build_timeline_gpu_data(prof, gpu, trim)[0]["kernels"]
+            for gpu in devices
+        }
+
+    conn = sqlite3.connect(str(DISTCA_SQLITE))
+    conn.row_factory = sqlite3.Row
+    try:
+        total_mem_events = 0
+        for gpu in devices:
+            events = payload_by_gpu[gpu]
+            memcpy_events = [e for e in events if e.get("type") == "memcpy"]
+            memset_events = [e for e in events if e.get("type") == "memset"]
+            total_mem_events += len(memcpy_events) + len(memset_events)
+
+            memcpy_count = conn.execute(
+                """
+                SELECT COUNT(*) AS n
+                FROM CUPTI_ACTIVITY_KIND_MEMCPY
+                WHERE deviceId = ? AND [end] >= ? AND start <= ?
+                """,
+                (gpu, trim[0], trim[1]),
+            ).fetchone()["n"]
+            memset_count = conn.execute(
+                """
+                SELECT COUNT(*) AS n
+                FROM CUPTI_ACTIVITY_KIND_MEMSET
+                WHERE deviceId = ? AND [end] >= ? AND start <= ?
+                """,
+                (gpu, trim[0], trim[1]),
+            ).fetchone()["n"]
+
+            assert len(memcpy_events) == memcpy_count
+            assert len(memset_events) == memset_count
+    finally:
+        conn.close()
+
+    assert total_mem_events > 0


### PR DESCRIPTION
## Summary
- include `CUPTI_ACTIVITY_KIND_MEMCPY` and `CUPTI_ACTIVITY_KIND_MEMSET` when building timeline-web GPU rows
- keep NVTX annotation as metadata-only: kernel path mapping applies only to true kernel events
- add regression test coverage for memory ops in timeline payload
- add distca regression for 23-24s window to ensure memcpy/memset counts match DB overlap counts

## Why
Timeline-web previously queried only kernel activity, so memory transfers/sets were missing even though they exist in the profile.

## Validation
- `PYTHONPATH=src pytest -q tests/test_timeline_web_data.py tests/test_timeline_web_distca_profile.py`

## Cache Note
If an older `.timeline-cache-v3-kernels.json` exists, remove it once so the server rebuilds cache with memcpy/memset events.
