### PR TITLE
feat: tab through NVTX siblings on same level

### DIFF
--- a/src/nsys_ai/templates/timeline.html
+++ b/src/nsys_ai/templates/timeline.html
@@ -119,11 +119,11 @@
             </tr>
             <tr>
                 <td><span class="key">Tab</span></td>
-                <td>Next kernel in stream</td>
+                <td>Next kernel (or NVTX at same level)</td>
             </tr>
             <tr>
                 <td><span class="key">S+Tab</span></td>
-                <td>Previous kernel</td>
+                <td>Previous kernel/NVTX</td>
             </tr>
             <tr>
                 <td><span class="key">/</span></td>

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -1304,6 +1304,52 @@
             }
         }
 
+        function ensureNvtxVisible(span) {
+            const spanNs = viewEnd - viewStart;
+            if (span.start < viewStart || span.end > viewEnd) {
+                const center = (span.start + span.end) / 2;
+                viewStart = center - spanNs / 2;
+                viewEnd = center + spanNs / 2;
+                clampView();
+                draw();
+                afterViewChange();
+            }
+        }
+
+        function nextNvtx(dir) {
+            const { spans } = activeNvtxLayout();
+            if (!spans.length) return false;
+            const ordered = spans
+                .slice()
+                .sort((a, b) => (a.start - b.start) || (a.end - b.end) || a.name.localeCompare(b.name));
+
+            if (!selectedNvtx || !selectedNvtx.key) {
+                const first = dir >= 0 ? ordered[0] : ordered[ordered.length - 1];
+                selectNvtx(first);
+                ensureNvtxVisible(first);
+                return true;
+            }
+
+            const currentIdx = ordered.findIndex(s => s._key === selectedNvtx.key);
+            if (currentIdx < 0) {
+                const first = dir >= 0 ? ordered[0] : ordered[ordered.length - 1];
+                selectNvtx(first);
+                ensureNvtxVisible(first);
+                return true;
+            }
+
+            const current = ordered[currentIdx];
+            const sameLevel = ordered.filter(s => s._lane === current._lane);
+            if (!sameLevel.length) return false;
+            const laneIdx = sameLevel.findIndex(s => s._key === current._key);
+            const nextIdx = laneIdx + dir;
+            if (nextIdx < 0 || nextIdx >= sameLevel.length) return false;
+            const target = sameLevel[nextIdx];
+            selectNvtx(target);
+            ensureNvtxVisible(target);
+            return true;
+        }
+
         function ensureVisible(k) {
             const span = viewEnd - viewStart;
             if (k.start_ns < viewStart || k.end_ns > viewEnd) {
@@ -1725,7 +1771,16 @@
                 case '+': case '=': zoomIn(); break;
                 case '-': case '_': zoomOut(); break;
                 case 'Home': case '0': fitAll(); break;
-                case 'Tab': e.preventDefault(); nextKernel(e.shiftKey ? -1 : 1); break;
+                case 'Tab':
+                    e.preventDefault();
+                    if (selectedNvtx) {
+                        if (!nextNvtx(e.shiftKey ? -1 : 1)) {
+                            showToast('No more NVTX at this level');
+                        }
+                    } else {
+                        nextKernel(e.shiftKey ? -1 : 1);
+                    }
+                    break;
                 case 'g': case 'G': e.preventDefault(); gotoTimePrompt(); break;
                 case 'v': case 'V': e.preventDefault(); gotoNvtxPrompt(); break;
                 case '/': e.preventDefault(); document.getElementById('searchInput').focus(); break;


### PR DESCRIPTION
## Summary
- add NVTX sibling navigation with `Tab`/`Shift+Tab` when an NVTX span is selected
- keep existing kernel navigation on `Tab` when no NVTX is selected
- auto-pan viewport to keep the newly selected NVTX visible
- update help text to reflect combined kernel/NVTX Tab behavior

## Validation
- node --check src/nsys_ai/templates/timeline.js
- pytest -q tests/test_timeline_web_data.py tests/test_timeline_web_distca_profile.py
