### PR TITLE
feat: integrate sync cost analysis and resolve attribution semantics

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -32,7 +32,7 @@ log = logging.getLogger(__name__)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
 _CACHE_VERSION = (
-    5  # bumped: added profiler_overhead to _BASE_TABLES
+    6  # bumped: added CUPTI_ACTIVITY_KIND_SYNCHRONIZATION and ENUM_CUPTI_SYNC_TYPE
 )
 
 # Tables to export as-is from SQLite → Parquet.
@@ -48,6 +48,8 @@ _BASE_TABLES = [
     ("gpu_info", "TARGET_INFO_GPU"),
     ("cuda_device", "TARGET_INFO_CUDA_DEVICE"),
     ("thread_names", "ThreadNames"),
+    ("sync", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"),
+    ("sync_type", "ENUM_CUPTI_SYNC_TYPE"),
 ]
 
 
@@ -209,6 +211,8 @@ _ALIASES: dict[str, list[str]] = {
     "thread_names": ["ThreadNames"],
     "overhead": ["CUPTI_ACTIVITY_KIND_OVERHEAD"],
     "composite_events": ["COMPOSITE_EVENTS"],
+    "sync": ["CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"],
+    "sync_type": ["ENUM_CUPTI_SYNC_TYPE"],
 }
 
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -174,6 +174,10 @@ _TABLE_PROJECTIONS: dict[str, str] = {
     "CUPTI_ACTIVITY_KIND_RUNTIME": 'start, "end", correlationId, globalTid, nameId',
     "CUPTI_ACTIVITY_KIND_RUNTIME_V2": 'start, "end", correlationId, globalTid, nameId',
     "CUPTI_ACTIVITY_KIND_RUNTIME_V3": 'start, "end", correlationId, globalTid, nameId',
+    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION": 'start, "end", globalPid, syncType',
+    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION_V2": 'start, "end", globalPid, syncType',
+    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION_V3": 'start, "end", globalPid, syncType',
+    "ENUM_CUPTI_SYNC_TYPE": 'id, name',
 }
 
 _TC_ELIGIBLE_PATTERN = "'(gemm|conv|linear|attention|matmul)'"

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -209,6 +209,14 @@ class Skill:
             "memset_table",
             tables.get("memset", "CUPTI_ACTIVITY_KIND_MEMSET"),
         )
+        resolved.setdefault(
+            "sync_table",
+            tables.get("sync", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"),
+        )
+        resolved.setdefault(
+            "sync_type_table",
+            tables.get("sync_type", "ENUM_CUPTI_SYNC_TYPE"),
+        )
 
         # NVTX text resolution: handle both legacy (text column only)
         # and modern schemas (textId → StringIds lookup).

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -61,6 +61,16 @@ def _execute(conn, **kwargs):
     except DB_ERRORS:
         _log.debug("Failed to enrich stream compute/nccl overlap", exc_info=True)
 
+    try:
+        from ...skills.registry import get_skill
+        sync_skill = get_skill("sync_cost_analysis")
+        if sync_skill:
+            sync_data = sync_skill.execute(conn, **kwargs)
+            if sync_data and "error" not in sync_data[0]:
+                result["sync_ms"] = sync_data[0].get("total_sync_wall_ms", 0)
+    except Exception as exc:
+        _log.debug("Failed to enrich sync cost", exc_info=True)
+
     result["device_id"] = device
     return [result]
 
@@ -71,17 +81,22 @@ def _format(rows):
     r = rows[0]
     if "error" in r:
         return f"(Overlap analysis: {r['error']})"
-    return (
-        "── Compute/Communication Overlap ──\n"
-        f"  Total span:    {r['total_ms']:.1f}ms\n"
-        f"  Compute only:  {r['compute_only_ms']:.1f}ms\n"
-        f"  NCCL only:     {r['nccl_only_ms']:.1f}ms\n"
+    lines = [
+        "── Compute/Communication Overlap ──",
+        f"  Total span:    {r['total_ms']:.1f}ms",
+        f"  Compute only:  {r['compute_only_ms']:.1f}ms",
+        f"  NCCL only:     {r['nccl_only_ms']:.1f}ms",
         f"  Overlap:       {r['overlap_ms']:.1f}ms"
-        f" ({r['overlap_pct']}% of NCCL overlapped)\n"
-        f"  Idle:          {r['idle_ms']:.1f}ms\n"
+        f" ({r['overlap_pct']}% of NCCL overlapped)",
+        f"  Idle:          {r['idle_ms']:.1f}ms",
+    ]
+    if r.get("sync_ms"):
+        lines.append(f"  ⚡ CPU Sync:     {r['sync_ms']:.1f}ms (global host-side blocking)")
+    lines.append(
         f"  Kernels:       {r['compute_kernels']} compute"
         f" + {r['nccl_kernels']} NCCL"
     )
+    return "\n".join(lines)
 
 
 def _to_findings(rows: list[dict]) -> list:

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -68,7 +68,7 @@ def _execute(conn, **kwargs):
             sync_data = sync_skill.execute(conn, **kwargs)
             if sync_data and "error" not in sync_data[0]:
                 result["sync_ms"] = sync_data[0].get("total_sync_wall_ms", 0)
-    except Exception as exc:
+    except Exception:
         _log.debug("Failed to enrich sync cost", exc_info=True)
 
     result["device_id"] = device

--- a/src/nsys_ai/skills/builtins/pipeline_bubble_metrics.py
+++ b/src/nsys_ai/skills/builtins/pipeline_bubble_metrics.py
@@ -30,12 +30,18 @@ def _format(rows):
         f"{'GPU':<4s}  {'Total Span(ms)':>15s}  {'Active(ms)':>12s}  {'Bubble(ms)':>12s}  {'Bubble %':>10s}",
         "-" * 61,
     ]
+    global_sync_ms = 0
     for r in rows:
         gpu_str = str(r["deviceId"])
+        if r.get("sync_ms", 0) > 0:
+            global_sync_ms = r["sync_ms"]
         lines.append(
             f"{gpu_str:<4s}  {r['total_span_ms']:>15.2f}  {r['active_ms']:>12.2f}  "
             f"{r['bubble_ms']:>12.2f}  {r['bubble_pct']:>9.1f}%"
         )
+    if global_sync_ms > 0:
+        lines.append("-" * 61)
+        lines.append(f"  ⚡ Global CPU Sync Stall: {global_sync_ms:.1f}ms (Host-blocking limits GPU feeding)")
     return "\n".join(lines)
 
 
@@ -47,6 +53,16 @@ def _execute(conn, **kwargs):
 
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")
+
+    if trim_start is None or trim_end is None:
+        try:
+            from ...profile import Profile
+            prof = Profile._from_conn(conn)
+            p_start, p_end = prof.meta.time_range
+            trim_start = trim_start if trim_start is not None else p_start
+            trim_end = trim_end if trim_end is not None else p_end
+        except Exception:
+            pass
 
     # --- Fetch kernel intervals per device (if available) ---
     kernel_rows = []
@@ -137,8 +153,21 @@ def _execute(conn, **kwargs):
                 "active_ms": round(active_ns / 1e6, 2),
                 "bubble_ms": round(bubble_ns / 1e6, 2),
                 "bubble_pct": round(bubble_pct, 2),
+                "sync_ms": 0.0,
             }
         )
+
+    # Attach CPU Sync Cost to the first device row as it's global host time
+    if results:
+        try:
+            from ...skills.registry import get_skill
+            sync_skill = get_skill("sync_cost_analysis")
+            if sync_skill:
+                sync_data = sync_skill.execute(conn, **kwargs)
+                if sync_data and "error" not in sync_data[0]:
+                    results[0]["sync_ms"] = sync_data[0].get("total_sync_wall_ms", 0)
+        except Exception as exc:
+            logger.debug(f"Failed to fetch sync cost data: {exc}")
 
     return results
 

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -164,7 +164,16 @@ def _execute(conn, **kwargs):
         idle_summary["idle_pct"] = summary_row.get("pct_of_profile", 0)
         idle_summary["total_idle_ms"] = summary_row.get("total_idle_ms", 0)
 
-    # ── 6. Root cause findings (count + top severity) ────────────
+    # ── 6. Sync Cost Analysis ────────────────────────────────────────
+    sync_summary = {}
+    try:
+        sync_data = _safe_skill_run("sync_cost_analysis", conn, **trim_kwargs)
+        if sync_data and "error" not in sync_data[0]:
+            sync_summary = sync_data[0]
+    except Exception as exc:
+        _log.debug("manifest: sync_cost_analysis failed: %s", exc)
+
+    # ── 7. Root cause findings (count + top severity) ────────────
     rc_rows = _safe_skill_run("root_cause_matcher", conn, device=device, **trim_kwargs)
     root_causes = []
     for r in rc_rows:
@@ -189,6 +198,7 @@ def _execute(conn, **kwargs):
         "total_kernel_ms": round(total_kernel_ms, 1),
         "overlap": overlap,
         "nccl": nccl_summary,
+        "sync": sync_summary,
         "idle": idle_summary,
         "root_cause_count": len(root_causes),
         "root_causes": root_causes[:5],  # Cap at 5 to keep output compact
@@ -205,6 +215,12 @@ def _execute(conn, **kwargs):
 
 def _infer_bottleneck(m: dict) -> str:
     """Heuristic bottleneck inference from manifest data."""
+    sync = m.get("sync", {})
+    sync_density = sync.get("sync_density_pct", 0)
+    # The new threshold
+    if sync_density > 20.0:
+        return f"High CPU Synchronization Blocking ({sync_density:.1f}% of span)"
+
     dq = m.get("data_quality", {})
     overhead_pct_val = dq.get("overhead_pct_raw", dq.get("overhead_pct", 0))
     if overhead_pct_val > 1.0:
@@ -287,9 +303,13 @@ def _format(rows):
 
     # Idle
     idle = m.get("idle", {})
+    sync = m.get("sync", {})
     if idle.get("gap_count", 0) > 0:
         lines.append("")
         lines.append(f"  GPU Idle: {idle['gap_count']} gaps, {idle.get('idle_pct', 0)}% of profile")
+    if sync.get("total_sync_wall_ms"):
+        lines.append("")
+        lines.append(f"  CPU Sync Block: {sync.get('total_sync_wall_ms', 0):.1f}ms ({sync.get('sync_density_pct', 0)}% of profile)")
 
     # Root causes
     rcs = m.get("root_causes", [])

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -39,24 +39,24 @@ def _resolve_active_device(conn, kwargs: dict) -> dict:
 
         current_device = kwargs.get("device", 0)
 
-        # Build optional trim filter
+        # Build optional trim filter (use "end" not [end] for DuckDB compat)
         trim_conds: list[str] = []
         trim_params: list = []
         if "trim_start_ns" in kwargs:
             trim_conds.append("start >= ?")
             trim_params.append(kwargs["trim_start_ns"])
         if "trim_end_ns" in kwargs:
-            trim_conds.append("[end] <= ?")
+            trim_conds.append('"end" <= ?')
             trim_params.append(kwargs["trim_end_ns"])
         trim_sql = f" AND {' AND '.join(trim_conds)}" if trim_conds else ""
 
-        cur_count = conn.execute(
+        cur_count = adapter.execute(
             f"SELECT COUNT(*) FROM {kernel_table} WHERE deviceId = ?{trim_sql}",
             [current_device] + trim_params,
         ).fetchone()[0]
 
         if cur_count == 0:
-            active_devs = conn.execute(
+            active_devs = adapter.execute(
                 f"SELECT deviceId, COUNT(*) as c FROM {kernel_table} "
                 f"WHERE 1=1{trim_sql} "
                 f"GROUP BY deviceId HAVING c > 0 ORDER BY c DESC LIMIT 1",

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -33,10 +33,30 @@ def _execute(conn: sqlite3.Connection, **kwargs):
     top_kernels_data = _safe_execute("top_kernels", conn, limit=1000, **kwargs)
     # GPU idle gaps
     idle_gaps_data = _safe_execute("gpu_idle_gaps", conn, **kwargs)
+
+    # Auto-detect an active device if the current device has no kernel data.
+    # This prevents GPU Bubbles (and sync override) from being silently skipped
+    # on multi-GPU profiles where the default device is unused.
+    if idle_gaps_data:
+        gap_summary_check = next((g for g in idle_gaps_data if g.get("_summary")), None)
+        if gap_summary_check and gap_summary_check.get("gap_count", 0) == 0:
+            try:
+                active_devs = conn.execute(
+                    "SELECT DISTINCT deviceId FROM CUPTI_ACTIVITY_KIND_KERNEL "
+                    "ORDER BY deviceId LIMIT 1"
+                ).fetchall()
+                if active_devs and active_devs[0][0] != kwargs.get("device", 0):
+                    active_device = active_devs[0][0]
+                    kwargs = {**kwargs, "device": active_device}
+                    idle_gaps_data = _safe_execute("gpu_idle_gaps", conn, **kwargs)
+            except Exception:
+                pass
     # Overlap
     overlap_data = _safe_execute("overlap_breakdown", conn, **kwargs)
     # Kernel launch overhead
     launch_data = _safe_execute("kernel_launch_overhead", conn, **kwargs)
+    # Sync Cost
+    sync_data = _safe_execute("sync_cost_analysis", conn, **kwargs)
 
     # --- GPU Bubbles (Pipeline Stalls) ---
     if idle_gaps_data:
@@ -93,6 +113,22 @@ def _execute(conn: sqlite3.Connection, **kwargs):
             )
             if pct > 0:
                 evidence += f" ({pct}% of profile)"
+                
+            # If Sync Cost Analysis indicates massive CPU blockage, overwrite the guess!
+            if sync_data and "error" not in sync_data[0]:
+                sync_ms = sync_data[0].get("total_sync_wall_ms", 0)
+                sync_density = sync_data[0].get("sync_density_pct", 0)
+                # If sync time accounts for more than half of the idle time, or > 15% of profile:
+                if (total_idle_ms > 0 and sync_ms / total_idle_ms > 0.5) or sync_density > 15.0:
+                    rec = (
+                        "Critical Over-Synchronization Detected. "
+                        f"{sync_density:.1f}% of this profile is CPU-blocked by synchronization calls "
+                        f"(torch.cuda.synchronize / cudaDeviceSynchronize). "
+                        "Action: (1) Remove unnecessary sync calls, "
+                        "(2) replace device-wide sync with stream-scoped cudaStreamWaitEvent, "
+                        "(3) ensure .item() or .cpu() calls are deferred to avoid implicit sync."
+                    )
+                    evidence += f". Validated via explicit CPU sync stall of {sync_ms:.1f}ms"
 
             findings.append(
                 {

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -41,7 +41,7 @@ def _execute(conn: sqlite3.Connection, **kwargs):
         from ...connection import wrap_connection
         adapter = wrap_connection(conn)
         kernel_table = adapter.resolve_activity_tables().get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
-        
+
         current_device = kwargs.get("device", 0)
         trim_conds = []
         trim_params = []
@@ -51,15 +51,15 @@ def _execute(conn: sqlite3.Connection, **kwargs):
         if "trim_end_ns" in kwargs:
             trim_conds.append("[end] <= ?")
             trim_params.append(kwargs["trim_end_ns"])
-            
+
         trim_sql = f" AND {' AND '.join(trim_conds)}" if trim_conds else ""
-        
+
         # Check current device kernel count
         cur_count = conn.execute(
             f"SELECT COUNT(*) FROM {kernel_table} WHERE deviceId = ? {trim_sql}",
             [current_device] + trim_params
         ).fetchone()[0]
-        
+
         if cur_count == 0:
             # Find an active device
             active_devs = conn.execute(
@@ -68,7 +68,7 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                 f"GROUP BY deviceId HAVING c > 0 ORDER BY c DESC LIMIT 1",
                 trim_params
             ).fetchall()
-            
+
             if active_devs and active_devs[0][0] != current_device:
                 active_device = active_devs[0][0]
                 kwargs = {**kwargs, "device": active_device}

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -113,7 +113,7 @@ def _execute(conn: sqlite3.Connection, **kwargs):
             )
             if pct > 0:
                 evidence += f" ({pct}% of profile)"
-                
+
             # If Sync Cost Analysis indicates massive CPU blockage, overwrite the guess!
             if sync_data and "error" not in sync_data[0]:
                 sync_ms = sync_data[0].get("total_sync_wall_ms", 0)

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -37,20 +37,46 @@ def _execute(conn: sqlite3.Connection, **kwargs):
     # Auto-detect an active device if the current device has no kernel data.
     # This prevents GPU Bubbles (and sync override) from being silently skipped
     # on multi-GPU profiles where the default device is unused.
-    if idle_gaps_data:
-        gap_summary_check = next((g for g in idle_gaps_data if g.get("_summary")), None)
-        if gap_summary_check and gap_summary_check.get("gap_count", 0) == 0:
-            try:
-                active_devs = conn.execute(
-                    "SELECT DISTINCT deviceId FROM CUPTI_ACTIVITY_KIND_KERNEL "
-                    "ORDER BY deviceId LIMIT 1"
-                ).fetchall()
-                if active_devs and active_devs[0][0] != kwargs.get("device", 0):
-                    active_device = active_devs[0][0]
-                    kwargs = {**kwargs, "device": active_device}
-                    idle_gaps_data = _safe_execute("gpu_idle_gaps", conn, **kwargs)
-            except Exception:
-                pass
+    try:
+        from ...connection import wrap_connection
+        adapter = wrap_connection(conn)
+        kernel_table = adapter.resolve_activity_tables().get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
+        
+        current_device = kwargs.get("device", 0)
+        trim_conds = []
+        trim_params = []
+        if "trim_start_ns" in kwargs:
+            trim_conds.append("start >= ?")
+            trim_params.append(kwargs["trim_start_ns"])
+        if "trim_end_ns" in kwargs:
+            trim_conds.append("[end] <= ?")
+            trim_params.append(kwargs["trim_end_ns"])
+            
+        trim_sql = f" AND {' AND '.join(trim_conds)}" if trim_conds else ""
+        
+        # Check current device kernel count
+        cur_count = conn.execute(
+            f"SELECT COUNT(*) FROM {kernel_table} WHERE deviceId = ? {trim_sql}",
+            [current_device] + trim_params
+        ).fetchone()[0]
+        
+        if cur_count == 0:
+            # Find an active device
+            active_devs = conn.execute(
+                f"SELECT deviceId, COUNT(*) as c FROM {kernel_table} "
+                f"WHERE 1=1 {trim_sql} "
+                f"GROUP BY deviceId HAVING c > 0 ORDER BY c DESC LIMIT 1",
+                trim_params
+            ).fetchall()
+            
+            if active_devs and active_devs[0][0] != current_device:
+                active_device = active_devs[0][0]
+                kwargs = {**kwargs, "device": active_device}
+                # Rerun device-scoped skills
+                top_kernels_data = _safe_execute("top_kernels", conn, limit=1000, **kwargs)
+                idle_gaps_data = _safe_execute("gpu_idle_gaps", conn, **kwargs)
+    except Exception:
+        pass
     # Overlap
     overlap_data = _safe_execute("overlap_breakdown", conn, **kwargs)
     # Kernel launch overhead

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -23,6 +23,52 @@ from ..base import Skill, SkillParam
 _log = logging.getLogger(__name__)
 
 
+def _resolve_active_device(conn, kwargs: dict) -> dict:
+    """Return kwargs with 'device' set to an active GPU if the current one has no kernels.
+
+    Multi-GPU profiles (e.g. Megatron) often have device 0 unused while devices
+    1-7 run all computation.  Without this fallback, root-cause patterns that
+    depend on per-device kernel data silently produce empty results.
+    """
+    try:
+        from ...connection import wrap_connection
+        adapter = wrap_connection(conn)
+        kernel_table = adapter.resolve_activity_tables().get(
+            "kernel", "CUPTI_ACTIVITY_KIND_KERNEL"
+        )
+
+        current_device = kwargs.get("device", 0)
+
+        # Build optional trim filter
+        trim_conds: list[str] = []
+        trim_params: list = []
+        if "trim_start_ns" in kwargs:
+            trim_conds.append("start >= ?")
+            trim_params.append(kwargs["trim_start_ns"])
+        if "trim_end_ns" in kwargs:
+            trim_conds.append("[end] <= ?")
+            trim_params.append(kwargs["trim_end_ns"])
+        trim_sql = f" AND {' AND '.join(trim_conds)}" if trim_conds else ""
+
+        cur_count = conn.execute(
+            f"SELECT COUNT(*) FROM {kernel_table} WHERE deviceId = ?{trim_sql}",
+            [current_device] + trim_params,
+        ).fetchone()[0]
+
+        if cur_count == 0:
+            active_devs = conn.execute(
+                f"SELECT deviceId, COUNT(*) as c FROM {kernel_table} "
+                f"WHERE 1=1{trim_sql} "
+                f"GROUP BY deviceId HAVING c > 0 ORDER BY c DESC LIMIT 1",
+                trim_params,
+            ).fetchall()
+            if active_devs and active_devs[0][0] != current_device:
+                return {**kwargs, "device": active_devs[0][0]}
+    except Exception:
+        pass
+    return kwargs
+
+
 def _execute(conn: sqlite3.Connection, **kwargs):
     """Run all pattern matchers against the profile."""
     findings = []
@@ -34,49 +80,13 @@ def _execute(conn: sqlite3.Connection, **kwargs):
     # GPU idle gaps
     idle_gaps_data = _safe_execute("gpu_idle_gaps", conn, **kwargs)
 
-    # Auto-detect an active device if the current device has no kernel data.
-    # This prevents GPU Bubbles (and sync override) from being silently skipped
-    # on multi-GPU profiles where the default device is unused.
-    try:
-        from ...connection import wrap_connection
-        adapter = wrap_connection(conn)
-        kernel_table = adapter.resolve_activity_tables().get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
+    # If the current device has no kernels, pivot to an active device and re-fetch.
+    resolved_kwargs = _resolve_active_device(conn, kwargs)
+    if resolved_kwargs.get("device") != kwargs.get("device", 0):
+        kwargs = resolved_kwargs
+        top_kernels_data = _safe_execute("top_kernels", conn, limit=1000, **kwargs)
+        idle_gaps_data = _safe_execute("gpu_idle_gaps", conn, **kwargs)
 
-        current_device = kwargs.get("device", 0)
-        trim_conds = []
-        trim_params = []
-        if "trim_start_ns" in kwargs:
-            trim_conds.append("start >= ?")
-            trim_params.append(kwargs["trim_start_ns"])
-        if "trim_end_ns" in kwargs:
-            trim_conds.append("[end] <= ?")
-            trim_params.append(kwargs["trim_end_ns"])
-
-        trim_sql = f" AND {' AND '.join(trim_conds)}" if trim_conds else ""
-
-        # Check current device kernel count
-        cur_count = conn.execute(
-            f"SELECT COUNT(*) FROM {kernel_table} WHERE deviceId = ? {trim_sql}",
-            [current_device] + trim_params
-        ).fetchone()[0]
-
-        if cur_count == 0:
-            # Find an active device
-            active_devs = conn.execute(
-                f"SELECT deviceId, COUNT(*) as c FROM {kernel_table} "
-                f"WHERE 1=1 {trim_sql} "
-                f"GROUP BY deviceId HAVING c > 0 ORDER BY c DESC LIMIT 1",
-                trim_params
-            ).fetchall()
-
-            if active_devs and active_devs[0][0] != current_device:
-                active_device = active_devs[0][0]
-                kwargs = {**kwargs, "device": active_device}
-                # Rerun device-scoped skills
-                top_kernels_data = _safe_execute("top_kernels", conn, limit=1000, **kwargs)
-                idle_gaps_data = _safe_execute("gpu_idle_gaps", conn, **kwargs)
-    except Exception:
-        pass
     # Overlap
     overlap_data = _safe_execute("overlap_breakdown", conn, **kwargs)
     # Kernel launch overhead

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -1,8 +1,8 @@
 """Sync Cost Analysis skill.
 
 Examines CUPTI_ACTIVITY_KIND_SYNCHRONIZATION to compute the true wall-clock
-duration that the CPU was blocked by synchonizations, identifying explicit pipeline
-stalls vs naturally overlapping communications.
+duration that the CPU was blocked by synchronizations, distinguishing explicit pipeline
+stalls from naturally overlapping communications.
 """
 
 from collections import defaultdict
@@ -11,11 +11,30 @@ from ...connection import DB_ERRORS, wrap_connection
 from ..base import Skill, _compute_interval_union
 
 
+def _resolve_table_name(conn, candidate: str) -> str:
+    """Resolve an Nsight table name, allowing for version-suffixed variants."""
+    try:
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name LIKE ?
+            ORDER BY name DESC LIMIT 1
+            """,
+            (candidate + "%",),
+        )
+        row = cursor.fetchone()
+        if row:
+            return row[0]
+    except Exception:
+        pass
+    return candidate
+
+
 def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
     adapter = wrap_connection(conn)
-    tables = adapter.resolve_activity_tables()
-    sync_table = tables.get("sync", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
-    type_table = tables.get("sync_type", "ENUM_CUPTI_SYNC_TYPE")
+    sync_table = _resolve_table_name(conn, "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
+    type_table = _resolve_table_name(conn, "ENUM_CUPTI_SYNC_TYPE")
 
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -31,7 +31,28 @@ def _resolve_table_name(conn, candidate: str) -> str:
     return candidate
 
 
+_sync_result_cache: dict[tuple, list[dict]] = {}
+
+
 def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
+    # Module-level cache keyed by (connection identity, trim window).
+    # Avoids redundant re-execution when called by multiple consumer skills
+    # (manifest, root_cause, overlap, bubble) within the same profile session.
+    cache_key = (
+        id(conn),
+        kwargs.get("trim_start_ns"),
+        kwargs.get("trim_end_ns"),
+    )
+    cached = _sync_result_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    result = _execute_sync_analysis_impl(conn, **kwargs)
+    _sync_result_cache[cache_key] = result
+    return result
+
+
+def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
     adapter = wrap_connection(conn)
     sync_table = _resolve_table_name(conn, "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
     type_table = _resolve_table_name(conn, "ENUM_CUPTI_SYNC_TYPE")

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -1,0 +1,152 @@
+"""Sync Cost Analysis skill.
+
+Examines CUPTI_ACTIVITY_KIND_SYNCHRONIZATION to compute the true wall-clock
+duration that the CPU was blocked by synchonizations, identifying explicit pipeline
+stalls vs naturally overlapping communications.
+"""
+
+from collections import defaultdict
+
+from ...connection import DB_ERRORS, wrap_connection
+from ..base import Skill, _compute_interval_union
+
+
+def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
+    adapter = wrap_connection(conn)
+    tables = adapter.resolve_activity_tables()
+    sync_table = tables.get("sync", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
+    type_table = tables.get("sync_type", "ENUM_CUPTI_SYNC_TYPE")
+
+    trim_start = kwargs.get("trim_start_ns")
+    trim_end = kwargs.get("trim_end_ns")
+
+    if trim_start is None or trim_end is None:
+        try:
+            # Attempt to retrieve true profile bounds to clamp host events
+            from ...profile import Profile
+            prof = Profile._from_conn(conn)
+            p_start, p_end = prof.meta.time_range
+            trim_start = trim_start if trim_start is not None else p_start
+            trim_end = trim_end if trim_end is not None else p_end
+        except Exception:
+            pass
+
+    conds = ["1=1"]
+    params = []
+
+    # We must explicitly clamp within SQL or Python. We'll do it in Python,
+    # but we can filter eagerly in SQL to limit data loading overhead.
+    if trim_start is not None:
+        conds.append("s.[end] >= ?")
+        params.append(int(trim_start))
+    if trim_end is not None:
+        conds.append("s.start <= ?")
+        params.append(int(trim_end))
+
+    where_clause = " AND ".join(conds)
+
+    query = f"""
+    SELECT
+        s.start,
+        s.[end],
+        s.globalPid,
+        COALESCE(e.name, 'Unknown') AS sync_type_name
+    FROM {sync_table} s
+    LEFT JOIN {type_table} e ON s.syncType = e.id
+    WHERE {where_clause}
+    """
+
+    try:
+        cur = adapter.execute(query, params)
+        rows = cur.fetchall()
+    except DB_ERRORS:
+        # Table might not exist in old profiles
+        return [{
+            "total_sync_wall_ms": 0.0,
+            "sync_by_type_ms": {},
+            "profile_span_ms": 0.0,
+            "sync_density_pct": 0.0,
+            "error": "Synchronization tables not found in profile"
+        }]
+
+    # Filter and clamp intervals
+    global_intervals = []
+    type_intervals = defaultdict(list)
+
+    for row in rows:
+        s_start, s_end = int(row[0]), int(row[1])
+        sync_type_name = str(row[3])
+
+        # Explicit clamping to trim window
+        if trim_start is not None:
+            s_start = max(s_start, int(trim_start))
+        if trim_end is not None:
+            s_end = min(s_end, int(trim_end))
+
+        if s_start < s_end:
+            global_intervals.append((s_start, s_end))
+            type_intervals[sync_type_name].append((s_start, s_end))
+
+    total_sync_wall_ns = _compute_interval_union(global_intervals)
+    sync_by_type_ms = {}
+    for t_name, intervals in type_intervals.items():
+        type_ns = _compute_interval_union(intervals)
+        sync_by_type_ms[t_name] = round(type_ns / 1e6, 3)
+
+    profile_span_ns = 0
+    if trim_start is not None and trim_end is not None:
+        profile_span_ns = max(0, int(trim_end) - int(trim_start))
+
+    # Fallback to absolute min/max if no span provided
+    if profile_span_ns == 0 and global_intervals:
+        min_s = min([ival[0] for ival in global_intervals])
+        max_e = max([ival[1] for ival in global_intervals])
+        profile_span_ns = max_e - min_s
+
+    total_sync_wall_ms = total_sync_wall_ns / 1e6
+    profile_span_ms = profile_span_ns / 1e6
+
+    sync_density_pct = 0.0
+    if profile_span_ms > 0:
+        sync_density_pct = (total_sync_wall_ms / profile_span_ms) * 100
+
+    return [{
+        "total_sync_wall_ms": round(total_sync_wall_ms, 3),
+        "sync_by_type_ms": sync_by_type_ms,
+        "profile_span_ms": round(profile_span_ms, 3),
+        "sync_density_pct": round(sync_density_pct, 2)
+    }]
+
+
+def _format_sync_analysis(rows: list[dict]) -> str:
+    if not rows:
+        return "(No synchronization data)"
+
+    m = rows[0]
+    if "error" in m:
+        return f"Sync Cost Analysis Error: {m['error']}"
+
+    lines = ["══ Sync Cost Analysis ══"]
+    lines.append(f"  Total Wall-Clock Sync Delay: {m['total_sync_wall_ms']:.1f}ms")
+    lines.append(f"  Profile Span Evaluated:      {m['profile_span_ms']:.1f}ms")
+    lines.append(f"  Sync Density (Stall %):      {m['sync_density_pct']:.1f}%")
+
+    lines.append("\n  Breakdown by Sync Type:")
+    if m["sync_by_type_ms"]:
+        for t_name, ms_val in sorted(m["sync_by_type_ms"].items(), key=lambda x: x[1], reverse=True):
+            lines.append(f"    - {t_name:<30}: {ms_val:8.1f}ms")
+    else:
+        lines.append("    (None)")
+
+    return "\n".join(lines)
+
+
+SKILL = Skill(
+    name="sync_cost_analysis",
+    title="Sync Cost Analysis",
+    description="Measures total wall-clock time the host CPU was blocked by CUPTI synchronization calls (e.g. cudaDeviceSynchronize, cudaStreamSynchronize). Reports sync density as a percentage of the profile span.",
+    category="system",
+    sql="",
+    execute_fn=_execute_sync_analysis,
+    format_fn=_format_sync_analysis
+)

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -137,12 +137,6 @@ def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
     if trim_start is not None and trim_end is not None:
         profile_span_ns = max(0, int(trim_end) - int(trim_start))
 
-    # Fallback to absolute min/max if no span provided
-    if profile_span_ns == 0 and global_intervals:
-        min_s = min([ival[0] for ival in global_intervals])
-        max_e = max([ival[1] for ival in global_intervals])
-        profile_span_ns = max_e - min_s
-
     total_sync_wall_ms = total_sync_wall_ns / 1e6
     profile_span_ms = profile_span_ns / 1e6
 

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -7,7 +7,7 @@ stalls from naturally overlapping communications.
 
 from collections import defaultdict
 
-from ...connection import DB_ERRORS, wrap_connection
+from ...connection import DB_ERRORS, is_safe_identifier, wrap_connection
 from ..base import Skill, _compute_interval_union
 
 
@@ -32,6 +32,7 @@ def _resolve_table_name(conn, candidate: str) -> str:
 
 
 _sync_result_cache: dict[tuple, list[dict]] = {}
+_CACHE_MAX_SIZE = 8  # bounded to prevent unbounded growth / id() reuse
 
 
 def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
@@ -48,6 +49,9 @@ def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
         return cached
 
     result = _execute_sync_analysis_impl(conn, **kwargs)
+
+    if len(_sync_result_cache) >= _CACHE_MAX_SIZE:
+        _sync_result_cache.clear()
     _sync_result_cache[cache_key] = result
     return result
 
@@ -56,6 +60,12 @@ def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
     adapter = wrap_connection(conn)
     sync_table = _resolve_table_name(conn, "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
     type_table = _resolve_table_name(conn, "ENUM_CUPTI_SYNC_TYPE")
+
+    # Guard against SQL injection from maliciously crafted table names
+    if not is_safe_identifier(sync_table) or not is_safe_identifier(type_table):
+        return [{"total_sync_wall_ms": 0.0, "sync_by_type_ms": {},
+                 "profile_span_ms": 0.0, "sync_density_pct": 0.0,
+                 "error": f"Unsafe table name resolved: {sync_table!r} / {type_table!r}"}]
 
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -38,6 +38,7 @@ def test_list_skills():
         "schema_inspect",
         "speedup_estimator",
         "stream_concurrency",
+        "sync_cost_analysis",
         "tensor_core_usage",
         "theoretical_flops",
         "thread_utilization",

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -3,6 +3,13 @@ import sqlite3
 import pytest
 
 from nsys_ai.skills.registry import get_skill
+from nsys_ai.skills.builtins.sync_cost_analysis import _sync_result_cache
+
+
+@pytest.fixture(autouse=True)
+def _clear_sync_cache():
+    """Prevent id(conn) reuse of in-memory connections from poisoning results."""
+    _sync_result_cache.clear()
 
 
 @pytest.fixture

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -30,7 +30,7 @@ def test_sync_analysis_math(sync_skill):
     conn.execute("INSERT INTO ENUM_CUPTI_SYNC_TYPE VALUES (1, 'Event sync'), (2, 'Stream sync')")
 
     # Thread 1 does Event Sync 100-200 ms
-    # Thread 2 does Event Sync 150-300 ms (Overlap union logic should yield 100-300 = 200ns)
+    # Thread 2 does Event Sync 150-300 ms (Overlap union logic should yield 100-300 = 200ms)
     # Thread 1 does Stream Sync 500-600 ms
     conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES (100000000, 200000000, 1, 1)")
     conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES (150000000, 300000000, 2, 1)")
@@ -60,7 +60,7 @@ def test_sync_analysis_trimming(sync_skill):
     conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES (100000000, 300000000, 1, 1)")
 
     # Trim to [200, 400] ms
-    # Expectation: start is clamped to 200, end remains 300 -> 100ns duration
+    # Expectation: start is clamped to 200, end remains 300 -> 100ms duration
     rows = sync_skill.execute(conn, trim_start_ns=200000000, trim_end_ns=400000000)
     m = rows[0]
 

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -2,8 +2,8 @@ import sqlite3
 
 import pytest
 
-from nsys_ai.skills.registry import get_skill
 from nsys_ai.skills.builtins.sync_cost_analysis import _sync_result_cache
+from nsys_ai.skills.registry import get_skill
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -1,0 +1,69 @@
+import sqlite3
+
+import pytest
+
+from nsys_ai.skills.registry import get_skill
+
+
+@pytest.fixture
+def sync_skill():
+    skill = get_skill("sync_cost_analysis")
+    assert skill is not None, "sync_cost_analysis skill not registered"
+    return skill
+
+
+def test_sync_analysis_without_tables(sync_skill):
+    conn = sqlite3.connect(":memory:")
+
+    rows = sync_skill.execute(conn)
+    assert len(rows) == 1
+    assert "error" in rows[0]
+    assert "not found" in rows[0]["error"]
+
+
+def test_sync_analysis_math(sync_skill):
+    conn = sqlite3.connect(":memory:")
+
+    conn.execute("CREATE TABLE CUPTI_ACTIVITY_KIND_SYNCHRONIZATION (start INTEGER, [end] INTEGER, globalPid INTEGER, syncType INTEGER)")
+    conn.execute("CREATE TABLE ENUM_CUPTI_SYNC_TYPE (id INTEGER, name TEXT)")
+
+    conn.execute("INSERT INTO ENUM_CUPTI_SYNC_TYPE VALUES (1, 'Event sync'), (2, 'Stream sync')")
+
+    # Thread 1 does Event Sync 100-200 ms
+    # Thread 2 does Event Sync 150-300 ms (Overlap union logic should yield 100-300 = 200ns)
+    # Thread 1 does Stream Sync 500-600 ms
+    conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES (100000000, 200000000, 1, 1)")
+    conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES (150000000, 300000000, 2, 1)")
+    conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES (500000000, 600000000, 1, 2)")
+
+    rows = sync_skill.execute(conn)
+    assert len(rows) == 1
+    m = rows[0]
+
+    # Global Union: [100, 300] and [500, 600] -> 200 + 100 = 300ms total
+    assert m["total_sync_wall_ms"] == 300.0
+
+    # Event Union: [100, 300] -> 200ms
+    # Stream Union: [500, 600] -> 100ms
+    assert m["sync_by_type_ms"]["Event sync"] == 200.0
+    assert m["sync_by_type_ms"]["Stream sync"] == 100.0
+
+
+def test_sync_analysis_trimming(sync_skill):
+    conn = sqlite3.connect(":memory:")
+
+    conn.execute("CREATE TABLE CUPTI_ACTIVITY_KIND_SYNCHRONIZATION (start INTEGER, [end] INTEGER, globalPid INTEGER, syncType INTEGER)")
+    conn.execute("CREATE TABLE ENUM_CUPTI_SYNC_TYPE (id INTEGER, name TEXT)")
+    conn.execute("INSERT INTO ENUM_CUPTI_SYNC_TYPE VALUES (1, 'Event sync')")
+
+    # [100, 300] ms event
+    conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES (100000000, 300000000, 1, 1)")
+
+    # Trim to [200, 400] ms
+    # Expectation: start is clamped to 200, end remains 300 -> 100ns duration
+    rows = sync_skill.execute(conn, trim_start_ns=200000000, trim_end_ns=400000000)
+    m = rows[0]
+
+    assert m["total_sync_wall_ms"] == 100.0
+    assert m["profile_span_ms"] == 200.0
+    assert m["sync_density_pct"] == 50.0


### PR DESCRIPTION
## Description

This PR introduces the `sync_cost_analysis` diagnostic skill and integrates it deeply into the core `nsys-ai` analysis pipeline. It enables the system to reliably differentiate between implicit GPU idle bubbles (e.g., IO starvation) and explicit host-side blocking (e.g., `torch.cuda.synchronize`, `.item()`), surfacing highly actionable root causes.

### Key Changes
1. **New Core Skill (`sync_cost_analysis.py`):** 
   - Uses O(N log N) sweep logic (`_compute_interval_union` in `base.py`) to correctly deduplicate concurrent thread/PID synchronization events into true wall-clock stall time.
   - Enforces a strict global profile boundary (`prof.meta.time_range`) clamp. This prevents early PyTorch initialization events (e.g., `dist.init_process_group`) from artificially inflating the global evaluated span and distorting density ratios.

2. **Integration & Semantic Formatting:**
   - **`profile_health_manifest`**: Automatically flags "High CPU Synchronization Blocking" as the primary heuristic bottleneck if sync density exceeds 20%.
   - **`pipeline_bubble_metrics` / `overlap_breakdown`**: CPU Sync time has been decoupled from inline pipeline bubble metrics. Since host-sync duration can mathematically exceed individual GPU-bubble duration, it is safely presented as a separated global footer to prevent contradictory `(sync_ms > bubble_ms)` paradoxes in downstream output.

3. **Multi-GPU Fallback Architecture:**
   - Greatly hardened `root_cause_matcher`. If the default analyzed device (`device=0`) has zero kernels across the timeline, the engine dynamically probes and auto-detects an active `deviceId`. This prevents critical root cause patterns from silently bypassing the analysis loop in complex multi-node environments.

4. **Actionable Recommendations:**
   - The Root Cause Matcher will directly overwrite generic "GPU Bubble" advice when sync is the dominant bottleneck. It no longer errantly suggests "using CUDA Graphs for explicit GPU sync." It correctly prompts users to use stream-scoped `cudaStreamWaitEvent` and eliminate `.item()` blocking calls.

## Testing
- [x] Tested locally via `python -m nsys_ai --help` and CLI verification.
- [x] All 59 core analytic regression tests pass (`pytest tests/test_skills.py tests/test_sync_cost_analysis.py -v`).
- [x] Numerically validated on both async-bound (VLLM) and synchronous-bound (Megatron) multi-GPU traces.
