### PR TITLE
refactor: finalize database connection abstraction and eradicate engine type checks

### DIFF
--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -10,10 +10,6 @@ import logging
 import re
 import sqlite3
 import threading
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    import duckdb
 
 _log = logging.getLogger(__name__)
 
@@ -110,18 +106,19 @@ def query_profile_db(
             "SELECT start, [end], shortName FROM <table> WHERE ... LIMIT 20"
         )
 
-    import sqlite3
-
-    import duckdb
+    from nsys_ai.connection import DuckDBAdapter, SQLiteAdapter, wrap_connection
+    adapter = wrap_connection(conn)
+    is_duckdb = isinstance(adapter, DuckDBAdapter)
+    is_sqlite = isinstance(adapter, SQLiteAdapter)
 
     # Rewrite sqlite_master to SHOW TABLES (LLMs love sqlite_master)
-    if "SQLITE_MASTER" in upper and isinstance(conn, duckdb.DuckDBPyConnection):
+    if "SQLITE_MASTER" in upper and is_duckdb:
         q = "SHOW TABLES"
         upper = "SHOW TABLES"
 
     # SQLite fallback: support DuckDB-style helper commands used in docs.
     # This keeps schema discovery working even when DuckDB is unavailable.
-    if isinstance(conn, sqlite3.Connection):
+    if is_sqlite:
         if upper == "SHOW TABLES":
             q = (
                 "SELECT name AS table_name "
@@ -137,16 +134,7 @@ def query_profile_db(
             q = f"PRAGMA table_info('{safe_table_name}')"
             upper = q.upper()
 
-    # DuckDB translation for LLM-generated SQL
-    if (
-        isinstance(conn, duckdb.DuckDBPyConnection)
-        and "SHOW TABLES" not in upper
-        and "DESCRIBE " not in upper
-    ):
-        from nsys_ai.sql_compat import sqlite_to_duckdb
-
-        q = sqlite_to_duckdb(q)
-        upper = q.upper()
+    # Adapter handles sqlite_to_duckdb automatically, so we don't need manual translation here anymore
 
     # Adaptive LIMIT: narrow projections allow more rows; wide ones get fewer.
     effective_limit = _adaptive_limit(upper, max_limit)
@@ -168,16 +156,14 @@ def query_profile_db(
             q = q + f" LIMIT {effective_limit}"
 
     try:
-        cur = conn.execute(q)
+        cur = adapter.execute(q)
         # duckdb cursor fetchall returns list of tuples
         rows = cur.fetchall()
 
         # Determine column names (works for both duckdb and sqlite)
         names = [d[0] for d in cur.description] if cur.description else []
 
-        if getattr(conn, "row_factory", None) is sqlite3.Row and not isinstance(
-            conn, duckdb.DuckDBPyConnection
-        ):
+        if getattr(conn, "row_factory", None) is sqlite3.Row and is_sqlite:
             out = [dict(r) for r in rows]
         else:
             out = [dict(zip(names, r)) for r in rows]
@@ -206,12 +192,12 @@ def query_profile_db(
                 "(e.g. start, [end], shortName) or reduce the LIMIT."
             )
         return json_str
-    except (sqlite3.Error, duckdb.Error) as e:
+    except Exception as e:
         return f"Error: Database error: {e}"
 
 
 def get_profile_schema(
-    conn: "sqlite3.Connection | duckdb.DuckDBPyConnection",
+    conn,
     table_names: tuple[str, ...] | None = None,
 ) -> str:
     """
@@ -241,25 +227,26 @@ def get_profile_schema(
 
     parts = []
 
-    # Support DuckDB connection
-    import duckdb
+    from nsys_ai.connection import DuckDBAdapter, wrap_connection
+    adapter = wrap_connection(conn)
+    is_duckdb = isinstance(adapter, DuckDBAdapter)
 
-    if isinstance(conn, duckdb.DuckDBPyConnection):
+    if is_duckdb:
         # In DuckDB, views from parquet_cache don't have detailed DDL in duckdb_views()
         # so we just return DESCRIBE for each table
         for table in want:
             try:
-                cur = conn.execute(f"DESCRIBE {table}")
+                cur = adapter.execute(f"DESCRIBE {table}")
                 cols = [f"  {r[0]} {r[1]}" for r in cur.fetchall()]
                 parts.append(f"CREATE TABLE {table} (\n" + ",\n".join(cols) + "\n);")
-            except duckdb.Error:
+            except Exception:
                 pass
         return "\n\n".join(parts) if parts else "(Could not read schema from DuckDB.)"
 
     # Standard SQLite path
     placeholders = ",".join("?" * len(want))
     try:
-        cur = conn.execute(
+        cur = adapter.execute(
             f"SELECT name, sql FROM sqlite_master WHERE type='table' AND name IN ({placeholders})",
             want,
         )
@@ -281,7 +268,7 @@ _schema_cache_lock = threading.Lock()
 
 
 def get_profile_schema_cached(
-    conn: "sqlite3.Connection | duckdb.DuckDBPyConnection", path: str | None = None
+    conn, path: str | None = None
 ) -> str:
     """
     Return schema for the given connection, using a cache keyed by path when provided.
@@ -301,7 +288,7 @@ def get_profile_schema_cached(
     return schema
 
 
-def open_profile_readonly(path: str) -> "duckdb.DuckDBPyConnection | sqlite3.Connection":
+def open_profile_readonly(path: str):
     """Open a profile in read-only mode, using DuckDB Parquet cache if available.
 
     Note: If the Parquet cache is missing or stale, this function will build
@@ -323,7 +310,7 @@ def open_profile_readonly(path: str) -> "duckdb.DuckDBPyConnection | sqlite3.Con
     return conn
 
 
-def open_profile_readonly_for_worker(path: str) -> "duckdb.DuckDBPyConnection | sqlite3.Connection":
+def open_profile_readonly_for_worker(path: str):
     """
     Open a read-only profile connection for use from a worker thread.
 

--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -139,6 +139,13 @@ def query_profile_db(
     # Adaptive LIMIT: narrow projections allow more rows; wide ones get fewer.
     effective_limit = _adaptive_limit(upper, max_limit)
 
+    error_types = (sqlite3.Error,)
+    try:
+        import duckdb
+        error_types = error_types + (duckdb.Error,)
+    except ImportError:
+        pass
+
     # Enforce LIMIT only on SELECT/WITH/FROM queries to avoid syntax errors on PRAGMA/SHOW
     if upper.startswith(("SELECT", "WITH", "(", "FROM")):
         limit_match = re.search(r"\bLIMIT\s+(\d+)", upper, re.IGNORECASE)
@@ -192,7 +199,7 @@ def query_profile_db(
                 "(e.g. start, [end], shortName) or reduce the LIMIT."
             )
         return json_str
-    except Exception as e:
+    except error_types as e:
         return f"Error: Database error: {e}"
 
 

--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -246,8 +246,12 @@ def get_profile_schema(
                 cur = adapter.execute(f"DESCRIBE {table}")
                 cols = [f"  {r[0]} {r[1]}" for r in cur.fetchall()]
                 parts.append(f"CREATE TABLE {table} (\n" + ",\n".join(cols) + "\n);")
-            except Exception:
-                pass
+            except Exception as e:
+                # Only swallow DuckDB database errors cleanly. Propagate others or log them.
+                if type(e).__name__ in ("CatalogException", "Error", "ParserException"):
+                    pass
+                else:
+                    raise
         return "\n\n".join(parts) if parts else "(Could not read schema from DuckDB.)"
 
     # Standard SQLite path

--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -131,8 +131,8 @@ def query_profile_db(
             table_token = rest.split(None, 1)[0] if rest else ""
             table_name = table_token.strip("'\"`[]")
 
-            from nsys_ai.connection import _SAFE_IDENT_RE
-            if not _SAFE_IDENT_RE.match(table_name):
+            from nsys_ai.connection import is_safe_identifier
+            if not is_safe_identifier(table_name):
                 return f"Error: Invalid or unsafe table name '{table_name}'."
 
             q = f"PRAGMA table_info('{table_name}')"
@@ -238,7 +238,7 @@ def get_profile_schema(
 
     parts = []
 
-    from nsys_ai.connection import DuckDBAdapter, wrap_connection
+    from nsys_ai.connection import DB_ERRORS, DuckDBAdapter, wrap_connection
     adapter = wrap_connection(conn)
     is_duckdb = isinstance(adapter, DuckDBAdapter)
 
@@ -250,12 +250,8 @@ def get_profile_schema(
                 cur = adapter.execute(f"DESCRIBE {table}")
                 cols = [f"  {r[0]} {r[1]}" for r in cur.fetchall()]
                 parts.append(f"CREATE TABLE {table} (\n" + ",\n".join(cols) + "\n);")
-            except Exception as e:
-                # Only swallow DuckDB database errors cleanly. Propagate others or log them.
-                if type(e).__name__ in ("CatalogException", "Error", "ParserException"):
-                    pass
-                else:
-                    raise
+            except DB_ERRORS:
+                pass
         return "\n\n".join(parts) if parts else "(Could not read schema from DuckDB.)"
 
     # Standard SQLite path

--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -130,8 +130,12 @@ def query_profile_db(
             rest = q[9:].strip()
             table_token = rest.split(None, 1)[0] if rest else ""
             table_name = table_token.strip("'\"`[]")
-            safe_table_name = table_name.replace("'", "''")
-            q = f"PRAGMA table_info('{safe_table_name}')"
+
+            from nsys_ai.connection import _SAFE_IDENT_RE
+            if not _SAFE_IDENT_RE.match(table_name):
+                return f"Error: Invalid or unsafe table name '{table_name}'."
+
+            q = f"PRAGMA table_info('{table_name}')"
             upper = q.upper()
 
     # Adapter handles sqlite_to_duckdb automatically, so we don't need manual translation here anymore

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -1,0 +1,170 @@
+import logging
+import sqlite3
+from typing import Any, Protocol, runtime_checkable
+
+_log = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class ConnectionAdapter(Protocol):
+    """Abstracts SQLite and DuckDB connections for cross-engine compatibility."""
+
+    @property
+    def raw_conn(self) -> Any:
+        ...
+
+    def execute(self, sql: str, parameters: tuple | list = ()) -> Any:
+        ...
+
+    def resolve_activity_tables(self) -> dict[str, str]:
+        ...
+
+    def detect_nvtx_text_id(self) -> bool:
+        ...
+
+    def get_table_columns(self, table_name: str) -> list[str]:
+        ...
+
+    def get_table_names(self) -> set[str]:
+        ...
+
+
+class SQLiteAdapter:
+    def __init__(self, conn: sqlite3.Connection):
+        self.conn = conn
+
+    @property
+    def raw_conn(self) -> sqlite3.Connection:
+        return self.conn
+
+    def execute(self, sql: str, parameters: tuple | list = ()) -> sqlite3.Cursor:
+        return self.conn.execute(sql, parameters)
+
+    def resolve_activity_tables(self) -> dict[str, str]:
+        try:
+            cur = self.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            tables = {row[0] for row in cur.fetchall()}
+        except sqlite3.Error as exc:
+            _log.debug("Failed to resolve activity tables (sqlite): %s", exc, exc_info=True)
+            return {}
+        return _find_activity_tables(tables)
+
+    def detect_nvtx_text_id(self) -> bool:
+        try:
+            cur = self.conn.execute("PRAGMA table_info(NVTX_EVENTS)")
+            cols = [row[1] for row in cur.fetchall()]
+            return "textId" in cols
+        except sqlite3.Error as exc:
+            _log.debug("NVTX textId detection failed (sqlite): %s", exc, exc_info=True)
+            return False
+
+    def get_table_columns(self, table_name: str) -> list[str]:
+        cur = self.conn.execute(f"PRAGMA table_info({table_name})")
+        return [row[1] for row in cur.fetchall()]
+
+    def get_table_names(self) -> set[str]:
+        try:
+            cur = self.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            return {row[0] for row in cur.fetchall()}
+        except sqlite3.Error:
+            return set()
+
+
+class DuckDBAdapter:
+    def __init__(self, conn):
+        self.conn = conn
+
+    @property
+    def raw_conn(self) -> Any:
+        return self.conn
+
+    def execute(self, sql: str, parameters: tuple | list = ()) -> Any:
+        from .sql_compat import sqlite_to_duckdb
+        rewritten_sql = sqlite_to_duckdb(sql)
+        # duckdb parameters need to be passed directly to connection execute
+        return self.conn.execute(rewritten_sql, list(parameters) if parameters else [])
+
+    def resolve_activity_tables(self) -> dict[str, str]:
+        try:
+            tables = {row[0] for row in self.conn.execute("SHOW TABLES").fetchall()}
+        except Exception as exc:
+            _log.debug("Failed to resolve activity tables (duckdb): %s", exc, exc_info=True)
+            return {}
+        return _find_activity_tables(tables)
+
+    def detect_nvtx_text_id(self) -> bool:
+        try:
+            tables = {row[0] for row in self.conn.execute("SHOW TABLES").fetchall()}
+            if "NVTX_EVENTS" not in tables:
+                return False
+
+            # Use DESCRIBE for duckdb
+            cols = [row[0] for row in self.conn.execute("DESCRIBE NVTX_EVENTS").fetchall()]
+            return "textId" in cols
+        except Exception as exc:
+            _log.debug("NVTX textId detection failed (duckdb): %s", exc, exc_info=True)
+            return False
+
+    def get_table_columns(self, table_name: str) -> list[str]:
+        cur = self.conn.execute(f"DESCRIBE {table_name}")
+        return [row[0] for row in cur.fetchall()]
+
+    def get_table_names(self) -> set[str]:
+        try:
+            return {row[0] for row in self.conn.execute("SHOW TABLES").fetchall()}
+        except Exception:
+            return set()
+
+
+def _find_activity_tables(tables: set[str]) -> dict[str, str]:
+    def _find_by_prefix(prefix: str) -> str | None:
+        if prefix in tables:
+            return prefix
+        candidates = sorted(t for t in tables if t.startswith(prefix))
+        return candidates[0] if candidates else None
+
+    resolved: dict[str, str] = {}
+
+    kernel_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_KERNEL")
+    if kernel_table:
+        resolved["kernel"] = kernel_table
+
+    runtime_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_RUNTIME")
+    if runtime_table:
+        resolved["runtime"] = runtime_table
+
+    memcpy_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_MEMCPY")
+    if memcpy_table:
+        resolved["memcpy"] = memcpy_table
+
+    memset_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_MEMSET")
+    if memset_table:
+        resolved["memset"] = memset_table
+
+    if "NVTX_EVENTS" in tables:
+        nvtx_table = "NVTX_EVENTS"
+    else:
+        nvtx_table = _find_by_prefix("NVTX_EVENTS")
+    if nvtx_table:
+        resolved["nvtx"] = nvtx_table
+
+    return resolved
+
+
+def wrap_connection(conn) -> ConnectionAdapter:
+    """Wraps a raw connection in the appropriate adapter."""
+    if isinstance(conn, ConnectionAdapter):
+        return conn
+
+    # Attempt duckdb detection without forced import
+    is_duckdb = False
+    try:
+        import duckdb
+        if isinstance(conn, duckdb.DuckDBPyConnection):
+            is_duckdb = True
+    except ImportError:
+        pass
+
+    if is_duckdb:
+        return DuckDBAdapter(conn)
+    return SQLiteAdapter(conn)

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -1,8 +1,13 @@
 import logging
+import re
 import sqlite3
 from typing import Any, Protocol, runtime_checkable
 
 _log = logging.getLogger(__name__)
+
+# Defence-in-depth: reject identifiers with special chars even though
+# callers should only pass schema-derived names.
+_SAFE_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
 @runtime_checkable
@@ -59,6 +64,8 @@ class SQLiteAdapter:
             return False
 
     def get_table_columns(self, table_name: str) -> list[str]:
+        if not _SAFE_IDENT_RE.match(table_name):
+            raise ValueError(f"Unsafe table name: {table_name!r}")
         cur = self.conn.execute(f"PRAGMA table_info({table_name})")
         return [row[1] for row in cur.fetchall()]
 
@@ -106,6 +113,8 @@ class DuckDBAdapter:
             return False
 
     def get_table_columns(self, table_name: str) -> list[str]:
+        if not _SAFE_IDENT_RE.match(table_name):
+            raise ValueError(f"Unsafe table name: {table_name!r}")
         cur = self.conn.execute(f"DESCRIBE {table_name}")
         return [row[0] for row in cur.fetchall()]
 

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -65,10 +65,9 @@ class SQLiteAdapter:
     def detect_nvtx_text_id(self) -> bool:
         try:
             nvtx_table = self.resolve_activity_tables().get("nvtx", "NVTX_EVENTS")
-            cur = self.conn.execute(f"PRAGMA table_info({nvtx_table})")
-            cols = [row[1] for row in cur.fetchall()]
+            cols = self.get_table_columns(nvtx_table)
             return "textId" in cols
-        except sqlite3.Error as exc:
+        except (sqlite3.Error, ValueError) as exc:
             _log.debug("NVTX textId detection failed (sqlite): %s", exc, exc_info=True)
             return False
 
@@ -114,10 +113,9 @@ class DuckDBAdapter:
             if not nvtx_table:
                 return False
 
-            # Use DESCRIBE for duckdb
-            cols = [row[0] for row in self.conn.execute(f"DESCRIBE {nvtx_table}").fetchall()]
+            cols = self.get_table_columns(nvtx_table)
             return "textId" in cols
-        except Exception as exc:
+        except (Exception, ValueError) as exc:
             _log.debug("NVTX textId detection failed (duckdb): %s", exc, exc_info=True)
             return False
 

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -18,6 +18,11 @@ _log = logging.getLogger(__name__)
 _SAFE_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+def is_safe_identifier(name: str) -> bool:
+    """Check if the string is safe to be structurally spliced into a SQL query."""
+    return bool(_SAFE_IDENT_RE.match(name))
+
+
 @runtime_checkable
 class ConnectionAdapter(Protocol):
     """Abstracts SQLite and DuckDB connections for cross-engine compatibility."""
@@ -102,7 +107,7 @@ class DuckDBAdapter:
     def resolve_activity_tables(self) -> dict[str, str]:
         try:
             tables = {row[0] for row in self.conn.execute("SHOW TABLES").fetchall()}
-        except Exception as exc:
+        except DB_ERRORS as exc:
             _log.debug("Failed to resolve activity tables (duckdb): %s", exc, exc_info=True)
             return {}
         return _find_activity_tables(tables)
@@ -115,12 +120,12 @@ class DuckDBAdapter:
 
             cols = self.get_table_columns(nvtx_table)
             return "textId" in cols
-        except (Exception, ValueError) as exc:
+        except DB_ERRORS + (ValueError,) as exc:
             _log.debug("NVTX textId detection failed (duckdb): %s", exc, exc_info=True)
             return False
 
     def get_table_columns(self, table_name: str) -> list[str]:
-        if not _SAFE_IDENT_RE.match(table_name):
+        if not is_safe_identifier(table_name):
             raise ValueError(f"Unsafe table name: {table_name!r}")
         cur = self.conn.execute(f"DESCRIBE {table_name}")
         return [row[0] for row in cur.fetchall()]
@@ -128,7 +133,8 @@ class DuckDBAdapter:
     def get_table_names(self) -> set[str]:
         try:
             return {row[0] for row in self.conn.execute("SHOW TABLES").fetchall()}
-        except Exception:
+        except DB_ERRORS as exc:
+            _log.debug("Failed to get table names (duckdb): %s", exc, exc_info=True)
             return set()
 
 

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -56,7 +56,8 @@ class SQLiteAdapter:
 
     def detect_nvtx_text_id(self) -> bool:
         try:
-            cur = self.conn.execute("PRAGMA table_info(NVTX_EVENTS)")
+            nvtx_table = self.resolve_activity_tables().get("nvtx", "NVTX_EVENTS")
+            cur = self.conn.execute(f"PRAGMA table_info({nvtx_table})")
             cols = [row[1] for row in cur.fetchall()]
             return "textId" in cols
         except sqlite3.Error as exc:
@@ -101,12 +102,12 @@ class DuckDBAdapter:
 
     def detect_nvtx_text_id(self) -> bool:
         try:
-            tables = {row[0] for row in self.conn.execute("SHOW TABLES").fetchall()}
-            if "NVTX_EVENTS" not in tables:
+            nvtx_table = self.resolve_activity_tables().get("nvtx")
+            if not nvtx_table:
                 return False
 
             # Use DESCRIBE for duckdb
-            cols = [row[0] for row in self.conn.execute("DESCRIBE NVTX_EVENTS").fetchall()]
+            cols = [row[0] for row in self.conn.execute(f"DESCRIBE {nvtx_table}").fetchall()]
             return "textId" in cols
         except Exception as exc:
             _log.debug("NVTX textId detection failed (duckdb): %s", exc, exc_info=True)

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -3,6 +3,14 @@ import re
 import sqlite3
 from typing import Any, Protocol, runtime_checkable
 
+# Narrow exception tuple for diagnostic query blocks.
+DB_ERRORS: tuple[type[Exception], ...] = (sqlite3.Error, sqlite3.OperationalError)
+try:
+    import duckdb  # noqa: E402
+    DB_ERRORS = DB_ERRORS + (duckdb.Error,)
+except ImportError:
+    pass
+
 _log = logging.getLogger(__name__)
 
 # Defence-in-depth: reject identifiers with special chars even though

--- a/src/nsys_ai/indexing.py
+++ b/src/nsys_ai/indexing.py
@@ -29,50 +29,7 @@ def _quote_identifier(name: str) -> str:
     return '"' + name.replace('"', '""') + '"'
 
 
-def _resolve_activity_tables(conn: sqlite3.Connection) -> dict[str, str]:
-    """Resolve Nsight activity table names (kernel/runtime/NVTX/memcpy/memset).
 
-    Nsight may emit versioned table names such as
-    ``CUPTI_ACTIVITY_KIND_KERNEL_V2``.
-    This helper finds the first matching table for each logical kind.
-    """
-    try:
-        tables = {
-            row[0]
-            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
-        }
-    except Exception:
-        _log.debug("Failed to resolve activity tables for indexing", exc_info=True)
-        return {}
-
-    def _find_by_prefix(prefix: str) -> str | None:
-        if prefix in tables:
-            return prefix
-        candidates = sorted(t for t in tables if t.startswith(prefix))
-        return candidates[0] if candidates else None
-
-    kernel_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_KERNEL")
-    runtime_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_RUNTIME")
-    memcpy_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_MEMCPY")
-    memset_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_MEMSET")
-    if "NVTX_EVENTS" in tables:
-        nvtx_table: str | None = "NVTX_EVENTS"
-    else:
-        nvtx_table = _find_by_prefix("NVTX_EVENTS")
-
-    resolved: dict[str, str] = {}
-    if kernel_table:
-        resolved["kernel"] = kernel_table
-    if runtime_table:
-        resolved["runtime"] = runtime_table
-    if memcpy_table:
-        resolved["memcpy"] = memcpy_table
-    if memset_table:
-        resolved["memset"] = memset_table
-    if nvtx_table:
-        resolved["nvtx"] = nvtx_table
-
-    return resolved
 
 
 def ensure_performance_indexes(conn: sqlite3.Connection) -> None:
@@ -85,19 +42,16 @@ def ensure_performance_indexes(conn: sqlite3.Connection) -> None:
     Index naming convention: ``_nsysai_<table_kind>_<column(s)>``
     """
     # DuckDB connections (Parquet cache) don't need SQLite indexes.
-    try:
-        import duckdb as _ddb
-
-        if isinstance(conn, _ddb.DuckDBPyConnection):
-            return
-    except ImportError:
-        pass
+    from .connection import DuckDBAdapter, wrap_connection
+    adapter = wrap_connection(conn)
+    if isinstance(adapter, DuckDBAdapter):
+        return
 
     conn_id = id(conn)
     if conn_id in _indexed_connections:
         return
 
-    tables = _resolve_activity_tables(conn)
+    tables = adapter.resolve_activity_tables()
 
     index_stmts: list[str] = []
 

--- a/src/nsys_ai/nvtx_attribution.py
+++ b/src/nsys_ai/nvtx_attribution.py
@@ -84,6 +84,7 @@ def _sort_merge_attribute(
         FROM {nvtx_table} n
         {text_join}
         WHERE n.eventType = 59 AND n.[end] > n.start
+        ORDER BY n.globalTid, n.start
         """
     ).fetchall()
 

--- a/src/nsys_ai/nvtx_attribution.py
+++ b/src/nsys_ai/nvtx_attribution.py
@@ -39,10 +39,9 @@ def _sort_merge_attribute(
     Overall complexity is O(N+M) per thread (each NVTX is pushed and
     popped at most once; each runtime call is processed once).
     """
-    # Detect versioned table names
-    from .skills.base import _resolve_activity_tables
-
-    resolved_tables = _resolve_activity_tables(conn)
+    from .connection import wrap_connection
+    adapter = wrap_connection(conn)
+    resolved_tables = adapter.resolve_activity_tables()
 
     kernel_table = resolved_tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
     runtime_table = resolved_tables.get("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME")
@@ -55,20 +54,14 @@ def _sort_merge_attribute(
         trim_sql = "AND k.start >= ? AND k.[end] <= ?"
         trim_params = (trim[0], trim[1])
 
-    # Phase 1: Kernel → Runtime via correlationId (indexed, fast)
-    from .sql_compat import sqlite_to_duckdb
-
-    kr_rows = conn.execute(
-        sqlite_to_duckdb(
+    kr_rows = adapter.execute(
             f"""
         SELECT r.globalTid, r.start, r.[end],
                k.start AS ks, k.[end] AS ke, k.shortName
         FROM {kernel_table} k
         JOIN {runtime_table} r ON r.correlationId = k.correlationId
         WHERE 1=1 {trim_sql}
-        ORDER BY r.globalTid, r.start
-        """
-        ),
+        """,
         trim_params,
     ).fetchall()
 
@@ -76,23 +69,7 @@ def _sort_merge_attribute(
         return []
 
     # Phase 2: Load NVTX ranges (eventType 59 = NVTX push/pop range)
-    # Resolve text expression (handles textId vs text column)
-    has_textid = False
-    try:
-        import duckdb as _ddb
-
-        if isinstance(conn, _ddb.DuckDBPyConnection):
-            cols = [c[0] for c in conn.execute(f"DESCRIBE {nvtx_table}").fetchall()]
-            has_textid = "textId" in cols
-        else:
-            has_textid = (
-                conn.execute(
-                    f"SELECT COUNT(*) FROM pragma_table_info('{nvtx_table}') WHERE name='textId'"
-                ).fetchone()[0]
-                > 0
-            )
-    except Exception:
-        _log.debug("NVTX textId detection failed", exc_info=True)
+    has_textid = adapter.detect_nvtx_text_id()
 
     if has_textid:
         text_expr = "COALESCE(n.text, s.value)"
@@ -101,23 +78,20 @@ def _sort_merge_attribute(
         text_expr = "n.text"
         text_join = ""
 
-    nvtx_rows = conn.execute(
-        sqlite_to_duckdb(
+    nvtx_rows = adapter.execute(
             f"""
         SELECT n.globalTid, n.start, n.[end], {text_expr} AS text
         FROM {nvtx_table} n
         {text_join}
         WHERE n.eventType = 59 AND n.[end] > n.start
-        ORDER BY n.globalTid, n.start
         """
-        )
     ).fetchall()
 
     # StringIds lookup for kernel names — only fetch the IDs we need
     short_name_ids = {r[5] for r in kr_rows if r[5] is not None}
     if short_name_ids:
         placeholders = ",".join("?" for _ in short_name_ids)
-        sid_rows = conn.execute(
+        sid_rows = adapter.execute(
             f"SELECT id, value FROM StringIds WHERE id IN ({placeholders})",
             tuple(short_name_ids),
         ).fetchall()
@@ -218,16 +192,17 @@ def attribute_kernels_to_nvtx(
 
     # DuckDB: Try reading from purely precomputed Parquet bounds!
     try:
-        import duckdb as _ddb
+        from .connection import DuckDBAdapter, wrap_connection
+        adapter = wrap_connection(conn)
 
-        if isinstance(conn, _ddb.DuckDBPyConnection):
+        if isinstance(adapter, DuckDBAdapter):
             trim_sql = ""
             params = []
             if trim:
                 trim_sql = "WHERE k_start >= ? AND k_end <= ?"
                 params = [trim[0], trim[1]]
 
-            cur = conn.execute(f"SELECT * FROM nvtx_kernel_map {trim_sql} ORDER BY k_start", params)
+            cur = adapter.execute(f"SELECT * FROM nvtx_kernel_map {trim_sql} ORDER BY k_start", params)
             cols = [d[0] for d in cur.description]
             return [dict(zip(cols, row)) for row in cur.fetchall()]
     except Exception:

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -23,7 +23,6 @@ from nsys_ai.exceptions import (
     ExportToolMissingError,
     SchemaError,
 )
-from nsys_ai.sql_compat import sqlite_to_duckdb
 
 # Regex for safe SQL identifiers (table/column names).
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -51,14 +50,11 @@ class NsightSchema:
 
     def __init__(self, conn: sqlite3.Connection):
         self._conn = conn
-        import duckdb as _ddb
+        from .connection import wrap_connection
+        self._adapter = wrap_connection(conn)
 
-        if isinstance(conn, _ddb.DuckDBPyConnection):
-            cur = self._conn.execute("SHOW TABLES")
-            self.tables: list[str] = [r[0] for r in cur.fetchall()]
-        else:
-            cur = self._conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            self.tables: list[str] = [r[0] for r in cur.fetchall()]
+        self.tables = list(self._adapter.get_table_names())
+
         self.version: str | None = self._detect_version()
         kt = self._detect_kernel_table()
         self.kernel_table: str | None = _validate_table_name(kt) if kt else None
@@ -73,14 +69,7 @@ class NsightSchema:
         if table not in self.tables:
             return {}
 
-        import duckdb as _ddb
-
-        if isinstance(self._conn, _ddb.DuckDBPyConnection):
-            cur = self._conn.execute(f"DESCRIBE {table}")
-            cols = [row[0] for row in cur.fetchall()]  # 0 = column_name
-        else:
-            cur = self._conn.execute(f"PRAGMA table_info({table})")
-            cols = [row[1] for row in cur.fetchall()]  # 1 = name
+        cols = self._adapter.get_table_columns(table)
         key_col = None
         val_col = None
 
@@ -194,9 +183,11 @@ class Profile:
         self._owns_conn = True
         self.conn = sqlite3.connect(path, check_same_thread=False)
         self.conn.row_factory = sqlite3.Row
+        from .connection import wrap_connection
+        self.adapter = wrap_connection(self.conn)
         self.schema = NsightSchema(self.conn)
         self.meta = self._discover()
-        self._nvtx_has_text_id: bool = self._detect_nvtx_text_id()
+        self._nvtx_has_text_id: bool = self.adapter.detect_nvtx_text_id()
 
         # DuckDB connection strategy — see parquet_cache module
         try:
@@ -236,9 +227,9 @@ class Profile:
         The connection is borrowed — ``close()`` will NOT close it.
         Supports both SQLite and DuckDB connections.
         """
-        import duckdb
-
-        is_duckdb = isinstance(conn, duckdb.DuckDBPyConnection)
+        from .connection import DuckDBAdapter, wrap_connection
+        adapter = wrap_connection(conn)
+        is_duckdb = isinstance(adapter, DuckDBAdapter)
         if not is_duckdb:
             conn.row_factory = sqlite3.Row
         obj = cls.__new__(cls)
@@ -247,28 +238,13 @@ class Profile:
         obj._owns_conn = False
         obj.path = ""
         obj.db = conn if is_duckdb else None  # type: ignore[assignment]
+        obj.adapter = adapter
         obj.schema = NsightSchema(conn)
         obj.meta = obj._discover()
-        obj._nvtx_has_text_id = obj._detect_nvtx_text_id()
+        obj._nvtx_has_text_id = obj.adapter.detect_nvtx_text_id()
         return obj
 
-    def _detect_nvtx_text_id(self) -> bool:
-        """Return True if NVTX_EVENTS uses textId -> StringIds (newer schema)."""
-        if "NVTX_EVENTS" not in self.schema.tables:
-            return False
-        try:
-            import duckdb
 
-            if isinstance(self.conn, duckdb.DuckDBPyConnection):
-                cols = [r[0] for r in self.conn.execute("DESCRIBE NVTX_EVENTS").fetchall()]
-            else:
-                cols = [
-                    r[1] for r in self.conn.execute("PRAGMA table_info(NVTX_EVENTS)").fetchall()
-                ]
-            return "textId" in cols
-        except (sqlite3.Error, duckdb.Error):
-            self._log.debug("NVTX textId detection failed", exc_info=True)
-            return False
 
     def _discover(self) -> ProfileMeta:
         tables = self.schema.tables
@@ -285,29 +261,26 @@ class Profile:
 
         kernel_table = self.schema.kernel_table
 
-        import duckdb
-
-        is_duckdb = isinstance(self.conn, duckdb.DuckDBPyConnection)
+        kernel_table = self.schema.kernel_table
 
         devices = [
             r[0]
-            for r in self.conn.execute(
+            for r in self.adapter.execute(
                 f"SELECT DISTINCT deviceId FROM {kernel_table} ORDER BY deviceId"
             ).fetchall()
         ]
 
         streams: dict[int, list[int]] = {}
-        for r in self.conn.execute(
+        for r in self.adapter.execute(
             f"SELECT DISTINCT deviceId, streamId FROM {kernel_table} ORDER BY deviceId, streamId"
         ).fetchall():
             streams.setdefault(r[0], []).append(r[1])
 
-        end_col = '"end"' if is_duckdb else "[end]"
-        tr = self.conn.execute(f"SELECT MIN(start), MAX({end_col}) FROM {kernel_table}").fetchone()
+        tr = self.adapter.execute(f"SELECT MIN(start), MAX([end]) FROM {kernel_table}").fetchone()
 
-        kc = self.conn.execute(f"SELECT COUNT(*) FROM {kernel_table}").fetchone()[0]
+        kc = self.adapter.execute(f"SELECT COUNT(*) FROM {kernel_table}").fetchone()[0]
         nc = (
-            self.conn.execute("SELECT COUNT(*) FROM NVTX_EVENTS").fetchone()[0]
+            self.adapter.execute("SELECT COUNT(*) FROM NVTX_EVENTS").fetchone()[0]
             if "NVTX_EVENTS" in tables
             else 0
         )
@@ -664,18 +637,24 @@ class Profile:
         """
         conn = self.db if self.db is not None else self.conn
 
-        if isinstance(conn, duckdb.DuckDBPyConnection):
-            ddb_sql = sqlite_to_duckdb(sql)
-            with self._lock:
-                cur = conn.execute(ddb_sql, params or [])
+        from .connection import DuckDBAdapter, wrap_connection
+        adapter = getattr(self, "adapter", None)
+        if adapter is None:
+            adapter = self.adapter = wrap_connection(conn)
+
+        is_duckdb = isinstance(adapter, DuckDBAdapter)
+
+        if not is_duckdb and not getattr(self, "_warned_sqlite_fallback", False):
+            self._log.warning("DuckDB unavailable, falling back to SQLite (slower)")
+            self._warned_sqlite_fallback = True
+
+        with self._lock:
+            cur = adapter.execute(sql, params or [])
+            if is_duckdb:
                 cols = [d[0] for d in cur.description]
                 return [dict(zip(cols, row)) for row in cur.fetchall()]
-        else:
-            if not getattr(self, "_warned_sqlite_fallback", False):
-                self._log.warning("DuckDB unavailable, falling back to SQLite (slower)")
-                self._warned_sqlite_fallback = True
-            with self._lock:
-                return [dict(r) for r in conn.execute(sql, params or [])]
+            else:
+                return [dict(r) for r in cur.fetchall()]
 
     def close(self):
         # Close the primary connection only if we own it.
@@ -765,13 +744,9 @@ def get_first_gpu_name(conn) -> str:
 
     Accepts both sqlite3.Connection and duckdb.DuckDBPyConnection.
     """
-    if isinstance(conn, duckdb.DuckDBPyConnection):
-        try:
-            tables = [r[0] for r in conn.execute("SHOW TABLES").fetchall()]
-        except duckdb.Error:
-            return ""
-    else:
-        tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+    from .connection import wrap_connection
+    adapter = wrap_connection(conn)
+    tables = adapter.get_table_names()
     if "TARGET_INFO_GPU" not in tables and "gpu_info" not in tables:
         return ""
     if "TARGET_INFO_CUDA_DEVICE" not in tables and "cuda_device" not in tables:
@@ -779,7 +754,7 @@ def get_first_gpu_name(conn) -> str:
     # Use Parquet view names if available, otherwise original SQLite names
     gpu_tbl = "gpu_info" if "gpu_info" in tables else "TARGET_INFO_GPU"
     dev_tbl = "cuda_device" if "cuda_device" in tables else "TARGET_INFO_CUDA_DEVICE"
-    row = conn.execute(f"""
+    row = adapter.execute(f"""
         SELECT g.name
         FROM {gpu_tbl} g
         JOIN {dev_tbl} c ON g.id = c.gpuId

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -638,9 +638,9 @@ class Profile:
         conn = self.db if self.db is not None else self.conn
 
         from .connection import DuckDBAdapter, wrap_connection
-        adapter = getattr(self, "adapter", None)
-        if adapter is None:
-            adapter = self.adapter = wrap_connection(conn)
+        # Always wrap the actual connection being used — self.adapter may
+        # reference self.conn (SQLite) while conn here is self.db (DuckDB).
+        adapter = wrap_connection(conn)
 
         is_duckdb = isinstance(adapter, DuckDBAdapter)
 

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -261,8 +261,6 @@ class Profile:
 
         kernel_table = self.schema.kernel_table
 
-        kernel_table = self.schema.kernel_table
-
         devices = [
             r[0]
             for r in self.adapter.execute(

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -643,7 +643,7 @@ class Profile:
         is_duckdb = isinstance(adapter, DuckDBAdapter)
 
         if not is_duckdb and not getattr(self, "_warned_sqlite_fallback", False):
-            self._log.warning("DuckDB unavailable, falling back to SQLite (slower)")
+            self._log.warning("DuckDB cache unavailable or not in use; falling back to SQLite (slower)")
             self._warned_sqlite_fallback = True
 
         with self._lock:

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -185,7 +185,8 @@ def find_nvtx_ranges(
         return []
 
     from .connection import wrap_connection
-    has_text_id = wrap_connection(conn).detect_nvtx_text_id()
+    adapter = wrap_connection(conn)
+    has_text_id = adapter.detect_nvtx_text_id()
     if match_mode not in ("contains", "exact"):
         match_mode = "contains"
 
@@ -221,8 +222,7 @@ def find_nvtx_ranges(
 
     base_sql += "ORDER BY start_ns"
 
-    from .connection import wrap_connection
-    cur = wrap_connection(conn).execute(base_sql, params)
+    cur = adapter.execute(base_sql, params)
     rows: list[RowDict] = []
     for text, start_ns, end_ns, global_tid in cur.fetchall():
         if text is None:

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -44,15 +44,6 @@ ErrorDict = dict[str, Any]
 RowDict = dict[str, Any]
 
 
-def _compat_execute(conn, sql, params=None):
-    """Execute SQL, translating bracket syntax for DuckDB connections."""
-    import duckdb as _ddb
-
-    if isinstance(conn, _ddb.DuckDBPyConnection):
-        from .sql_compat import sqlite_to_duckdb
-
-        sql = sqlite_to_duckdb(sql)
-    return conn.execute(sql, params or [])
 
 
 def _escape_like(value: str) -> str:
@@ -174,25 +165,7 @@ def compute_theoretical_flops(
     }
 
 
-def _detect_nvtx_text_id(conn: sqlite3.Connection) -> bool:
-    """Return True if NVTX_EVENTS uses textId -> StringIds."""
-    try:
-        import duckdb
 
-        if isinstance(conn, duckdb.DuckDBPyConnection):
-            cols = [r[0] for r in conn.execute("DESCRIBE NVTX_EVENTS").fetchall()]
-        else:
-            cur = conn.execute("PRAGMA table_info(NVTX_EVENTS)")
-            cols = [r[1] for r in cur.fetchall()]
-        return "textId" in cols
-    except (sqlite3.Error, ImportError) as exc:
-        _log.debug("NVTX textId detection failed: %s", exc, exc_info=True)
-        return False
-    except Exception as exc:
-        if type(exc).__module__.startswith("duckdb"):
-            _log.debug("NVTX textId detection failed (duckdb): %s", exc, exc_info=True)
-            return False
-        raise
 
 
 def find_nvtx_ranges(
@@ -211,7 +184,8 @@ def find_nvtx_ranges(
     if not nvtx_name:
         return []
 
-    has_text_id = _detect_nvtx_text_id(conn)
+    from .connection import wrap_connection
+    has_text_id = wrap_connection(conn).detect_nvtx_text_id()
     if match_mode not in ("contains", "exact"):
         match_mode = "contains"
 
@@ -247,7 +221,8 @@ def find_nvtx_ranges(
 
     base_sql += "ORDER BY start_ns"
 
-    cur = _compat_execute(conn, base_sql, params)
+    from .connection import wrap_connection
+    cur = wrap_connection(conn).execute(base_sql, params)
     rows: list[RowDict] = []
     for text, start_ns, end_ns, global_tid in cur.fetchall():
         if text is None:
@@ -285,7 +260,8 @@ def _resolve_string_ids(
         sql = "SELECT id, value FROM StringIds WHERE value LIKE ? ESCAPE '\\'"
         params = [f"%{_escape_like(pattern)}%"]
 
-    cur = _compat_execute(conn, sql, params)
+    from .connection import wrap_connection
+    cur = wrap_connection(conn).execute(sql, params)
     return {int(row[0]): str(row[1]) for row in cur.fetchall()}
 
 
@@ -349,7 +325,8 @@ def find_kernels_by_name(
         f"ORDER BY k.start"
     )
 
-    cur = _compat_execute(conn, sql, params)
+    from .connection import wrap_connection
+    cur = wrap_connection(conn).execute(sql, params)
     kernels: list[RowDict] = []
     for short_id, start_ns, end_ns, duration_ns, dev, stream_id in cur.fetchall():
         d = int(duration_ns) if duration_ns is not None else int(end_ns) - int(start_ns)
@@ -434,7 +411,8 @@ def get_region_kernels(
         "ORDER BY start_ns"
     )
 
-    cur = _compat_execute(conn, sql, params)
+    from .connection import wrap_connection
+    cur = wrap_connection(conn).execute(sql, params)
     kernels: list[RowDict] = []
     for row in cur.fetchall():
         (

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -21,66 +21,6 @@ _indexed_connections: set[int] = set()
 # hard-coding them here.
 
 
-def _resolve_activity_tables(conn: sqlite3.Connection) -> dict[str, str]:
-    """Resolve Nsight activity table names (kernel/runtime/NVTX) from sqlite_master.
-
-    Nsight may emit versioned table names such as
-    CUPTI_ACTIVITY_KIND_KERNEL_V2.
-    This helper finds the first matching table for each logical kind.
-    """
-    try:
-        # DuckDB: use SHOW TABLES; SQLite: use sqlite_master
-        import duckdb as _ddb
-
-        if isinstance(conn, _ddb.DuckDBPyConnection):
-            tables = {row[0] for row in conn.execute("SHOW TABLES").fetchall()}
-        else:
-            tables = {
-                row[0]
-                for row in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table'"
-                ).fetchall()
-            }
-    except (sqlite3.Error, ImportError) as exc:
-        _log.debug("Failed to resolve activity tables: %s", exc, exc_info=True)
-        return {}
-    except Exception as exc:
-        # Catch duckdb.Error without importing duckdb at module level
-        if type(exc).__module__.startswith("duckdb"):
-            _log.debug("Failed to resolve activity tables (duckdb): %s", exc, exc_info=True)
-            return {}
-        raise
-
-    def _find_by_prefix(prefix: str) -> str | None:
-        if prefix in tables:
-            return prefix
-        candidates = sorted(t for t in tables if t.startswith(prefix))
-        return candidates[0] if candidates else None
-
-    kernel_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_KERNEL")
-    runtime_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_RUNTIME")
-    memcpy_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_MEMCPY")
-    memset_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_MEMSET")
-    if "NVTX_EVENTS" in tables:
-        nvtx_table = "NVTX_EVENTS"
-    else:
-        nvtx_table = _find_by_prefix("NVTX_EVENTS")
-
-    resolved: dict[str, str] = {}
-    if kernel_table:
-        resolved["kernel"] = kernel_table
-    if runtime_table:
-        resolved["runtime"] = runtime_table
-    if memcpy_table:
-        resolved["memcpy"] = memcpy_table
-    if memset_table:
-        resolved["memset"] = memset_table
-    if nvtx_table:
-        resolved["nvtx"] = nvtx_table
-
-    return resolved
-
-
 def ensure_indexes(conn: sqlite3.Connection) -> None:
     """Create performance indexes on the profile DB if they don't already exist.
 
@@ -149,6 +89,9 @@ class Skill:
         # Auto-create performance indexes (one-time per connection).
         ensure_indexes(conn)
 
+        from ..connection import wrap_connection
+        adapter = wrap_connection(conn)
+
         # Apply parameter defaults and required checks for all skill types.
         # Start from the provided kwargs so we preserve any extra arguments.
         resolved: dict[str, object] = dict(kwargs)
@@ -181,7 +124,7 @@ class Skill:
         # SQL templates use {kernel_table} etc. instead of hardcoding
         # CUPTI_ACTIVITY_KIND_KERNEL which may be _KERNEL_V2/_V3 in
         # newer Nsight Systems versions.
-        tables = _resolve_activity_tables(conn)
+        tables = adapter.resolve_activity_tables()
         resolved.setdefault(
             "kernel_table",
             tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL"),
@@ -205,30 +148,8 @@ class Skill:
 
         # NVTX text resolution: handle both legacy (text column only)
         # and modern schemas (textId → StringIds lookup).
-        nvtx_tbl = resolved.get("nvtx_table", "NVTX_EVENTS")
         if "{nvtx_text_expr}" in self.sql or "{nvtx_text_join}" in self.sql:
-            try:
-                import duckdb as _ddb
-
-                if isinstance(conn, _ddb.DuckDBPyConnection):
-                    cols = [r[0] for r in conn.execute(f"DESCRIBE {nvtx_tbl}").fetchall()]
-                    has_textid = "textId" in cols
-                else:
-                    has_textid = (
-                        conn.execute(
-                            f"SELECT COUNT(*) FROM pragma_table_info('{nvtx_tbl}') WHERE name='textId'"
-                        ).fetchone()[0]
-                        > 0
-                    )
-            except (sqlite3.Error, ImportError) as exc:
-                _log.debug("NVTX textId detection failed: %s", exc, exc_info=True)
-                has_textid = False
-            except Exception as exc:
-                if type(exc).__module__.startswith("duckdb"):
-                    _log.debug("NVTX textId detection failed (duckdb): %s", exc, exc_info=True)
-                    has_textid = False
-                else:
-                    raise
+            has_textid = adapter.detect_nvtx_text_id()
             if has_textid:
                 resolved.setdefault("nvtx_text_expr", "COALESCE(n.text, s2.value)")
                 resolved.setdefault("nvtx_text_join", "LEFT JOIN StringIds s2 ON n.textId = s2.id")
@@ -237,15 +158,8 @@ class Skill:
                 resolved.setdefault("nvtx_text_join", "")
 
         sql = self.sql.format(**resolved) if resolved else self.sql
-        # Apply DuckDB SQL translation if needed
-        import duckdb as _ddb
-
-        if isinstance(conn, _ddb.DuckDBPyConnection):
-            from nsys_ai.sql_compat import sqlite_to_duckdb
-
-            sql = sqlite_to_duckdb(sql)
         try:
-            cursor = conn.execute(sql)
+            cursor = adapter.execute(sql)
             columns = [desc[0] for desc in cursor.description] if cursor.description else []
             return [dict(zip(columns, row)) for row in cursor.fetchall()]
         except Exception as exc:

--- a/src/nsys_ai/skills/builtins/arithmetic_intensity.py
+++ b/src/nsys_ai/skills/builtins/arithmetic_intensity.py
@@ -17,9 +17,10 @@ try:
 except ImportError:
     _DB_ERRORS = (sqlite3.Error,)
 
+from nsys_ai.connection import wrap_connection
 from nsys_ai.hardware import get_peak_tflops
 
-from ..base import Skill, SkillParam, _resolve_activity_tables
+from ..base import Skill, SkillParam
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +29,7 @@ def _execute(conn, **kwargs):
     theoretical_flops = float(kwargs["theoretical_flops"])
     device = int(kwargs.get("device", 0))
 
-    tables = _resolve_activity_tables(conn)
+    tables = wrap_connection(conn).resolve_activity_tables()
     kernel_table = tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
 
     # --- Get GPU hardware spec ---

--- a/src/nsys_ai/skills/builtins/gc_impact.py
+++ b/src/nsys_ai/skills/builtins/gc_impact.py
@@ -1,6 +1,8 @@
 """Detect Python Garbage Collection and intensive memory free stalls."""
 
-from ..base import Skill, _resolve_activity_tables
+from nsys_ai.connection import wrap_connection
+
+from ..base import Skill
 
 
 def _format(rows):
@@ -23,14 +25,15 @@ def _format(rows):
 
 
 def _execute(conn, **kwargs):
-    tables = _resolve_activity_tables(conn)
+    adapter = wrap_connection(conn)
+    tables = adapter.resolve_activity_tables()
     runtime_table = tables.get("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME")
 
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")
 
     try:
-        conn.execute(f"SELECT 1 FROM {runtime_table} LIMIT 1")
+        adapter.execute(f"SELECT 1 FROM {runtime_table} LIMIT 1")
     except Exception:
         return []
 
@@ -58,7 +61,7 @@ def _execute(conn, **kwargs):
         GROUP BY s.value
         ORDER BY total_ms DESC
     """
-    rows_runtime = conn.execute(sql_runtime, params_r).fetchall()
+    rows_runtime = adapter.execute(sql_runtime, params_r).fetchall()
     cols = ["event_name", "occurrences", "total_ms", "max_ms", "avg_ms"]
     results = [dict(zip(cols, r)) if isinstance(r, tuple) else dict(r) for r in rows_runtime]
 
@@ -74,14 +77,7 @@ def _execute(conn, **kwargs):
 
         # Handle both text and textId schemas
         try:
-            import duckdb as _ddb
-
-            if isinstance(conn, _ddb.DuckDBPyConnection):
-                nvtx_cols = [r[0] for r in conn.execute(f"DESCRIBE {nvtx_table}").fetchall()]
-            else:
-                nvtx_cols = [
-                    r[1] for r in conn.execute(f"PRAGMA table_info({nvtx_table})").fetchall()
-                ]
+            nvtx_cols = adapter.get_table_columns(nvtx_table)
         except Exception:
             nvtx_cols = []
 
@@ -118,7 +114,7 @@ def _execute(conn, **kwargs):
                 GROUP BY text
             """
         try:
-            rows_nvtx = conn.execute(sql_nvtx, params_n).fetchall()
+            rows_nvtx = adapter.execute(sql_nvtx, params_n).fetchall()
             results.extend(
                 dict(zip(cols, r)) if isinstance(r, tuple) else dict(r) for r in rows_nvtx
             )

--- a/src/nsys_ai/skills/builtins/gc_impact.py
+++ b/src/nsys_ai/skills/builtins/gc_impact.py
@@ -1,6 +1,6 @@
 """Detect Python Garbage Collection and intensive memory free stalls."""
 
-from nsys_ai.connection import wrap_connection
+from nsys_ai.connection import DB_ERRORS, wrap_connection
 
 from ..base import Skill
 
@@ -34,7 +34,7 @@ def _execute(conn, **kwargs):
 
     try:
         adapter.execute(f"SELECT 1 FROM {runtime_table} LIMIT 1")
-    except Exception:
+    except DB_ERRORS:
         return []
 
     # --- Part 1: CUDA Memory APIs from Runtime table ---
@@ -78,7 +78,7 @@ def _execute(conn, **kwargs):
         # Handle both text and textId schemas
         try:
             nvtx_cols = adapter.get_table_columns(nvtx_table)
-        except Exception:
+        except DB_ERRORS:
             nvtx_cols = []
 
         if "textId" in nvtx_cols:
@@ -118,7 +118,7 @@ def _execute(conn, **kwargs):
             results.extend(
                 dict(zip(cols, r)) if isinstance(r, tuple) else dict(r) for r in rows_nvtx
             )
-        except Exception:
+        except DB_ERRORS:
             pass  # NVTX query is best-effort
 
     # Sort combined results by total_ms descending

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -8,7 +8,9 @@ Enhanced with:
 import logging
 import sqlite3
 
-from ..base import Skill, SkillParam, _resolve_activity_tables
+from nsys_ai.connection import wrap_connection
+
+from ..base import Skill, SkillParam
 
 _log = logging.getLogger(__name__)
 
@@ -44,25 +46,8 @@ def _classify_gap_apis(api_names: list[str]) -> tuple[str, str]:
 
 def _execute(conn: sqlite3.Connection, **kwargs):
     """Execute GPU idle gaps analysis with aggregation and CPU attribution."""
-    import duckdb
-
-    if isinstance(conn, duckdb.DuckDBPyConnection):
-        # DuckDB has no row_factory; _execute_inner builds dicts via cursor.description
-        return _execute_inner(conn, **kwargs)
-
-    # Ensure row_factory is set for dict-like access from raw SQL
-    old_factory = conn.row_factory
-    conn.row_factory = sqlite3.Row
-    try:
-        return _execute_inner(conn, **kwargs)
-    finally:
-        conn.row_factory = old_factory
-
-
-def _execute_inner(conn: sqlite3.Connection, **kwargs):
-    """Inner implementation (row_factory managed by _execute)."""
-
-    tables = _resolve_activity_tables(conn)
+    adapter = wrap_connection(conn)
+    tables = adapter.resolve_activity_tables()
     kernel_tbl = tables.get("kernel")
     runtime_tbl = tables.get("runtime")
     if not kernel_tbl:
@@ -105,17 +90,11 @@ FROM ordered
 WHERE prev_end IS NOT NULL AND (start - prev_end) > ?
 ORDER BY gap_ns DESC
 LIMIT ?"""
-    import sqlite3
-
-    import duckdb
-
-    from ...sql_compat import sqlite_to_duckdb
-
     try:
-        cur = conn.execute(sqlite_to_duckdb(gap_sql), trim_params + [min_gap_ns, limit])
+        cur = adapter.execute(gap_sql, trim_params + [min_gap_ns, limit])
         cols = [d[0] for d in cur.description]
         rows = [dict(zip(cols, r)) for r in cur.fetchall()]
-    except (sqlite3.Error, duckdb.Error) as e:
+    except Exception as e:
         _log.debug("gpu_idle_gaps: %s", e, exc_info=True)
         return []
 
@@ -153,14 +132,14 @@ SELECT COUNT(*) AS gap_count,
 FROM ordered
 WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
     try:
-        cur_agg = conn.execute(sqlite_to_duckdb(agg_sql), trim_params + [min_gap_ns])
+        cur_agg = adapter.execute(agg_sql, trim_params + [min_gap_ns])
         agg_row = cur_agg.fetchone()
         if agg_row is not None:
             agg_cols = [d[0] for d in cur_agg.description]
             agg = dict(zip(agg_cols, agg_row))
         else:
             agg = {}
-    except (sqlite3.Error, duckdb.Error) as exc:
+    except Exception as exc:
         _log.debug("gpu_idle_gaps aggregation query failed: %s", exc, exc_info=True)
         agg = {}
 
@@ -168,21 +147,17 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
     # Gaps are summed across ALL streams, so we need to normalize by
     # the number of active streams to avoid pct > 100%.
     try:
-        time_range = conn.execute(
-            sqlite_to_duckdb(
-                f"SELECT MIN(k.start), MAX(k.[end]) FROM {kernel_tbl} AS k WHERE k.deviceId = ? {trim_clause}"
-            ),
+        time_range = adapter.execute(
+            f"SELECT MIN(k.start), MAX(k.[end]) FROM {kernel_tbl} AS k WHERE k.deviceId = ? {trim_clause}",
             trim_params,
         ).fetchone()
         profile_span_ns = (time_range[1] or 0) - (time_range[0] or 0)
-        stream_count_row = conn.execute(
-            sqlite_to_duckdb(
-                f"SELECT COUNT(DISTINCT k.streamId) AS n FROM {kernel_tbl} AS k WHERE k.deviceId = ? {trim_clause}"
-            ),
+        stream_count_row = adapter.execute(
+            f"SELECT COUNT(DISTINCT k.streamId) AS n FROM {kernel_tbl} AS k WHERE k.deviceId = ? {trim_clause}",
             trim_params,
         ).fetchone()
         n_streams = stream_count_row[0] if stream_count_row else 1
-    except (sqlite3.Error, duckdb.Error) as exc:
+    except Exception as exc:
         _log.debug("gpu_idle_gaps profile span query failed: %s", exc, exc_info=True)
         profile_span_ns = 0
         n_streams = 1
@@ -214,9 +189,8 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
             gap_start = gap["start_ns"]
             gap_end = gap["end_ns"]
             try:
-                cur_api = conn.execute(
-                    sqlite_to_duckdb(
-                        f"""\
+                cur_api = adapter.execute(
+                    f"""\
 SELECT s.value AS api_name, COUNT(*) AS call_count,
        SUM(r.[end] - r.start) AS total_ns
 FROM {runtime_tbl} r
@@ -224,14 +198,13 @@ JOIN StringIds s ON r.nameId = s.id
 WHERE r.start < ? AND r.[end] > ?
 GROUP BY s.value
 ORDER BY total_ns DESC
-LIMIT 5"""
-                    ),
+LIMIT 5""",
                     (gap_end, gap_start),
                 )
                 api_rows = cur_api.fetchall()
                 api_cols = [d[0] for d in cur_api.description]
                 apis = [dict(zip(api_cols, r)) for r in api_rows]
-            except (sqlite3.Error, duckdb.Error) as exc:
+            except Exception as exc:
                 _log.debug("gpu_idle_gaps CPU attribution query failed: %s", exc, exc_info=True)
                 apis = []
 

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -14,6 +14,14 @@ from ..base import Skill, SkillParam
 
 _log = logging.getLogger(__name__)
 
+# Narrow exception tuple for diagnostic query blocks.
+_DB_ERRORS: tuple[type[Exception], ...] = (sqlite3.Error, sqlite3.OperationalError)
+try:
+    import duckdb  # noqa: E402
+    _DB_ERRORS = _DB_ERRORS + (duckdb.Error,)
+except ImportError:
+    pass
+
 # Gap classification rules based on dominant CUDA Runtime API during the gap
 # NOTE: More specific patterns (e.g. cudaMemcpyAsync) must appear BEFORE
 # less specific ones (e.g. cudaMemcpy) since matching uses substring search.
@@ -94,7 +102,7 @@ LIMIT ?"""
         cur = adapter.execute(gap_sql, trim_params + [min_gap_ns, limit])
         cols = [d[0] for d in cur.description]
         rows = [dict(zip(cols, r)) for r in cur.fetchall()]
-    except Exception as e:
+    except _DB_ERRORS as e:
         _log.debug("gpu_idle_gaps: %s", e, exc_info=True)
         return []
 
@@ -139,7 +147,7 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
             agg = dict(zip(agg_cols, agg_row))
         else:
             agg = {}
-    except Exception as exc:
+    except _DB_ERRORS as exc:
         _log.debug("gpu_idle_gaps aggregation query failed: %s", exc, exc_info=True)
         agg = {}
 
@@ -157,7 +165,7 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
             trim_params,
         ).fetchone()
         n_streams = stream_count_row[0] if stream_count_row else 1
-    except Exception as exc:
+    except _DB_ERRORS as exc:
         _log.debug("gpu_idle_gaps profile span query failed: %s", exc, exc_info=True)
         profile_span_ns = 0
         n_streams = 1
@@ -204,7 +212,7 @@ LIMIT 5""",
                 api_rows = cur_api.fetchall()
                 api_cols = [d[0] for d in cur_api.description]
                 apis = [dict(zip(api_cols, r)) for r in api_rows]
-            except Exception as exc:
+            except _DB_ERRORS as exc:
                 _log.debug("gpu_idle_gaps CPU attribution query failed: %s", exc, exc_info=True)
                 apis = []
 

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -8,19 +8,11 @@ Enhanced with:
 import logging
 import sqlite3
 
-from nsys_ai.connection import wrap_connection
+from nsys_ai.connection import DB_ERRORS, wrap_connection
 
 from ..base import Skill, SkillParam
 
 _log = logging.getLogger(__name__)
-
-# Narrow exception tuple for diagnostic query blocks.
-_DB_ERRORS: tuple[type[Exception], ...] = (sqlite3.Error, sqlite3.OperationalError)
-try:
-    import duckdb  # noqa: E402
-    _DB_ERRORS = _DB_ERRORS + (duckdb.Error,)
-except ImportError:
-    pass
 
 # Gap classification rules based on dominant CUDA Runtime API during the gap
 # NOTE: More specific patterns (e.g. cudaMemcpyAsync) must appear BEFORE
@@ -102,7 +94,7 @@ LIMIT ?"""
         cur = adapter.execute(gap_sql, trim_params + [min_gap_ns, limit])
         cols = [d[0] for d in cur.description]
         rows = [dict(zip(cols, r)) for r in cur.fetchall()]
-    except _DB_ERRORS as e:
+    except DB_ERRORS as e:
         _log.debug("gpu_idle_gaps: %s", e, exc_info=True)
         return []
 
@@ -147,7 +139,7 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
             agg = dict(zip(agg_cols, agg_row))
         else:
             agg = {}
-    except _DB_ERRORS as exc:
+    except DB_ERRORS as exc:
         _log.debug("gpu_idle_gaps aggregation query failed: %s", exc, exc_info=True)
         agg = {}
 
@@ -165,7 +157,7 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
             trim_params,
         ).fetchone()
         n_streams = stream_count_row[0] if stream_count_row else 1
-    except _DB_ERRORS as exc:
+    except DB_ERRORS as exc:
         _log.debug("gpu_idle_gaps profile span query failed: %s", exc, exc_info=True)
         profile_span_ns = 0
         n_streams = 1
@@ -212,7 +204,7 @@ LIMIT 5""",
                 api_rows = cur_api.fetchall()
                 api_cols = [d[0] for d in cur_api.description]
                 apis = [dict(zip(api_cols, r)) for r in api_rows]
-            except _DB_ERRORS as exc:
+            except DB_ERRORS as exc:
                 _log.debug("gpu_idle_gaps CPU attribution query failed: %s", exc, exc_info=True)
                 apis = []
 

--- a/src/nsys_ai/skills/builtins/module_loading.py
+++ b/src/nsys_ai/skills/builtins/module_loading.py
@@ -1,6 +1,8 @@
 """Detect JIT compilation and module loading stalls."""
 
-from ..base import Skill, _resolve_activity_tables
+from nsys_ai.connection import wrap_connection
+
+from ..base import Skill
 
 
 def _format(rows):
@@ -23,7 +25,7 @@ def _format(rows):
 
 
 def _execute(conn, **kwargs):
-    tables = _resolve_activity_tables(conn)
+    tables = wrap_connection(conn).resolve_activity_tables()
     runtime_table = tables.get("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME")
 
     trim_start = kwargs.get("trim_start_ns")

--- a/src/nsys_ai/skills/builtins/module_loading.py
+++ b/src/nsys_ai/skills/builtins/module_loading.py
@@ -1,6 +1,6 @@
 """Detect JIT compilation and module loading stalls."""
 
-from nsys_ai.connection import wrap_connection
+from nsys_ai.connection import DB_ERRORS, wrap_connection
 
 from ..base import Skill
 
@@ -33,7 +33,7 @@ def _execute(conn, **kwargs):
 
     try:
         conn.execute(f"SELECT 1 FROM {runtime_table} LIMIT 1")
-    except Exception:
+    except DB_ERRORS:
         return []
 
     params = []

--- a/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
@@ -16,6 +16,8 @@ Features:
 
 from collections import defaultdict
 
+from nsys_ai.connection import DB_ERRORS
+
 from ..base import Skill, SkillParam
 
 
@@ -56,7 +58,7 @@ def _execute(conn, **kwargs):
     try:
         conn.execute("SELECT 1 FROM nvtx_kernel_map LIMIT 1")
         has_nkm = True
-    except Exception:
+    except DB_ERRORS:
         has_nkm = False
 
     if not has_nkm:

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -8,6 +8,8 @@ logic that can't be expressed in a single SQL query.
 
 import logging
 
+from nsys_ai.connection import DB_ERRORS
+
 from ..base import Skill, SkillParam
 
 _log = logging.getLogger(__name__)
@@ -56,7 +58,7 @@ def _execute(conn, **kwargs):
             )
             if same_stream:
                 result["same_stream_diagnosis"] = [str(r["streamId"]) for r in same_stream]
-    except Exception:
+    except DB_ERRORS:
         _log.debug("Failed to enrich stream compute/nccl overlap", exc_info=True)
 
     result["device_id"] = device

--- a/src/nsys_ai/skills/builtins/pipeline_bubble_metrics.py
+++ b/src/nsys_ai/skills/builtins/pipeline_bubble_metrics.py
@@ -7,7 +7,9 @@ of SQL window functions, which are prohibitively slow on large profiles.
 import logging
 import sqlite3
 
-from ..base import Skill, _resolve_activity_tables
+from nsys_ai.connection import wrap_connection
+
+from ..base import Skill
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +40,7 @@ def _format(rows):
 
 
 def _execute(conn, **kwargs):
-    tables = _resolve_activity_tables(conn)
+    tables = wrap_connection(conn).resolve_activity_tables()
     kernel_table = tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
     memcpy_table = tables.get("memcpy")
     memset_table = tables.get("memset")

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -853,14 +853,23 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
 
 def _safe_execute(skill_name, conn: sqlite3.Connection, **kwargs):
     """Execute a skill, returning [] on DB or skill execution errors."""
+    from ...exceptions import SkillExecutionError
     from ...skills.registry import get_skill
+
+    error_types = (sqlite3.Error, SkillExecutionError)
+    try:
+        import duckdb
+
+        error_types = error_types + (duckdb.Error,)
+    except ImportError:
+        pass
 
     try:
         skill = get_skill(skill_name)
         if skill is None:
             return []
         return skill.execute(conn, **kwargs)
-    except Exception as e:
+    except error_types as e:
         _log.debug("root_cause_matcher (%s): %s", skill_name, e, exc_info=True)
         return []
 

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -22,6 +22,15 @@ from ..base import Skill, SkillParam
 
 _log = logging.getLogger(__name__)
 
+# Narrow exception tuple for diagnostic query blocks.
+# Catches only expected DB errors so programming bugs propagate.
+_DB_ERRORS: tuple[type[Exception], ...] = (sqlite3.Error, sqlite3.OperationalError)
+try:
+    import duckdb  # noqa: E402
+    _DB_ERRORS = _DB_ERRORS + (duckdb.Error,)
+except ImportError:
+    pass
+
 
 def _execute(conn: sqlite3.Connection, **kwargs):
     """Run all pattern matchers against the profile."""
@@ -372,7 +381,7 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
                 "cause": "same_stream",
                 "detail": (f"Stream(s) [{', '.join(streams)}] run both NCCL and compute kernels"),
             }
-    except Exception as e:
+    except _DB_ERRORS as e:
         _log.debug("_diagnose_low_overlap (same_stream): %s", e, exc_info=True)
 
     # --- Check 2: Sync-after-NCCL detection ---
@@ -417,7 +426,7 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
                             "detected immediately after NCCL kernel completion"
                         ),
                     }
-        except Exception as e:
+        except _DB_ERRORS as e:
             _log.debug("_diagnose_low_overlap (sync_after_nccl): %s", e, exc_info=True)
 
     return {"cause": "general", "detail": ""}
@@ -654,7 +663,7 @@ def _check_sync_apis(conn: sqlite3.Connection, **kwargs):
                     ),
                 }
             ]
-    except Exception as e:
+    except _DB_ERRORS as e:
         _log.debug("root_cause_matcher (_check_sync_apis): %s", e, exc_info=True)
     return []
 
@@ -723,7 +732,7 @@ def _check_sync_memcpy(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except Exception as e:
+    except _DB_ERRORS as e:
         _log.debug("root_cause_matcher (_check_sync_memcpy): %s", e, exc_info=True)
     return []
 
@@ -777,7 +786,7 @@ def _check_pageable_memcpy(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except Exception as e:
+    except _DB_ERRORS as e:
         _log.debug("root_cause_matcher (_check_pageable_memcpy): %s", e, exc_info=True)
     return []
 
@@ -843,7 +852,7 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except Exception as e:
+    except _DB_ERRORS as e:
         _log.debug("root_cause_matcher (_check_sync_memset): %s", e, exc_info=True)
     return []
 
@@ -856,20 +865,14 @@ def _safe_execute(skill_name, conn: sqlite3.Connection, **kwargs):
     from ...exceptions import SkillExecutionError
     from ...skills.registry import get_skill
 
-    error_types = (sqlite3.Error, SkillExecutionError)
-    try:
-        import duckdb
-
-        error_types = error_types + (duckdb.Error,)
-    except ImportError:
-        pass
+    _safe_errors = _DB_ERRORS + (SkillExecutionError,)
 
     try:
         skill = get_skill(skill_name)
         if skill is None:
             return []
         return skill.execute(conn, **kwargs)
-    except error_types as e:
+    except _safe_errors as e:
         _log.debug("root_cause_matcher (%s): %s", skill_name, e, exc_info=True)
         return []
 

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -16,11 +16,9 @@ to gather evidence, then matches against known patterns.
 import logging
 import sqlite3
 
-import duckdb
+from nsys_ai.connection import wrap_connection
 
-from nsys_ai.sql_compat import sqlite_to_duckdb
-
-from ..base import Skill, SkillParam, _resolve_activity_tables
+from ..base import Skill, SkillParam
 
 _log = logging.getLogger(__name__)
 
@@ -342,7 +340,7 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
     Returns dict with 'cause' ('same_stream', 'sync_after_nccl', 'general')
     and 'detail' string.
     """
-    tables = _resolve_activity_tables(conn)
+    tables = wrap_connection(conn).resolve_activity_tables()
     kernel_tbl = tables.get("kernel")
     runtime_tbl = tables.get("runtime")
 
@@ -374,7 +372,7 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
                 "cause": "same_stream",
                 "detail": (f"Stream(s) [{', '.join(streams)}] run both NCCL and compute kernels"),
             }
-    except (sqlite3.Error, duckdb.Error) as e:
+    except Exception as e:
         _log.debug("_diagnose_low_overlap (same_stream): %s", e, exc_info=True)
 
     # --- Check 2: Sync-after-NCCL detection ---
@@ -394,8 +392,8 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
 
                 # Single query: check if ANY sync call starts within 1ms
                 # after ANY NCCL kernel's end time (avoids N+1 loop).
-                found = conn.execute(
-                    sqlite_to_duckdb(
+                adapter = wrap_connection(conn)
+                found = adapter.execute(
                         f"""
                     SELECT 1 FROM {kernel_tbl} k
                     JOIN StringIds s ON k.shortName = s.id
@@ -408,8 +406,7 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
                             AND r.start <= k.[end] + 1000000
                       )
                     LIMIT 1
-                    """
-                    ),
+                    """,
                     [device] + sync_id_list,
                 ).fetchone()
                 if found:
@@ -420,7 +417,7 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
                             "detected immediately after NCCL kernel completion"
                         ),
                     }
-        except (sqlite3.Error, duckdb.Error) as e:
+        except Exception as e:
             _log.debug("_diagnose_low_overlap (sync_after_nccl): %s", e, exc_info=True)
 
     return {"cause": "general", "detail": ""}
@@ -584,9 +581,8 @@ def _check_sync_apis(conn: sqlite3.Connection, **kwargs):
     Note: Nsight exports use versioned API names (e.g. cudaDeviceSynchronize_v3020),
     so we use LIKE prefix matching via a two-step nameId resolution.
     """
-    from ...sql_compat import sqlite_to_duckdb
-
-    tables = _resolve_activity_tables(conn)
+    adapter = wrap_connection(conn)
+    tables = adapter.resolve_activity_tables()
     runtime_tbl = tables.get("runtime")
     kernel_tbl = tables.get("kernel")
     if not runtime_tbl:
@@ -594,14 +590,14 @@ def _check_sync_apis(conn: sqlite3.Connection, **kwargs):
 
     try:
         # Step 1: resolve nameIds from StringIds (fast, tiny table)
-        sync_names = conn.execute(
-            sqlite_to_duckdb("""
+        sync_names = adapter.execute(
+            """
             SELECT id, value FROM StringIds
             WHERE value LIKE 'cudaDeviceSynchronize%'
                OR value LIKE 'cudaStreamSynchronize%'
                OR value LIKE 'cudaEventSynchronize%'
                OR value LIKE 'cudaStreamWaitEvent%'
-        """)
+        """
         ).fetchall()
         if not sync_names:
             return []
@@ -610,14 +606,14 @@ def _check_sync_apis(conn: sqlite3.Connection, **kwargs):
         placeholders = ",".join(str(nid) for nid in name_ids)
 
         # Step 2: count sync calls by nameId (fast with index)
-        rows = conn.execute(
-            sqlite_to_duckdb(f"""
+        rows = adapter.execute(
+            f"""
             SELECT nameId, COUNT(*) AS call_count,
                    SUM([end] - start) AS total_ns
             FROM {runtime_tbl}
             WHERE nameId IN ({placeholders})
             GROUP BY nameId
-        """)
+        """
         ).fetchall()
         if not rows:
             return []
@@ -633,8 +629,8 @@ def _check_sync_apis(conn: sqlite3.Connection, **kwargs):
         # Total GPU kernel time as baseline for percentage threshold
         total_gpu_ns = 0
         if kernel_tbl:
-            gpu_row = conn.execute(
-                sqlite_to_duckdb(f"SELECT SUM([end] - start) FROM {kernel_tbl}")
+            gpu_row = adapter.execute(
+                f"SELECT SUM([end] - start) FROM {kernel_tbl}"
             ).fetchone()
             total_gpu_ns = gpu_row[0] or 0 if gpu_row else 0
 
@@ -658,7 +654,7 @@ def _check_sync_apis(conn: sqlite3.Connection, **kwargs):
                     ),
                 }
             ]
-    except (sqlite3.Error, duckdb.Error) as e:
+    except Exception as e:
         _log.debug("root_cause_matcher (_check_sync_apis): %s", e, exc_info=True)
     return []
 
@@ -672,9 +668,8 @@ def _check_sync_memcpy(conn: sqlite3.Connection, **kwargs):
     Note: Nsight exports use versioned API names (e.g. cudaMemcpy_v3020).
     We match any name starting with 'cudaMemcpy' but NOT 'cudaMemcpyAsync'.
     """
-    from ...sql_compat import sqlite_to_duckdb
-
-    tables = _resolve_activity_tables(conn)
+    adapter = wrap_connection(conn)
+    tables = adapter.resolve_activity_tables()
     runtime_tbl = tables.get("runtime")
     memcpy_tbl = tables.get("memcpy")
     if not runtime_tbl or not memcpy_tbl:
@@ -682,12 +677,12 @@ def _check_sync_memcpy(conn: sqlite3.Connection, **kwargs):
 
     try:
         # Step 1: find nameIds for sync cudaMemcpy (NOT async)
-        sync_names = conn.execute(
-            sqlite_to_duckdb("""
+        sync_names = adapter.execute(
+            """
             SELECT id, value FROM StringIds
             WHERE value LIKE 'cudaMemcpy%'
               AND value NOT LIKE 'cudaMemcpyAsync%'
-        """)
+        """
         ).fetchall()
         if not sync_names:
             return []
@@ -696,15 +691,15 @@ def _check_sync_memcpy(conn: sqlite3.Connection, **kwargs):
         placeholders = ",".join(str(nid) for nid in name_ids)
 
         # Step 2: find memcpy ops correlated with sync runtime calls
-        row = conn.execute(
-            sqlite_to_duckdb(f"""
+        row = adapter.execute(
+            f"""
             SELECT COUNT(*) AS count,
                    COALESCE(SUM(m.bytes), 0) AS total_bytes,
                    COALESCE(SUM(m.[end] - m.start), 0) AS total_ns
             FROM {runtime_tbl} r
             JOIN {memcpy_tbl} m ON r.correlationId = m.correlationId
             WHERE r.nameId IN ({placeholders})
-        """)
+        """
         ).fetchone()
         if not row or row[0] == 0:
             return []
@@ -728,7 +723,7 @@ def _check_sync_memcpy(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except (sqlite3.Error, duckdb.Error) as e:
+    except Exception as e:
         _log.debug("root_cause_matcher (_check_sync_memcpy): %s", e, exc_info=True)
     return []
 
@@ -744,22 +739,21 @@ def _check_pageable_memcpy(conn: sqlite3.Connection, **kwargs):
       4 = Managed, 5 = Device Static, 6 = Managed Static, 7 = Pinned
     Source: CUPTI_ACTIVITY_KIND_MEMCPY table schema, Nsight Systems export.
     """
-    from ...sql_compat import sqlite_to_duckdb
-
-    tables = _resolve_activity_tables(conn)
+    adapter = wrap_connection(conn)
+    tables = adapter.resolve_activity_tables()
     memcpy_tbl = tables.get("memcpy")
     if not memcpy_tbl:
         return []
 
     try:
-        row = conn.execute(
-            sqlite_to_duckdb(f"""
+        row = adapter.execute(
+            f"""
             SELECT COUNT(*) AS pageable_count,
                    COALESCE(SUM(bytes), 0) AS total_bytes,
                    COALESCE(SUM([end] - start), 0) AS total_ns
             FROM {memcpy_tbl}
             WHERE srcKind = 1 OR dstKind = 1
-        """)
+        """
         ).fetchone()
         if not row or row[0] == 0:
             return []
@@ -783,7 +777,7 @@ def _check_pageable_memcpy(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except (sqlite3.Error, duckdb.Error) as e:
+    except Exception as e:
         _log.debug("root_cause_matcher (_check_pageable_memcpy): %s", e, exc_info=True)
     return []
 
@@ -797,9 +791,8 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
     Note: Nsight exports use versioned API names (e.g. cudaMemset_v3020).
     We match any name starting with 'cudaMemset' but NOT 'cudaMemsetAsync'.
     """
-    from ...sql_compat import sqlite_to_duckdb
-
-    tables = _resolve_activity_tables(conn)
+    adapter = wrap_connection(conn)
+    tables = adapter.resolve_activity_tables()
     runtime_tbl = tables.get("runtime")
     memset_tbl = tables.get("memset")
     if not runtime_tbl or not memset_tbl:
@@ -807,12 +800,12 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
 
     try:
         # Step 1: find nameIds for sync cudaMemset (NOT async)
-        sync_names = conn.execute(
-            sqlite_to_duckdb("""
+        sync_names = adapter.execute(
+            """
             SELECT id, value FROM StringIds
             WHERE value LIKE 'cudaMemset%'
               AND value NOT LIKE 'cudaMemsetAsync%'
-        """)
+        """
         ).fetchall()
         if not sync_names:
             return []
@@ -821,14 +814,14 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
         placeholders = ",".join(str(nid) for nid in name_ids)
 
         # Step 2: find memset ops correlated with sync runtime calls
-        row = conn.execute(
-            sqlite_to_duckdb(f"""
+        row = adapter.execute(
+            f"""
             SELECT COUNT(*) AS count,
                    COALESCE(SUM(ms.[end] - ms.start), 0) AS total_ns
             FROM {runtime_tbl} r
             JOIN {memset_tbl} ms ON r.correlationId = ms.correlationId
             WHERE r.nameId IN ({placeholders})
-        """)
+        """
         ).fetchone()
         if not row or row[0] == 0:
             return []
@@ -850,7 +843,7 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except (sqlite3.Error, duckdb.Error) as e:
+    except Exception as e:
         _log.debug("root_cause_matcher (_check_sync_memset): %s", e, exc_info=True)
     return []
 
@@ -860,23 +853,14 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
 
 def _safe_execute(skill_name, conn: sqlite3.Connection, **kwargs):
     """Execute a skill, returning [] on DB or skill execution errors."""
-    from ...exceptions import SkillExecutionError
     from ...skills.registry import get_skill
-
-    error_types = [sqlite3.Error, SkillExecutionError]
-    try:
-        import duckdb
-
-        error_types.extend([duckdb.Error, duckdb.CatalogException])
-    except ImportError:
-        pass
 
     try:
         skill = get_skill(skill_name)
         if skill is None:
             return []
         return skill.execute(conn, **kwargs)
-    except tuple(error_types) as e:
+    except Exception as e:
         _log.debug("root_cause_matcher (%s): %s", skill_name, e, exc_info=True)
         return []
 

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -16,20 +16,11 @@ to gather evidence, then matches against known patterns.
 import logging
 import sqlite3
 
-from nsys_ai.connection import wrap_connection
+from nsys_ai.connection import DB_ERRORS, wrap_connection
 
 from ..base import Skill, SkillParam
 
 _log = logging.getLogger(__name__)
-
-# Narrow exception tuple for diagnostic query blocks.
-# Catches only expected DB errors so programming bugs propagate.
-_DB_ERRORS: tuple[type[Exception], ...] = (sqlite3.Error, sqlite3.OperationalError)
-try:
-    import duckdb  # noqa: E402
-    _DB_ERRORS = _DB_ERRORS + (duckdb.Error,)
-except ImportError:
-    pass
 
 
 def _execute(conn: sqlite3.Connection, **kwargs):

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -372,7 +372,7 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
                 "cause": "same_stream",
                 "detail": (f"Stream(s) [{', '.join(streams)}] run both NCCL and compute kernels"),
             }
-    except _DB_ERRORS as e:
+    except DB_ERRORS as e:
         _log.debug("_diagnose_low_overlap (same_stream): %s", e, exc_info=True)
 
     # --- Check 2: Sync-after-NCCL detection ---
@@ -417,7 +417,7 @@ def _diagnose_low_overlap(conn: sqlite3.Connection, **kwargs) -> dict:
                             "detected immediately after NCCL kernel completion"
                         ),
                     }
-        except _DB_ERRORS as e:
+        except DB_ERRORS as e:
             _log.debug("_diagnose_low_overlap (sync_after_nccl): %s", e, exc_info=True)
 
     return {"cause": "general", "detail": ""}
@@ -654,7 +654,7 @@ def _check_sync_apis(conn: sqlite3.Connection, **kwargs):
                     ),
                 }
             ]
-    except _DB_ERRORS as e:
+    except DB_ERRORS as e:
         _log.debug("root_cause_matcher (_check_sync_apis): %s", e, exc_info=True)
     return []
 
@@ -723,7 +723,7 @@ def _check_sync_memcpy(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except _DB_ERRORS as e:
+    except DB_ERRORS as e:
         _log.debug("root_cause_matcher (_check_sync_memcpy): %s", e, exc_info=True)
     return []
 
@@ -777,7 +777,7 @@ def _check_pageable_memcpy(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except _DB_ERRORS as e:
+    except DB_ERRORS as e:
         _log.debug("root_cause_matcher (_check_pageable_memcpy): %s", e, exc_info=True)
     return []
 
@@ -843,7 +843,7 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
                 ),
             }
         ]
-    except _DB_ERRORS as e:
+    except DB_ERRORS as e:
         _log.debug("root_cause_matcher (_check_sync_memset): %s", e, exc_info=True)
     return []
 
@@ -856,7 +856,7 @@ def _safe_execute(skill_name, conn: sqlite3.Connection, **kwargs):
     from ...exceptions import SkillExecutionError
     from ...skills.registry import get_skill
 
-    _safe_errors = _DB_ERRORS + (SkillExecutionError,)
+    _safe_errors = DB_ERRORS + (SkillExecutionError,)
 
     try:
         skill = get_skill(skill_name)

--- a/src/nsys_ai/skills/builtins/schema_inspect.py
+++ b/src/nsys_ai/skills/builtins/schema_inspect.py
@@ -4,10 +4,11 @@ from ..base import Skill
 
 
 def _execute(conn, **kwargs):
-    import duckdb
+    from nsys_ai.connection import DuckDBAdapter, wrap_connection
+    adapter = wrap_connection(conn)
 
-    if isinstance(conn, duckdb.DuckDBPyConnection):
-        cur = conn.execute(
+    if isinstance(adapter, DuckDBAdapter):
+        cur = adapter.execute(
             """
             SELECT table_name,
                    column_name,
@@ -33,7 +34,7 @@ def _execute(conn, **kwargs):
           AND m.name NOT LIKE 'sqlite_%'
         ORDER BY m.name, p.cid
         """
-        cur = conn.execute(sql)
+        cur = adapter.execute(sql)
         cols = [d[0] for d in cur.description]
         return [dict(zip(cols, row)) for row in cur.fetchall()]
 

--- a/src/nsys_ai/skills/builtins/tensor_core_usage.py
+++ b/src/nsys_ai/skills/builtins/tensor_core_usage.py
@@ -5,6 +5,8 @@ acceleration (e.g. GEMM, Convolutions) and checks whether they successfully
 utilized the hardware Tensor Cores. Helps find FP32 fallbacks and alignment errors.
 """
 
+from nsys_ai.connection import DB_ERRORS
+
 from ..base import Skill, SkillParam
 
 
@@ -38,7 +40,7 @@ def _execute(conn, **kwargs):
         rows = conn.execute(sql, params).fetchall()
         cols = ["name", "total_ns", "call_count", "tc_active_ns", "tc_active_calls"]
         rows = [dict(zip(cols, r)) for r in rows]
-    except Exception:
+    except DB_ERRORS:
         return [
             {
                 "error": (

--- a/src/nsys_ai/skills/builtins/thread_utilization.py
+++ b/src/nsys_ai/skills/builtins/thread_utilization.py
@@ -9,20 +9,13 @@ from ..base import Skill, SkillParam
 
 def _execute(conn: Any, *, limit: int = 10, **_kwargs):
     """Check for COMPOSITE_EVENTS table before querying."""
-    import duckdb as _ddb
+    from nsys_ai.connection import wrap_connection
+    adapter = wrap_connection(conn)
 
-    if isinstance(conn, _ddb.DuckDBPyConnection):
-        tables = {r[0] for r in conn.execute("SHOW TABLES").fetchall()}
-    else:
-        tables = {
-            r[0]
-            for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
-        }
+    tables = adapter.get_table_names()
 
     if "COMPOSITE_EVENTS" not in tables:
         return []
-
-    from nsys_ai.sql_compat import sqlite_to_duckdb
 
     sql = f"""\
 SELECT ce.globalTid % 0x1000000 AS tid,
@@ -38,9 +31,7 @@ GROUP BY ce.globalTid
 ORDER BY cpu_pct DESC
 LIMIT {int(limit)}"""
 
-    if isinstance(conn, _ddb.DuckDBPyConnection):
-        sql = sqlite_to_duckdb(sql)
-    cursor = conn.execute(sql)
+    cursor = adapter.execute(sql)
     columns = [desc[0] for desc in cursor.description] if cursor.description else []
     return [dict(zip(columns, row)) for row in cursor.fetchall()]
 

--- a/src/nsys_ai/skills/builtins/top_kernels.py
+++ b/src/nsys_ai/skills/builtins/top_kernels.py
@@ -76,9 +76,9 @@ def _execute(conn, **kwargs):
         return [dict(zip(cols, r)) for r in rows]
     else:
         # Pure SQLite fallback (lacks TC eligibility analysis)
-        from nsys_ai.skills.base import _resolve_activity_tables
+        from nsys_ai.connection import wrap_connection
 
-        tables = _resolve_activity_tables(conn)
+        tables = wrap_connection(conn).resolve_activity_tables()
         kernel_table = tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
 
         trim_clause = ""

--- a/src/nsys_ai/skills/builtins/top_kernels.py
+++ b/src/nsys_ai/skills/builtins/top_kernels.py
@@ -1,5 +1,7 @@
 """Top GPU kernels by total execution time."""
 
+from nsys_ai.connection import DB_ERRORS
+
 from ..base import Skill, SkillParam
 
 
@@ -37,7 +39,7 @@ def _execute(conn, **kwargs):
     try:
         conn.execute("SELECT 1 FROM kernels LIMIT 1")
         has_kernels = True
-    except Exception:
+    except DB_ERRORS:
         has_kernels = False
 
     params = []

--- a/tests/test_duckdb_path.py
+++ b/tests/test_duckdb_path.py
@@ -215,11 +215,12 @@ class TestDuckDBCompatibilityFixes:
         assert isinstance(rows, list)
 
     def test_region_mfu_detect_nvtx_text_id(self, duckdb_conn):
-        """region_mfu._detect_nvtx_text_id should use DESCRIBE for DuckDB."""
-        from nsys_ai.region_mfu import _detect_nvtx_text_id
+        """ConnectionAdapter.detect_nvtx_text_id should use DESCRIBE for DuckDB."""
+        from nsys_ai.connection import wrap_connection
 
         # Our mock duckdb_conn has an NVTX_EVENTS table with textId
-        has_text_id = _detect_nvtx_text_id(duckdb_conn)
+        adapter = wrap_connection(duckdb_conn)
+        has_text_id = adapter.detect_nvtx_text_id()
         assert has_text_id is True
 
     def test_profile_metadata_discovery(self, duckdb_conn):


### PR DESCRIPTION
## Description
This PR addresses significant technical debt by systematically removing explicit DuckDB type checks, manual SQL dialect translations, and redundant database introspection logic previously scattered across the codebase. 

By fully integrating the unified `ConnectionAdapter` (`SQLiteAdapter` / `DuckDBAdapter`) protocol, we permanently decouple the core diagnostic framework and built-in skills from the underlying database execution engine, paving the way for cleaner feature development.

### Key Changes
* **Unified Connection Abstraction**: Centralized `sqlite_master` introspection and automatic `sqlite_to_duckdb()` dialect translations into the `ConnectionAdapter` wrapper.
* **Engine Branch Eradication**: Obliterated all inline `isinstance(conn, duckdb.DuckDBPyConnection)` paths. Framework internals (`profile.py`) and AI query interceptors (`profile_db_tool.py`) now dynamically route through the adapter instead of branching manually.
* **Skill Standardization**: Upgraded all built-in diagnostic skills—including complex multi-step queries in `root_cause_matcher.py`—to seamlessly use `adapter.execute(...)`, dropping all custom runtime SQL transformations.
* **Logic Deduplication**: Consolidated scattered schema detection helpers like `_detect_nvtx_text_id()` and `_resolve_activity_tables()` directly into the adapter instance.
* **Linter & Test Integrity**: Resolved lingering `ruff` violations (unused imports/variables) and guaranteed mathematical stability against the full test suite.

## Motivation & Impact
Prior to this PR, developers writing new diagnostic skills had to awkwardly handle schema metadata or SQL dialect variances depending on whether the profile was loaded via raw SQLite or our cached DuckDB/Parquet layers. This refactor cleanly eliminates that friction, ensuring that upcoming analytical PRs (i.e., NCCL overhead mapping, Async Memory diagnostics) can focus purely on analysis logic without infrastructure diff noise.

## Verification Checklist
- [x] `pytest tests/ -v` completes with 100% success (442 passing tests).
- [x] `ruff check .` completes with zero formatting errors or undefined variables.
- [x] Fallback logic rigorously handles DuckDB absence without panicking.
