### PR TITLE
feat: add parquetdir-native backend for communicator-aware NCCL analysis

### DIFF
--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -40,16 +40,33 @@ class Agent:
         "h2d": ["memory_transfers", "memory_bandwidth"],
         "copy": ["memory_transfers", "memory_bandwidth"],
         "bandwidth": ["memory_bandwidth"],
-        "nccl": ["nccl_breakdown", "overlap_breakdown", "kernel_overlap_matrix", "nccl_anomaly"],
-        "allreduce": ["nccl_breakdown", "nccl_anomaly"],
-        "collective": ["nccl_breakdown", "nccl_anomaly"],
-        "distributed": [
+        "nccl": [
             "nccl_breakdown",
+            "nccl_communicator_analysis",
             "overlap_breakdown",
             "kernel_overlap_matrix",
             "nccl_anomaly",
         ],
-        "multi-gpu": ["nccl_breakdown", "overlap_breakdown", "kernel_overlap_matrix"],
+        "allreduce": ["nccl_breakdown", "nccl_communicator_analysis", "nccl_anomaly"],
+        "collective": ["nccl_breakdown", "nccl_communicator_analysis", "nccl_anomaly"],
+        "distributed": [
+            "nccl_breakdown",
+            "nccl_communicator_analysis",
+            "overlap_breakdown",
+            "kernel_overlap_matrix",
+            "nccl_anomaly",
+        ],
+        "multi-gpu": [
+            "nccl_breakdown",
+            "nccl_communicator_analysis",
+            "overlap_breakdown",
+            "kernel_overlap_matrix",
+        ],
+        "communicator": ["nccl_communicator_analysis", "nccl_breakdown"],
+        "rank": ["nccl_communicator_analysis", "nccl_breakdown"],
+        "tensor parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
+        "pipeline parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
+        "data parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
         "anomaly": ["nccl_anomaly"],
         "outlier": ["nccl_anomaly"],
         "overlap": ["overlap_breakdown", "kernel_overlap_matrix"],
@@ -131,14 +148,15 @@ class Agent:
         3. memory_transfers
         4. memory_bandwidth
         5. nccl_breakdown
-        6. nccl_anomaly
-        7. kernel_launch_overhead
-        8. kernel_launch_pattern
-        9. stream_concurrency
-        10. overlap_breakdown
-        11. kernel_overlap_matrix
-        12. iteration_timing
-        13. nvtx_layer_breakdown
+        6. nccl_communicator_analysis
+        7. nccl_anomaly
+        8. kernel_launch_overhead
+        9. kernel_launch_pattern
+        10. stream_concurrency
+        11. overlap_breakdown
+        12. kernel_overlap_matrix
+        13. iteration_timing
+        14. nvtx_layer_breakdown
 
         Returns:
             Formatted multi-section report with optional AI synthesis.
@@ -156,6 +174,7 @@ class Agent:
             "memory_transfers",
             "memory_bandwidth",
             "nccl_breakdown",
+            "nccl_communicator_analysis",
             "nccl_anomaly",
             "kernel_launch_overhead",
             "kernel_launch_pattern",

--- a/src/nsys_ai/nccl_communicator.py
+++ b/src/nsys_ai/nccl_communicator.py
@@ -12,10 +12,10 @@ followed by the payload bytes referenced by `NVTX_PAYLOAD_SCHEMAS` and
 
 from __future__ import annotations
 
-from collections import defaultdict
-from dataclasses import dataclass
 import os
 import sqlite3
+from collections import defaultdict
+from dataclasses import dataclass
 
 from .connection import DB_ERRORS
 from .profile import Profile, get_first_gpu_name

--- a/src/nsys_ai/nccl_communicator.py
+++ b/src/nsys_ai/nccl_communicator.py
@@ -1,0 +1,714 @@
+"""Communicator-aware NCCL analysis from NVTX extended payload blobs.
+
+The enriched Nsight SQLite export (`nsys export --include-blobs=true`) stores
+per-event NVTX payloads in `NVTX_EVENTS.binaryData`. For NCCL events, the blob
+starts with a fixed 32-byte header:
+
+    [domainId:u64][schemaId:u64][payloadSize:u64][payloadOffset:u64]
+
+followed by the payload bytes referenced by `NVTX_PAYLOAD_SCHEMAS` and
+`NVTX_PAYLOAD_SCHEMA_ENTRIES`.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+import os
+import sqlite3
+
+from .connection import DB_ERRORS
+from .profile import Profile, get_first_gpu_name
+
+_NVTX_RANGE_EVENT = 59
+_BLOB_HEADER_SIZE = 32
+_NCCL_KERNEL_PATTERNS = (
+    "nccldevkernel",
+    "ncclkernel",
+    "ncclsend",
+    "ncclrecv",
+    "ncclallreduce",
+)
+_COLLECTIVE_NAME_HINTS = {
+    "allgather": "allgather",
+    "reducescatter": "reducescatter",
+    "allreduce": "allreduce",
+    "broadcast": "broadcast",
+    "sendrecv": "sendrecv",
+    "reduce": "reduce",
+}
+_NVLINK_PEAK_GBPS = {
+    "B200": 1800.0,
+    "GB200": 1800.0,
+    "H200": 900.0,
+    "H100": 900.0,
+    "H800": 900.0,
+    "A100": 600.0,
+    "V100": 300.0,
+}
+
+
+@dataclass
+class _DecodedEvent:
+    nvtx_text: str
+    global_tid: int
+    start_ns: int
+    end_ns: int
+    domain_id: int
+    schema_id: int
+    communicator_id: int | None
+    message_size_bytes: int | None
+    num_ranks: int | None
+    rank: int | None
+    cuda_device: int | None
+    reduction_op: str | None
+    root_rank: int | None
+    collective_type: str | None
+
+
+def analyze_nccl_communicators(
+    prof: Profile,
+    device: int | None = None,
+    trim: tuple[int, int] | None = None,
+) -> list[dict]:
+    """Aggregate NCCL communication by communicator ID and collective type."""
+    events, diagnostics = _load_nccl_payload_events(prof, trim=trim)
+    if not events:
+        return [
+            {
+                "_diagnostic": True,
+                "message": diagnostics[0]
+                if diagnostics
+                else (
+                    "No NCCL payload blobs found. Re-export the profile with "
+                    "`nsys export --include-blobs=true`."
+                ),
+            }
+        ]
+
+    communicator_meta = _build_communicator_metadata(events)
+    attributed, dropped = _attribute_events_to_kernels(prof, events, device=device, trim=trim)
+    diagnostics.extend(dropped)
+
+    if not attributed:
+        return [
+            {
+                "_diagnostic": True,
+                "message": (
+                    "Decoded NCCL payload events were found, but no NCCL kernels could be "
+                    "attributed to them on the selected device scope."
+                ),
+                "details": diagnostics,
+            }
+        ]
+
+    peak_gbps, peak_source = _estimate_peak_bandwidth_gbps(prof)
+    world_size = len(prof.meta.devices or [])
+
+    grouped: dict[tuple[int, str], dict] = {}
+    for row in attributed:
+        comm_id = row["communicator_id"]
+        collective_type = row["collective_type"]
+        key = (comm_id, collective_type)
+        meta = communicator_meta.get(comm_id, {})
+        bucket = grouped.setdefault(
+            key,
+            {
+                "communicator_id": comm_id,
+                "communicator_hex": f"0x{comm_id:016x}",
+                "collective_type": collective_type,
+                "durations_ns": [],
+                "total_bytes": 0,
+                "sized_count": 0,
+                "count": 0,
+                "devices": set(),
+                "streams": set(),
+                "num_ranks": meta.get("num_ranks"),
+                "rank": meta.get("rank"),
+                "cuda_device": meta.get("cuda_device"),
+                "reduction_op": row.get("reduction_op") or meta.get("reduction_op"),
+                "root_rank": row.get("root_rank") or meta.get("root_rank"),
+            },
+        )
+        bucket["durations_ns"].append(row["duration_ns"])
+        bucket["count"] += 1
+        bucket["devices"].add(row["device_id"])
+        bucket["streams"].add(row["stream_id"])
+        if row.get("message_size_bytes") is not None:
+            bucket["sized_count"] += 1
+            bucket["total_bytes"] += int(row["message_size_bytes"])
+        for key_name in ("num_ranks", "rank", "cuda_device", "reduction_op", "root_rank"):
+            if bucket.get(key_name) is None and row.get(key_name) is not None:
+                bucket[key_name] = row[key_name]
+
+    results = []
+    for bucket in grouped.values():
+        durations = bucket.pop("durations_ns")
+        total_ns = sum(durations)
+        avg_ns = total_ns / len(durations)
+        bandwidth_gbps = None
+        total_bytes = bucket["total_bytes"]
+        if bucket["sized_count"] == bucket["count"] and total_bytes > 0 and total_ns > 0:
+            bandwidth_gbps = total_bytes / (total_ns / 1e9) / 1e9
+        efficiency_pct = None
+        if bandwidth_gbps is not None and peak_gbps:
+            efficiency_pct = (bandwidth_gbps / peak_gbps) * 100.0
+        num_ranks = bucket.get("num_ranks")
+        devices = sorted(bucket["devices"])
+        device_scope = "all" if device is None else str(device)
+        results.append(
+            {
+                "communicator_id": bucket["communicator_id"],
+                "communicator_hex": bucket["communicator_hex"],
+                "collective_type": bucket["collective_type"],
+                "count": bucket["count"],
+                "total_ms": round(total_ns / 1e6, 3),
+                "avg_ms": round(avg_ns / 1e6, 3),
+                "min_ms": round(min(durations) / 1e6, 3),
+                "max_ms": round(max(durations) / 1e6, 3),
+                "total_bytes": total_bytes if bucket["sized_count"] == bucket["count"] else None,
+                "avg_bytes": round(total_bytes / bucket["count"], 1)
+                if bucket["sized_count"] == bucket["count"] and bucket["count"] > 0
+                else None,
+                "bandwidth_gbps": round(bandwidth_gbps, 3) if bandwidth_gbps is not None else None,
+                "peak_gbps": round(peak_gbps, 3) if peak_gbps else None,
+                "peak_source": peak_source,
+                "efficiency_pct": round(efficiency_pct, 1) if efficiency_pct is not None else None,
+                "num_ranks": num_ranks,
+                "rank": bucket.get("rank"),
+                "cuda_device": bucket.get("cuda_device"),
+                "root_rank": bucket.get("root_rank"),
+                "reduction_op": bucket.get("reduction_op"),
+                "inferred_dimension": _infer_parallel_dimension(num_ranks, world_size),
+                "device_scope": device_scope,
+                "device_count": len(devices),
+                "devices": ",".join(str(d) for d in devices),
+                "stream_count": len(bucket["streams"]),
+            }
+        )
+
+    results.sort(key=lambda r: (-r["total_ms"], r["communicator_hex"], r["collective_type"]))
+    if diagnostics:
+        results.append(
+            {
+                "_diagnostic": True,
+                "message": "Additional communicator-analysis diagnostics",
+                "details": diagnostics,
+            }
+        )
+    return results
+
+
+def format_nccl_communicator(rows: list[dict]) -> str:
+    """Render communicator-aware NCCL rows as grouped text."""
+    if not rows:
+        return "No communicator-aware NCCL rows found"
+
+    diagnostic = [r for r in rows if r.get("_diagnostic")]
+    data_rows = [r for r in rows if not r.get("_diagnostic")]
+    if not data_rows:
+        if diagnostic:
+            details = diagnostic[0].get("details") or []
+            lines = [diagnostic[0].get("message", "No communicator-aware NCCL rows found")]
+            for detail in details[:8]:
+                lines.append(f"  - {detail}")
+            return "\n".join(lines)
+        return "No communicator-aware NCCL rows found"
+
+    lines = ["NCCL Communication by Communicator"]
+    current_comm = None
+    for row in sorted(data_rows, key=lambda r: (r["communicator_hex"], -r["total_ms"])):
+        comm = row["communicator_hex"]
+        if comm != current_comm:
+            current_comm = comm
+            header = (
+                f"  [{comm}] {row['inferred_dimension']}  "
+                f"ranks={row['num_ranks'] if row['num_ranks'] is not None else '?'}  "
+                f"devices={row['devices'] or row['device_scope']}"
+            )
+            lines.append(header)
+        bandwidth = (
+            f"  BW={row['bandwidth_gbps']:.2f}GB/s"
+            if row.get("bandwidth_gbps") is not None
+            else "  BW=n/a"
+        )
+        if row.get("efficiency_pct") is not None:
+            bandwidth += f" ({row['efficiency_pct']:.1f}% of {row['peak_source']})"
+        lines.append(
+            f"    {row['collective_type']:16s} {row['total_ms']:8.3f}ms  "
+            f"×{row['count']:<4d} avg={row['avg_ms']:.3f}ms{bandwidth}"
+        )
+
+    if diagnostic:
+        lines.append("")
+        lines.append("  Diagnostics:")
+        for item in diagnostic:
+            for detail in item.get("details") or [item.get("message")]:
+                if detail:
+                    lines.append(f"    - {detail}")
+    return "\n".join(lines)
+
+
+def _load_nccl_payload_events(
+    prof: Profile,
+    trim: tuple[int, int] | None = None,
+) -> tuple[list[_DecodedEvent], list[str]]:
+    schemas = _load_payload_schemas(prof)
+    enum_maps = _load_payload_enums(prof)
+    if not schemas:
+        return [], [
+            "Payload schema tables are unavailable. Use an enriched SQLite export with "
+            "`--include-blobs=true`."
+        ]
+
+    trim_clause = ""
+    params: list[object] = []
+    if trim:
+        trim_clause = "AND n.[end] >= ? AND n.start <= ?"
+        params.extend([int(trim[0]), int(trim[1])])
+
+    try:
+        rows = prof._duckdb_query(
+            f"""
+            SELECT
+                COALESCE(n.text, s.value) AS nvtx_text,
+                n.start,
+                n.[end],
+                n.eventType,
+                n.globalTid,
+                n.domainId,
+                n.binaryData
+            FROM NVTX_EVENTS n
+            LEFT JOIN StringIds s ON n.textId = s.id
+            WHERE n.binaryData IS NOT NULL
+              AND n.eventType = {_NVTX_RANGE_EVENT}
+              AND n.[end] > n.start
+              {trim_clause}
+            ORDER BY n.globalTid, n.start
+            """,
+            params,
+        )
+    except DB_ERRORS as exc:
+        msg = str(exc)
+        if "Invalid type in column \"binaryData\"" in msg:
+            sqlite_path = _discover_sqlite_path(prof)
+            if sqlite_path:
+                rows, sqlite_diagnostics = _load_nvtx_payload_rows_sqlite(sqlite_path, trim=trim)
+                events, diagnostics = _decode_events_from_rows(rows, schemas, enum_maps)
+                return events, [
+                    "Used SQLite side-connection fallback for NVTX blob decoding in direct mode."
+                ] + sqlite_diagnostics + diagnostics
+            return [], [
+                "Direct DuckDB-over-SQLite mode cannot read mixed TEXT/BLOB NVTX payload data "
+                "from this export, and the underlying SQLite path could not be discovered for "
+                "automatic fallback."
+            ]
+        return [], [f"Failed to read NVTX payload events: {msg}"]
+
+    return _decode_events_from_rows(rows, schemas, enum_maps)
+
+
+def _decode_events_from_rows(
+    rows: list[dict],
+    schemas: dict[tuple[int, int], list[dict]],
+    enum_maps: dict[int, dict[int, str]],
+) -> tuple[list[_DecodedEvent], list[str]]:
+    diagnostics: list[str] = []
+    events: list[_DecodedEvent] = []
+    for row in rows:
+        nvtx_text = (row.get("nvtx_text") or "").strip()
+        if not nvtx_text.lower().startswith("nccl"):
+            continue
+        try:
+            domain_id, schema_id, payload_bytes = _decode_blob_header(row["binaryData"])
+        except ValueError as exc:
+            diagnostics.append(f"Failed to decode NCCL blob header for '{nvtx_text}': {exc}")
+            continue
+
+        schema_entries = schemas.get((domain_id, schema_id))
+        if not schema_entries:
+            diagnostics.append(
+                f"Missing payload schema definition for domain={domain_id} schema={schema_id}"
+            )
+            continue
+        payload = _decode_payload(schema_entries, payload_bytes, enum_maps)
+        event = _DecodedEvent(
+            nvtx_text=nvtx_text,
+            global_tid=int(row["globalTid"]),
+            start_ns=int(row["start"]),
+            end_ns=int(row["end"]),
+            domain_id=domain_id,
+            schema_id=schema_id,
+            communicator_id=_lookup_field(payload, "communicator id"),
+            message_size_bytes=_lookup_field(payload, "message size"),
+            num_ranks=_lookup_field(payload, "no. of ranks"),
+            rank=_lookup_exact_field(payload, "rank"),
+            cuda_device=_lookup_field(payload, "cuda device"),
+            reduction_op=_lookup_field(payload, "reduction operation"),
+            root_rank=_lookup_exact_field(payload, "root"),
+            collective_type=_classify_collective_name(nvtx_text),
+        )
+        events.append(event)
+    return events, diagnostics
+
+
+def _discover_sqlite_path(prof: Profile) -> str | None:
+    path = getattr(prof, "path", "")
+    if path and os.path.isfile(path) and path.lower().endswith(".sqlite"):
+        return path
+    try:
+        rows = prof.adapter.execute(
+            """
+            SELECT path
+            FROM duckdb_databases()
+            WHERE type = 'sqlite' AND path IS NOT NULL
+            ORDER BY database_name
+            LIMIT 1
+            """
+        ).fetchall()
+        if rows and rows[0][0]:
+            return str(rows[0][0])
+    except Exception:
+        return None
+    return None
+
+
+def _load_nvtx_payload_rows_sqlite(
+    sqlite_path: str,
+    trim: tuple[int, int] | None = None,
+) -> tuple[list[dict], list[str]]:
+    diagnostics: list[str] = []
+    trim_clause = ""
+    params: list[object] = []
+    if trim:
+        trim_clause = "AND n.[end] >= ? AND n.start <= ?"
+        params.extend([int(trim[0]), int(trim[1])])
+    try:
+        conn = sqlite3.connect(sqlite_path)
+        conn.row_factory = sqlite3.Row
+        cur = conn.cursor()
+        result = [
+            dict(row)
+            for row in cur.execute(
+                f"""
+                SELECT
+                    COALESCE(n.text, s.value) AS nvtx_text,
+                    n.start,
+                    n.[end],
+                    n.eventType,
+                    n.globalTid,
+                    n.domainId,
+                    n.binaryData
+                FROM NVTX_EVENTS n
+                LEFT JOIN StringIds s ON n.textId = s.id
+                WHERE n.binaryData IS NOT NULL
+                  AND n.eventType = {_NVTX_RANGE_EVENT}
+                  AND n.[end] > n.start
+                  {trim_clause}
+                ORDER BY n.globalTid, n.start
+                """,
+                params,
+            )
+        ]
+        conn.close()
+        return result, diagnostics
+    except sqlite3.Error as exc:
+        diagnostics.append(f"SQLite fallback for NVTX blob decoding failed: {exc}")
+        return [], diagnostics
+
+
+def _build_communicator_metadata(events: list[_DecodedEvent]) -> dict[int, dict]:
+    metadata: dict[int, dict] = {}
+    for event in events:
+        if event.communicator_id is None:
+            continue
+        entry = metadata.setdefault(event.communicator_id, {})
+        for key in ("num_ranks", "rank", "cuda_device", "reduction_op", "root_rank"):
+            value = getattr(event, key)
+            if value is not None and entry.get(key) is None:
+                entry[key] = value
+    return metadata
+
+
+def _attribute_events_to_kernels(
+    prof: Profile,
+    events: list[_DecodedEvent],
+    *,
+    device: int | None,
+    trim: tuple[int, int] | None,
+) -> tuple[list[dict], list[str]]:
+    tables = prof.adapter.resolve_activity_tables()
+    kernel_table = tables.get("kernel", prof.schema.kernel_table or "CUPTI_ACTIVITY_KIND_KERNEL")
+    runtime_table = tables.get("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME")
+
+    params: list[object] = []
+    where = ["(COALESCE(d.value, s.value, '') LIKE '%nccl%' OR COALESCE(d.value, s.value, '') LIKE '%NCCL%')"]
+    if device is not None:
+        where.append("k.deviceId = ?")
+        params.append(int(device))
+    if trim:
+        where.append("k.[end] >= ? AND k.start <= ?")
+        params.extend([int(trim[0]), int(trim[1])])
+
+    kernel_rows = prof._duckdb_query(
+        f"""
+        SELECT
+            r.globalTid,
+            r.start AS rt_start,
+            r.[end] AS rt_end,
+            k.deviceId,
+            k.streamId,
+            k.correlationId,
+            k.start AS k_start,
+            k.[end] AS k_end,
+            COALESCE(d.value, s.value, 'kernel_' || CAST(k.shortName AS VARCHAR)) AS kernel_name
+        FROM {kernel_table} k
+        JOIN {runtime_table} r ON r.correlationId = k.correlationId
+        LEFT JOIN StringIds s ON k.shortName = s.id
+        LEFT JOIN StringIds d ON k.demangledName = d.id
+        WHERE {' AND '.join(where)}
+        ORDER BY r.globalTid, r.start
+        """,
+        params,
+    )
+
+    events_by_tid: dict[int, list[_DecodedEvent]] = defaultdict(list)
+    for event in events:
+        if event.collective_type is None or event.communicator_id is None:
+            continue
+        events_by_tid[event.global_tid].append(event)
+    for rows in events_by_tid.values():
+        rows.sort(key=lambda e: (e.start_ns, e.end_ns))
+
+    diagnostics: list[str] = []
+    attributed: list[dict] = []
+    for kernel in kernel_rows:
+        kernel_name = str(kernel["kernel_name"] or "")
+        if not _matches_nccl_kernel_allowlist(kernel_name):
+            continue
+        tid = int(kernel["globalTid"])
+        candidates = events_by_tid.get(tid) or []
+        if not candidates:
+            continue
+        rt_start = int(kernel["rt_start"])
+        rt_end = int(kernel["rt_end"])
+        best_event = None
+        best_span = None
+        for event in candidates:
+            if event.start_ns > rt_start:
+                break
+            if event.end_ns >= rt_end:
+                span = event.end_ns - event.start_ns
+                if best_span is None or span < best_span:
+                    best_span = span
+                    best_event = event
+        if best_event is None:
+            continue
+        attributed.append(
+            {
+                "communicator_id": best_event.communicator_id,
+                "collective_type": best_event.collective_type,
+                "duration_ns": int(kernel["k_end"]) - int(kernel["k_start"]),
+                "device_id": int(kernel["deviceId"]),
+                "stream_id": int(kernel["streamId"]),
+                "kernel_name": kernel_name,
+                "message_size_bytes": best_event.message_size_bytes,
+                "num_ranks": best_event.num_ranks,
+                "rank": best_event.rank,
+                "cuda_device": best_event.cuda_device,
+                "reduction_op": best_event.reduction_op,
+                "root_rank": best_event.root_rank,
+            }
+        )
+
+    if not attributed and kernel_rows:
+        diagnostics.append(
+            "NCCL kernels were present, but none matched the communicator-event allowlist "
+            "after runtime/NVTX attribution."
+        )
+    return attributed, diagnostics
+
+
+def _load_payload_schemas(prof: Profile) -> dict[tuple[int, int], list[dict]]:
+    try:
+        rows = prof._duckdb_query(
+            """
+            SELECT
+                se.domainId,
+                se.schemaId,
+                se.idx,
+                se.name,
+                se.type,
+                se.offset,
+                ps.payloadSize
+            FROM NVTX_PAYLOAD_SCHEMA_ENTRIES se
+            JOIN NVTX_PAYLOAD_SCHEMAS ps
+              ON se.domainId = ps.domainId
+             AND se.schemaId = ps.schemaId
+            ORDER BY se.domainId, se.schemaId, se.idx
+            """
+        )
+    except DB_ERRORS:
+        return {}
+
+    deduped: dict[tuple[int, int, int], dict] = {}
+    for row in rows:
+        key = (int(row["domainId"]), int(row["schemaId"]), int(row["idx"]))
+        deduped.setdefault(key, row)
+
+    grouped: dict[tuple[int, int], list[dict]] = defaultdict(list)
+    for (_, _, _), row in deduped.items():
+        grouped[(int(row["domainId"]), int(row["schemaId"]))].append(row)
+    for entries in grouped.values():
+        entries.sort(key=lambda r: int(r["idx"]))
+    return grouped
+
+
+def _load_payload_enums(prof: Profile) -> dict[int, dict[int, str]]:
+    try:
+        rows = prof._duckdb_query(
+            """
+            SELECT schemaId, idx, name, value
+            FROM NVTX_PAYLOAD_ENUM_ENTRIES
+            ORDER BY schemaId, idx
+            """
+        )
+    except DB_ERRORS:
+        return {}
+
+    enums: dict[int, dict[int, str]] = defaultdict(dict)
+    for row in rows:
+        schema_id = int(row["schemaId"])
+        value = int(row["value"]) if row["value"] is not None else int(row["idx"])
+        enums[schema_id].setdefault(value, str(row["name"]))
+    return enums
+
+
+def _decode_blob_header(blob: bytes | bytearray | memoryview | str) -> tuple[int, int, bytes]:
+    if isinstance(blob, str):
+        raw = bytes.fromhex(blob)
+    else:
+        raw = bytes(blob)
+    if len(raw) < _BLOB_HEADER_SIZE:
+        raise ValueError(f"blob too short ({len(raw)} bytes)")
+    domain_id = int.from_bytes(raw[0:8], "little", signed=False)
+    schema_id = int.from_bytes(raw[8:16], "little", signed=False)
+    payload_size = int.from_bytes(raw[16:24], "little", signed=False)
+    payload_offset = int.from_bytes(raw[24:32], "little", signed=False)
+    if payload_offset < _BLOB_HEADER_SIZE or payload_offset > len(raw):
+        raise ValueError(f"unexpected payload offset {payload_offset}")
+    payload = raw[payload_offset : payload_offset + payload_size]
+    if len(payload) != payload_size:
+        raise ValueError(
+            f"payload truncated (expected {payload_size} bytes, got {len(payload)})"
+        )
+    return domain_id, schema_id, payload
+
+
+def _decode_payload(
+    entries: list[dict],
+    payload: bytes,
+    enum_maps: dict[int, dict[int, str]],
+) -> dict[str, object]:
+    decoded: dict[str, object] = {}
+    offsets = []
+    payload_size = int(entries[0]["payloadSize"]) if entries else len(payload)
+    for entry in entries:
+        start = int(entry["offset"]) if entry["offset"] is not None else 0
+        offsets.append(start)
+
+    for index, entry in enumerate(entries):
+        start = int(entry["offset"]) if entry["offset"] is not None else 0
+        end = payload_size
+        if index + 1 < len(entries):
+            next_offset = entries[index + 1]["offset"]
+            if next_offset is not None:
+                end = int(next_offset)
+        chunk = payload[start:end]
+        if not chunk:
+            continue
+        value = int.from_bytes(chunk, "little", signed=False)
+        enum_type = int(entry["type"]) if entry["type"] is not None else None
+        if enum_type in enum_maps:
+            low32 = value & 0xFFFFFFFF
+            decoded[str(entry["name"])] = enum_maps[enum_type].get(low32, str(low32))
+        else:
+            if len(chunk) == 4:
+                value &= 0xFFFFFFFF
+            decoded[str(entry["name"])] = value
+    return decoded
+
+
+def _lookup_field(payload: dict[str, object], needle: str) -> object | None:
+    needle = _normalize_name(needle)
+    for key, value in payload.items():
+        if needle in _normalize_name(key):
+            return value
+    return None
+
+
+def _lookup_exact_field(payload: dict[str, object], needle: str) -> object | None:
+    needle = _normalize_name(needle)
+    for key, value in payload.items():
+        if _normalize_name(key) == needle:
+            return value
+    return None
+
+
+def _normalize_name(text: str) -> str:
+    return "".join(ch.lower() for ch in text if ch.isalnum())
+
+
+def _classify_collective_name(text: str) -> str | None:
+    lower = text.lower()
+    if "groupstart" in lower or "groupend" in lower or "comminit" in lower or "commabort" in lower:
+        return None
+    for hint, label in _COLLECTIVE_NAME_HINTS.items():
+        if hint in lower:
+            return label
+    return None
+
+
+def _matches_nccl_kernel_allowlist(kernel_name: str) -> bool:
+    lower = kernel_name.lower()
+    return any(pattern in lower for pattern in _NCCL_KERNEL_PATTERNS)
+
+
+def _infer_parallel_dimension(num_ranks: int | None, world_size: int | None) -> str:
+    if not num_ranks or num_ranks <= 1:
+        return "single_rank_or_unknown"
+    if world_size and num_ranks == world_size:
+        return "data_parallel_or_global"
+    if world_size and 1 < num_ranks < world_size:
+        return f"subgroup_parallelism({num_ranks})"
+    return f"subgroup_parallelism({num_ranks})"
+
+
+def _estimate_peak_bandwidth_gbps(prof: Profile) -> tuple[float | None, str | None]:
+    # `TARGET_INFO_NIC_INFO` does not expose link speed in the checked exports,
+    # so only use NIC info when an explicit speed-like column exists. Otherwise
+    # fall back to a conservative NVLink estimate from the GPU model.
+    try:
+        nic_cols = set(prof.adapter.get_table_columns("TARGET_INFO_NIC_INFO"))
+    except Exception:
+        nic_cols = set()
+    speed_cols = next(
+        (col for col in nic_cols if col.lower() in {"speed", "linkspeed", "linkspeedgbps"}),
+        None,
+    )
+    if speed_cols:
+        try:
+            row = prof.adapter.execute(
+                f"SELECT MAX({speed_cols}) FROM TARGET_INFO_NIC_INFO"
+            ).fetchone()
+            if row and row[0]:
+                return float(row[0]), f"NIC {speed_cols}"
+        except Exception:
+            pass
+
+    gpu_name = get_first_gpu_name(prof.conn if prof.db is None else prof.db)
+    normalized = (gpu_name or "").upper()
+    for key, gbps in sorted(_NVLINK_PEAK_GBPS.items(), key=lambda item: len(item[0]), reverse=True):
+        if key in normalized:
+            return gbps, f"{key} NVLink"
+    return None, None

--- a/src/nsys_ai/nccl_communicator.py
+++ b/src/nsys_ai/nccl_communicator.py
@@ -37,6 +37,11 @@ _COLLECTIVE_NAME_HINTS = {
     "sendrecv": "sendrecv",
     "reduce": "reduce",
 }
+# Peak NVLink bandwidth in GB/s (gigabytes/sec).
+# Note: field names use the suffix ``_gbps`` for brevity, but the values and
+# all downstream computations (bandwidth_gbps, peak_gbps, efficiency_pct) are
+# in GB/s — not Gb/s (gigabits).  Renaming would be a breaking JSON schema
+# change, so we keep the suffix and document the units here.
 _NVLINK_PEAK_GBPS = {
     "B200": 1800.0,
     "GB200": 1800.0,
@@ -146,10 +151,10 @@ def analyze_nccl_communicators(
         durations = bucket.pop("durations_ns")
         total_ns = sum(durations)
         avg_ns = total_ns / len(durations)
-        bandwidth_gbps = None
+        bandwidth_gbps = None  # GB/s (see _NVLINK_PEAK_GBPS note)
         total_bytes = bucket["total_bytes"]
         if bucket["sized_count"] == bucket["count"] and total_bytes > 0 and total_ns > 0:
-            bandwidth_gbps = total_bytes / (total_ns / 1e9) / 1e9
+            bandwidth_gbps = total_bytes / (total_ns / 1e9) / 1e9  # bytes/sec → GB/s
         efficiency_pct = None
         if bandwidth_gbps is not None and peak_gbps:
             efficiency_pct = (bandwidth_gbps / peak_gbps) * 100.0

--- a/src/nsys_ai/nccl_communicator.py
+++ b/src/nsys_ai/nccl_communicator.py
@@ -288,6 +288,8 @@ def _load_nccl_payload_events(
             WHERE n.binaryData IS NOT NULL
               AND n.eventType = {_NVTX_RANGE_EVENT}
               AND n.[end] > n.start
+              AND COALESCE(n.text, s.value) IS NOT NULL
+              AND lower(COALESCE(n.text, s.value)) LIKE 'nccl%'
               {trim_clause}
             ORDER BY n.globalTid, n.start
             """,

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -23,8 +23,8 @@ import json
 import logging
 import os
 import re
-import tempfile
 import sys
+import tempfile
 import time
 from hashlib import sha256
 from pathlib import Path

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -24,7 +24,6 @@ import logging
 import os
 import re
 import sys
-import tempfile
 import time
 from hashlib import sha256
 from pathlib import Path
@@ -589,7 +588,9 @@ def _repair_parquet_binary_columns_to_disk(parquet_file: Path, table_name: str) 
         f"{','.join(sorted(binary_columns))}"
     )
     digest = sha256(cache_key.encode("utf-8")).hexdigest()[:20]
-    out_dir = Path(tempfile.gettempdir()) / "nsys_ai_parquetdir_repaired"
+    # Keep repaired artifacts scoped to the profile directory instead of
+    # global /tmp, so lifecycle naturally tracks the source parquetdir.
+    out_dir = parquet_file.parent / ".nsys_ai_parquetdir_repaired"
     out_dir.mkdir(parents=True, exist_ok=True)
     out_path = out_dir / f"{parquet_file.stem}.{digest}.parquet"
     if out_path.exists():

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -23,8 +23,10 @@ import json
 import logging
 import os
 import re
+import tempfile
 import sys
 import time
+from hashlib import sha256
 from pathlib import Path
 
 import duckdb
@@ -514,10 +516,22 @@ def _register_parquetdir_tables(
         # Escape double-quotes in identifiers as defence-in-depth.
         safe_name = table_name.replace('"', '""')
         if table_name in _PARQUETDIR_BINARY_COLUMNS:
-            arrow_name = f"_parquetdir_{table_name}"
-            table = _load_parquet_table_for_duckdb(parquet_file, table_name)
-            db.register(arrow_name, table)
-            db.execute(f'CREATE VIEW "{safe_name}" AS SELECT * FROM "{arrow_name}"')
+            try:
+                repaired = _repair_parquet_binary_columns_to_disk(parquet_file, table_name)
+                safe_fpath = str(repaired).replace("'", "''")
+                db.execute(
+                    f'CREATE VIEW "{safe_name}" AS SELECT * FROM read_parquet(\'{safe_fpath}\')'
+                )
+            except Exception as exc:
+                log.warning(
+                    "Falling back to in-memory Arrow repair for %s due to: %s",
+                    parquet_file,
+                    exc,
+                )
+                arrow_name = f"_parquetdir_{table_name}"
+                table = _load_parquet_table_for_duckdb(parquet_file, table_name)
+                db.register(arrow_name, table)
+                db.execute(f'CREATE VIEW "{safe_name}" AS SELECT * FROM "{arrow_name}"')
             continue
 
         safe_fpath = str(parquet_file).replace("'", "''")
@@ -557,6 +571,62 @@ def _load_parquet_table_for_duckdb(parquet_file: Path, table_name: str):
             batch_arrays.append(column)
         batches.append(pa.record_batch(batch_arrays, names=batch.schema.names))
     return pa.Table.from_batches(batches)
+
+
+def _repair_parquet_binary_columns_to_disk(parquet_file: Path, table_name: str) -> Path:
+    """Repair mis-typed binary columns into a cached parquet file on disk."""
+    import pyarrow as pa
+    import pyarrow.compute as pc
+    import pyarrow.parquet as pq
+
+    binary_columns = set(_PARQUETDIR_BINARY_COLUMNS.get(table_name, ()))
+    if not binary_columns:
+        return parquet_file
+
+    src_stat = parquet_file.stat()
+    cache_key = (
+        f"{parquet_file.resolve()}:{src_stat.st_mtime_ns}:{src_stat.st_size}:"
+        f"{','.join(sorted(binary_columns))}"
+    )
+    digest = sha256(cache_key.encode("utf-8")).hexdigest()[:20]
+    out_dir = Path(tempfile.gettempdir()) / "nsys_ai_parquetdir_repaired"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"{parquet_file.stem}.{digest}.parquet"
+    if out_path.exists():
+        return out_path
+
+    parquet = pq.ParquetFile(parquet_file)
+    source_schema = parquet.schema_arrow
+    fields = []
+    cast_targets: dict[str, pa.DataType] = {}
+    for field in source_schema:
+        if field.name in binary_columns:
+            cast_targets[field.name] = pa.large_binary()
+            fields.append(
+                pa.field(
+                    field.name,
+                    pa.large_binary(),
+                    nullable=field.nullable,
+                    metadata=field.metadata,
+                )
+            )
+        else:
+            fields.append(field)
+    target_schema = pa.schema(fields, metadata=source_schema.metadata)
+
+    tmp_path = out_path.with_suffix(out_path.suffix + ".tmp")
+    with pq.ParquetWriter(tmp_path, target_schema, compression="zstd") as writer:
+        for batch in parquet.iter_batches():
+            arrays = []
+            for idx, field in enumerate(batch.schema):
+                col = batch.column(idx)
+                target_type = cast_targets.get(field.name)
+                if target_type is not None:
+                    col = pc.cast(col, target_type, safe=False)
+                arrays.append(col)
+            writer.write_batch(pa.record_batch(arrays, schema=target_schema))
+    tmp_path.replace(out_path)
+    return out_path
 
 
 def _export_nvtx_with_blobs(sqlite_path: str, nvtx_table: str, cache_dir: Path) -> None:

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sys
 import time
 from pathlib import Path
@@ -32,6 +33,8 @@ log = logging.getLogger(__name__)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
 _CACHE_VERSION = 7  # bumped: preserve NVTX blobs and payload schema tables
+
+_SAFE_PARQUETDIR_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
 # Tables to export as-is from SQLite → Parquet.
 # (view_name, source_table_name)
@@ -420,6 +423,10 @@ def open_cached_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
 def open_parquetdir_db(parquetdir_path: str) -> duckdb.DuckDBPyConnection:
     """Open a DuckDB connection over an Nsight `parquetdir` export."""
     parquet_dir = Path(parquetdir_path)
+    if not parquet_dir.is_dir():
+        raise RuntimeError(
+            f"Parquet directory path does not exist or is not a directory: {parquet_dir}"
+        )
     parquet_files = sorted(parquet_dir.glob("*.parquet"))
     if not parquet_files:
         raise RuntimeError(
@@ -500,16 +507,22 @@ def _register_parquetdir_tables(
     """
     for parquet_file in parquet_files:
         table_name = parquet_file.stem
+        # Validate table name to prevent SQL injection from unexpected filenames.
+        if not _SAFE_PARQUETDIR_NAME_RE.match(table_name):
+            log.warning("Skipping parquet file with unsafe name: %s", parquet_file.name)
+            continue
+        # Escape double-quotes in identifiers as defence-in-depth.
+        safe_name = table_name.replace('"', '""')
         if table_name in _PARQUETDIR_BINARY_COLUMNS:
             arrow_name = f"_parquetdir_{table_name}"
             table = _load_parquet_table_for_duckdb(parquet_file, table_name)
             db.register(arrow_name, table)
-            db.execute(f'CREATE VIEW "{table_name}" AS SELECT * FROM "{arrow_name}"')
+            db.execute(f'CREATE VIEW "{safe_name}" AS SELECT * FROM "{arrow_name}"')
             continue
 
         safe_fpath = str(parquet_file).replace("'", "''")
         db.execute(
-            f'CREATE VIEW "{table_name}" AS SELECT * FROM read_parquet(\'{safe_fpath}\')'
+            f'CREATE VIEW "{safe_name}" AS SELECT * FROM read_parquet(\'{safe_fpath}\')'
         )
 
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -31,7 +31,7 @@ import duckdb
 log = logging.getLogger(__name__)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
-_CACHE_VERSION = 6  # bumped: added CUPTI_ACTIVITY_KIND_SYNCHRONIZATION and ENUM_CUPTI_SYNC_TYPE
+_CACHE_VERSION = 7  # bumped: preserve NVTX blobs and payload schema tables
 
 # Tables to export as-is from SQLite → Parquet.
 # (view_name, source_table_name)
@@ -48,6 +48,11 @@ _BASE_TABLES = [
     ("thread_names", "ThreadNames"),
     ("sync", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"),
     ("sync_type", "ENUM_CUPTI_SYNC_TYPE"),
+    ("nic_info", "TARGET_INFO_NIC_INFO"),
+    ("nvtx_payload_schemas", "NVTX_PAYLOAD_SCHEMAS"),
+    ("nvtx_payload_schema_entries", "NVTX_PAYLOAD_SCHEMA_ENTRIES"),
+    ("nvtx_payload_enums", "NVTX_PAYLOAD_ENUMS"),
+    ("nvtx_payload_enum_entries", "NVTX_PAYLOAD_ENUM_ENTRIES"),
 ]
 
 
@@ -210,11 +215,20 @@ _ALIASES: dict[str, list[str]] = {
     "string_ids": ["StringIds"],
     "gpu_info": ["TARGET_INFO_GPU"],
     "cuda_device": ["TARGET_INFO_CUDA_DEVICE"],
+    "nic_info": ["TARGET_INFO_NIC_INFO"],
     "thread_names": ["ThreadNames"],
     "overhead": ["CUPTI_ACTIVITY_KIND_OVERHEAD"],
     "composite_events": ["COMPOSITE_EVENTS"],
     "sync": ["CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"],
     "sync_type": ["ENUM_CUPTI_SYNC_TYPE"],
+    "nvtx_payload_schemas": ["NVTX_PAYLOAD_SCHEMAS"],
+    "nvtx_payload_schema_entries": ["NVTX_PAYLOAD_SCHEMA_ENTRIES"],
+    "nvtx_payload_enums": ["NVTX_PAYLOAD_ENUMS"],
+    "nvtx_payload_enum_entries": ["NVTX_PAYLOAD_ENUM_ENTRIES"],
+}
+
+_PARQUETDIR_BINARY_COLUMNS: dict[str, tuple[str, ...]] = {
+    "NVTX_EVENTS": ("binaryData",),
 }
 
 
@@ -316,26 +330,7 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
         nvtx_table = _find_table(src_tables, "NVTX_EVENTS")
         if nvtx_table:
             _progress("nvtx.parquet")
-            # Detect whether textId column exists
-            has_textid = _table_has_column(db, f"src.{nvtx_table}", "textId")
-            if has_textid:
-                db.execute(f"""
-                    COPY (
-                        SELECT n.globalTid, n.start, n."end", n.eventType, n.rangeId,
-                               COALESCE(n.text, s.value) AS text,
-                               n.textId
-                        FROM src.{nvtx_table} n
-                        LEFT JOIN src.StringIds s ON n.textId = s.id
-                    ) TO '{_safe_path(cache_dir / "nvtx.parquet")}' (FORMAT PARQUET, COMPRESSION ZSTD)
-                """)
-            else:
-                db.execute(f"""
-                    COPY (
-                        SELECT n.globalTid, n.start, n."end", n.eventType, n.rangeId,
-                               n.text
-                        FROM src.{nvtx_table} n
-                    ) TO '{_safe_path(cache_dir / "nvtx.parquet")}' (FORMAT PARQUET, COMPRESSION ZSTD)
-                """)
+            _export_nvtx_with_blobs(sqlite_path, nvtx_table, cache_dir)
 
         for view_name, src_name in _BASE_TABLES:
             actual = _find_table(src_tables, src_name)
@@ -417,17 +412,30 @@ def open_cached_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
         safe_fpath = str(parquet_file).replace("'", "''")
         db.execute(f"CREATE VIEW \"{view_name}\" AS SELECT * FROM '{safe_fpath}'")
 
-    existing_views = {r[0] for r in db.execute("SHOW TABLES").fetchall()}
-    for parquet_name, aliases in _ALIASES.items():
-        if parquet_name not in existing_views:
-            continue
-        for alias in aliases:
-            if alias not in existing_views:
-                try:
-                    db.execute(f'CREATE VIEW "{alias}" AS SELECT * FROM {parquet_name}')
-                except duckdb.Error:
-                    pass  # View already exists or name conflict
+    _create_existing_alias_views(db)
 
+    return db
+
+
+def open_parquetdir_db(parquetdir_path: str) -> duckdb.DuckDBPyConnection:
+    """Open a DuckDB connection over an Nsight `parquetdir` export."""
+    parquet_dir = Path(parquetdir_path)
+    parquet_files = sorted(parquet_dir.glob("*.parquet"))
+    if not parquet_files:
+        raise RuntimeError(
+            f"Parquet directory at {parquet_dir} does not contain any .parquet files"
+        )
+
+    db = duckdb.connect()
+    try:
+        _register_parquetdir_tables(db, parquet_dir, parquet_files)
+        _create_existing_alias_views(db)
+    except Exception:
+        try:
+            db.close()
+        except Exception:
+            pass
+        raise
     return db
 
 
@@ -449,6 +457,165 @@ def _table_has_column(db: duckdb.DuckDBPyConnection, table: str, column: str) ->
         return any(c[0] == column for c in cols)
     except duckdb.Error:
         return False
+
+
+def _create_existing_alias_views(db: duckdb.DuckDBPyConnection) -> None:
+    """Create stable aliases for whatever canonical tables already exist."""
+    existing_views = {r[0] for r in db.execute("SHOW TABLES").fetchall()}
+    for short_name, aliases in _ALIASES.items():
+        actual = None
+        if short_name in existing_views:
+            actual = short_name
+        else:
+            for alias in aliases:
+                if alias in existing_views:
+                    actual = alias
+                    break
+            if actual is None and aliases:
+                actual = _find_table(existing_views, aliases[0])
+        if not actual:
+            continue
+        for alias in [short_name, *aliases]:
+            if alias in existing_views:
+                continue
+            try:
+                db.execute(f'CREATE VIEW "{alias}" AS SELECT * FROM "{actual}"')
+                existing_views.add(alias)
+            except duckdb.Error:
+                pass
+
+
+def _register_parquetdir_tables(
+    db: duckdb.DuckDBPyConnection,
+    parquet_dir: Path,
+    parquet_files: list[Path],
+) -> None:
+    """Create views for a raw Nsight parquetdir export.
+
+    Nsight 2026 marks `NVTX_EVENTS.binaryData` as a UTF-8 string in Parquet
+    metadata even though it contains arbitrary bytes. DuckDB rejects those
+    rows during direct Parquet scans, so we repair that column via PyArrow and
+    register the resulting Arrow table with DuckDB. Other tables can stay on
+    the normal `read_parquet()` path.
+    """
+    for parquet_file in parquet_files:
+        table_name = parquet_file.stem
+        if table_name in _PARQUETDIR_BINARY_COLUMNS:
+            arrow_name = f"_parquetdir_{table_name}"
+            table = _load_parquet_table_for_duckdb(parquet_file, table_name)
+            db.register(arrow_name, table)
+            db.execute(f'CREATE VIEW "{table_name}" AS SELECT * FROM "{arrow_name}"')
+            continue
+
+        safe_fpath = str(parquet_file).replace("'", "''")
+        db.execute(
+            f'CREATE VIEW "{table_name}" AS SELECT * FROM read_parquet(\'{safe_fpath}\')'
+        )
+
+
+def _load_parquet_table_for_duckdb(parquet_file: Path, table_name: str):
+    """Load a Parquet file into Arrow and normalize binary payload columns."""
+    import pyarrow as pa
+    import pyarrow.compute as pc
+    import pyarrow.parquet as pq
+
+    table = pq.read_table(parquet_file)
+    binary_columns = set(_PARQUETDIR_BINARY_COLUMNS.get(table_name, ()))
+    if not binary_columns:
+        return table
+
+    arrays = []
+    for field in table.schema:
+        column = table.column(field.name)
+        if field.name in binary_columns:
+            column = pc.cast(column, pa.large_binary(), safe=False)
+        arrays.append(column)
+    return pa.table(arrays, names=table.column_names)
+
+
+def _export_nvtx_with_blobs(sqlite_path: str, nvtx_table: str, cache_dir: Path) -> None:
+    """Export NVTX rows via a varchar-only attachment so mixed TEXT/BLOB columns survive.
+
+    The regular typed SQLite scanner cannot read NVTX `binaryData` when the
+    SQLite export mixes TEXT and BLOB affinity in that column. A separate
+    DuckDB connection with `sqlite_all_varchar=true` avoids that issue; we
+    cast numeric columns back to their intended types and store the blob as a
+    hex string for cache portability.
+    """
+    safe_sqlite_path = sqlite_path.replace("'", "''")
+    db = duckdb.connect()
+    try:
+        db.execute("SET sqlite_all_varchar = true")
+        db.execute(f"ATTACH '{safe_sqlite_path}' AS srcv (TYPE SQLITE, READ_ONLY)")
+        table_ref = f"srcv.{nvtx_table}"
+
+        def _expr(column: str, sql_type: str, alias: str | None = None) -> str:
+            alias = alias or column
+            if _table_has_column(db, table_ref, column):
+                return f'CAST(n."{column}" AS {sql_type}) AS "{alias}"'
+            return f'CAST(NULL AS {sql_type}) AS "{alias}"'
+
+        has_textid = _table_has_column(db, f"srcv.{nvtx_table}", "textId")
+        has_text = _table_has_column(db, table_ref, "text")
+        has_json_text = _table_has_column(db, table_ref, "jsonText")
+        has_binary = _table_has_column(db, table_ref, "binaryData")
+        binary_expr = "hex(n.binaryData) AS binaryData" if has_binary else "CAST(NULL AS VARCHAR) AS binaryData"
+        json_text_expr = "n.jsonText AS jsonText" if has_json_text else "CAST(NULL AS VARCHAR) AS jsonText"
+        text_expr = "n.text" if has_text else "CAST(NULL AS VARCHAR)"
+        if has_textid:
+            db.execute(f"""
+                COPY (
+                    SELECT {_expr("globalTid", "BIGINT")},
+                           {_expr("start", "BIGINT")},
+                           {_expr("end", "BIGINT")},
+                           {_expr("eventType", "INTEGER")},
+                           {_expr("rangeId", "BIGINT")},
+                           {_expr("category", "BIGINT")},
+                           {_expr("color", "BIGINT")},
+                           {_expr("endGlobalTid", "BIGINT")},
+                           {_expr("domainId", "BIGINT")},
+                           {_expr("uint64Value", "BIGINT")},
+                           {_expr("int64Value", "BIGINT")},
+                           {_expr("doubleValue", "DOUBLE")},
+                           {_expr("uint32Value", "BIGINT")},
+                           {_expr("int32Value", "BIGINT")},
+                           {_expr("floatValue", "DOUBLE")},
+                           {_expr("jsonTextId", "BIGINT")},
+                           {json_text_expr},
+                           {binary_expr},
+                           COALESCE({text_expr}, s.value) AS text,
+                           {_expr("textId", "BIGINT")}
+                    FROM srcv.{nvtx_table} n
+                    LEFT JOIN srcv.StringIds s ON n.textId = s.id
+                ) TO '{_safe_path(cache_dir / "nvtx.parquet")}' (FORMAT PARQUET, COMPRESSION ZSTD)
+            """)
+        else:
+            db.execute(f"""
+                COPY (
+                    SELECT {_expr("globalTid", "BIGINT")},
+                           {_expr("start", "BIGINT")},
+                           {_expr("end", "BIGINT")},
+                           {_expr("eventType", "INTEGER")},
+                           {_expr("rangeId", "BIGINT")},
+                           {_expr("category", "BIGINT")},
+                           {_expr("color", "BIGINT")},
+                           {_expr("endGlobalTid", "BIGINT")},
+                           {_expr("domainId", "BIGINT")},
+                           {_expr("uint64Value", "BIGINT")},
+                           {_expr("int64Value", "BIGINT")},
+                           {_expr("doubleValue", "DOUBLE")},
+                           {_expr("uint32Value", "BIGINT")},
+                           {_expr("int32Value", "BIGINT")},
+                           {_expr("floatValue", "DOUBLE")},
+                           {_expr("jsonTextId", "BIGINT")},
+                           {json_text_expr},
+                           {binary_expr},
+                           {text_expr} AS text
+                    FROM srcv.{nvtx_table} n
+                ) TO '{_safe_path(cache_dir / "nvtx.parquet")}' (FORMAT PARQUET, COMPRESSION ZSTD)
+            """)
+    finally:
+        db.close()
 
 
 def _build_nvtx_kernel_map(

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -532,23 +532,31 @@ def _load_parquet_table_for_duckdb(parquet_file: Path, table_name: str):
     import pyarrow.compute as pc
     import pyarrow.parquet as pq
 
-    # TODO: pq.read_table() materializes the entire Parquet file in memory.
-    # For very large NVTX_EVENTS files this could cause memory spikes.
-    # A future optimization could use RecordBatchReader-based streaming,
-    # but the column type repair (large_string → large_binary) requires
-    # touching every value, making full materialization hard to avoid.
-    table = pq.read_table(parquet_file)
     binary_columns = set(_PARQUETDIR_BINARY_COLUMNS.get(table_name, ()))
     if not binary_columns:
-        return table
+        return pq.read_table(parquet_file)
 
-    arrays = []
-    for field in table.schema:
-        column = table.column(field.name)
+    parquet = pq.ParquetFile(parquet_file)
+    cast_targets: dict[str, pa.DataType] = {}
+    for field in parquet.schema_arrow:
         if field.name in binary_columns:
-            column = pc.cast(column, pa.large_binary(), safe=False)
-        arrays.append(column)
-    return pa.table(arrays, names=table.column_names)
+            cast_targets[field.name] = pa.large_binary()
+    if not cast_targets:
+        return parquet.read()
+
+    # Process by record batch so we do not hold both pre-cast and post-cast
+    # full tables at once for large NVTX payload datasets.
+    batches = []
+    for batch in parquet.iter_batches():
+        batch_arrays = []
+        for idx, field in enumerate(batch.schema):
+            column = batch.column(idx)
+            target_type = cast_targets.get(field.name)
+            if target_type is not None:
+                column = pc.cast(column, target_type, safe=False)
+            batch_arrays.append(column)
+        batches.append(pa.record_batch(batch_arrays, names=batch.schema.names))
+    return pa.Table.from_batches(batches)
 
 
 def _export_nvtx_with_blobs(sqlite_path: str, nvtx_table: str, cache_dir: Path) -> None:

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -519,6 +519,11 @@ def _load_parquet_table_for_duckdb(parquet_file: Path, table_name: str):
     import pyarrow.compute as pc
     import pyarrow.parquet as pq
 
+    # TODO: pq.read_table() materializes the entire Parquet file in memory.
+    # For very large NVTX_EVENTS files this could cause memory spikes.
+    # A future optimization could use RecordBatchReader-based streaming,
+    # but the column type repair (large_string → large_binary) requires
+    # touching every value, making full materialization hard to avoid.
     table = pq.read_table(parquet_file)
     binary_columns = set(_PARQUETDIR_BINARY_COLUMNS.get(table_name, ()))
     if not binary_columns:

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -866,10 +866,10 @@ def _resolve_parquetdir_path(path: str) -> str:
 
 
 def _sqlite_needs_blob_reexport(path: str) -> bool:
-    """Check whether a SQLite export is missing NVTX extended payload values.
+    """Check whether a SQLite export is missing NVTX payload schema/blob support.
 
-    The communicator-aware NCCL analysis relies on `binaryData` (or another
-    populated NVTX payload carrier field) being preserved during export.
+    This is a capability check (schema/tables present), not a content check.
+    Some profiles legitimately contain no NVTX payload rows.
     """
     if not (os.path.exists(path) and os.path.getsize(path) > 0):
         return True
@@ -884,28 +884,9 @@ def _sqlite_needs_blob_reexport(path: str) -> bool:
                 # --include-blobs=true → needs re-export.
                 return True
             cols = {row[1] for row in cur.execute("PRAGMA table_info(NVTX_EVENTS)")}
-            payload_cols = [
-                col
-                for col in (
-                    "binaryData",
-                    "uint64Value",
-                    "int64Value",
-                    "doubleValue",
-                    "uint32Value",
-                    "int32Value",
-                    "floatValue",
-                    "jsonText",
-                    "jsonTextId",
-                )
-                if col in cols
-            ]
-            if not payload_cols:
-                return True
-            predicate = " OR ".join(f"{col} IS NOT NULL" for col in payload_cols)
-            has_payload = cur.execute(
-                f"SELECT 1 FROM NVTX_EVENTS WHERE {predicate} LIMIT 1"
-            ).fetchone()
-            return has_payload is None
+            # Require binaryData column presence; row values may legitimately
+            # all be NULL on profiles without payload-bearing NVTX ranges.
+            return "binaryData" not in cols
     except sqlite3.Error:
         # If the file is unreadable or corrupt, we cannot use it
         return True

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -862,7 +862,9 @@ def _sqlite_needs_blob_reexport(path: str) -> bool:
                 row[0] for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
             }
             if "NVTX_EVENTS" not in tables or "NVTX_PAYLOAD_SCHEMAS" not in tables:
-                return False
+                # Missing payload tables means the export was not done with
+                # --include-blobs=true → needs re-export.
+                return True
             cols = {row[1] for row in cur.execute("PRAGMA table_info(NVTX_EVENTS)")}
             payload_cols = [
                 col

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -734,7 +734,9 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
     if not nsys_exe:
         raise ExportToolMissingError(
             "Profile is .nsys-rep; conversion requires 'nsys' (NVIDIA Nsight Systems) on PATH. "
-            "Install Nsight Systems or export manually: nsys export --type sqlite -o <out.sqlite> --force-overwrite true <file.nsys-rep>"
+            "Install Nsight Systems or export manually: "
+            "nsys export --type sqlite --include-blobs=true -o <out.sqlite> "
+            "--force-overwrite=true <file.nsys-rep>"
         )
 
     try:
@@ -760,12 +762,13 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
             "nsys export timed out after 300 seconds. This may indicate that nsys is waiting "
             "for interactive input (for example, a license prompt) or that the .nsys-rep file "
             "is corrupted. Try running the export manually to see the full output:\n"
-            f"  nsys export --type sqlite -o {out} {path}\n"
+            f"  nsys export --type sqlite --include-blobs=true -o {out} --force-overwrite=true {path}\n"
         ) from e
     except subprocess.CalledProcessError as e:
         raise ExportError(
             f"nsys export failed: {e.stderr or e.stdout or str(e)}. "
-            "Export manually: nsys export --type sqlite -o <out.sqlite> --force-overwrite true <file.nsys-rep>"
+            "Export manually: nsys export --type sqlite --include-blobs=true "
+            "-o <out.sqlite> --force-overwrite=true <file.nsys-rep>"
         ) from e
     if not (os.path.exists(out) and os.path.getsize(out) > 0):
         stdout = getattr(result, "stdout", None) or "(empty)"
@@ -853,35 +856,36 @@ def _sqlite_needs_blob_reexport(path: str) -> bool:
     if not (os.path.exists(path) and os.path.getsize(path) > 0):
         return True
     try:
-        conn = sqlite3.connect(path)
-        cur = conn.cursor()
-        tables = {row[0] for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-        if "NVTX_EVENTS" not in tables or "NVTX_PAYLOAD_SCHEMAS" not in tables:
-            conn.close()
-            return False
-        cols = {row[1] for row in cur.execute("PRAGMA table_info(NVTX_EVENTS)")}
-        payload_cols = [
-            col
-            for col in (
-                "binaryData",
-                "uint64Value",
-                "int64Value",
-                "doubleValue",
-                "uint32Value",
-                "int32Value",
-                "floatValue",
-                "jsonText",
-                "jsonTextId",
-            )
-            if col in cols
-        ]
-        if not payload_cols:
-            conn.close()
-            return True
-        predicate = " OR ".join(f"{col} IS NOT NULL" for col in payload_cols)
-        has_payload = cur.execute(f"SELECT 1 FROM NVTX_EVENTS WHERE {predicate} LIMIT 1").fetchone()
-        conn.close()
-        return has_payload is None
+        with sqlite3.connect(path) as conn:
+            cur = conn.cursor()
+            tables = {
+                row[0] for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
+            }
+            if "NVTX_EVENTS" not in tables or "NVTX_PAYLOAD_SCHEMAS" not in tables:
+                return False
+            cols = {row[1] for row in cur.execute("PRAGMA table_info(NVTX_EVENTS)")}
+            payload_cols = [
+                col
+                for col in (
+                    "binaryData",
+                    "uint64Value",
+                    "int64Value",
+                    "doubleValue",
+                    "uint32Value",
+                    "int32Value",
+                    "floatValue",
+                    "jsonText",
+                    "jsonTextId",
+                )
+                if col in cols
+            ]
+            if not payload_cols:
+                return True
+            predicate = " OR ".join(f"{col} IS NOT NULL" for col in payload_cols)
+            has_payload = cur.execute(
+                f"SELECT 1 FROM NVTX_EVENTS WHERE {predicate} LIMIT 1"
+            ).fetchone()
+            return has_payload is None
     except sqlite3.Error:
         return False
 

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -717,14 +717,26 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
 
     # Reuse an existing up-to-date SQLite export if possible.
     out = path[:-9] + ".sqlite"  # .nsys-rep -> .sqlite
-    if (
+    reuse_by_mtime = (
         os.path.exists(path)
         and os.path.exists(out)
         and os.path.getsize(out) > 0
         and os.path.getmtime(out) >= os.path.getmtime(path)
-        and not _sqlite_needs_blob_reexport(out)
-    ):
-        return out
+    )
+    if reuse_by_mtime:
+        if not _sqlite_needs_blob_reexport(out):
+            return out
+        # Missing NVTX payload blobs: re-export only when nsys is available so we
+        # do not regress users with a valid sidecar .sqlite but no Nsight install.
+        if not shutil.which("nsys"):
+            logging.getLogger(__name__).warning(
+                "Reusing existing SQLite export at %r without NVTX payload blobs; "
+                "communicator-aware analysis and other payload-dependent features may be incomplete. "
+                "Install Nsight Systems and re-export with: nsys export --type sqlite "
+                "--include-blobs=true -o <out.sqlite> --force-overwrite=true <file.nsys-rep>",
+                out,
+            )
+            return out
 
     nsys_exe = shutil.which("nsys")
     if not nsys_exe:
@@ -829,7 +841,7 @@ def _resolve_parquetdir_path(path: str) -> str:
         raise ExportTimeoutError(
             "nsys export timed out after 300 seconds while producing a parquetdir export. "
             "Try running the export manually to inspect the full output:\n"
-            f"  nsys export --type parquetdir --include-blobs=true -o {out} {path}\n"
+            f"  nsys export --type parquetdir --include-blobs=true --force-overwrite=true -o {out} {path}\n"
         ) from e
     except subprocess.CalledProcessError as e:
         raise ExportError(

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -53,7 +53,7 @@ class NsightSchema:
     and exposes canonical table choices (e.g., kernel activity table).
     """
 
-    def __init__(self, conn: sqlite3.Connection):
+    def __init__(self, conn):
         self._conn = conn
         from .connection import wrap_connection
 
@@ -93,7 +93,7 @@ class NsightSchema:
             return {}
 
         kv: dict[str, str] = {}
-        cur = self._conn.execute(f"SELECT {key_col}, {val_col} FROM {table}")
+        cur = self._adapter.execute(f"SELECT {key_col}, {val_col} FROM {table}")
         for k, v in cur.fetchall():
             if k is not None and v is not None:
                 kv[str(k)] = str(v)
@@ -179,53 +179,58 @@ class Profile:
 
     _log = logging.getLogger(__name__)
 
-    def __init__(self, path: str, *, cache_mode: str = "auto"):
+    def __init__(self, path: str, *, cache_mode: str = "auto", backend: str = "sqlite"):
         if cache_mode not in ("auto", "parquet", "direct"):
             raise ValueError(
                 f"Unknown cache_mode: {cache_mode!r}. Expected 'auto', 'parquet', or 'direct'."
             )
+        if backend not in ("sqlite", "parquetdir"):
+            raise ValueError(f"Unknown backend: {backend!r}. Expected 'sqlite' or 'parquetdir'.")
         self.path = path
+        self.backend = backend
         self._lock = threading.Lock()
         self._owns_conn = True
-        self.conn = sqlite3.connect(path, check_same_thread=False)
-        self.conn.row_factory = sqlite3.Row
-        from .connection import wrap_connection
-
-        self.adapter = wrap_connection(self.conn)
-        self.schema = NsightSchema(self.conn)
-        self.meta = self._discover()
-        self._nvtx_has_text_id: bool = self.adapter.detect_nvtx_text_id()
-
-        # DuckDB connection strategy — see parquet_cache module
-        try:
-            if cache_mode == "direct":
-                # Force direct SQLite via DuckDB — zero ETL, instant startup
-                self.db: duckdb.DuckDBPyConnection = parquet_cache.open_direct_sqlite(path)
-            elif cache_mode == "parquet":
-                # Original behaviour: block until cache is built
-                self.db = parquet_cache.open_cached_db(path)
-            else:
-                # "auto" mode: use cache if valid, else smart fallback
-                if parquet_cache.is_cache_valid(path):
+        if backend == "parquetdir":
+            self.db = parquet_cache.open_parquetdir_db(path)
+            self.conn = self.db
+        else:
+            self.conn = sqlite3.connect(path, check_same_thread=False)
+            self.conn.row_factory = sqlite3.Row
+            try:
+                if cache_mode == "direct":
+                    # Force direct SQLite via DuckDB — zero ETL, instant startup
+                    self.db = parquet_cache.open_direct_sqlite(path)
+                elif cache_mode == "parquet":
+                    # Original behaviour: block until cache is built
                     self.db = parquet_cache.open_cached_db(path)
                 else:
-                    size_mb = os.path.getsize(path) / 1e6
-                    if size_mb > 50:
-                        self._log.info(
-                            "Large profile (%.0fMB), using direct query mode (instant startup).",
-                            size_mb,
-                        )
-                        self._log.info(
-                            "To build a Parquet cache for faster repeated queries, re-run with "
-                            "cache_mode='parquet' or pre-build the cache."
-                        )
-                        self.db = parquet_cache.open_direct_sqlite(path)
-                    else:
-                        # Small file — build cache now (seconds)
+                    # "auto" mode: use cache if valid, else smart fallback
+                    if parquet_cache.is_cache_valid(path):
                         self.db = parquet_cache.open_cached_db(path)
-        except Exception as e:
-            self._log.warning("DuckDB cache unavailable, falling back to SQLite: %s", e)
-            self.db = None  # type: ignore[assignment]
+                    else:
+                        size_mb = os.path.getsize(path) / 1e6
+                        if size_mb > 50:
+                            self._log.info(
+                                "Large profile (%.0fMB), using direct query mode (instant startup).",
+                                size_mb,
+                            )
+                            self._log.info(
+                                "To build a Parquet cache for faster repeated queries, re-run with "
+                                "cache_mode='parquet' or pre-build the cache."
+                            )
+                            self.db = parquet_cache.open_direct_sqlite(path)
+                        else:
+                            # Small file — build cache now (seconds)
+                            self.db = parquet_cache.open_cached_db(path)
+            except Exception as e:
+                self._log.warning("DuckDB cache unavailable, falling back to SQLite: %s", e)
+                self.db = None  # type: ignore[assignment]
+        from .connection import wrap_connection
+
+        self.adapter = wrap_connection(self.db if self.db is not None else self.conn)
+        self.schema = NsightSchema(self.db if self.db is not None else self.conn)
+        self.meta = self._discover()
+        self._nvtx_has_text_id = self.adapter.detect_nvtx_text_id()
 
     @classmethod
     def _from_conn(cls, conn: sqlite3.Connection) -> "Profile":
@@ -245,6 +250,7 @@ class Profile:
         obj._lock = threading.Lock()
         obj._owns_conn = False
         obj.path = ""
+        obj.backend = "sqlite"
         obj.db = conn if is_duckdb else None  # type: ignore[assignment]
         obj.adapter = adapter
         obj.schema = NsightSchema(conn)
@@ -305,7 +311,8 @@ class Profile:
 
         # Kernel counts per device
         kcounts = {}
-        for r in self.conn.execute(
+        query_conn = self.db if self.db is not None else self.conn
+        for r in query_conn.execute(
             f"SELECT deviceId, COUNT(*) FROM {self.schema.kernel_table} GROUP BY deviceId"
         ).fetchall():
             kcounts[r[0]] = r[1]
@@ -313,7 +320,7 @@ class Profile:
         # Hardware info from TARGET_INFO_GPU + TARGET_INFO_CUDA_DEVICE
         hw = {}
         if "TARGET_INFO_GPU" in tables and "TARGET_INFO_CUDA_DEVICE" in tables:
-            for r in self.conn.execute("""
+            for r in query_conn.execute("""
                 SELECT c.cudaId as dev, g.name, g.busLocation,
                        g.smCount as sms, g.totalMemory as mem,
                        g.chipName, g.memoryBandwidth as bw
@@ -672,10 +679,16 @@ class Profile:
     def close(self):
         # Close the primary connection only if we own it.
         if getattr(self, "_owns_conn", True):
-            self.conn.close()
+            try:
+                self.conn.close()
+            except Exception:
+                pass
 
         db = getattr(self, "db", None)
         if db is None:
+            return
+
+        if db is self.conn:
             return
 
         # If db is just an alias to a borrowed conn, do not close it.
@@ -694,12 +707,16 @@ class Profile:
         self.close()
 
 
-def resolve_profile_path(path: str) -> str:
+def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
     """
-    Return a path to a .sqlite profile. If path is .nsys-rep, export via
-    `nsys export --type sqlite` and return the path to the resulting .sqlite.
-    (NVIDIA Nsight Systems exporter: docs.nvidia.com/nsight-systems/nsys-exporter)
+    Resolve a profile path for the selected backend.
+
+    `backend='sqlite'` returns a `.sqlite` file, exporting from `.nsys-rep`
+    when needed. `backend='parquetdir'` returns a Parquet directory, exporting
+    from `.nsys-rep` when needed.
     """
+    if backend == "parquetdir":
+        return _resolve_parquetdir_path(path)
     if not path.lower().endswith(".nsys-rep"):
         return path
 
@@ -710,6 +727,7 @@ def resolve_profile_path(path: str) -> str:
         and os.path.exists(out)
         and os.path.getsize(out) > 0
         and os.path.getmtime(out) >= os.path.getmtime(path)
+        and not _sqlite_needs_blob_reexport(out)
     ):
         return out
 
@@ -723,7 +741,16 @@ def resolve_profile_path(path: str) -> str:
     try:
         # path/out passed as list args to nsys, no shell; caller-controlled paths only
         result = subprocess.run(  # nosec B603
-            [nsys_exe, "export", "--type=sqlite", "-o", out, "--force-overwrite=true", path],
+            [
+                nsys_exe,
+                "export",
+                "--type=sqlite",
+                "--include-blobs=true",
+                "-o",
+                out,
+                "--force-overwrite=true",
+                path,
+            ],
             check=True,
             capture_output=True,
             text=True,
@@ -752,6 +779,114 @@ def resolve_profile_path(path: str) -> str:
     return out
 
 
+def _resolve_parquetdir_path(path: str) -> str:
+    """Return a path to an Nsight `parquetdir` export."""
+    if os.path.isdir(path):
+        parquet_files = [name for name in os.listdir(path) if name.endswith(".parquet")]
+        if parquet_files:
+            return path
+        raise ExportError(f"Parquet directory '{path}' does not contain any .parquet files.")
+
+    if not path.lower().endswith(".nsys-rep"):
+        return path
+
+    out = path[:-9] + ".parquetdir"
+    if (
+        os.path.exists(path)
+        and os.path.isdir(out)
+        and any(name.endswith(".parquet") for name in os.listdir(out))
+        and os.path.getmtime(out) >= os.path.getmtime(path)
+    ):
+        return out
+
+    nsys_exe = shutil.which("nsys")
+    if not nsys_exe:
+        raise ExportToolMissingError(
+            "Profile is .nsys-rep; conversion requires 'nsys' (NVIDIA Nsight Systems) on PATH. "
+            "Install Nsight Systems or export manually: "
+            "nsys export --type parquetdir --include-blobs=true -o <out.parquetdir> "
+            "--force-overwrite=true <file.nsys-rep>"
+        )
+
+    try:
+        subprocess.run(  # nosec B603
+            [
+                nsys_exe,
+                "export",
+                "--type=parquetdir",
+                "--include-blobs=true",
+                "-o",
+                out,
+                "--force-overwrite=true",
+                path,
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except subprocess.TimeoutExpired as e:
+        raise ExportTimeoutError(
+            "nsys export timed out after 300 seconds while producing a parquetdir export. "
+            "Try running the export manually to inspect the full output:\n"
+            f"  nsys export --type parquetdir --include-blobs=true -o {out} {path}\n"
+        ) from e
+    except subprocess.CalledProcessError as e:
+        raise ExportError(
+            f"nsys parquetdir export failed: {e.stderr or e.stdout or str(e)}. "
+            "Export manually: nsys export --type parquetdir --include-blobs=true "
+            "-o <out.parquetdir> --force-overwrite=true <file.nsys-rep>"
+        ) from e
+
+    if not (os.path.isdir(out) and any(name.endswith(".parquet") for name in os.listdir(out))):
+        raise ExportError(
+            f"nsys export completed without error but did not produce a usable parquetdir at '{out}'."
+        )
+    return out
+
+
+def _sqlite_needs_blob_reexport(path: str) -> bool:
+    """Check whether a SQLite export is missing NVTX extended payload values.
+
+    The communicator-aware NCCL analysis relies on `binaryData` (or another
+    populated NVTX payload carrier field) being preserved during export.
+    """
+    if not (os.path.exists(path) and os.path.getsize(path) > 0):
+        return True
+    try:
+        conn = sqlite3.connect(path)
+        cur = conn.cursor()
+        tables = {row[0] for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        if "NVTX_EVENTS" not in tables or "NVTX_PAYLOAD_SCHEMAS" not in tables:
+            conn.close()
+            return False
+        cols = {row[1] for row in cur.execute("PRAGMA table_info(NVTX_EVENTS)")}
+        payload_cols = [
+            col
+            for col in (
+                "binaryData",
+                "uint64Value",
+                "int64Value",
+                "doubleValue",
+                "uint32Value",
+                "int32Value",
+                "floatValue",
+                "jsonText",
+                "jsonTextId",
+            )
+            if col in cols
+        ]
+        if not payload_cols:
+            conn.close()
+            return True
+        predicate = " OR ".join(f"{col} IS NOT NULL" for col in payload_cols)
+        has_payload = cur.execute(f"SELECT 1 FROM NVTX_EVENTS WHERE {predicate} LIMIT 1").fetchone()
+        conn.close()
+        return has_payload is None
+    except sqlite3.Error:
+        return False
+
+
 def get_first_gpu_name(conn) -> str:
     """Return the first GPU name from TARGET_INFO_GPU (for peak TFLOPS lookup). Empty if tables missing.
 
@@ -778,16 +913,16 @@ def get_first_gpu_name(conn) -> str:
     return (row[0] or "").strip() if row else ""
 
 
-def open(path: str) -> Profile:
-    """Open an Nsight Systems SQLite database."""
-    path = resolve_profile_path(path)
+def open(path: str, *, backend: str = "sqlite", cache_mode: str = "auto") -> Profile:
+    """Open an Nsight Systems profile using the requested backend."""
+    path = resolve_profile_path(path, backend=backend)
     # Heuristic: if the given path is an empty .sqlite stub but a sibling
     # file without the .sqlite suffix exists and is a non-empty SQLite DB,
     # prefer the sibling. This helps when users accidentally point nsys-ai
     # at a placeholder file instead of the real Nsight export.
-    if path.endswith(".sqlite") and os.path.exists(path) and not os.path.getsize(path):
+    if backend == "sqlite" and path.endswith(".sqlite") and os.path.exists(path) and not os.path.getsize(path):
         base = path[:-7]
         if os.path.exists(base) and os.path.getsize(base) > 0:
             path = base
 
-    return Profile(path)
+    return Profile(path, cache_mode=cache_mode, backend=backend)

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -690,10 +690,6 @@ class Profile:
         if db is self.conn:
             return
 
-        # If db is just an alias to a borrowed conn, do not close it.
-        if db is self.conn and not getattr(self, "_owns_conn", True):
-            return
-
         try:
             db.close()
         except Exception:
@@ -746,6 +742,8 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
                 nsys_exe,
                 "export",
                 "--type=sqlite",
+                # Always explicitly request payload blobs so communicator
+                # analysis and other payload-dependent features function.
                 "--include-blobs=true",
                 "-o",
                 out,
@@ -889,7 +887,8 @@ def _sqlite_needs_blob_reexport(path: str) -> bool:
             ).fetchone()
             return has_payload is None
     except sqlite3.Error:
-        return False
+        # If the file is unreadable or corrupt, we cannot use it
+        return True
 
 
 def get_first_gpu_name(conn) -> str:

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -170,8 +170,9 @@ class Profile:
     """Handle to an opened Nsight Systems SQLite database.
 
     Exposes two database connections:
-      - ``self.conn`` (sqlite3.Connection): the original SQLite DB, used only for
-        schema discovery (NsightSchema) and backwards compatibility.
+      - ``self.conn`` (sqlite3.Connection | duckdb.DuckDBPyConnection): the primary
+        backend connection. For ``backend='sqlite'`` this is the original SQLite DB;
+        for ``backend='parquetdir'`` this is the DuckDB connection over Parquet.
       - ``self.db`` (duckdb.DuckDBPyConnection): DuckDB over Parquet cache — the
         primary query path for all analytical queries.
     """
@@ -185,6 +186,10 @@ class Profile:
             )
         if backend not in ("sqlite", "parquetdir"):
             raise ValueError(f"Unknown backend: {backend!r}. Expected 'sqlite' or 'parquetdir'.")
+        if backend == "parquetdir" and cache_mode != "auto":
+            raise ValueError(
+                "cache_mode is not supported with backend='parquetdir'; use cache_mode='auto'."
+            )
         self.path = path
         self.backend = backend
         self._lock = threading.Lock()
@@ -709,6 +714,9 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
     `backend='sqlite'` returns a `.sqlite` file, exporting from `.nsys-rep`
     when needed. `backend='parquetdir'` returns a Parquet directory, exporting
     from `.nsys-rep` when needed.
+
+    Exports always pass `--include-blobs=true` so NVTX payload-dependent
+    analysis (for example communicator-aware NCCL diagnostics) remains available.
     """
     if backend == "parquetdir":
         return _resolve_parquetdir_path(path)

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass, field
 if typing.TYPE_CHECKING:
     from .fingerprint import ProfileFingerprint
 
-import duckdb
 
 from nsys_ai import parquet_cache
 from nsys_ai.exceptions import (

--- a/src/nsys_ai/skills/builtins/nccl_communicator_analysis.py
+++ b/src/nsys_ai/skills/builtins/nccl_communicator_analysis.py
@@ -1,0 +1,51 @@
+"""Communicator-aware NCCL analysis skill."""
+
+from ..base import Skill, SkillParam
+
+
+def _execute(conn, **kwargs):
+    from ...nccl_communicator import analyze_nccl_communicators
+    from ...profile import Profile
+
+    prof = Profile._from_conn(conn)
+    device = kwargs.get("device")
+    if device is not None:
+        device = int(device)
+
+    trim = None
+    trim_start = kwargs.get("trim_start_ns")
+    trim_end = kwargs.get("trim_end_ns")
+    if trim_start is not None and trim_end is not None:
+        trim = (int(trim_start), int(trim_end))
+
+    return analyze_nccl_communicators(prof, device=device, trim=trim)
+
+
+def _format(rows):
+    from ...nccl_communicator import format_nccl_communicator
+
+    return format_nccl_communicator(rows)
+
+
+SKILL = Skill(
+    name="nccl_communicator_analysis",
+    title="NCCL Communicator-Aware Analysis",
+    description=(
+        "Decodes NVTX extended payload blobs from enriched Nsight exports to group NCCL "
+        "communication by communicator ID and collective type. Reports rank-count hints, "
+        "message sizes, and effective bandwidth when the payload contains full byte counts."
+    ),
+    category="communication",
+    execute_fn=_execute,
+    format_fn=_format,
+    params=[SkillParam("device", "Optional GPU device ID for drill-down", "int", False, None)],
+    tags=[
+        "nccl",
+        "communicator",
+        "allreduce",
+        "allgather",
+        "broadcast",
+        "distributed",
+        "payload",
+    ],
+)

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -5,7 +5,7 @@ profile characteristics in a single tool call, eliminating the need for
 5-8 sequential skill invocations during agent exploration.
 
 Internally orchestrates: overlap_breakdown, nccl_breakdown,
-gpu_idle_gaps, and root_cause_matcher.
+nccl_communicator_analysis, gpu_idle_gaps, and root_cause_matcher.
 """
 
 import dataclasses
@@ -157,6 +157,31 @@ def _execute(conn, **kwargs):
         nccl_summary["dominant_pct"] = dominant.get("pct", 0)
         nccl_summary["total_nccl_ms"] = round(sum(r.get("total_ms", 0) for r in nccl_rows), 1)
 
+    communicator_rows = _safe_skill_run("nccl_communicator_analysis", conn, device=device, **trim_kwargs)
+    communicator_data = [r for r in communicator_rows if not r.get("_diagnostic")]
+    communicator_summary = {"communicators": 0, "collective_rows": 0}
+    if communicator_data:
+        communicator_summary["communicators"] = len(
+            {r.get("communicator_hex") for r in communicator_data if r.get("communicator_hex")}
+        )
+        communicator_summary["collective_rows"] = len(communicator_data)
+        dominant_comm = max(communicator_data, key=lambda r: r.get("total_ms", 0))
+        communicator_summary["dominant_collective"] = dominant_comm.get("collective_type", "?")
+        communicator_summary["dominant_dimension"] = dominant_comm.get(
+            "inferred_dimension", "single_rank_or_unknown"
+        )
+        communicator_summary["top_total_ms"] = round(dominant_comm.get("total_ms", 0), 1)
+        communicator_summary["subgroup_count"] = sum(
+            1
+            for r in communicator_data
+            if str(r.get("inferred_dimension", "")).startswith("subgroup_parallelism")
+        )
+        communicator_summary["low_efficiency_count"] = sum(
+            1
+            for r in communicator_data
+            if r.get("efficiency_pct") is not None and r.get("efficiency_pct", 100) < 20.0
+        )
+
     # ── 5. GPU idle gaps (summary only) ──────────────────────────
     idle_rows = _safe_skill_run("gpu_idle_gaps", conn, device=device, limit=1, **trim_kwargs)
     idle_summary = {"gap_count": 0, "idle_pct": 0}
@@ -202,6 +227,7 @@ def _execute(conn, **kwargs):
         "total_kernel_ms": round(total_kernel_ms, 1),
         "overlap": overlap,
         "nccl": nccl_summary,
+        "communicators": communicator_summary,
         "sync": sync_summary,
         "idle": idle_summary,
         "root_cause_count": len(root_causes),
@@ -314,6 +340,19 @@ def _format(rows):
         )
         lines.append(f"    Total: {nccl.get('total_nccl_ms', 0):.1f}ms")
 
+    comm = m.get("communicators", {})
+    if comm.get("communicators", 0) > 0:
+        lines.append("")
+        lines.append("  NCCL Communicators:")
+        lines.append(
+            f"    Communicators: {comm.get('communicators', 0)}, grouped rows: {comm.get('collective_rows', 0)}"
+        )
+        lines.append(
+            f"    Dominant: {comm.get('dominant_collective', '?')} / {comm.get('dominant_dimension', '?')}"
+        )
+        if comm.get("low_efficiency_count", 0):
+            lines.append(f"    Low efficiency groups: {comm.get('low_efficiency_count', 0)}")
+
     # Idle
     idle = m.get("idle", {})
     sync = m.get("sync", {})
@@ -349,8 +388,8 @@ SKILL = Skill(
     title="Profile Health Manifest",
     description=(
         "One-shot profile health summary for AI agents. Returns a compact JSON manifest "
-        "covering GPU info, top kernels, compute/NCCL overlap and NCCL summary, "
-        "idle gaps, and root cause findings — all in a single call. "
+        "covering GPU info, top kernels, compute/NCCL overlap, NCCL summary, "
+        "communicator-aware NCCL hints, idle gaps, and root cause findings — all in a single call. "
         "If Profiler Overhead is >1%, advise the user to use torch.cuda.profiler.start/stop() "
         "and --capture-range=cudaProfilerApi instead of full-script profiling. "
         "Use this as the FIRST skill to call on any new profile."

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -201,7 +201,12 @@ def _execute(conn, **kwargs):
         _log.debug("manifest: sync_cost_analysis failed: %s", exc)
 
     # ── 7. Root cause findings (count + top severity) ────────────
-    rc_rows = _safe_skill_run("root_cause_matcher", conn, device=device, **trim_kwargs)
+    # Pass precomputed communicator rows to avoid re-running the expensive
+    # nccl_communicator_analysis inside root_cause_matcher.
+    rc_rows = _safe_skill_run(
+        "root_cause_matcher", conn, device=device,
+        communicator_data=communicator_rows, **trim_kwargs,
+    )
     root_causes = []
     for r in rc_rows:
         pattern = r.get("pattern", "")

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -88,7 +88,18 @@ def _execute(conn: sqlite3.Connection, **kwargs):
 
     # Overlap
     overlap_data = _safe_execute("overlap_breakdown", conn, **kwargs)
-    communicator_data = _safe_execute("nccl_communicator_analysis", conn, **kwargs)
+    # Communicator analysis — accept precomputed rows from callers (e.g.
+    # profile_health_manifest) to avoid running the expensive NVTX blob
+    # decode + kernel attribution twice.
+    communicator_data = kwargs.pop("communicator_data", None)
+    if communicator_data is None:
+        # Only run when NCCL payload tables exist (cheap check).
+        adapter = wrap_connection(conn)
+        tables = set(adapter.get_table_names())
+        if "NVTX_PAYLOAD_SCHEMAS" in tables or "nvtx_payload_schemas" in tables:
+            communicator_data = _safe_execute("nccl_communicator_analysis", conn, **kwargs)
+        else:
+            communicator_data = []
     # Kernel launch overhead
     launch_data = _safe_execute("kernel_launch_overhead", conn, **kwargs)
     # Sync Cost

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -88,6 +88,7 @@ def _execute(conn: sqlite3.Connection, **kwargs):
 
     # Overlap
     overlap_data = _safe_execute("overlap_breakdown", conn, **kwargs)
+    communicator_data = _safe_execute("nccl_communicator_analysis", conn, **kwargs)
     # Kernel launch overhead
     launch_data = _safe_execute("kernel_launch_overhead", conn, **kwargs)
     # Sync Cost
@@ -222,6 +223,41 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                         "recommendation": rec,
                     }
                 )
+
+    # --- Inefficient NCCL Communicators ---
+    comm_rows = [r for r in communicator_data if not r.get("_diagnostic")]
+    if comm_rows:
+        low_efficiency = [
+            r
+            for r in comm_rows
+            if r.get("efficiency_pct") is not None
+            and r.get("efficiency_pct", 100) < 20.0
+            and r.get("total_ms", 0) >= 0.001
+        ]
+        if low_efficiency:
+            worst = min(low_efficiency, key=lambda r: r.get("efficiency_pct", 100))
+            dimension = worst.get("inferred_dimension", "single_rank_or_unknown")
+            dim_hint = (
+                "This looks like a subgroup communicator; check TP/PP stream placement and rank grouping."
+                if str(dimension).startswith("subgroup_parallelism")
+                else "This looks global/data-parallel; check bucket sizing, message fusion, and comm/compute overlap."
+            )
+            findings.append(
+                {
+                    "pattern": "Inefficient NCCL Communicator",
+                    "severity": "warning",
+                    "evidence": (
+                        f"{worst.get('communicator_hex', '?')} {worst.get('collective_type', '?')} "
+                        f"ran at {worst.get('bandwidth_gbps', 0):.2f} GB/s "
+                        f"({worst.get('efficiency_pct', 0):.1f}% of {worst.get('peak_source', 'peak')}). "
+                        f"Inferred dimension: {dimension}."
+                    ),
+                    "recommendation": (
+                        f"{dim_hint} If this profile has enriched NVTX payloads, use "
+                        "`nccl_communicator_analysis` to inspect communicator IDs, rank counts, and message sizes directly."
+                    ),
+                }
+            )
 
     # --- Excessive H2D Transfers ---
     mem_data = _safe_execute("memory_bandwidth", conn, **kwargs)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -44,6 +44,10 @@ def test_agent_skill_selection(minimal_nsys_db_path):
 
         selected = agent._select_skills("is NCCL overlapping with compute?")
         assert "nccl_breakdown" in selected
+        assert "nccl_communicator_analysis" in selected
+
+        selected = agent._select_skills("which communicator is slow in tensor parallel allreduce?")
+        assert "nccl_communicator_analysis" in selected
 
         selected = agent._select_skills("what is the top kernel?")
         assert "top_kernels" in selected

--- a/tests/test_nccl_communicator_analysis.py
+++ b/tests/test_nccl_communicator_analysis.py
@@ -1,0 +1,392 @@
+"""Tests for communicator-aware NCCL analysis."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.nccl_communicator import analyze_nccl_communicators
+from nsys_ai.profile import Profile
+from nsys_ai.skills.registry import get_skill
+
+COMM_SCHEMA = 1001
+ALLREDUCE_SCHEMA = 1002
+ALLGATHER_SCHEMA = 1003
+SENDRECV_SCHEMA = 1004
+REDUCTION_ENUM = 9001
+
+
+def _pack_u32(value: int) -> bytes:
+    return int(value).to_bytes(4, "little", signed=False)
+
+
+def _pack_u64(value: int) -> bytes:
+    return int(value).to_bytes(8, "little", signed=False)
+
+
+def _make_blob(domain_id: int, schema_id: int, payload: bytes) -> bytes:
+    header = (
+        _pack_u64(domain_id)
+        + _pack_u64(schema_id)
+        + _pack_u64(len(payload))
+        + _pack_u64(32)
+    )
+    return header + payload
+
+
+def _payload_comm_init(comm_id: int, num_ranks: int, rank: int, cuda_device: int) -> bytes:
+    return _pack_u64(comm_id) + _pack_u32(num_ranks) + _pack_u32(rank) + _pack_u32(cuda_device) + b"\x00" * 4
+
+
+def _payload_allreduce(comm_id: int, message_size: int, reduction_value: int = 0) -> bytes:
+    return _pack_u64(comm_id) + _pack_u64(message_size) + _pack_u32(reduction_value) + b"\x00" * 4
+
+
+def _payload_allgather(comm_id: int, message_size: int) -> bytes:
+    return _pack_u64(comm_id) + _pack_u64(message_size)
+
+
+def _payload_sendrecv_no_size(comm_id: int) -> bytes:
+    return _pack_u64(comm_id)
+
+
+def _create_blob_profile(db_path: Path, *, binary_decl: str = "BLOB") -> str:
+    conn = sqlite3.connect(str(db_path))
+    cur = conn.cursor()
+    cur.executescript(
+        f"""
+        CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE TARGET_INFO_GPU (
+            id INTEGER PRIMARY KEY,
+            name TEXT,
+            busLocation TEXT DEFAULT '',
+            totalMemory INTEGER DEFAULT 0,
+            smCount INTEGER DEFAULT 0,
+            chipName TEXT DEFAULT '',
+            memoryBandwidth INTEGER DEFAULT 0
+        );
+        CREATE TABLE TARGET_INFO_CUDA_DEVICE (
+            gpuId INTEGER,
+            cudaId INTEGER,
+            pid INTEGER DEFAULT 0,
+            uuid TEXT DEFAULT '',
+            numMultiprocessors INTEGER DEFAULT 0
+        );
+        CREATE TABLE TARGET_INFO_NIC_INFO (
+            GUID INTEGER,
+            stateName TEXT,
+            nicId INTEGER,
+            name TEXT,
+            deviceId INTEGER,
+            vendorId INTEGER,
+            linkLayer INTEGER
+        );
+        CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+            globalPid INTEGER DEFAULT 0,
+            deviceId INTEGER DEFAULT 0,
+            streamId INTEGER DEFAULT 0,
+            correlationId INTEGER DEFAULT 0,
+            start INTEGER NOT NULL,
+            end INTEGER NOT NULL,
+            shortName INTEGER NOT NULL,
+            demangledName INTEGER DEFAULT 0,
+            gridX INTEGER DEFAULT 1,
+            gridY INTEGER DEFAULT 1,
+            gridZ INTEGER DEFAULT 1,
+            blockX INTEGER DEFAULT 1,
+            blockY INTEGER DEFAULT 1,
+            blockZ INTEGER DEFAULT 1
+        );
+        CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+            globalTid INTEGER DEFAULT 0,
+            correlationId INTEGER DEFAULT 0,
+            start INTEGER NOT NULL,
+            end INTEGER NOT NULL,
+            nameId INTEGER DEFAULT 0
+        );
+        CREATE TABLE NVTX_EVENTS (
+            start INTEGER NOT NULL,
+            end INTEGER,
+            eventType INTEGER NOT NULL,
+            rangeId INTEGER,
+            category INTEGER,
+            color INTEGER,
+            text TEXT,
+            globalTid INTEGER,
+            endGlobalTid INTEGER,
+            textId INTEGER,
+            domainId INTEGER,
+            uint64Value INTEGER,
+            int64Value INTEGER,
+            doubleValue REAL,
+            uint32Value INTEGER,
+            int32Value INTEGER,
+            floatValue REAL,
+            jsonTextId INTEGER,
+            jsonText TEXT,
+            binaryData {binary_decl}
+        );
+        CREATE TABLE NVTX_PAYLOAD_SCHEMAS (
+            domainId INTEGER,
+            schemaId INTEGER,
+            name TEXT,
+            type INTEGER,
+            flags INTEGER,
+            numEntries INTEGER,
+            payloadSize INTEGER,
+            alignTo INTEGER
+        );
+        CREATE TABLE NVTX_PAYLOAD_SCHEMA_ENTRIES (
+            domainId INTEGER NOT NULL,
+            schemaId INTEGER NOT NULL,
+            idx INTEGER NOT NULL,
+            flags INTEGER,
+            type INTEGER,
+            name TEXT,
+            description TEXT,
+            arrayOrUnionDetail INTEGER,
+            offset INTEGER
+        );
+        CREATE TABLE NVTX_PAYLOAD_ENUM_ENTRIES (
+            domainId INTEGER NOT NULL,
+            schemaId INTEGER NOT NULL,
+            idx INTEGER NOT NULL,
+            name TEXT,
+            value INTEGER,
+            isFlag INTEGER
+        );
+        """
+    )
+
+    cur.executemany(
+        "INSERT INTO StringIds VALUES (?, ?)",
+        [
+            (1, "ncclDevKernel_AllReduce"),
+            (2, "nccl_preprocess_helper"),
+            (3, "ncclKernel_AllGather"),
+            (4, "ncclSendKernel"),
+            (100, "ncclCommInitRankConfig"),
+            (101, "ncclAllReduce"),
+            (102, "ncclAllGather"),
+            (103, "ncclSendRecv"),
+            (200, "cudaLaunchKernel"),
+        ],
+    )
+    cur.executemany(
+        "INSERT INTO TARGET_INFO_GPU VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [
+            (0, "NVIDIA H100 SXM", "0000:00:00.0", 0, 132, "GH100", 0),
+            (1, "NVIDIA H100 SXM", "0000:00:00.1", 0, 132, "GH100", 0),
+        ],
+    )
+    cur.executemany(
+        "INSERT INTO TARGET_INFO_CUDA_DEVICE VALUES (?, ?, ?, ?, ?)",
+        [(0, 0, 10, "", 132), (1, 1, 10, "", 132)],
+    )
+    cur.executemany(
+        "INSERT INTO TARGET_INFO_NIC_INFO VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [(1, "Local", 0, "mlx5_0", 1, 5555, 2)],
+    )
+
+    cur.executemany(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMAS VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, COMM_SCHEMA, None, 1, None, 4, 24, None),
+            (1, ALLREDUCE_SCHEMA, None, 1, None, 3, 24, None),
+            (1, ALLGATHER_SCHEMA, None, 1, None, 2, 16, None),
+            (1, SENDRECV_SCHEMA, None, 1, None, 1, 8, None),
+        ],
+    )
+    cur.executemany(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1, COMM_SCHEMA, 0, None, 18, "NCCL communicator ID", None, None, None),
+            (1, COMM_SCHEMA, 1, None, 5, "No. of ranks", None, None, 8),
+            (1, COMM_SCHEMA, 2, None, 5, "Rank", None, None, 12),
+            (1, COMM_SCHEMA, 3, None, 5, "CUDA device", None, None, 16),
+            (1, ALLREDUCE_SCHEMA, 0, None, 18, "NCCL communicator ID", None, None, None),
+            (1, ALLREDUCE_SCHEMA, 1, None, 22, "Message size [bytes]", None, None, 8),
+            (1, ALLREDUCE_SCHEMA, 2, None, REDUCTION_ENUM, "Reduction operation", None, None, 16),
+            (1, ALLGATHER_SCHEMA, 0, None, 18, "NCCL communicator ID", None, None, None),
+            (1, ALLGATHER_SCHEMA, 1, None, 22, "Message size [bytes]", None, None, 8),
+            (1, SENDRECV_SCHEMA, 0, None, 18, "NCCL communicator ID", None, None, None),
+        ],
+    )
+    cur.executemany(
+        "INSERT INTO NVTX_PAYLOAD_ENUM_ENTRIES VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            (1, REDUCTION_ENUM, 0, "Sum", 0, None),
+            (1, REDUCTION_ENUM, 1, "Product", 1, None),
+        ],
+    )
+
+    cur.executemany(
+        "INSERT INTO NVTX_EVENTS VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (1000, 2000, 59, None, None, None, None, 100, None, 100, 1, None, None, None, None, None, None, None, None, sqlite3.Binary(_make_blob(1, COMM_SCHEMA, _payload_comm_init(0xABC, 2, 0, 0)))),
+            (1000, 2000, 59, None, None, None, None, 101, None, 100, 1, None, None, None, None, None, None, None, None, sqlite3.Binary(_make_blob(1, COMM_SCHEMA, _payload_comm_init(0xABC, 2, 1, 1)))),
+            (2100, 2200, 59, None, None, None, None, 100, None, 100, 1, None, None, None, None, None, None, None, None, sqlite3.Binary(_make_blob(1, COMM_SCHEMA, _payload_comm_init(0xDEF, 2, 0, 0)))),
+            (3000, 8000, 59, None, None, None, None, 100, None, 101, 1, None, None, None, None, None, None, None, None, sqlite3.Binary(_make_blob(1, ALLREDUCE_SCHEMA, _payload_allreduce(0xABC, 4096)))),
+            (3000, 8000, 59, None, None, None, None, 101, None, 101, 1, None, None, None, None, None, None, None, None, sqlite3.Binary(_make_blob(1, ALLREDUCE_SCHEMA, _payload_allreduce(0xABC, 4096)))),
+            (9000, 13000, 59, None, None, None, None, 100, None, 103, 1, None, None, None, None, None, None, None, None, sqlite3.Binary(_make_blob(1, SENDRECV_SCHEMA, _payload_sendrecv_no_size(0xDEF)))),
+            (14000, 18000, 59, None, None, None, None, 100, None, 102, 1, None, None, None, None, None, None, None, None, sqlite3.Binary(_make_blob(1, ALLGATHER_SCHEMA, _payload_allgather(0xABC, 8192)))),
+        ],
+    )
+
+    cur.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (?, ?, ?, ?, ?)",
+        [
+            (100, 10, 3500, 3600, 200),
+            (100, 11, 3600, 3700, 200),
+            (101, 20, 3500, 3600, 200),
+            (100, 30, 9500, 9600, 200),
+            (100, 40, 14500, 14600, 200),
+        ],
+    )
+    cur.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        [
+            (10, 0, 7, 10, 4000, 5000, 1, 1, 1, 1, 1, 1, 1, 1),
+            (10, 0, 7, 11, 4200, 4700, 2, 2, 1, 1, 1, 1, 1, 1),
+            (10, 1, 7, 20, 4300, 5300, 1, 1, 1, 1, 1, 1, 1, 1),
+            (10, 0, 8, 30, 10000, 11000, 4, 4, 1, 1, 1, 1, 1, 1),
+            (10, 0, 9, 40, 15000, 16000, 3, 3, 1, 1, 1, 1, 1, 1),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return str(db_path)
+
+
+@pytest.fixture
+def nccl_blob_db_path(tmp_path):
+    return _create_blob_profile(tmp_path / "nccl_blob_profile.sqlite")
+
+
+@pytest.fixture
+def nccl_mixed_blob_db_path(tmp_path):
+    return _create_blob_profile(tmp_path / "nccl_mixed_blob_profile.sqlite", binary_decl="TEXT")
+
+
+@pytest.fixture
+def nccl_blob_conn(nccl_blob_db_path):
+    conn = sqlite3.connect(nccl_blob_db_path)
+    yield conn
+    conn.close()
+
+
+def _rows_without_diagnostics(rows: list[dict]) -> list[dict]:
+    return [row for row in rows if not row.get("_diagnostic")]
+
+
+def test_sqlite_analysis_groups_by_communicator(nccl_blob_conn):
+    prof = Profile._from_conn(nccl_blob_conn)
+    rows = _rows_without_diagnostics(analyze_nccl_communicators(prof))
+    assert rows
+
+    allreduce = next(r for r in rows if r["collective_type"] == "allreduce")
+    assert allreduce["communicator_hex"] == "0x0000000000000abc"
+    assert allreduce["count"] == 2
+    assert allreduce["num_ranks"] == 2
+    assert allreduce["inferred_dimension"] == "data_parallel_or_global"
+    assert allreduce["total_bytes"] == 8192
+    assert allreduce["bandwidth_gbps"] is not None
+    assert allreduce["reduction_op"] == "Sum"
+
+
+def test_device_filter_excludes_other_devices(nccl_blob_conn):
+    prof = Profile._from_conn(nccl_blob_conn)
+    rows = _rows_without_diagnostics(analyze_nccl_communicators(prof, device=0))
+    allreduce = next(r for r in rows if r["collective_type"] == "allreduce")
+    assert allreduce["count"] == 1
+    assert allreduce["devices"] == "0"
+
+
+def test_multi_kernel_tiebreaker_ignores_helper_kernel(nccl_blob_conn):
+    prof = Profile._from_conn(nccl_blob_conn)
+    rows = _rows_without_diagnostics(analyze_nccl_communicators(prof, device=0))
+    allreduce = next(r for r in rows if r["collective_type"] == "allreduce")
+    assert allreduce["total_ms"] == pytest.approx(0.001, abs=1e-6)
+
+
+def test_missing_message_size_omits_bandwidth(nccl_blob_conn):
+    prof = Profile._from_conn(nccl_blob_conn)
+    rows = _rows_without_diagnostics(analyze_nccl_communicators(prof, device=0))
+    sendrecv = next(r for r in rows if r["collective_type"] == "sendrecv")
+    assert sendrecv["total_bytes"] is None
+    assert sendrecv["bandwidth_gbps"] is None
+
+
+def test_skill_formats_grouped_output(nccl_blob_conn):
+    skill = get_skill("nccl_communicator_analysis")
+    assert skill is not None
+    text = skill.run(nccl_blob_conn)
+    assert "NCCL Communication by Communicator" in text
+    assert "0x0000000000000abc" in text
+    assert "allreduce" in text
+
+
+def test_direct_and_cached_paths_match(nccl_blob_db_path):
+    skill = get_skill("nccl_communicator_analysis")
+    assert skill is not None
+
+    direct = Profile(nccl_blob_db_path, cache_mode="direct")
+    cached = Profile(nccl_blob_db_path, cache_mode="parquet")
+    try:
+        direct_rows = _rows_without_diagnostics(skill.execute(direct.db))
+        cached_rows = _rows_without_diagnostics(skill.execute(cached.db))
+    finally:
+        direct.close()
+        cached.close()
+
+    def _key(rows: list[dict]) -> list[tuple]:
+        return sorted(
+            (
+                row["communicator_hex"],
+                row["collective_type"],
+                row["count"],
+                row["total_bytes"],
+                row["devices"],
+            )
+            for row in rows
+        )
+
+    assert _key(direct_rows) == _key(cached_rows)
+
+
+def test_direct_mode_uses_sqlite_fallback_for_mixed_text_blob_column(nccl_mixed_blob_db_path):
+    skill = get_skill("nccl_communicator_analysis")
+    assert skill is not None
+
+    direct = Profile(nccl_mixed_blob_db_path, cache_mode="direct")
+    try:
+        rows = skill.execute(direct.db)
+    finally:
+        direct.close()
+
+    data_rows = _rows_without_diagnostics(rows)
+    diagnostics = [row for row in rows if row.get("_diagnostic")]
+    assert data_rows
+    assert any("SQLite side-connection fallback" in detail for row in diagnostics for detail in row.get("details", []))
+
+
+def test_profile_health_manifest_includes_communicator_summary(nccl_blob_conn):
+    skill = get_skill("profile_health_manifest")
+    assert skill is not None
+
+    rows = skill.execute(nccl_blob_conn, device=0)
+    manifest = rows[0]
+
+    assert manifest["communicators"]["communicators"] >= 1
+    assert manifest["communicators"]["dominant_collective"] in {"allreduce", "allgather", "sendrecv"}
+
+
+def test_root_cause_matcher_uses_communicator_evidence(nccl_blob_conn):
+    skill = get_skill("root_cause_matcher")
+    assert skill is not None
+
+    rows = skill.execute(nccl_blob_conn, device=0)
+    patterns = {row["pattern"] for row in rows}
+    assert "Inefficient NCCL Communicator" in patterns

--- a/tests/test_parquetdir_backend.py
+++ b/tests/test_parquetdir_backend.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+
+from nsys_ai.profile import Profile
+from nsys_ai.skills.registry import get_skill
+
+COMM_SCHEMA = 1001
+ALLREDUCE_SCHEMA = 1002
+REDUCTION_ENUM = 9001
+
+
+def _pack_u32(value: int) -> bytes:
+    return int(value).to_bytes(4, "little", signed=False)
+
+
+def _pack_u64(value: int) -> bytes:
+    return int(value).to_bytes(8, "little", signed=False)
+
+
+def _make_blob(domain_id: int, schema_id: int, payload: bytes) -> bytes:
+    header = (
+        _pack_u64(domain_id)
+        + _pack_u64(schema_id)
+        + _pack_u64(len(payload))
+        + _pack_u64(32)
+    )
+    return header + payload
+
+
+def _payload_comm_init(comm_id: int, num_ranks: int, rank: int, cuda_device: int) -> bytes:
+    return (
+        _pack_u64(comm_id)
+        + _pack_u32(num_ranks)
+        + _pack_u32(rank)
+        + _pack_u32(cuda_device)
+        + b"\x00" * 4
+    )
+
+
+def _payload_allreduce(comm_id: int, message_size: int, reduction_value: int = 0) -> bytes:
+    return _pack_u64(comm_id) + _pack_u64(message_size) + _pack_u32(reduction_value) + b"\x00" * 4
+
+
+def _invalid_large_string(values: list[bytes | None]) -> pa.Array:
+    binary = pa.array(values, type=pa.large_binary())
+    null_bitmap, offsets, data = binary.buffers()
+    return pa.LargeStringArray.from_buffers(
+        len(binary),
+        offsets,
+        data,
+        null_bitmap=null_bitmap,
+        null_count=binary.null_count,
+    )
+
+
+def _write_table(parquet_dir: Path, name: str, table: pa.Table) -> None:
+    pq.write_table(table, parquet_dir / f"{name}.parquet")
+
+
+def _create_parquetdir_profile(parquet_dir: Path) -> str:
+    parquet_dir.mkdir()
+    schema_entries = [
+        (1, COMM_SCHEMA, 0, None, 18, "NCCL communicator ID", None, None, 0),
+        (1, COMM_SCHEMA, 1, None, 5, "No. of ranks", None, None, 8),
+        (1, COMM_SCHEMA, 2, None, 5, "Rank", None, None, 12),
+        (1, COMM_SCHEMA, 3, None, 5, "CUDA device", None, None, 16),
+        (1, ALLREDUCE_SCHEMA, 0, None, 18, "NCCL communicator ID", None, None, 0),
+        (1, ALLREDUCE_SCHEMA, 1, None, 22, "Message size [bytes]", None, None, 8),
+        (1, ALLREDUCE_SCHEMA, 2, None, REDUCTION_ENUM, "Reduction operation", None, None, 16),
+    ]
+    _write_table(
+        parquet_dir,
+        "StringIds",
+        pa.table(
+            {
+                "id": pa.array([1, 100, 101, 200], type=pa.int32()),
+                "value": pa.array(
+                    [
+                        "ncclDevKernel_AllReduce",
+                        "ncclCommInitRankConfig",
+                        "ncclAllReduce",
+                        "cudaLaunchKernel",
+                    ]
+                ),
+            }
+        ),
+    )
+    _write_table(
+        parquet_dir,
+        "TARGET_INFO_GPU",
+        pa.table(
+            {
+                "id": pa.array([0, 1], type=pa.int64()),
+                "name": pa.array(["NVIDIA H100 SXM", "NVIDIA H100 SXM"]),
+                "busLocation": pa.array(["0000:00:00.0", "0000:00:00.1"]),
+                "totalMemory": pa.array([0, 0], type=pa.int64()),
+                "smCount": pa.array([132, 132], type=pa.int32()),
+                "chipName": pa.array(["GH100", "GH100"]),
+                "memoryBandwidth": pa.array([0, 0], type=pa.int64()),
+            }
+        ),
+    )
+    _write_table(
+        parquet_dir,
+        "TARGET_INFO_CUDA_DEVICE",
+        pa.table(
+            {
+                "gpuId": pa.array([0, 1], type=pa.int64()),
+                "cudaId": pa.array([0, 1], type=pa.int64()),
+                "pid": pa.array([10, 10], type=pa.int64()),
+                "uuid": pa.array(["", ""]),
+                "numMultiprocessors": pa.array([132, 132], type=pa.int64()),
+            }
+        ),
+    )
+    _write_table(
+        parquet_dir,
+        "TARGET_INFO_NIC_INFO",
+        pa.table(
+            {
+                "GUID": pa.array([], type=pa.int64()),
+                "stateName": pa.array([], type=pa.string()),
+                "nicId": pa.array([], type=pa.int64()),
+                "name": pa.array([], type=pa.string()),
+                "deviceId": pa.array([], type=pa.int64()),
+                "vendorId": pa.array([], type=pa.int64()),
+                "linkLayer": pa.array([], type=pa.int64()),
+            }
+        ),
+    )
+    _write_table(
+        parquet_dir,
+        "CUPTI_ACTIVITY_KIND_RUNTIME",
+        pa.table(
+            {
+                "globalTid": pa.array([100, 101], type=pa.int64()),
+                "correlationId": pa.array([10, 20], type=pa.int64()),
+                "start": pa.array([3500, 3500], type=pa.int64()),
+                "end": pa.array([3600, 3600], type=pa.int64()),
+                "nameId": pa.array([200, 200], type=pa.int64()),
+            }
+        ),
+    )
+    _write_table(
+        parquet_dir,
+        "CUPTI_ACTIVITY_KIND_KERNEL",
+        pa.table(
+            {
+                "globalPid": pa.array([10, 10], type=pa.int64()),
+                "deviceId": pa.array([0, 1], type=pa.int64()),
+                "streamId": pa.array([7, 7], type=pa.int64()),
+                "correlationId": pa.array([10, 20], type=pa.int64()),
+                "start": pa.array([4000, 4300], type=pa.int64()),
+                "end": pa.array([5000, 5300], type=pa.int64()),
+                "shortName": pa.array([1, 1], type=pa.int64()),
+                "demangledName": pa.array([1, 1], type=pa.int64()),
+                "gridX": pa.array([1, 1], type=pa.int64()),
+                "gridY": pa.array([1, 1], type=pa.int64()),
+                "gridZ": pa.array([1, 1], type=pa.int64()),
+                "blockX": pa.array([1, 1], type=pa.int64()),
+                "blockY": pa.array([1, 1], type=pa.int64()),
+                "blockZ": pa.array([1, 1], type=pa.int64()),
+            }
+        ),
+    )
+    _write_table(
+        parquet_dir,
+        "NVTX_PAYLOAD_SCHEMAS",
+        pa.table(
+            {
+                "domainId": pa.array([1, 1], type=pa.int64()),
+                "schemaId": pa.array([COMM_SCHEMA, ALLREDUCE_SCHEMA], type=pa.int64()),
+                "name": pa.array([None, None], type=pa.string()),
+                "type": pa.array([1, 1], type=pa.int64()),
+                "flags": pa.array([None, None], type=pa.int64()),
+                "numEntries": pa.array([4, 3], type=pa.int64()),
+                "payloadSize": pa.array([24, 24], type=pa.int64()),
+                "alignTo": pa.array([None, None], type=pa.int64()),
+            }
+        ),
+    )
+    _write_table(
+        parquet_dir,
+        "NVTX_PAYLOAD_SCHEMA_ENTRIES",
+        pa.table(
+            {
+                "domainId": pa.array([row[0] for row in schema_entries], type=pa.int64()),
+                "schemaId": pa.array([row[1] for row in schema_entries], type=pa.int64()),
+                "idx": pa.array([row[2] for row in schema_entries], type=pa.int64()),
+                "flags": pa.array([row[3] for row in schema_entries], type=pa.int64()),
+                "type": pa.array([row[4] for row in schema_entries], type=pa.int64()),
+                "name": pa.array([row[5] for row in schema_entries]),
+                "description": pa.array([row[6] for row in schema_entries], type=pa.string()),
+                "arrayOrUnionDetail": pa.array([row[7] for row in schema_entries], type=pa.int64()),
+                "offset": pa.array([row[8] for row in schema_entries], type=pa.int64()),
+            }
+        ),
+    )
+    _write_table(
+        parquet_dir,
+        "NVTX_PAYLOAD_ENUM_ENTRIES",
+        pa.table(
+            {
+                "domainId": pa.array([1, 1], type=pa.int64()),
+                "schemaId": pa.array([REDUCTION_ENUM, REDUCTION_ENUM], type=pa.int64()),
+                "idx": pa.array([0, 1], type=pa.int64()),
+                "name": pa.array(["Sum", "Product"]),
+                "value": pa.array([0, 1], type=pa.int64()),
+                "isFlag": pa.array([None, None], type=pa.int64()),
+            }
+        ),
+    )
+
+    binary_values = [
+        _make_blob(1, COMM_SCHEMA, _payload_comm_init(0xABC, 2, 0, 0)),
+        _make_blob(1, COMM_SCHEMA, _payload_comm_init(0xABC, 2, 1, 1)),
+        _make_blob(1, ALLREDUCE_SCHEMA, _payload_allreduce(0xABC, 4096)),
+        _make_blob(1, ALLREDUCE_SCHEMA, _payload_allreduce(0xABC, 4096)),
+    ]
+    _write_table(
+        parquet_dir,
+        "NVTX_EVENTS",
+        pa.Table.from_arrays(
+            [
+                pa.array([1000, 1000, 3000, 3000], type=pa.int64()),
+                pa.array([2000, 2000, 8000, 8000], type=pa.int64()),
+                pa.array([59, 59, 59, 59], type=pa.uint32()),
+                pa.array([None, None, None, None], type=pa.uint64()),
+                pa.array([None, None, None, None], type=pa.uint64()),
+                pa.array([None, None, None, None], type=pa.uint32()),
+                pa.array([None, None, None, None], type=pa.large_string()),
+                pa.array([100, 101, 100, 101], type=pa.uint64()),
+                pa.array([None, None, None, None], type=pa.uint64()),
+                pa.array([100, 100, 101, 101], type=pa.uint32()),
+                pa.array([1, 1, 1, 1], type=pa.uint64()),
+                pa.array([None, None, None, None], type=pa.uint64()),
+                pa.array([None, None, None, None], type=pa.int64()),
+                pa.array([None, None, None, None], type=pa.float64()),
+                pa.array([None, None, None, None], type=pa.uint32()),
+                pa.array([None, None, None, None], type=pa.int32()),
+                pa.array([None, None, None, None], type=pa.float32()),
+                pa.array([None, None, None, None], type=pa.uint32()),
+                pa.array([None, None, None, None], type=pa.large_string()),
+                _invalid_large_string(binary_values),
+            ],
+            schema=pa.schema(
+                [
+                    ("start", pa.int64()),
+                    ("end", pa.int64()),
+                    ("eventType", pa.uint32()),
+                    ("rangeId", pa.uint64()),
+                    ("category", pa.uint64()),
+                    ("color", pa.uint32()),
+                    ("text", pa.large_string()),
+                    ("globalTid", pa.uint64()),
+                    ("endGlobalTid", pa.uint64()),
+                    ("textId", pa.uint32()),
+                    ("domainId", pa.uint64()),
+                    ("uint64Value", pa.uint64()),
+                    ("int64Value", pa.int64()),
+                    ("doubleValue", pa.float64()),
+                    ("uint32Value", pa.uint32()),
+                    ("int32Value", pa.int32()),
+                    ("floatValue", pa.float32()),
+                    ("jsonTextId", pa.uint32()),
+                    ("jsonText", pa.large_string()),
+                    ("binaryData", pa.large_string()),
+                ]
+            ),
+        ),
+    )
+    return str(parquet_dir)
+
+
+def _rows_without_diagnostics(rows: list[dict]) -> list[dict]:
+    return [row for row in rows if not row.get("_diagnostic")]
+
+
+def test_profile_parquetdir_backend_opens_and_aliases(tmp_path):
+    parquetdir = _create_parquetdir_profile(tmp_path / "synthetic.parquetdir")
+    with Profile(parquetdir, backend="parquetdir") as prof:
+        assert prof.meta.devices == [0, 1]
+        assert prof.db.execute("SELECT COUNT(*) FROM NVTX_EVENTS WHERE binaryData IS NOT NULL").fetchone()[0] == 4
+        assert prof.db.execute("SELECT COUNT(*) FROM gpu_info").fetchone()[0] == 2
+        assert prof.db.execute("SELECT COUNT(*) FROM cuda_device").fetchone()[0] == 2
+
+
+def test_schema_inspect_runs_on_parquetdir_backend(tmp_path):
+    parquetdir = _create_parquetdir_profile(tmp_path / "synthetic.parquetdir")
+    skill = get_skill("schema_inspect")
+    assert skill is not None
+    with Profile(parquetdir, backend="parquetdir") as prof:
+        rows = skill.execute(prof.db)
+    table_names = {row["table_name"] for row in rows}
+    assert "NVTX_EVENTS" in table_names
+    assert "NVTX_PAYLOAD_SCHEMAS" in table_names
+    assert "string_ids" in table_names
+
+
+def test_nccl_communicator_skill_runs_on_parquetdir_without_sqlite_fallback(tmp_path):
+    parquetdir = _create_parquetdir_profile(tmp_path / "synthetic.parquetdir")
+    skill = get_skill("nccl_communicator_analysis")
+    assert skill is not None
+    with Profile(parquetdir, backend="parquetdir") as prof:
+        rows = skill.execute(prof.db)
+    data_rows = _rows_without_diagnostics(rows)
+    assert data_rows
+    assert data_rows[0]["communicator_hex"] == "0x0000000000000abc"
+    diagnostic_details = [
+        detail for row in rows if row.get("_diagnostic") for detail in row.get("details", [])
+    ]
+    assert not any("SQLite side-connection fallback" in detail for detail in diagnostic_details)

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -36,6 +36,7 @@ class TestManifestExecute:
             "total_kernel_ms",
             "overlap",
             "nccl",
+            "communicators",
             "idle",
             "root_cause_count",
             "root_causes",
@@ -54,6 +55,12 @@ class TestManifestExecute:
         rows = manifest_skill.execute(minimal_nsys_conn, device=0)
         m = rows[0]
         assert m["nccl"]["streams"] > 0
+
+    def test_communicator_summary_defaults_without_payloads(self, minimal_nsys_conn, manifest_skill):
+        rows = manifest_skill.execute(minimal_nsys_conn, device=0)
+        m = rows[0]
+        assert m["communicators"]["communicators"] == 0
+        assert m["communicators"]["collective_rows"] == 0
 
     def test_root_causes_capped(self, minimal_nsys_conn, manifest_skill):
         """root_causes list should never exceed 5 entries."""

--- a/tests/test_profile_modes.py
+++ b/tests/test_profile_modes.py
@@ -16,6 +16,14 @@ def test_invalid_backend(minimal_nsys_db_path):
         Profile(str(minimal_nsys_db_path), backend="invalid")
 
 
+def test_parquetdir_backend_rejects_non_auto_cache_mode(minimal_nsys_db_path):
+    with pytest.raises(
+        ValueError,
+        match="cache_mode is not supported with backend='parquetdir'; use cache_mode='auto'.",
+    ):
+        Profile(str(minimal_nsys_db_path), backend="parquetdir", cache_mode="direct")
+
+
 def test_cache_mode_parquet(minimal_nsys_db_path):
     with Profile(str(minimal_nsys_db_path), cache_mode="parquet") as prof:
         # Execute a query using alias view syntax (which Parquet mode supports via registration)

--- a/tests/test_profile_modes.py
+++ b/tests/test_profile_modes.py
@@ -11,6 +11,11 @@ def test_invalid_cache_mode(minimal_nsys_db_path):
         Profile(str(minimal_nsys_db_path), cache_mode="invalid")
 
 
+def test_invalid_backend(minimal_nsys_db_path):
+    with pytest.raises(ValueError, match="Unknown backend: 'invalid'"):
+        Profile(str(minimal_nsys_db_path), backend="invalid")
+
+
 def test_cache_mode_parquet(minimal_nsys_db_path):
     with Profile(str(minimal_nsys_db_path), cache_mode="parquet") as prof:
         # Execute a query using alias view syntax (which Parquet mode supports via registration)

--- a/tests/test_profile_resolve.py
+++ b/tests/test_profile_resolve.py
@@ -150,3 +150,24 @@ def test_resolve_nsys_rep_timeout(monkeypatch, tmp_path: Path):
     with pytest.raises(ExportTimeoutError) as exc:
         profile_mod.resolve_profile_path(str(rep))
     assert "timed out after 300 seconds" in str(exc.value)
+
+
+def test_sqlite_blob_reexport_check_uses_schema_not_row_values(tmp_path: Path):
+    sqlite_path = tmp_path / "blob_schema_only.sqlite"
+    with sqlite3.connect(sqlite_path) as conn:
+        cur = conn.cursor()
+        cur.executescript("""
+            CREATE TABLE NVTX_EVENTS (
+                start INTEGER,
+                end INTEGER,
+                binaryData BLOB
+            );
+            CREATE TABLE NVTX_PAYLOAD_SCHEMAS (
+                domainId INTEGER,
+                schemaId INTEGER
+            );
+            INSERT INTO NVTX_EVENTS (start, end, binaryData) VALUES (1, 2, NULL);
+        """)
+        conn.commit()
+
+    assert profile_mod._sqlite_needs_blob_reexport(str(sqlite_path)) is False

--- a/tests/test_profile_resolve.py
+++ b/tests/test_profile_resolve.py
@@ -1,3 +1,5 @@
+import logging
+import sqlite3
 import subprocess
 from pathlib import Path
 
@@ -31,6 +33,24 @@ def test_resolve_nsys_rep_missing_nsys(monkeypatch, tmp_path: Path):
     with pytest.raises(ExportToolMissingError) as exc:
         profile_mod.resolve_profile_path(str(path))
     assert "requires 'nsys'" in str(exc.value)
+
+
+def test_resolve_nsys_rep_missing_nsys_reuses_blobless_sqlite(
+    monkeypatch, tmp_path: Path, caplog
+):
+    """Up-to-date .sqlite without payload blobs: reuse when nsys is unavailable."""
+    monkeypatch.setattr(profile_mod.shutil, "which", lambda name: None)
+    rep = tmp_path / "foo.nsys-rep"
+    rep.write_bytes(b"0")
+    sqlite_path = tmp_path / "foo.sqlite"
+    with sqlite3.connect(sqlite_path) as conn:
+        conn.execute("CREATE TABLE dummy (id INTEGER)")
+        conn.commit()
+
+    with caplog.at_level(logging.WARNING, logger="nsys_ai.profile"):
+        out = profile_mod.resolve_profile_path(str(rep))
+    assert out == str(sqlite_path)
+    assert any("without NVTX payload blobs" in r.message for r in caplog.records)
 
 
 def test_resolve_nsys_rep_success(monkeypatch, tmp_path: Path):

--- a/tests/test_profile_resolve.py
+++ b/tests/test_profile_resolve.py
@@ -15,6 +15,14 @@ def test_resolve_non_nsys_rep_passthrough(tmp_path: Path):
     assert result == str(path)
 
 
+def test_resolve_parquetdir_passthrough_directory(tmp_path: Path):
+    path = tmp_path / "foo.parquetdir"
+    path.mkdir()
+    (path / "NVTX_EVENTS.parquet").write_bytes(b"x")
+    result = profile_mod.resolve_profile_path(str(path), backend="parquetdir")
+    assert result == str(path)
+
+
 def test_resolve_nsys_rep_missing_nsys(monkeypatch, tmp_path: Path):
     """If nsys is not on PATH, resolve_profile_path should raise a clear error."""
     monkeypatch.setattr(profile_mod.shutil, "which", lambda name: None)
@@ -59,6 +67,36 @@ def test_resolve_nsys_rep_success(monkeypatch, tmp_path: Path):
     assert o_idx + 1 < len(args)
     assert args[o_idx + 1] == out
     assert str(rep) in args
+
+
+def test_resolve_nsys_rep_parquetdir_success(monkeypatch, tmp_path: Path):
+    calls = {}
+    monkeypatch.setattr(profile_mod.shutil, "which", lambda name: "/opt/nsys")
+
+    def fake_run(args, check, capture_output, text, timeout):
+        calls["args"] = args
+        if "-o" in args:
+            o_idx = args.index("-o")
+            if o_idx + 1 < len(args):
+                out_dir = Path(args[o_idx + 1])
+                out_dir.mkdir()
+                (out_dir / "NVTX_EVENTS.parquet").write_bytes(b"x")
+
+        class Result:
+            stdout = ""
+            stderr = ""
+
+        return Result()
+
+    monkeypatch.setattr(profile_mod.subprocess, "run", fake_run)
+
+    rep = tmp_path / "foo.nsys-rep"
+    rep.write_bytes(b"0")
+    out = profile_mod.resolve_profile_path(str(rep), backend="parquetdir")
+    assert out.endswith(".parquetdir")
+    args = calls["args"]
+    assert "--type=parquetdir" in args
+    assert "--include-blobs=true" in args
 
 
 def test_resolve_nsys_rep_failure(monkeypatch, tmp_path: Path):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -28,6 +28,7 @@ def test_list_skills():
         "module_loading",
         "nccl_anomaly",
         "nccl_breakdown",
+        "nccl_communicator_analysis",
         "nvtx_kernel_map",
         "nvtx_layer_breakdown",
         "overlap_breakdown",


### PR DESCRIPTION
## Summary
- add an opt-in `parquetdir-native` backend so `nsys-ai` can read Nsight `parquetdir --include-blobs=true` exports directly
- add communicator-aware NCCL analysis that decodes NVTX payload blobs, groups by communicator ID, infers likely parallelism scope, and reports effective bandwidth
- integrate communicator evidence into `profile_health_manifest`, `root_cause_matcher`, and agent skill selection/auto-analysis
- keep existing `.sqlite` + cache behavior unchanged (`direct`/`parquet`/`auto` remain as-is)

## Why
Communicator-aware NCCL diagnostics depend on NVTX blob payloads, but DuckDB-over-SQLite is fragile for this data due to weak typing/mixed blob-string behavior.  
This PR adds a cleaner backend for payload-heavy analysis and makes communicator-level NCCL evidence a reusable platform capability instead of a one-off fallback path.

## What Changed
- added `backend='parquetdir'` profile loading with `.nsys-rep -> parquetdir` export resolution using `nsys export --type parquetdir --include-blobs=true`
- added direct DuckDB opening of raw Nsight parquet directories plus stable aliases for core tables used by metadata and communicator analysis
- added a repair path for `NVTX_EVENTS.binaryData` in raw parquet exports (Arrow normalization before DuckDB view registration)
- added built-in `nccl_communicator_analysis` skill and communicator decode/attribution logic
- integrated communicator evidence into:
  - `profile_health_manifest`
  - `root_cause_matcher`
  - agent keyword/core-skill flow
- added tests for backend resolution/opening, schema inspection, communicator analysis across backends, and integration into manifest/root-cause paths

## Test Plan
- [x] `pytest tests/test_profile_resolve.py tests/test_profile_modes.py tests/test_parquetdir_backend.py tests/test_nccl_communicator_analysis.py -q`
- [x] `pytest tests/test_agent.py tests/test_profile_health_manifest.py tests/test_nccl_communicator_analysis.py tests/test_parquetdir_backend.py -q`
- [x] `pytest tests/test_parquet_cache.py tests/test_fingerprint.py tests/test_nccl_breakdown.py -q`
- [x] smoke-tested updated skills on real `.nsys-rep` profiles via `open(..., backend='parquetdir')`

## Known Limitations
- backend is opt-in (not auto-selected yet)
- parquet normalization currently special-cases `NVTX_EVENTS.binaryData`
- `Profile(path, backend='parquetdir')` expects an already-resolved parquetdir path; `open(..., backend='parquetdir')` is the `.nsys-rep` entrypoint