### PR TITLE
fix: stabilize NVTX hierarchy across timeline tiles

### DIFF
--- a/src/nsys_ai/nvtx_tree.py
+++ b/src/nsys_ai/nvtx_tree.py
@@ -63,22 +63,28 @@ def _build_single_thread_tree(profile, device: int, trim: tuple[int, int],
 
     Each node: {name, start, end, type: "nvtx"|"kernel", stream?, children: [...]}
     """
-    # Load runtime calls for this thread
-    with profile._lock:
-        rt_rows = profile.conn.execute("""
-            SELECT start, [end], correlationId FROM CUPTI_ACTIVITY_KIND_RUNTIME
-            WHERE globalTid = ? AND start >= ? AND [end] <= ?  ORDER BY start
-        """, (tid, trim[0] - pad, trim[1] + int(2e9))).fetchall()
-
     # Load NVTX for this thread only
     with profile._lock:
         nvtx_rows = profile.conn.execute("""
             SELECT text, start, [end] FROM NVTX_EVENTS
             WHERE text IS NOT NULL AND [end] > start
               AND globalTid = ?
-              AND start >= ? AND start <= ?
+              AND [end] >= ? AND start <= ?
             ORDER BY start
         """, (tid, trim[0] - pad, trim[1])).fetchall()
+    if not nvtx_rows:
+        return []
+
+    # Load runtime calls for this thread covering the discovered NVTX span set.
+    # Using NVTX-derived bounds keeps GPU projection (start/end/depth/path)
+    # stable across adjacent timeline tiles near boundaries.
+    rt_lo = min(int(n["start"]) for n in nvtx_rows)
+    rt_hi = max(int(n["end"]) for n in nvtx_rows) + int(2e9)
+    with profile._lock:
+        rt_rows = profile.conn.execute("""
+            SELECT start, [end], correlationId FROM CUPTI_ACTIVITY_KIND_RUNTIME
+            WHERE globalTid = ? AND start >= ? AND [end] <= ?  ORDER BY start
+        """, (tid, rt_lo, rt_hi)).fetchall()
 
     # Build projected entries: each NVTX span → projected GPU bounds + child kernels
     entries = []  # list of {name, gpu_start, gpu_end, cpu_start, cpu_end, kernels: [...]}
@@ -302,4 +308,3 @@ def format_markdown(roots, depth=0) -> str:
             lines.append(f"- ⚡ **{node['name']}** [stream {stream}] ({dur_ms:.3f}ms)")
 
     return "\n".join(lines)
-

--- a/tests/test_timeline_web_distca_profile.py
+++ b/tests/test_timeline_web_distca_profile.py
@@ -93,3 +93,46 @@ def test_distca_timeline_web_includes_memcpy_memset_23s_to_24s():
         conn.close()
 
     assert total_mem_events > 0
+
+
+@pytest.mark.skipif(not DISTCA_SQLITE.exists(), reason="distca example sqlite not found")
+def test_distca_nvtx_path_depth_stable_across_adjacent_tiles():
+    gpu = 3
+    left_trim = (int(40.0 * 1e9), int(45.0 * 1e9))
+    right_trim = (int(45.0 * 1e9), int(50.0 * 1e9))
+
+    with Profile(str(DISTCA_SQLITE)) as prof:
+        left_spans = build_timeline_gpu_data(
+            prof, gpu, left_trim, include_kernels=False, include_nvtx=True
+        )[0]["nvtx_spans"]
+        right_spans = build_timeline_gpu_data(
+            prof, gpu, right_trim, include_kernels=False, include_nvtx=True
+        )[0]["nvtx_spans"]
+
+    # Boundary NVTX span we observed drifting from depth 1->0 when parent context
+    # was missing in one tile.
+    def _pick(spans):
+        for s in spans:
+            if (
+                s["name"] == "TransformerLayer._forward_attention.self_attention"
+                and 44.97e9 <= s["start"] <= 44.99e9
+                and 45.02e9 <= s["end"] <= 45.03e9
+            ):
+                return s
+        return None
+
+    left = _pick(left_spans)
+    right = _pick(right_spans)
+    assert left is not None and right is not None
+    assert left["depth"] == right["depth"]
+    assert left["path"] == right["path"]
+
+    right_bad_roots = [
+        s for s in right_spans
+        if (
+            s["name"] == "TransformerLayer._forward_attention.self_attention"
+            and s.get("depth", 0) == 0
+            and 44.97e9 <= s["start"] <= 44.99e9
+        )
+    ]
+    assert not right_bad_roots


### PR DESCRIPTION
## Summary
- fix NVTX tile-boundary instability that could shift span depth/path across adjacent tiles
- prevent false same-level overlap artifacts (for example around 44.9s-45.25s in distca)

## Root cause
- NVTX rows were included by `start >= trim - pad`
- near tile boundaries, parent scopes starting slightly earlier than `trim - pad` were dropped
- children then appeared as roots in one tile (depth/path drift), and merge showed overlapping level artifacts

## Changes
- in `nvtx_tree._build_single_thread_tree()`:
  - load NVTX rows by overlap (`end >= trim - pad` and `start <= trim_end`)
  - derive runtime query bounds from discovered NVTX rows so projection is stable for those spans across tiles
- add distca regression test for adjacent tiles (`40-45s` vs `45-50s`) asserting stable depth/path and no incorrect root-level transformer span

## Validation
- `pytest -q tests/test_timeline_web_data.py tests/test_timeline_web_distca_profile.py`
  - result: `11 passed`
