### PR TITLE
feat(plugin): Stage A — Mode 1 auto triage + PRINCIPLES guards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "nsys-ai",
+  "description": "GPU profile analysis for NVIDIA Nsight Systems. Triage bottlenecks, diagnose NCCL, compute MFU, compare regressions, and drill into SASS instructions.",
+  "author": {
+    "name": "GindaChen",
+    "url": "https://github.com/GindaChen"
+  },
+  "repository": "https://github.com/GindaChen/nsys-ai",
+  "license": "MIT",
+  "keywords": ["gpu", "nvidia", "nsight", "profiling", "cuda", "nccl", "mfu", "performance", "cutracer"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ data/nsys-hero/
 *.sqlite
 *.nsys-rep
 *.nsys-cache/
+*.sqlite.timeline-cache-*.json
 examples/*/output/
 snapshot_report.html
 uv.lock

--- a/docs/claude-plugin-quickstart.md
+++ b/docs/claude-plugin-quickstart.md
@@ -1,0 +1,54 @@
+# Quick Start — nsys-ai Claude Skill
+
+## 1. Install nsys-ai
+
+```bash
+pip install "nsys-ai[agent]"
+```
+
+## 2. Install this skill
+
+```bash
+git clone https://github.com/GindaChen/nsys-ai ~/.claude/skills/nsys-ai
+```
+
+## 3. Profile your workload
+
+```bash
+# Full run
+nsys profile python train.py
+
+# Recommended: capture only the training loop
+nsys profile --capture-range=cudaProfilerApi python train.py
+# (requires torch.cuda.profiler.start()/stop() in your script)
+```
+
+This produces `report.nsys-rep`. The skill auto-converts it — no manual export needed.
+
+## 4. Run the skill
+
+In Claude Code, type:
+```
+/analyze
+```
+
+Or with a direct question (skips the mode menu):
+```
+/analyze report.nsys-rep why is my training slow?
+```
+
+## 5. What you get
+
+Within 3 turns:
+- Root cause identified (e.g. "NCCL serialization at 18% overlap")
+- Code fix with example (e.g. `DDP(model, bucket_cap_mb=256)`)
+- Interactive timeline with the bottleneck highlighted
+
+## Common invocations
+
+```
+/analyze report.nsys-rep
+/analyze before.nsys-rep after.nsys-rep regression
+/analyze profile.sqlite what is my mfu?
+/analyze profile.sqlite why is flash attention slow?
+```

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -31,7 +31,7 @@ pip install "nsys-ai[agent]"
 git clone https://github.com/GindaChen/nsys-ai ~/.claude/skills/nsys-ai
 ```
 
-See [QUICKSTART.md](QUICKSTART.md) for a 2-minute walkthrough.
+See [claude-plugin-quickstart.md](claude-plugin-quickstart.md) for a 2-minute walkthrough.
 
 ## Usage
 
@@ -55,7 +55,7 @@ skills/analyze/
   SKILL.md              ← main skill instructions (Claude reads this)
   references/
     PRINCIPLES.md       ← non-negotiable analysis rules
-    TRIAGE.md           ← 6-stage triage workflow
+    M1_AUTO.md          ← 6-stage triage workflow
     DISTRIBUTED.md      ← NCCL / multi-GPU analysis
     DIFF.md             ← regression comparison workflow
     MFU.md              ← MFU / efficiency workflow

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -1,0 +1,64 @@
+# nsys-ai Claude Skill
+
+A Claude Code plugin that turns NVIDIA Nsight Systems GPU profiles into actionable
+performance fixes — without knowing any CLI commands.
+
+## What it does
+
+Point it at a `.nsys-rep` or `.sqlite` profile and get:
+
+- **Root cause** — NCCL serialization, GPU idle bubbles, kernel hotspot, memory bottleneck
+- **Code fix** — specific Python change with line reference
+- **Expected speedup** — quantified via `speedup_estimator`
+- **Interactive timeline** — bottleneck highlighted in browser
+
+## Modes
+
+| Mode | Use when |
+|------|----------|
+| **Diagnose** | "Why is my training slow?" — auto-routes to the right analysis |
+| **Compare** | "Did my change help?" — before/after regression diff |
+| **Efficiency** | "What is my MFU?" — requires model architecture |
+| **CUTracer** | "Why is this kernel slow at the instruction level?" — requires GPU re-run |
+
+## Install
+
+```bash
+# Install nsys-ai CLI
+pip install "nsys-ai[agent]"
+
+# Install this skill
+git clone https://github.com/GindaChen/nsys-ai ~/.claude/skills/nsys-ai
+```
+
+See [QUICKSTART.md](QUICKSTART.md) for a 2-minute walkthrough.
+
+## Usage
+
+```
+/analyze                                  # show mode menu
+/analyze profile.nsys-rep                 # with profile
+/analyze profile.nsys-rep why slow?       # skip menu, direct question
+/analyze before.sqlite after.sqlite diff  # compare mode
+```
+
+## Requirements
+
+- `nsys-ai >= 0.9.0` (`pip install "nsys-ai[agent]"`)
+- NVIDIA Nsight Systems (for profiling — not needed for analysis)
+- CUTracer mode additionally requires: `cutracer.so` + `nvdisasm` (optional)
+
+## What's in this repo
+
+```
+skills/analyze/
+  SKILL.md              ← main skill instructions (Claude reads this)
+  references/
+    PRINCIPLES.md       ← non-negotiable analysis rules
+    TRIAGE.md           ← 6-stage triage workflow
+    DISTRIBUTED.md      ← NCCL / multi-GPU analysis
+    DIFF.md             ← regression comparison workflow
+    MFU.md              ← MFU / efficiency workflow
+    VARIANCE.md         ← iteration variance analysis
+    SKILLS_REF.md       ← 33-skill quick reference card
+```

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -72,7 +72,16 @@ run_capture "profile_health_manifest" "$MANIFEST_OUT" \
 check_regex "manifest has gpu field"         "$MANIFEST_OUT" '"gpu"'
 check_regex "manifest has profile_span_ms"   "$MANIFEST_OUT" '"profile_span_ms"'
 check_regex "manifest has suspected_bottleneck" "$MANIFEST_OUT" '"suspected_bottleneck"'
-run "nvtx_layer_breakdown"     nsys-ai skill run nvtx_layer_breakdown "$PROFILE" --format json --max-rows 1
+# NVTX-dependent skills fail on profiles without an NVTX_EVENTS table.
+# Missing NVTX is a non-blocking scenario for the plugin (Mode 5 falls back to Path B),
+# so we skip rather than fail here.
+HAS_NVTX=$(sqlite3 "$PROFILE" "SELECT COUNT(*) FROM sqlite_master WHERE name='NVTX_EVENTS';" 2>/dev/null || echo 0)
+if [[ "$HAS_NVTX" -gt 0 ]]; then
+  run "nvtx_layer_breakdown"   nsys-ai skill run nvtx_layer_breakdown "$PROFILE" --format json --max-rows 1
+else
+  printf "  %-45s " "nvtx_layer_breakdown"
+  echo "SKIP (no NVTX_EVENTS table)"
+fi
 run "root_cause_matcher"       nsys-ai skill run root_cause_matcher "$PROFILE" --format json
 
 echo "== Mode 2 drill-down skills (comms) =="
@@ -101,13 +110,13 @@ run "h2d_distribution"         nsys-ai skill run h2d_distribution "$PROFILE" --f
 echo "== Mode 5 drill-down skills (code mapping) =="
 run "iteration_timing"         nsys-ai skill run iteration_timing "$PROFILE" --format json
 
-echo "== Stage A Mode 1 E2E — evidence pipeline =="
-# The plugin ends every mode with evidence build + timeline-web. We can only smoke the
-# CLI surface here (can't actually launch a browser in CI).
+echo "== Stage A Mode 1 smoke — evidence/timeline CLI surface =="
+# The plugin ends every mode with evidence build + timeline-web. In CI we only smoke
+# the CLI boundary here: build findings JSON, validate its shape, and verify the
+# timeline-web command is available. This does not start the HTTP server.
 run "evidence build"           nsys-ai evidence build "$PROFILE" --format json -o /tmp/findings_smoke.json
 run "findings JSON is valid"   bash -c "python3 -c 'import json,sys; json.load(open(\"/tmp/findings_smoke.json\"))'"
 run "findings has findings key" bash -c "python3 -c 'import json; assert \"findings\" in json.load(open(\"/tmp/findings_smoke.json\"))'"
-# timeline-web starts an HTTP server; just verify --help works (full run would block)
 run "timeline-web --help"      nsys-ai timeline-web --help
 
 echo ""

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Smoke test for nsys-ai plugin — validates that every CLI command referenced
+# in skills/analyze/SKILL.md + M*.md still works with the installed nsys-ai version.
+#
+# Usage:  ./scripts/smoke_test.sh <profile.sqlite>
+# Exit 0 if all commands succeed, non-zero otherwise.
+#
+# Stage A extension: adds Mode 1 end-to-end dry-run covering the three CLI boundaries
+# that the plugin actually orchestrates (manifest → evidence → timeline). See
+# docs/claude-skill-plan.md §11 Stage A acceptance tests.
+
+set -euo pipefail
+
+PROFILE="${1:-}"
+if [[ -z "$PROFILE" || ! -f "$PROFILE" ]]; then
+  echo "usage: $0 <profile.sqlite>" >&2
+  exit 2
+fi
+
+FAIL=0
+run() {
+  local label="$1"; shift
+  printf "  %-45s " "$label"
+  if "$@" >/dev/null 2>&1; then
+    echo "OK"
+  else
+    echo "FAIL"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+run_capture() {
+  # Like run, but captures stdout to a temp file for subsequent regex checks.
+  local label="$1"; shift
+  local out="$1"; shift
+  printf "  %-45s " "$label"
+  if "$@" >"$out" 2>/dev/null; then
+    echo "OK"
+  else
+    echo "FAIL"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+check_regex() {
+  local label="$1"; local file="$2"; local pattern="$3"
+  printf "  %-45s " "$label"
+  if grep -qE "$pattern" "$file" 2>/dev/null; then
+    echo "OK"
+  else
+    echo "FAIL (pattern /$pattern/ not found)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+echo "== Top-level commands =="
+run "nsys-ai help"           nsys-ai --help
+run "nsys-ai skill list"     nsys-ai skill list
+# cutracer check exits non-zero if .so is not built — informational only
+printf "  %-45s " "nsys-ai cutracer check (info)"
+if nsys-ai cutracer check >/dev/null 2>&1; then
+  echo "OK (.so installed)"
+else
+  echo "SKIP (.so not built — expected for analysis-only installs)"
+fi
+
+echo "== Mode 1 routing skills (profile_health_manifest + drill-down targets) =="
+MANIFEST_OUT="$(mktemp)"
+trap 'rm -f "$MANIFEST_OUT" /tmp/findings_smoke.json' EXIT
+run_capture "profile_health_manifest" "$MANIFEST_OUT" \
+  nsys-ai skill run profile_health_manifest "$PROFILE" --format json
+check_regex "manifest has gpu field"         "$MANIFEST_OUT" '"gpu"'
+check_regex "manifest has profile_span_ms"   "$MANIFEST_OUT" '"profile_span_ms"'
+check_regex "manifest has suspected_bottleneck" "$MANIFEST_OUT" '"suspected_bottleneck"'
+run "nvtx_layer_breakdown"     nsys-ai skill run nvtx_layer_breakdown "$PROFILE" --format json --max-rows 1
+run "root_cause_matcher"       nsys-ai skill run root_cause_matcher "$PROFILE" --format json
+
+echo "== Mode 2 drill-down skills (comms) =="
+run "overlap_breakdown"        nsys-ai skill run overlap_breakdown "$PROFILE" --format json
+run "nccl_breakdown"           nsys-ai skill run nccl_breakdown "$PROFILE" --format json
+run "kernel_overlap_matrix"    nsys-ai skill run kernel_overlap_matrix "$PROFILE" --format json
+
+echo "== Mode 6 drill-down skills (idle / sync) =="
+run "gpu_idle_gaps"            nsys-ai skill run gpu_idle_gaps "$PROFILE" --format json -p min_gap_ns=1000000
+run "sync_cost_analysis"       nsys-ai skill run sync_cost_analysis "$PROFILE" --format json
+run "kernel_launch_overhead"   nsys-ai skill run kernel_launch_overhead "$PROFILE" --format json
+run "cpu_gpu_pipeline"         nsys-ai skill run cpu_gpu_pipeline "$PROFILE" --format json
+run "stream_concurrency"       nsys-ai skill run stream_concurrency "$PROFILE" --format json
+run "pipeline_bubble_metrics"  nsys-ai skill run pipeline_bubble_metrics "$PROFILE" --format json
+
+echo "== Mode 3 drill-down skills (compute hotspot) =="
+run "top_kernels"              nsys-ai skill run top_kernels "$PROFILE" --format json --max-rows 5
+run "tensor_core_usage"        nsys-ai skill run tensor_core_usage "$PROFILE" --format json
+run "kernel_launch_pattern"    nsys-ai skill run kernel_launch_pattern "$PROFILE" --format json
+
+echo "== Mode 4 drill-down skills (memory) =="
+run "memory_bandwidth"         nsys-ai skill run memory_bandwidth "$PROFILE" --format json
+run "memory_transfers"         nsys-ai skill run memory_transfers "$PROFILE" --format json
+run "h2d_distribution"         nsys-ai skill run h2d_distribution "$PROFILE" --format json
+
+echo "== Mode 5 drill-down skills (code mapping) =="
+run "iteration_timing"         nsys-ai skill run iteration_timing "$PROFILE" --format json
+
+echo "== Stage A Mode 1 E2E — evidence pipeline =="
+# The plugin ends every mode with evidence build + timeline-web. We can only smoke the
+# CLI surface here (can't actually launch a browser in CI).
+run "evidence build"           nsys-ai evidence build "$PROFILE" --format json -o /tmp/findings_smoke.json
+run "findings JSON is valid"   bash -c "python3 -c 'import json,sys; json.load(open(\"/tmp/findings_smoke.json\"))'"
+run "findings has findings key" bash -c "python3 -c 'import json; assert \"findings\" in json.load(open(\"/tmp/findings_smoke.json\"))'"
+# timeline-web starts an HTTP server; just verify --help works (full run would block)
+run "timeline-web --help"      nsys-ai timeline-web --help
+
+echo ""
+if [[ $FAIL -eq 0 ]]; then
+  echo "All checks passed."
+  exit 0
+else
+  echo "$FAIL check(s) FAILED."
+  exit 1
+fi

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -37,9 +37,11 @@ If not installed: `pip install "nsys-ai[agent]"`.
 
 If 0 args AND no profile path in message, scan CWD (top 10 by mtime):
 ```bash
-ls -t *.sqlite *.nsys-rep 2>/dev/null | head -10
+(ls -t *.sqlite *.nsys-rep 2>/dev/null || true) | head -10
 ```
-If empty: `"No profile found in CWD; give me a path to a .sqlite or .nsys-rep file."`
+(The `|| true` keeps the pipeline exit code 0 when no files match, so the "If empty" branch
+below is always reachable — without it, `ls` exits non-zero on no matches and may be treated
+as a tool failure.) If empty: `"No profile found in CWD; give me a path to a .sqlite or .nsys-rep file."`
 
 Otherwise, render the menu **once per session**:
 
@@ -93,20 +95,21 @@ through to Mode 1 with a one-line notice:
 
 ## Mode routing
 
-| Mode | Reference | Status |
-|------|----------|--------|
-| 1 Auto | `references/M1_AUTO.md` | Stage A (live) |
-| 2 Comms | `references/M2_COMMS.md` | Stage B1 |
-| 3 Compute | `references/M3_COMPUTE.md` | Stage B2 |
-| 4 Memory | `references/M4_MEMORY.md` | Stage B2 |
-| 5 NVTX | `references/M5_NVTX.md` | Stage B2 |
-| 6 Idle | `references/M6_IDLE.md` | Stage B1 |
-| 7 CUTracer | `references/M7_CUTRACER.md` | Stage C1 |
-| 8 Diff | `references/M8_DIFF.md` | Stage C2 |
-| 9 Variance | `references/M9_VARIANCE.md` | Stage C2 |
+| Mode | Reference | Fallback ref (today) | Status |
+|------|-----------|----------------------|--------|
+| 1 Auto | `references/M1_AUTO.md` | — | Stage A (live) |
+| 2 Comms | `references/M2_COMMS.md` *(not yet present)* | `references/DISTRIBUTED.md` | Stage B1 planned |
+| 3 Compute | `references/M3_COMPUTE.md` *(not yet present)* | `references/MFU.md` | Stage B2 planned |
+| 4 Memory | `references/M4_MEMORY.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage B2 planned |
+| 5 NVTX | `references/M5_NVTX.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage B2 planned |
+| 6 Idle | `references/M6_IDLE.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage B1 planned |
+| 7 CUTracer | `references/M7_CUTRACER.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage C1 planned |
+| 8 Diff | `references/M8_DIFF.md` *(not yet present)* | `references/DIFF.md` | Stage C2 planned |
+| 9 Variance | `references/M9_VARIANCE.md` *(not yet present)* | `references/VARIANCE.md` | Stage C2 planned |
 
-After mode pick: load the reference; follow its six sections (Precondition / Stages / Skills
-/ Signals / Cross-mode exits / Delivery).
+After mode pick: load the Mode ref if it exists; otherwise load the fallback ref if listed;
+otherwise fall through to Mode 1. For any loaded ref, follow its six sections
+(Precondition / Stages / Skills / Signals / Cross-mode exits / Delivery).
 
 ---
 

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: analyze
+description: >
+  GPU performance analysis for NVIDIA Nsight Systems profiles (.sqlite or .nsys-rep files).
+  Activates when the user opens a .sqlite/.nsys-rep profile, asks about GPU bottlenecks,
+  mentions NCCL / distributed slowdown, asks for MFU / efficiency, wants to compare two
+  runs, mentions CUTracer / SASS, asks about variance / spikes, or types /analyze,
+  /nsys-analyze, /gpu-profile, /profile-analysis.
+---
+
+# nsys-ai — GPU Profile Analysis Skill
+
+You are a **CUDA ML Systems Performance Expert** powered by the `nsys-ai` CLI and its
+33 builtin analysis skills. Deliver **one root cause + one actionable fix** within the
+mode's turn budget.
+
+Always read `references/PRINCIPLES.md` first — in particular §4 (CLI-level break guard
+table), §5 (universal evidence step), §6 (device propagation), and §7 (precondition-fail
+template). Those rules override any default behavior.
+
+---
+
+## Prerequisite check
+
+```bash
+nsys-ai --help   # exit 0 = ready
+```
+
+If not installed: `pip install "nsys-ai[agent]"`.
+
+**File format**: `.sqlite` used directly; `.nsys-rep` is auto-converted silently by
+`nsys-ai` (see PRINCIPLES.md §4.2). **Do not ask the user to convert.**
+
+---
+
+## Mode Menu
+
+If 0 args AND no profile path in message, scan CWD (top 10 by mtime):
+```bash
+ls -t *.sqlite *.nsys-rep 2>/dev/null | head -10
+```
+If empty: `"No profile found in CWD; give me a path to a .sqlite or .nsys-rep file."`
+
+Otherwise, render the menu **once per session**:
+
+```
+What would you like to analyze?
+
+  1. Auto triage      — not sure where to start                  [default]
+  2. Comms            — NCCL / overlap / multi-GPU               (coming Stage B1)
+  3. Compute          — top kernels / tensor core / MFU          (coming Stage B2)
+  4. Memory           — H2D / D2H / bandwidth                    (coming Stage B2)
+  5. NVTX / code map  — which layer / step consumes time         (coming Stage B2)
+  6. Idle / sync      — GPU gaps, CPU stalls, launch overhead    (coming Stage B1)
+  7. CUTracer         — SASS-level (requires re-run)             (coming Stage C1)
+  8. Diff             — compare two profiles                     (coming Stage C2)
+  9. Variance         — some iterations much slower than others  (coming Stage C2)
+
+Reply with a number, or ask a question directly — keywords auto-route.
+```
+
+Update the "(coming Stage X)" annotations as stages merge.
+
+---
+
+## Keyword Routing (priority order; first match wins)
+
+Scan user message lowercased; first priority group to match wins (regardless of keyword
+position).
+
+| Priority | Group | Regex (case-insensitive) | Mode |
+|---|---|---|---|
+| 1 | cutracer | `cutracer\|sass\|instruction-level\|warp divergence` | 7 |
+| 2 | diff | `\bdiff\b\|\bcompare\b\|regression\|before/after` OR 2 paths supplied | 8 |
+| 3 | variance | `variance\|spike\|jitter\|choppy\|some iterations\|straggler` | 9 |
+| 4 | comms | `\bnccl\b\|allreduce\|allgather\|reducescatter\|overlap\|comm-bound` | 2 |
+| 5 | memory | `\bmemory\b\|\bh2d\b\|\bd2h\b\|bandwidth\|\btransfer\b\|pin_memory` | 4 |
+| 6 | nvtx | `\bnvtx\b\|\blayer\b\|iteration timing\|per-layer\|code mapping` | 5 |
+| 7 | idle | `\bidle\b\|\bsync\b\|launch overhead\|dataloader\|\bgap\b` | 6 |
+| 8 | compute | `hotspot\|\bgemm\b\|\bflash\b\|\battention\b\|tensor core\|\bmfu\b\|\bkernel\b\|tflops\|utilization` | 3 |
+| 9 | auto | `why\|slow\|bottleneck\|\?` OR empty | 1 |
+
+For priorities not yet implemented (marked "(coming Stage …)" in the menu above), fall
+through to Mode 1 with a one-line notice:
+
+> "Specialist Mode <N> coming in Stage <B1/B2/C1/C2>. Running auto-triage (Mode 1) now."
+
+---
+
+## Mode routing
+
+| Mode | Reference | Status |
+|------|----------|--------|
+| 1 Auto | `references/M1_AUTO.md` | Stage A (live) |
+| 2 Comms | `references/M2_COMMS.md` | Stage B1 |
+| 3 Compute | `references/M3_COMPUTE.md` | Stage B2 |
+| 4 Memory | `references/M4_MEMORY.md` | Stage B2 |
+| 5 NVTX | `references/M5_NVTX.md` | Stage B2 |
+| 6 Idle | `references/M6_IDLE.md` | Stage B1 |
+| 7 CUTracer | `references/M7_CUTRACER.md` | Stage C1 |
+| 8 Diff | `references/M8_DIFF.md` | Stage C2 |
+| 9 Variance | `references/M9_VARIANCE.md` | Stage C2 |
+
+After mode pick: load the reference; follow its six sections (Precondition / Stages / Skills
+/ Signals / Cross-mode exits / Delivery).
+
+---
+
+## Non-negotiable rules (full list in PRINCIPLES.md §3)
+
+1. Never guess kernel or NVTX names — always query first.
+2. MFU > 100% is always wrong — recompute with narrower operation scope.
+3. `theoretical_flops` must come from the skill — never estimate.
+4. Time in DB is nanoseconds; divide by 1e6 for ms, 1e9 for s.
+5. No `SELECT *` — always name specific columns.
+6. Skip iteration 0 in Mode 3 MFU and Mode 8 diff — JIT warmup inflates it.
+7. Root cause statements must explain the mechanism — never "it got slower" alone.
+
+**Universal evidence step** (PRINCIPLES.md §5): before any mode's 3-part summary, run
+`nsys-ai evidence build … && nsys-ai timeline-web … --findings /tmp/findings.json`, then
+print the URL that `timeline-web` emits (`http://127.0.0.1:PORT`). Fail-soft on empty findings.

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -80,6 +80,10 @@ position).
 | 8 | compute | `hotspot\|\bgemm\b\|\bflash\b\|\battention\b\|tensor core\|\bmfu\b\|\bkernel\b\|tflops\|utilization` | 3 |
 | 9 | auto | `why\|slow\|bottleneck\|\?` OR empty | 1 |
 
+> **Note on pattern syntax**: backslashes in the Pattern column above are Markdown table
+> escapes only. When matching, treat `\|` as `|` (alternation) and `\b` as a word-boundary
+> assertion — not as literal characters.
+
 For priorities not yet implemented (marked "(coming Stage …)" in the menu above), fall
 through to Mode 1 with a one-line notice:
 

--- a/skills/analyze/references/DIFF.md
+++ b/skills/analyze/references/DIFF.md
@@ -28,8 +28,13 @@ You have access to before/after SQLite profiles and MUST use the following rules
 > **PhD-student reality**: They changed something (batch size, seq len, framework version)
 > and it's now slower. They want WHY and HOW TO FIX IT, not just where.
 
+**Note**: Steps below use tool-call names (`get_iteration_boundaries`, etc.) available in
+the `nsys-ai diff --chat` interactive interface (Stage C2). For the Claude Code plugin
+today, use the CLI equivalents shown in brackets.
+
 ```
-Step 1  Use `get_iteration_boundaries`
+Step 1  [CLI] nsys-ai skill run iteration_timing before.sqlite --format json
+        [CLI] nsys-ai skill run iteration_timing after.sqlite --format json
         → {is_aligned, iteration_count_before, iteration_count_after, boundaries}
 
         DECIDE STRATEGY based on what you get:
@@ -50,7 +55,9 @@ Step 2  Use `get_top_nvtx_diffs` (limit=20)
         • NCCL delta large                      → communication change → read skills/distributed.md
         • Many small changes, no dominant delta → broad config change (batch size, seq len)
 
-Step 3  Use `get_iteration_diff` (for stable N, not 0)
+Step 3  [CLI] nsys-ai skill run iteration_detail before.sqlite --format json -p iteration=<N>
+        [CLI] nsys-ai skill run iteration_detail after.sqlite --format json -p iteration=<N>
+        (`get_iteration_diff` is available in `nsys-ai diff --chat` — Stage C2 only)
         KEY SIGNALS:
         ┌────────────────────────────────────────┬────────────────────────────────────────┐
         │ Signal                                 │ Diagnosis                              │
@@ -71,8 +78,10 @@ Step 4  [If specific kernel/region changed] Micro-drill:
         → region-level wall_clock_ms, top_regressions, classification
         Ask user: "Did you change anything related to <regressed region>?"
 
-Step 5  [If NCCL regressed] read skills/distributed.md
-        Then: Use `get_gpu_imbalance_stats`(iteration_index=<N>)
+Step 5  [If NCCL regressed] read DISTRIBUTED.md
+        [CLI] nsys-ai skill run overlap_breakdown before.sqlite --format json
+        [CLI] nsys-ai skill run overlap_breakdown after.sqlite --format json
+        (`get_gpu_imbalance_stats` is available in `nsys-ai diff --chat` — Stage C2 only)
         Ask: "Did you change the number of GPUs, parallelism strategy, or network config?"
 
 Step 6  [Optional deep-dive tools]
@@ -97,16 +106,20 @@ Step 7  REQUIRED final statement:
 *Only when user explicitly asks about efficiency delta — do not proactively offer.*
 
 ```
-Step 1  Use `get_iteration_boundaries` → pick stable iteration (not index 0)
-Step 2  Use `get_iteration_diff`(iteration_index=<N>)
-        → step_time_before_s = wall_clock_ms.before / 1000
-           step_time_after_s  = wall_clock_ms.after  / 1000
-Step 3  Use `get_gpu_peak_tflops`
-Step 4  Resolve model architecture: use lookup table in skills/mfu.md first
-Step 5  Use `compute_theoretical_flops`(operation="full_model", multiplier=<3 or 4>, ...)
-Step 6  Use `compute_mfu` for both before and after profiles
+Step 1  [CLI] nsys-ai skill run iteration_timing before.sqlite --format json
+        [CLI] nsys-ai skill run iteration_timing after.sqlite --format json
+        → pick stable iteration (not index 0)
+Step 2  [CLI] nsys-ai skill run iteration_detail before.sqlite --format json -p iteration=<N>
+        [CLI] nsys-ai skill run iteration_detail after.sqlite --format json -p iteration=<N>
+        → step_time_before_s, step_time_after_s (divide ms by 1000)
+Step 3  GPU peak TFLOPS: auto-detected by `region_mfu`. Read `gpu` field from manifest; if unknown ask user for `-p peak_tflops=<value>`.
+Step 4  Resolve model architecture: use lookup table in MFU.md first
+Step 5  [CLI] nsys-ai skill run theoretical_flops before.sqlite --format json \
+            -p operation=full_model -p multiplier=<3 or 4> -p hidden_dim=H ...
+Step 6  [CLI] nsys-ai skill run region_mfu before.sqlite --format json -p name=<step_region> ...
+        [CLI] nsys-ai skill run region_mfu after.sqlite --format json -p name=<step_region> ...
         Report: "MFU: before 35% → after 51% (+16pp)"
-        Contextualise using reference ranges in skills/mfu.md Workflow 2 Step 6.
+        Contextualise using reference ranges in MFU.md Workflow 2 Step 6.
 ```
 
 ---

--- a/skills/analyze/references/DIFF.md
+++ b/skills/analyze/references/DIFF.md
@@ -1,0 +1,123 @@
+# Skill: Profile Diff — Regression Analysis
+
+Read this when two profiles (before + after) are loaded, or the user asks
+"why did it get slower?" / "compare these two runs".
+**Read `PRINCIPLES.md` first** for rules, error handling, and tool definitions.
+
+You are a Senior MLSys Performance Engineer analyzing Nsight Systems (nsys) profile diffs.
+You have access to before/after SQLite profiles and MUST use the following rules.
+
+## Non-Negotiable Rules
+
+1. **Never guess names** — Call `search_nvtx_regions` or `explore_nvtx_hierarchy` to get exact NVTX/kernel strings before any diff call.
+2. **Wall-clock vs kernel sum** — If they diverge, conclude stream serialization or external sync, not kernel regression.
+3. **Explain "why"** — For regressed kernels, use `get_launch_config_diff` when available; if kernel sped up with no config change, check `uses_tensor_core_likely`.
+4. **Strict modality (nsys, not ncu)** — No cache hit rate, bandwidth, or bank-conflict claims; tell user to use Nsight Compute for those.
+5. **NCCL spike → imbalance first** — Not "network"; use `get_gpu_imbalance_stats` to prove; if within-node GPUs are balanced but NCCL still high, conclude cross-node delay.
+6. **Idle spike → CPU starvation** — If iteration slower but sum_of_kernels_ms unchanged and idle spiked, steer toward DataLoader / Python overhead.
+7. **Overlap caution** — If a kernel or region got faster but overlap_pct is high, warn that E2E speedup may be smaller or zero.
+8. **Hardware_Warning present** — Prefer thermal/power explanation before software regression.
+9. **Workload_Mismatch_Warning** — Do not draw a performance conclusion; tell user the input dimensions may differ.
+10. **Impact ratio** — Check `pct_of_iteration_time` and `contribution_to_total_delta_pct`; if regression is <1% of iteration time, classify as Negligible Variance.
+11. **MFU** — Only when the user explicitly asks for MFU, utilization, or efficiency metrics. Then: (1) Get step_time_s from the iteration diff (wall_clock_ms/1000) or global diff. (2) Get GPU peak TFLOPS. (3) Ask the user for model_flops_per_step. **Do NOT compute MFU until the user has provided model_flops_per_step.** (4) For before/after: compute MFU twice and synthesize (e.g. "MFU before 35%, after 75%, +40%").
+
+---
+
+## Workflow 4: Diff — Root Cause Analysis
+
+> **PhD-student reality**: They changed something (batch size, seq len, framework version)
+> and it's now slower. They want WHY and HOW TO FIX IT, not just where.
+
+```
+Step 1  Use `get_iteration_boundaries`
+        → {is_aligned, iteration_count_before, iteration_count_after, boundaries}
+
+        DECIDE STRATEGY based on what you get:
+        ┌─────────────────────────────────┬────────────────────────────────────────────┐
+        │ Situation                       │ Action                                     │
+        ├─────────────────────────────────┼────────────────────────────────────────────┤
+        │ is_aligned, count ≥ 3           │ Use iteration_index=1 or 2 (skip JIT)      │
+        │ is_aligned, count = 2           │ Use index 1; note single-iteration caveat  │
+        │ is_aligned, count = 1           │ Profile too short! Ask user to re-profile  │
+        │ is_aligned=false                │ Warn user: workloads differ. Use           │
+        │                                 │ Global diff (skip_first_ms=2000) instead   │
+        └─────────────────────────────────┴────────────────────────────────────────────┘
+
+Step 2  Use `get_top_nvtx_diffs` (limit=20)
+        → Hotspot radar. Classify the pattern before diving in:
+        • Compute delta large, Memcpy unchanged → pure kernel regression
+        • Idle spiked, kernel sum unchanged     → CPU bottleneck (DataLoader / GIL)
+        • NCCL delta large                      → communication change → read skills/distributed.md
+        • Many small changes, no dominant delta → broad config change (batch size, seq len)
+
+Step 3  Use `get_iteration_diff` (for stable N, not 0)
+        KEY SIGNALS:
+        ┌────────────────────────────────────────┬────────────────────────────────────────┐
+        │ Signal                                 │ Diagnosis                              │
+        ├────────────────────────────────────────┼────────────────────────────────────────┤
+        │ wall_clock_ms.delta >> sum_kernels     │ Stream serialization or sync latency   │
+        │ Compute.delta >> Idle.delta            │ Kernel regression; look at top_regressions│
+        │ Idle.delta >> Compute.delta            │ CPU starvation (DataLoader / Python GIL)│
+        │ overlap_pct.after < before by > 10pp  │ Lost compute/NCCL pipeline             │
+        │ memcpy_ms.delta > 0                    │ New host-device transfers added        │
+        │ Hardware_Warning=true                  │ Thermal throttle — re-run to confirm   │
+        │ unique_streams increased               │ More parallelism; check if effective   │
+        └────────────────────────────────────────┴────────────────────────────────────────┘
+
+Step 4  [If specific kernel/region changed] Micro-drill:
+        `search_nvtx_regions`(query="<keyword>")  ← REQUIRED before region diff
+        → get exact NVTX name strings
+        `get_region_diff`(nvtx_exact_match="<exact>")
+        → region-level wall_clock_ms, top_regressions, classification
+        Ask user: "Did you change anything related to <regressed region>?"
+
+Step 5  [If NCCL regressed] read skills/distributed.md
+        Then: Use `get_gpu_imbalance_stats`(iteration_index=<N>)
+        Ask: "Did you change the number of GPUs, parallelism strategy, or network config?"
+
+Step 6  [Optional deep-dive tools]
+        • `explore_nvtx_hierarchy`(parent_path=...)         → navigate NVTX subtree
+        • `summarize_nvtx_subtree`(parent_path="<region>")  → roll up child deltas
+        • `get_launch_config_diff`(kernel_name=...)         → grid/block config change
+        • `get_source_code_context`(nvtx_path=...)          → file:line for code handoff
+        • `get_global_diff`(skip_first_ms=2000)             → fallback when no NVTX markers
+
+Step 7  REQUIRED final statement:
+        "The regression is caused by <X>.
+         Evidence: <specific field + delta value>.
+         Likely trigger: <batch size / seq len / framework version / config change>.
+         Suggested fix: <specific action>."
+        ← Never say "the model got slower" without explaining the mechanism.
+```
+
+---
+
+## Workflow 5: Diff MFU Comparison
+
+*Only when user explicitly asks about efficiency delta — do not proactively offer.*
+
+```
+Step 1  Use `get_iteration_boundaries` → pick stable iteration (not index 0)
+Step 2  Use `get_iteration_diff`(iteration_index=<N>)
+        → step_time_before_s = wall_clock_ms.before / 1000
+           step_time_after_s  = wall_clock_ms.after  / 1000
+Step 3  Use `get_gpu_peak_tflops`
+Step 4  Resolve model architecture: use lookup table in skills/mfu.md first
+Step 5  Use `compute_theoretical_flops`(operation="full_model", multiplier=<3 or 4>, ...)
+Step 6  Use `compute_mfu` for both before and after profiles
+        Report: "MFU: before 35% → after 51% (+16pp)"
+        Contextualise using reference ranges in skills/mfu.md Workflow 2 Step 6.
+```
+
+---
+
+## Error Handling
+
+| Signal | Action |
+|--------|--------|
+| `is_aligned=false` | Warn user; use `get_global_diff` instead |
+| `get_region_diff` returns "No NVTX region matching" | Call `search_nvtx_regions` first |
+| `get_launch_config_diff` returns "not available" | Skip; check `uses_tensor_core_likely` |
+| `workload_warning=true` | Do not draw performance conclusions; tell user |
+| `Hardware_Warning=true` | Thermal throttle likely; prefer re-run before concluding |
+| `JIT_Compilation_Warning=true` | Use iteration index > 0 |

--- a/skills/analyze/references/DISTRIBUTED.md
+++ b/skills/analyze/references/DISTRIBUTED.md
@@ -31,9 +31,12 @@ Step 1  Confirm NCCL activity + per-stream breakdown:
         GROUP BY k.streamId, op ORDER BY k.streamId, total_ms DESC LIMIT 20
 
 Step 2  Read overlap_pct and Overlap Matrix:
-        [Single profile] Use `get_gpu_overlap_stats` — returns per-GPU overlap_pct.
-                         Run `kernel_overlap_matrix` to identify EXACTLY which NCCL collective overlaps (or contends) with which compute/memcpy operation. This provides a pairwise matrix (e.g., Comm×Comm, Comm×Compute).
-        [Diff context]   Use `get_iteration_diff` — overlap_pct for before/after.
+        [Single profile — CLI] nsys-ai skill run overlap_breakdown <profile> --format json
+                               nsys-ai skill run kernel_overlap_matrix <profile> --format json
+                               → per-GPU overlap_pct + pairwise Comm×Compute matrix
+        [Diff context — CLI]   nsys-ai skill run overlap_breakdown before.sqlite --format json
+                               nsys-ai skill run overlap_breakdown after.sqlite --format json
+                               (`get_iteration_diff` is available in `nsys-ai diff --chat` only — Stage C2)
 
         overlap_pct = fraction of NCCL time that overlaps with compute kernels × 100
 
@@ -66,9 +69,11 @@ Step 3  Classify collective type + stream → infer parallelism strategy:
         Stream 37 shows AllReduce only → Stream 7 = PP, Stream 37 = DP.
 
 Step 4  Per-GPU imbalance diagnosis:
-        [Single profile] Use `get_gpu_overlap_stats` — compare compute_only_ms
-        across gpu_ids. If max/min ratio > 1.2, report GPU imbalance.
-        [Diff context]   Use `get_gpu_imbalance_stats(iteration_index=<N>)`
+        [Single profile — CLI] nsys-ai skill run overlap_breakdown <profile> --format json -p device=<N>
+                               Compare compute_only_ms across gpu_ids. If max/min ratio > 1.2, report GPU imbalance.
+        [Diff context — CLI]   nsys-ai skill run overlap_breakdown before.sqlite --format json
+                               nsys-ai skill run overlap_breakdown after.sqlite --format json
+                               (`get_gpu_imbalance_stats` is available in `nsys-ai diff --chat` only — Stage C2)
         → Per-GPU: {compute_ms, nccl_ms, idle_ms} for both profiles
 
         Diagnose:

--- a/skills/analyze/references/DISTRIBUTED.md
+++ b/skills/analyze/references/DISTRIBUTED.md
@@ -1,0 +1,105 @@
+# Skill: Distributed Training / NCCL Analysis
+
+Read this when the user asks about multi-GPU slowdowns, NCCL time, or GPU imbalance.
+**Read `PRINCIPLES.md` first** for rules, error handling, and tool definitions.
+
+> **PhD-student reality**: They see 40% NCCL time and don't know if it's normal.
+> The key is overlap_pct — NCCL is acceptable when hidden behind compute.
+
+---
+
+## Workflow 6: NCCL Efficiency Diagnosis
+
+```
+Step 1  Confirm NCCL activity + per-stream breakdown:
+        nsys-ai skill run nccl_breakdown <profile.sqlite> --format json
+
+        The output is grouped by CUDA stream, then by collective type.
+        Different streams typically correspond to different parallelism
+        dimensions (TP/PP/DP), so per-stream grouping directly reveals
+        which parallelism channel dominates communication cost.
+
+        Alternatively, example raw SQL (schema may vary):
+        -- NOTE: The kernel table name may be CUPTI_ACTIVITY_KIND_KERNEL,
+        --       CUPTI_ACTIVITY_KIND_KERNEL_V2/V3, etc. Run a schema
+        --       inspection (e.g., SELECT name FROM sqlite_master WHERE type='table';)
+        --       to find the actual kernel table name and substitute it below.
+        SELECT k.streamId, s.value AS op, COUNT(*) AS cnt,
+               SUM(k.[end]-k.start)/1e6 AS total_ms
+        FROM <KERNEL_TABLE> k JOIN StringIds s ON k.shortName=s.id
+        WHERE LOWER(s.value) LIKE '%nccl%'
+        GROUP BY k.streamId, op ORDER BY k.streamId, total_ms DESC LIMIT 20
+
+Step 2  Read overlap_pct and Overlap Matrix:
+        [Single profile] Use `get_gpu_overlap_stats` — returns per-GPU overlap_pct.
+                         Run `kernel_overlap_matrix` to identify EXACTLY which NCCL collective overlaps (or contends) with which compute/memcpy operation. This provides a pairwise matrix (e.g., Comm×Comm, Comm×Compute).
+        [Diff context]   Use `get_iteration_diff` — overlap_pct for before/after.
+
+        overlap_pct = fraction of NCCL time that overlaps with compute kernels × 100
+
+        Interpretation (framework-dependent, not hard boundaries):
+        ┌──────────────┬───────────────────────────────────────────────────────────────┐
+        │ overlap_pct  │ Reading                                                       │
+        ├──────────────┼───────────────────────────────────────────────────────────────┤
+        │ > 60%        │ NCCL well-hidden under compute; likely not the bottleneck      │
+        │ 30–60%       │ Partial overlap; ring allreduce partially pipelining           │
+        │ < 30%        │ NCCL serialized with compute; throughput loss is significant   │
+        └──────────────┴───────────────────────────────────────────────────────────────┘
+        Context: FSDP/ZeRO-3 with prefetch typically achieves 50–70%.
+                 DDP without bucketing often achieves < 20%.
+
+Step 3  Classify collective type + stream → infer parallelism strategy:
+        Use the per-stream nccl_breakdown output. Each stream usually maps
+        to one parallelism dimension:
+
+        ┌─────────────────────────┬────────────────────────────────────────────────────┐
+        │ Dominant operation      │ Strategy                                           │
+        ├─────────────────────────┼────────────────────────────────────────────────────┤
+        │ AllReduce               │ DDP (gradient sync after backward)                 │
+        │ ReduceScatter + AllGather│ FSDP / ZeRO-2/3 (sharded parameters)            │
+        │ AllGather (forward only) │ Tensor Parallelism or FSDP inference             │
+        │ SendRecv                │ Pipeline Parallelism (P2P communication)           │
+        │ Broadcast               │ Checkpoint sync / parameter broadcast at init     │
+        └─────────────────────────┴────────────────────────────────────────────────────┘
+
+        Example: If Stream 7 shows SendRecv (74%) + AllGather (20%), and
+        Stream 37 shows AllReduce only → Stream 7 = PP, Stream 37 = DP.
+
+Step 4  Per-GPU imbalance diagnosis:
+        [Single profile] Use `get_gpu_overlap_stats` — compare compute_only_ms
+        across gpu_ids. If max/min ratio > 1.2, report GPU imbalance.
+        [Diff context]   Use `get_gpu_imbalance_stats(iteration_index=<N>)`
+        → Per-GPU: {compute_ms, nccl_ms, idle_ms} for both profiles
+
+        Diagnose:
+        • One GPU has nccl_ms >> other GPUs  → STRAGGLER (slow NIC, load imbalance, link fault)
+        • All GPUs: nccl_ms up uniformly     → Cross-node bandwidth congestion
+        • All GPUs: idle_ms up, nccl_ms same → GPU launch latency / CPU overhead
+
+Step 5  Give actionable recommendations:
+        overlap_pct < 30%, using DDP:
+          → "Increase DDP bucket_cap_mb, or migrate to FSDP"
+        ReduceScatter+AllGather slow:
+          → "Check FSDP prefetch_factor; measure with/without cpu_offload"
+        Straggler identified (one GPU):
+          → "Check NIC health on node <X>; rebalance dataset sharding"
+        Cross-node uniform slowdown:
+          → "Likely infiniband / RoCE issue; try NCCL_SOCKET_IFNAME, check switch"
+```
+
+---
+
+## NCCL Kernel Name Patterns
+
+nsys captures NCCL ops as CUDA kernels. Common name substrings:
+
+| Name contains | Collective |
+|---------------|-----------|
+| `ncclAllReduce` | AllReduce |
+| `ncclReduceScatter` | ReduceScatter |
+| `ncclAllGather` | AllGather |
+| `ncclBroadcast` | Broadcast |
+| `ncclSendRecv` | P2P send/recv (pipeline parallel) |
+| `ncclKernel_AllR` | AllReduce internal kernel |
+
+All are matched by `WHERE LOWER(s.value) LIKE '%nccl%'`.

--- a/skills/analyze/references/M1_AUTO.md
+++ b/skills/analyze/references/M1_AUTO.md
@@ -63,7 +63,7 @@ If returns patterns, re-route via §4 keyword logic. If still empty, offer menu 
 ### 3.3 Device propagation
 
 If §2.2 auto-retry selected device N, every subsequent skill in the drill-down that accepts
-device must receive `-p device=N`. See PRINCIPLES.md §6 for the 11 / 12 / 10 partition.
+device must receive `-p device=N`. See PRINCIPLES.md §6 for the 13 / 1 / 9 / 10 partition.
 
 ---
 
@@ -138,8 +138,9 @@ in its stdout; `src/nsys_ai/web.py:674` hard-codes `127.0.0.1`, not `localhost`)
 
 > "Timeline ready at http://127.0.0.1:PORT — open in browser to see findings overlay."
 
-**WSL2**: browser does NOT auto-open. Always print the URL. Use `localhost` interchangeably
-with `127.0.0.1` — both reach the same server.
+**WSL2**: browser does NOT auto-open. Always print the exact URL emitted by `timeline-web`
+(typically `http://127.0.0.1:PORT`) — do not substitute `localhost` (on some systems it
+resolves to IPv6 ::1 and won't reach the server).
 
 **Fail-soft**: if `evidence build` produces empty `{"findings": []}`, still run `timeline-web`.
 Never block delivery on evidence failure.

--- a/skills/analyze/references/M1_AUTO.md
+++ b/skills/analyze/references/M1_AUTO.md
@@ -107,14 +107,14 @@ they reference `M1_AUTO.md §4.1`.
 After Mode 1 delivery, suggest specialist mode only if a second critical finding exists.
 **Cap 2 chains per session** (UX invariant 7).
 
-> **Mode 2 — Comms (NCCL / overlap)**: coming Stage B1. See `M2_COMMS.md` once landed.
-> **Mode 3 — Compute (kernels / MFU)**: coming Stage B2. See `M3_COMPUTE.md`.
-> **Mode 4 — Memory (H2D / bandwidth)**: coming Stage B2. See `M4_MEMORY.md`.
-> **Mode 5 — NVTX / code mapping**: coming Stage B2. See `M5_NVTX.md`.
-> **Mode 6 — Idle / sync**: coming Stage B1. See `M6_IDLE.md`.
-> **Mode 7 — CUTracer (SASS)**: coming Stage C1. See `M7_CUTRACER.md`.
-> **Mode 8 — Diff**: coming Stage C2. See `M8_DIFF.md`.
-> **Mode 9 — Variance**: coming Stage C2. See `M9_VARIANCE.md`.
+> **Mode 2 — Comms (NCCL / overlap)**: coming Stage B1 as `M2_COMMS.md`. Today: see `DISTRIBUTED.md`.
+> **Mode 3 — Compute (kernels / MFU)**: coming Stage B2 as `M3_COMPUTE.md`. Today: see `MFU.md`.
+> **Mode 4 — Memory (H2D / bandwidth)**: coming Stage B2 as `M4_MEMORY.md`. Today: no fallback ref — use Mode 1 auto-triage.
+> **Mode 5 — NVTX / code mapping**: coming Stage B2 as `M5_NVTX.md`. Today: no fallback ref — use Mode 1 auto-triage.
+> **Mode 6 — Idle / sync**: coming Stage B1 as `M6_IDLE.md`. Today: no fallback ref — use Mode 1 auto-triage.
+> **Mode 7 — CUTracer (SASS)**: coming Stage C1 as `M7_CUTRACER.md`. Today: no fallback ref — use Mode 1 auto-triage.
+> **Mode 8 — Diff**: coming Stage C2 as `M8_DIFF.md`. Today: see `DIFF.md`.
+> **Mode 9 — Variance**: coming Stage C2 as `M9_VARIANCE.md`. Today: see `VARIANCE.md`.
 
 During Stage A (only Mode 1 lives), after auto-triage completes, emit the 3-part summary
 directly — no chain prompt until Stage B1 lands.

--- a/skills/analyze/references/M1_AUTO.md
+++ b/skills/analyze/references/M1_AUTO.md
@@ -1,0 +1,172 @@
+# Mode 1 — Auto Triage
+
+Reference for `/analyze` Mode 1 (auto triage). **Read `PRINCIPLES.md` first** — in particular
+§4 (guards), §5 (evidence), §7 (fail template), §10 (acceptance checklist).
+
+---
+
+## 1. Precondition gate
+
+§4.1 rows 1–4 (see PRINCIPLES.md). If any fail, render via §7 template and abort.
+
+---
+
+## 2. Stages
+
+| # | Question | Condition |
+|---|----------|-----------|
+| 1 | Profile path | Only if not supplied in invocation |
+| 2 | "Is this training or inference?" | Only if framework ambiguous — see §2.1 |
+| 3 | "Detected N iterations. Analyze iterations 2 to N-1? (skips JIT warmup + teardown)" | Only if `iteration_timing` reports ≥3 iterations |
+
+### 2.1 Framework ambiguous definition
+
+Ambiguous = `fingerprint.framework == "Generic CUDA"` AND no top-10 kernel name matches any
+of: `ncclDevKernel*`, `flash_*`, `ampere_*gemm*`, `volta_*gemm*`, `cutlass_*`, `sm80_*`,
+`sm90_*`, `void at::*`. Otherwise skip Stage 2.
+
+User's answer overrides `fingerprint.framework` for the session only. "inference" →
+ms/token framing; "training" → look for `_bwd`/`wgrad`/`dgrad` kernels and DataLoader
+signals. No file writes.
+
+### 2.2 Device 0 auto-retry (silent — NOT a user stage)
+
+After Stage 1 runs `profile_health_manifest`, if the response has:
+- `overlap.error == "no kernels found"` AND
+- `overlap.available_devices` is non-empty
+
+…then plugin picks the first numeric key (lowest device id) and re-runs manifest with
+`-p device=N`. Tell user once: `"Detected active GPU: device N"`. No user question.
+
+---
+
+## 3. Skills
+
+### 3.1 Primary
+
+```bash
+nsys-ai skill run profile_health_manifest <profile> --format json
+```
+
+Then follow `suspected_bottleneck` routing (§4 below).
+
+### 3.2 Fallback
+
+If `suspected_bottleneck` is empty/"None" AND `root_causes[]` is empty:
+
+```bash
+nsys-ai skill run root_cause_matcher <profile> --format json
+```
+
+If returns patterns, re-route via §4 keyword logic. If still empty, offer menu 2/3/4/6.
+
+### 3.3 Device propagation
+
+If §2.2 auto-retry selected device N, every subsequent skill in the drill-down that accepts
+device must receive `-p device=N`. See PRINCIPLES.md §6 for the 11 / 12 / 10 partition.
+
+---
+
+## 4. Signals — routing from `suspected_bottleneck`
+
+| Keyword match (case-insensitive) | Drill into | Skills invoked |
+|----------------------------------|------------|----------------|
+| `nccl` / `comm` | Mode 2 subroutine | `overlap_breakdown`, `nccl_breakdown`, `kernel_overlap_matrix` |
+| `sync` / `idle` / `bubble` | Mode 6 subroutine | `gpu_idle_gaps`, `sync_cost_analysis`, `kernel_launch_overhead`, `cpu_gpu_pipeline` (+ `pipeline_bubble_metrics` if `nccl.collectives > 0`) |
+| `hotspot` / `kernel` | Mode 3 subroutine | `top_kernels`, `kernel_launch_pattern`, `tensor_core_usage` |
+| `h2d` / `transfer` | Mode 4 subroutine | `memory_bandwidth`, `memory_transfers`, `h2d_distribution` |
+
+### 4.1 CLI-field schema contract (source of truth for every mode ref)
+
+Pinned against `profile_health_manifest`. Do NOT restate this table in other mode refs —
+they reference `M1_AUTO.md §4.1`.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `gpu` | str | GPU name (not `gpu_name`) |
+| `profile_span_ms` | float | Total span in ms (not seconds) |
+| `fingerprint.framework` | str | "vLLM" / "Megatron-LM" / "Generic CUDA" / … |
+| `fingerprint.distributed` | bool | **Unreliable alone** — also check `nccl.collectives` |
+| `nccl.collectives` | int | >0 means multi-GPU workload |
+| `top_kernels[]` | list | `{name, total_ms, count}` (no `device` field — filter via manifest's `-p device=N` if needed) |
+| `top_kernels[].name` | str | First `ncclDevKernel*` ⇒ multi-GPU |
+| `overlap.overlap_pct` | float | <30% with NCCL ⇒ comm-bound (Mode 2) |
+| `overlap.error` | str | "no kernels found" → §2.2 auto-retry trigger |
+| `overlap.available_devices` | dict | `{N: kernel_count}` — §2.2 retry target |
+| `idle.idle_pct` | float | >15% → Mode 6 |
+| `sync.sync_density_pct` | float | >20% → Mode 6 |
+| `root_causes[].pattern` | str | Label (e.g. "NCCL Serialization") |
+| `root_causes[].severity` | str | `critical` / `warning` / `info` |
+| `suspected_bottleneck` | str | **Free-form** — keyword-match per §4 routing |
+| `data_quality.overhead_pct` | float | >1% → surface note (not a block) |
+
+---
+
+## 5. Cross-mode exits (placeholders for B/C stages)
+
+After Mode 1 delivery, suggest specialist mode only if a second critical finding exists.
+**Cap 2 chains per session** (UX invariant 7).
+
+> **Mode 2 — Comms (NCCL / overlap)**: coming Stage B1. See `M2_COMMS.md` once landed.
+> **Mode 3 — Compute (kernels / MFU)**: coming Stage B2. See `M3_COMPUTE.md`.
+> **Mode 4 — Memory (H2D / bandwidth)**: coming Stage B2. See `M4_MEMORY.md`.
+> **Mode 5 — NVTX / code mapping**: coming Stage B2. See `M5_NVTX.md`.
+> **Mode 6 — Idle / sync**: coming Stage B1. See `M6_IDLE.md`.
+> **Mode 7 — CUTracer (SASS)**: coming Stage C1. See `M7_CUTRACER.md`.
+> **Mode 8 — Diff**: coming Stage C2. See `M8_DIFF.md`.
+> **Mode 9 — Variance**: coming Stage C2. See `M9_VARIANCE.md`.
+
+During Stage A (only Mode 1 lives), after auto-triage completes, emit the 3-part summary
+directly — no chain prompt until Stage B1 lands.
+
+---
+
+## 6. Delivery
+
+Follow `PRINCIPLES.md` §5 (universal evidence + timeline step). Then the 3-part summary
+framed for Mode 1.
+
+### 6.1 Evidence CLI (inline here; other mode refs just point at PRINCIPLES.md §5)
+
+```bash
+nsys-ai evidence build <profile> --format json -o /tmp/findings.json
+nsys-ai timeline-web <profile> --findings /tmp/findings.json
+```
+
+Then print to user the URL that `timeline-web` emitted (look for `http://127.0.0.1:PORT`
+in its stdout; `src/nsys_ai/web.py:674` hard-codes `127.0.0.1`, not `localhost`):
+
+> "Timeline ready at http://127.0.0.1:PORT — open in browser to see findings overlay."
+
+**WSL2**: browser does NOT auto-open. Always print the URL. Use `localhost` interchangeably
+with `127.0.0.1` — both reach the same server.
+
+**Fail-soft**: if `evidence build` produces empty `{"findings": []}`, still run `timeline-web`.
+Never block delivery on evidence failure.
+
+### 6.2 3-part summary (Mode 1 framing)
+
+1. **Root cause** — one sentence citing the dominant bottleneck + quantified impact:
+   > "Your NCCL AllReduce is serialized with compute (overlap = 18%). This wastes
+   > approximately 3.2 s of every 8.4 s training step."
+
+2. **Specific fix** — code example (ideally file:line if source present):
+   ```python
+   model = DDP(model, bucket_cap_mb=256)
+   ```
+
+3. **Expected gain** — from `speedup_estimator` if NVTX present; **omit** the line otherwise:
+   > "speedup_estimator: this fix → ≈ 1.4× faster per step."
+
+### 6.3 Inference framing
+
+`fingerprint.framework ∈ {vLLM, SGLang, TensorRT}` OR no `_bwd`/`wgrad`/`dgrad` in top-10
+→ reframe metrics as ms/token and label "inference workload".
+
+### 6.4 Optional text report
+
+On explicit user request only: see PRINCIPLES.md §5.4 for the `nsys-ai report` CLI.
+
+### 6.5 Required output checklist
+
+See PRINCIPLES.md §10 — run that checklist before ending the turn.

--- a/skills/analyze/references/M1_AUTO.md
+++ b/skills/analyze/references/M1_AUTO.md
@@ -126,24 +126,17 @@ directly — no chain prompt until Stage B1 lands.
 Follow `PRINCIPLES.md` §5 (universal evidence + timeline step). Then the 3-part summary
 framed for Mode 1.
 
-### 6.1 Evidence CLI (inline here; other mode refs just point at PRINCIPLES.md §5)
+### 6.1 Evidence CLI
 
-```bash
-nsys-ai evidence build <profile> --format json -o /tmp/findings.json
-nsys-ai timeline-web <profile> --findings /tmp/findings.json
-```
+Follow `PRINCIPLES.md §5` for the canonical evidence/timeline sequence, including:
 
-Then print to user the URL that `timeline-web` emitted (look for `http://127.0.0.1:PORT`
-in its stdout; `src/nsys_ai/web.py:674` hard-codes `127.0.0.1`, not `localhost`):
+- the `nsys-ai evidence build` and `nsys-ai timeline-web` commands,
+- printing the exact URL emitted by `timeline-web` (typically `http://127.0.0.1:PORT`),
+- WSL2/browser behavior, and
+- fail-soft handling when findings are empty or evidence generation fails.
 
-> "Timeline ready at http://127.0.0.1:PORT — open in browser to see findings overlay."
-
-**WSL2**: browser does NOT auto-open. Always print the exact URL emitted by `timeline-web`
-(typically `http://127.0.0.1:PORT`) — do not substitute `localhost` (on some systems it
-resolves to IPv6 ::1 and won't reach the server).
-
-**Fail-soft**: if `evidence build` produces empty `{"findings": []}`, still run `timeline-web`.
-Never block delivery on evidence failure.
+Do not restate or modify that procedure here; treat `PRINCIPLES.md §5` as the single source
+of truth.
 
 ### 6.2 3-part summary (Mode 1 framing)
 

--- a/skills/analyze/references/MFU.md
+++ b/skills/analyze/references/MFU.md
@@ -42,8 +42,10 @@ per-kernel operation. Using `full_model` FLOPs for one kernel ALWAYS gives MFU >
 ## Workflow 1: MFU for a Specific NVTX Region or Kernel
 
 ```
-Step 1  Use `get_gpu_peak_tflops()`
-        If error → ask user for GPU model and consult hardware.py
+Step 1  GPU peak TFLOPS is auto-detected by `region_mfu` from the profile GPU name.
+        No separate call needed unless auto-detection fails (see Step 5 error table).
+        To preview the GPU model: run `profile_health_manifest` (already done in Mode 1) and read the `gpu` field.
+        If GPU unknown → ask user for peak TFLOPS (BF16, dense, no sparsity) and pass via `-p peak_tflops=<value>`.
 
 Step 2  Discover the target name (mandatory — never guess):
         [Check NVTX first]
@@ -62,13 +64,14 @@ Step 3  Resolve model architecture — in this order, stop when resolved:
         C. Ask: "What model are you training? (e.g. LLaMA-7B = H=4096, L=32)"
            → End message. Wait.
 
-Step 4  Use `compute_theoretical_flops`:
-            operation=<see table above>, hidden_dim=H, seq_len=S, num_layers=L
+Step 4  Compute theoretical FLOPs via the skill:
+        nsys-ai skill run theoretical_flops <profile> --format json \
+            -p operation=<see table above> -p hidden_dim=H -p seq_len=S -p num_layers=L
         → {theoretical_flops: <value>}
 
-Step 5  Use `compute_region_mfu`:
-            name="<from step 2>", theoretical_flops=<from step 4>,
-            source="nvtx" (or "kernel"), peak_tflops=<from step 1>, num_gpus=<world_size>
+Step 5  Compute region MFU via the skill:
+        nsys-ai skill run region_mfu <profile> --format json \
+            -p name="<from step 2>" -p theoretical_flops=<from step 4>
         → {mfu_pct_wall, mfu_pct_kernel_union, wall_time_s, kernel_count, ...}
 
 Step 6  Sanity check — MANDATORY before reporting:
@@ -88,7 +91,9 @@ Step 7  Interpret in context:
 ## Workflow 2: Step-Level MFU (Whole Training Throughput)
 
 ```
-Step 1  Use `get_gpu_peak_tflops()`
+Step 1  GPU peak TFLOPS is auto-detected by `region_mfu` from the profile.
+        To preview GPU model: read the `gpu` field from `profile_health_manifest` output (already run in Mode 1).
+        If GPU unknown → ask user for peak TFLOPS (BF16, dense, no sparsity); pass via `-p peak_tflops=<value>`.
 
 Step 2  Get a SINGLE representative step time (not the whole profile span):
         Option A — NVTX marker (preferred):
@@ -107,13 +112,15 @@ Step 3  Ask for model architecture:
          and whether this is forward-only, forward+backward, or with gradient checkpointing?"
         → End message. Wait. Use model table above if name is known.
 
-Step 4  Use `compute_theoretical_flops`:
-            operation="full_model", hidden_dim=H, seq_len=S, num_layers=L,
-            batch_size=B, multiplier=<1/3/4>
+Step 4  Compute theoretical FLOPs:
+        nsys-ai skill run theoretical_flops <profile> --format json \
+            -p operation=full_model -p hidden_dim=H -p seq_len=S -p num_layers=L \
+            -p batch_size=B -p multiplier=<1/3/4>
 
-Step 5  Use `compute_mfu`:
-            step_time_s=<step 2>, model_flops_per_step=<step 4 value>, peak_tflops=<step 1>
-        → {MFU_pct, achieved_model_TFLOPS}
+Step 5  Compute MFU:
+        nsys-ai skill run region_mfu <profile> --format json \
+            -p name="<step region>" -p theoretical_flops=<step 4 value>
+        → {mfu_pct_wall, mfu_pct_kernel_union, wall_time_s, ...}
 
 Step 6  Contextualise:
         < 20%  → significant problem; check NCCL, batch size, mixed precision

--- a/skills/analyze/references/MFU.md
+++ b/skills/analyze/references/MFU.md
@@ -48,10 +48,22 @@ Step 1  GPU peak TFLOPS is auto-detected by `region_mfu` from the profile GPU na
         If GPU unknown → ask user for peak TFLOPS (BF16, dense, no sparsity) and pass via `-p peak_tflops=<value>`.
 
 Step 2  Discover the target name (mandatory — never guess):
-        [Check NVTX first]
+        Prefer the CLI helpers which handle schema differences automatically:
+          nsys-ai search --nvtx <keyword> <profile>
+          nsys-ai tree <profile>
+
+        If using raw SQL, first check which columns exist:
+          PRAGMA table_info(NVTX_EVENTS)
+        Then pick the appropriate query:
+
+        [NVTX_EVENTS has textId column]
         SELECT DISTINCT COALESCE(n.text, s.value) AS name
         FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId=s.id
         WHERE COALESCE(n.text, s.value) IS NOT NULL LIMIT 30
+
+        [NVTX_EVENTS has only text column (no textId)]
+        SELECT DISTINCT text AS name FROM NVTX_EVENTS
+        WHERE text IS NOT NULL LIMIT 30
 
         [If no NVTX or targeting a kernel directly]
         SELECT DISTINCT s.value FROM StringIds s

--- a/skills/analyze/references/MFU.md
+++ b/skills/analyze/references/MFU.md
@@ -1,0 +1,149 @@
+# Skill: MFU Analysis
+
+Read this when the user asks about GPU efficiency, MFU, or TFLOPS utilization.
+**Read `PRINCIPLES.md` first** for rules, error handling, and tool definitions.
+
+---
+
+## Common Models Reference
+
+| Model | H (hidden) | L (layers) | ffn | Notes |
+|-------|-----------|-----------|-----|-------|
+| LLaMA-7B | 4096 | 32 | 11008 | SwiGLU, ffn≈2.69×H |
+| LLaMA-13B | 5120 | 40 | 13824 | |
+| LLaMA-70B / 65B | 8192 | 80 | 28672 | |
+| LLaMA-3.1-8B | 4096 | 32 | 14336 | |
+| Mistral-7B | 4096 | 32 | 14336 | GQA |
+| GPT-3 175B | 12288 | 96 | 49152 | Dense transformer |
+| Falcon-7B | 4544 | 32 | 18176 | MQA |
+| Falcon-40B | 8192 | 60 | 32768 | |
+
+---
+
+## Operation → FLOPs Mapping
+
+| Target kernel / region | `operation` arg | FLOPs (per layer) |
+|------------------------|-----------------|-------------------|
+| `flash_fwd`, `flash_bwd` | `"attention"` | 4·S²·H |
+| QKV linear projection | `"qkv_proj"` | 6·S·H² |
+| Output projection | `"output_proj"` | 2·S·H² |
+| FFN / MLP (up+gate+down) | `"mlp"` | 4·S·H·ffn |
+| One full transformer layer | `"full_layer"` | sum of above |
+| NVTX wrapping fwd pass | `"full_model"`, multiplier=1 | per_layer × L |
+| NVTX wrapping fwd+bwd | `"full_model"`, multiplier=3 | (no checkpointing) |
+| NVTX fwd+bwd+recompute | `"full_model"`, multiplier=4 | (gradient ckpt) |
+| Generic GEMM | `"linear"` | 2·M·N·K |
+
+**CRITICAL**: If the target is a SINGLE kernel type (e.g. `flash_fwd`), use the narrow
+per-kernel operation. Using `full_model` FLOPs for one kernel ALWAYS gives MFU > 100%.
+
+---
+
+## Workflow 1: MFU for a Specific NVTX Region or Kernel
+
+```
+Step 1  Use `get_gpu_peak_tflops()`
+        If error → ask user for GPU model and consult hardware.py
+
+Step 2  Discover the target name (mandatory — never guess):
+        [Check NVTX first]
+        SELECT DISTINCT COALESCE(n.text, s.value) AS name
+        FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId=s.id
+        WHERE COALESCE(n.text, s.value) IS NOT NULL LIMIT 30
+
+        [If no NVTX or targeting a kernel directly]
+        SELECT DISTINCT s.value FROM StringIds s
+        JOIN CUPTI_ACTIVITY_KIND_KERNEL k ON k.shortName=s.id
+        WHERE s.value LIKE '%<keyword>%' LIMIT 20
+
+Step 3  Resolve model architecture — in this order, stop when resolved:
+        A. User named the model → use the table above
+        B. Infer H from kernel timing: flash_fwd avg_ms ≈ 4·S²·H / (peak_tflops·1e12)
+        C. Ask: "What model are you training? (e.g. LLaMA-7B = H=4096, L=32)"
+           → End message. Wait.
+
+Step 4  Use `compute_theoretical_flops`:
+            operation=<see table above>, hidden_dim=H, seq_len=S, num_layers=L
+        → {theoretical_flops: <value>}
+
+Step 5  Use `compute_region_mfu`:
+            name="<from step 2>", theoretical_flops=<from step 4>,
+            source="nvtx" (or "kernel"), peak_tflops=<from step 1>, num_gpus=<world_size>
+        → {mfu_pct_wall, mfu_pct_kernel_union, wall_time_s, kernel_count, ...}
+
+Step 6  Sanity check — MANDATORY before reporting:
+        • mfu_pct_wall > 100% → operation scope too wide; use narrower operation from table
+        • mfu_pct_wall < 1%   → name match failed (check kernel_count) or FLOPs too low
+        • 40–80%              → healthy compute-bound
+        • < 30%               → possible memory bandwidth bottleneck
+
+Step 7  Interpret in context:
+        • flash_fwd: typical vendor benchmark is 60–70% for standard LLM configs
+        • Full training step: PaLM/Chinchilla ~46%, LLaMA ~38–45%
+        Always state whether MFU is "forward-only" or "forward+backward" to avoid confusion.
+```
+
+---
+
+## Workflow 2: Step-Level MFU (Whole Training Throughput)
+
+```
+Step 1  Use `get_gpu_peak_tflops()`
+
+Step 2  Get a SINGLE representative step time (not the whole profile span):
+        Option A — NVTX marker (preferred):
+          SELECT COALESCE(n.text, s.value) AS name, ([end]-start)/1e6 AS ms
+          FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId=s.id
+          WHERE name LIKE '%sample%' OR name LIKE '%step%' OR name LIKE '%iter%'
+          ORDER BY start LIMIT 10
+          → Skip index 0 (JIT); use median duration across iterations
+
+        Option B — No NVTX (rough upper bound):
+          SELECT (MAX([end]) - MIN(start)) / 1e9 AS total_span_s FROM CUPTI_ACTIVITY_KIND_KERNEL
+          ⚠ This includes warmup + all iterations combined. Tell user it will understate MFU.
+
+Step 3  Ask for model architecture:
+        "I need: model name (or hidden_dim, num_layers, seq_len), batch_size per GPU,
+         and whether this is forward-only, forward+backward, or with gradient checkpointing?"
+        → End message. Wait. Use model table above if name is known.
+
+Step 4  Use `compute_theoretical_flops`:
+            operation="full_model", hidden_dim=H, seq_len=S, num_layers=L,
+            batch_size=B, multiplier=<1/3/4>
+
+Step 5  Use `compute_mfu`:
+            step_time_s=<step 2>, model_flops_per_step=<step 4 value>, peak_tflops=<step 1>
+        → {MFU_pct, achieved_model_TFLOPS}
+
+Step 6  Contextualise:
+        < 20%  → significant problem; check NCCL, batch size, mixed precision
+        30–45% → typical well-tuned single-node training
+        45–60% → good; Flash Attention likely in use
+        > 60%  → excellent; publication-grade efficiency
+```
+
+---
+
+## Acceptance Criteria
+
+Before delivering MFU results, verify:
+
+- [ ] MFU between 0% and 100% (if > 100%, recompute with narrower operation)
+- [ ] `theoretical_flops` came from a theoretical FLOPs calculator, not estimated by hand
+- [ ] NVTX or kernel name came from a query (not guessed)
+- [ ] Step time is from a SINGLE representative iteration (not full profile kernel span)
+- [ ] `operation` matches the exact scope of the measured region/kernel
+- [ ] Result states forward-only or forward+backward to avoid ambiguity
+
+Also run global checklist in `PRINCIPLES.md`.
+
+---
+
+## Error Handling
+
+| Signal | Action |
+|--------|--------|
+| `mfu_pct_wall > 100%` | Recompute with narrower `operation`; explain to user |
+| `kernel_count = 0` | Report KERNEL_NOT_FOUND; try `source="kernel"` or fix name substring |
+| GPU unknown | Ask user for `peak_tflops` (BF16/FP16, dense, no sparsity) |
+| Model name not in table | Ask user for `hidden_dim`, `num_layers`, `seq_len` |

--- a/skills/analyze/references/MFU.md
+++ b/skills/analyze/references/MFU.md
@@ -109,10 +109,26 @@ Step 1  GPU peak TFLOPS is auto-detected by `region_mfu` from the profile.
 
 Step 2  Get a SINGLE representative step time (not the whole profile span):
         Option A — NVTX marker (preferred):
+          Prefer the CLI skill which handles schema differences automatically:
+            nsys-ai skill run iteration_timing <profile> --format json
+            → Skip index 0 (JIT); use median duration across iterations
+
+          If using raw SQL, check schema first: PRAGMA table_info(NVTX_EVENTS)
+
+          [NVTX_EVENTS has textId column]
           SELECT COALESCE(n.text, s.value) AS name, ([end]-start)/1e6 AS ms
           FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId=s.id
-          WHERE name LIKE '%sample%' OR name LIKE '%step%' OR name LIKE '%iter%'
+          WHERE COALESCE(n.text, s.value) LIKE '%sample%'
+             OR COALESCE(n.text, s.value) LIKE '%step%'
+             OR COALESCE(n.text, s.value) LIKE '%iter%'
           ORDER BY start LIMIT 10
+
+          [NVTX_EVENTS has only text column]
+          SELECT text AS name, ([end]-start)/1e6 AS ms
+          FROM NVTX_EVENTS
+          WHERE text LIKE '%sample%' OR text LIKE '%step%' OR text LIKE '%iter%'
+          ORDER BY start LIMIT 10
+
           → Skip index 0 (JIT); use median duration across iterations
 
         Option B — No NVTX (rough upper bound):

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -99,10 +99,10 @@ nsys-ai evidence build <profile> --format json -o /tmp/findings.json
 nsys-ai timeline-web <profile> --findings /tmp/findings.json
 ```
 
-Then tell the user:
-> "Timeline ready at http://localhost:PORT — open in browser to see findings overlay."
+Then tell the user the exact URL emitted by `timeline-web` (look for `http://127.0.0.1:PORT` in its stdout):
+> "Timeline ready at http://127.0.0.1:PORT — open in browser to see findings overlay."
 
-**WSL2**: browser does NOT auto-open. Always print the URL.
+**WSL2**: browser does NOT auto-open. Always print the exact URL emitted by `timeline-web` — do not substitute `localhost` (on some systems it resolves to IPv6 ::1 and won't reach the server).
 
 ### §5.2 Mode-specific findings override (optional)
 
@@ -143,18 +143,22 @@ supplies from manifest: `gpu` = first device in `overlap.available_devices` or 0
 When Mode 1's §2.2 auto-retry picks device N, or when any mode filters per device, pass
 `-p device=N`. Not all 33 skills accept it. Verified against `src/nsys_ai/skills/builtins/`.
 
-### §6.1 Accepts `-p device=N` (11 skills)
+### §6.1 Accepts `-p device=N` (13 skills)
 
 `profile_health_manifest`, `overlap_breakdown`, `nccl_breakdown`,
 `nccl_communicator_analysis`, `kernel_overlap_matrix`, `memory_bandwidth`,
-`iteration_timing`, `iteration_detail`, `arithmetic_intensity`, `region_mfu`,
-`stream_concurrency`.
+`iteration_timing`, `iteration_detail`, `arithmetic_intensity`,
+`gpu_idle_gaps`, `kernel_instances`, `h2d_distribution`, `root_cause_matcher`.
 
-### §6.2 Does NOT accept device — use `--iteration N` or `--trim` (12 skills)
+### §6.1a Accepts `-p device_id=N` (1 skill)
+
+`region_mfu` — uses `device_id` (not `device`) as the parameter name.
+
+### §6.2 Does NOT accept device — use `--iteration N` or `--trim` (9 skills)
 
 `top_kernels`, `tensor_core_usage`, `kernel_launch_overhead`, `cpu_gpu_pipeline`,
-`gpu_idle_gaps`, `sync_cost_analysis`, `kernel_instances`, `nvtx_layer_breakdown`,
-`nvtx_kernel_map`, `memory_transfers`, `h2d_distribution`, `root_cause_matcher`.
+`sync_cost_analysis`, `nvtx_layer_breakdown`, `nvtx_kernel_map`,
+`memory_transfers`, `stream_concurrency`.
 
 ### §6.3 Not device-scoped (10 skills)
 
@@ -231,7 +235,7 @@ After any mode completes, verify:
 - [ ] File:line fix when local source code accessible
 - [ ] No `SELECT *` used
 - [ ] Time values converted from ns (÷ 1e6 ms, ÷ 1e9 s)
-- [ ] §5 evidence step ran; `localhost:PORT` URL printed
+- [ ] §5 evidence step ran; `http://127.0.0.1:PORT` URL printed
 
 ---
 

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -1,0 +1,246 @@
+# nsys-ai Plugin Principles
+
+Source of truth for all `/analyze` modes. **Read this file before any mode runs.**
+Sections §4–§7 are pinned against `docs/claude-skill-plan.md` (§4 catalogue, §5.10 evidence,
+§8.5 device propagation, §7 fail template). Do not duplicate this content in mode refs.
+
+---
+
+## §1 Identity
+
+You are a **CUDA ML Systems Performance Expert** invoked via the `/analyze` slash command
+(see `../SKILL.md`). Your job: turn an NVIDIA Nsight Systems profile (`.sqlite` or
+`.nsys-rep`) into one root cause + one actionable fix within each mode's turn budget.
+
+---
+
+## §2 Core Discipline
+
+- **Use real tools** — Never compute FLOPs, MFU, or time deltas yourself. Call the
+  `theoretical_flops`, `region_mfu`, `arithmetic_intensity` skills.
+- **Discover before acting** — Never guess kernel or NVTX names. Query `StringIds` or
+  `NVTX_EVENTS` first (via `nsys-ai search`, `nsys-ai tree`, or relevant skills).
+- **JSON is ground truth** — Skill outputs are JSON. Parse them; do not summarize numbers
+  from prose. Pass `theoretical_flops` value directly between calls.
+- **Time is nanoseconds** — DB values are ns. Divide by 1e6 for ms, 1e9 for s.
+- **Correlate with source code** — If user's local `.py` files exist alongside the profile,
+  cross-reference NVTX regions with actual code; propose file:line fixes.
+
+---
+
+## §3 Non-negotiable Rules
+
+1. **MFU > 100% is always wrong.** Scope too wide. Stop, recompute with narrower `operation`.
+2. **Never use `SELECT *`.** Always name specific columns.
+3. **Search before diff.** Never pass a guessed NVTX name to `nsys-ai diff`. Use
+   `nsys-ai search --nvtx <keyword>` or `nsys-ai tree <profile>` first.
+4. **Skip iteration 0** in Mode 3 MFU and Mode 8 diff — JIT compilation inflates it.
+5. **Multi-iteration profiles**: never use whole-profile span as single-step time. Use
+   NVTX iteration markers via the `iteration_timing` skill.
+6. **Root cause statements must explain the mechanism** — never "it got slower" alone.
+   Always state: what changed, evidence field+value, what to do.
+7. **End your message before waiting for user input.** Ask → end message → wait. Do not
+   proceed without the answer.
+
+---
+
+## §4 CLI-level Precondition Guards
+
+Plugin guards eight code-level breaks **before** running any skill. Nine scenarios are
+handled silently by `nsys-ai` (plugin stays invisible there). Three user-choice fallbacks
+use the §7 template but offer an alternative path (not a hard block).
+
+### §4.1 Breaks — surface error via §7 template, then abort
+
+| # | Scenario | Code evidence | Plugin action |
+|---|----------|--------------|---------------|
+| 1 | `.nsys-rep` given + `nsys` not on PATH | `src/nsys_ai/profile.py:752` `ExportToolMissingError` | Pre-check `command -v nsys`; direct to Nsight install |
+| 2 | `nsys export` timeout (>300 s) | `profile.py:779-785` `ExportTimeoutError` | "License prompt or corrupt .nsys-rep; try `nsys status -p`" |
+| 3 | Profile has no kernel table | `profile.py:269-277` `SchemaError` | Halt; "profile contains no GPU kernel activity" |
+| 4 | Corrupted `.sqlite`, no `.nsys-rep` sidecar | `sqlite3.DatabaseError` on first query | "re-export from .nsys-rep if available" |
+| 5 | Mode 7 tool chain incomplete | `cutracer/installer.py:70-117` (nvcc / g++ / make / git / libzstd-dev) | Show exact `apt-get install` from error; stop |
+| 6 | Mode 7 on host without GPU AND user declined Modal | `cutracer/runner.py` subprocess fails | Pre-check `nvidia-smi`; §4.3 row 2 first |
+| 7 | Mode 8 paths resolve to same inode | Not validated in `diff.py` | Plugin `os.stat().st_ino` compare; stop before `nsys-ai diff` |
+| 8 | Mode 9 empty `iteration_timing` | Skill returns `[]` when no NVTX step markers | Offer Mode 5 Path B (see §4.3 row 3) |
+
+### §4.2 Auto-handled — plugin must NOT ask the user
+
+| Scenario | Code evidence |
+|----------|--------------|
+| `.nsys-rep` + `nsys` on PATH | `profile.py:711-801` subprocess `nsys export --type=sqlite --include-blobs=true` |
+| Cached `.sqlite` older than `.nsys-rep` | `profile.py:729-737` mtime check → re-export |
+| NVTX table missing | `profile.py:298-301` returns `[]` |
+| Device 0 empty (multi-GPU) | `overlap.py:49-77` diag with `available_devices` |
+| Diff: GPU id missing in one side | `diff.py:113-120` treats as 0 kernels |
+| CUTracer `.so` not built | `cutracer/runner.py:99-105` kernel-launch-logger fallback |
+| Framework unrecognised | `fingerprint.py:67` → "Generic CUDA" |
+| Profile ≥ 50 MB | `profile.py:216-229` direct-query mode |
+| Profiler overhead > 1% | Manifest `data_quality.overhead_pct`; plugin notes but doesn't block |
+
+### §4.3 User-choice fallbacks — §7 template with real alternative
+
+| # | Scenario | Used in | Alternative offered |
+|---|----------|---------|---------------------|
+| 1 | NVTX absent (no annotations) | Mode 5 | Path B (kernel-name heuristics, no layer attribution) OR abort |
+| 2 | No GPU on host | Mode 7 | Modal backend (`--backend modal`) OR abort |
+| 3 | No NVTX step markers | Mode 9 | Mode 5 Path B OR abort |
+
+---
+
+## §5 Universal Evidence & Delivery
+
+Every Mode 1–9 ends with this sequence between skill execution and the 3-part summary.
+**Single source of truth**; mode refs point here rather than restating.
+
+### §5.1 CLI sequence
+
+```bash
+nsys-ai evidence build <profile> --format json -o /tmp/findings.json
+nsys-ai timeline-web <profile> --findings /tmp/findings.json
+```
+
+Then tell the user:
+> "Timeline ready at http://localhost:PORT — open in browser to see findings overlay."
+
+**WSL2**: browser does NOT auto-open. Always print the URL.
+
+### §5.2 Mode-specific findings override (optional)
+
+If the auto-builder misses the mode's highlight, craft `findings.json` manually via
+`nsys-ai skill run kernel_instances <profile> --format json -p name=<hot>` for ns-level
+timestamps. Example for Mode 8 regression overlay:
+
+```json
+{"findings": [{"type": "regression", "label": "flash_bwd +31%",
+  "start_ns": 12340000, "end_ns": 15670000, "severity": "critical"}]}
+```
+
+Then `nsys-ai timeline-web <profile> --findings <custom.json>`.
+
+### §5.3 Fail-soft rule
+
+If `evidence build` fails (profile has no detectable pattern), emit `{"findings": []}`
+and still run `timeline-web`. User sees an unannotated timeline; delivery proceeds. **Never
+block delivery on evidence-step failure.**
+
+### §5.4 Optional text report
+
+Only on explicit user request ("save this", "generate report", "markdown report"):
+
+```bash
+nsys-ai report <profile> --gpu <device_id> --trim <start_s> <end_s> -o report.md
+```
+
+Both `--gpu` and `--trim` are required (verified `src/nsys_ai/cli/parsers.py:289`). Plugin
+supplies from manifest: `gpu` = first device in `overlap.available_devices` or 0; `trim`
+= smart-trim iteration range (if Mode 1 Stage 3 was taken) else
+`0 profile_span_ms/1000`. Slow on large profiles — confirm before running.
+
+---
+
+## §6 Device Propagation Table
+
+When Mode 1's §2.2 auto-retry picks device N, or when any mode filters per device, pass
+`-p device=N`. Not all 33 skills accept it. Verified against `src/nsys_ai/skills/builtins/`.
+
+### §6.1 Accepts `-p device=N` (11 skills)
+
+`profile_health_manifest`, `overlap_breakdown`, `nccl_breakdown`,
+`nccl_communicator_analysis`, `kernel_overlap_matrix`, `memory_bandwidth`,
+`iteration_timing`, `iteration_detail`, `arithmetic_intensity`, `region_mfu`,
+`stream_concurrency`.
+
+### §6.2 Does NOT accept device — use `--iteration N` or `--trim` (12 skills)
+
+`top_kernels`, `tensor_core_usage`, `kernel_launch_overhead`, `cpu_gpu_pipeline`,
+`gpu_idle_gaps`, `sync_cost_analysis`, `kernel_instances`, `nvtx_layer_breakdown`,
+`nvtx_kernel_map`, `memory_transfers`, `h2d_distribution`, `root_cause_matcher`.
+
+### §6.3 Not device-scoped (10 skills)
+
+`kernel_launch_pattern`, `thread_utilization`, `module_loading`, `gc_impact`,
+`nccl_anomaly`, `pipeline_bubble_metrics`, `schema_inspect`, `theoretical_flops`,
+`speedup_estimator`, `cutracer_analysis`.
+
+---
+
+## §7 Precondition-fail UX Template
+
+Every §4.1 block and every §4.3 fallback renders via this exact shape. **No mode overrides.**
+
+```
+<Mode N blocked [or "requires a user choice"]>
+
+Why: <one-line diagnosis from §4.1 or §4.3 table>
+Fix: <concrete shell command or config change>
+Alternative: <other mode/backend that may work, if applicable>
+
+Reply with <options>, or "stop" to abort.
+```
+
+### §7.1 Rendered examples
+
+| Source | Rendered |
+|--------|---------|
+| §4.1 row 1 | "Mode 1 blocked. Why: `.nsys-rep` requires `nsys` to convert. Fix: install Nsight Systems (https://developer.nvidia.com/nsight-systems). Alternative: give me a pre-exported .sqlite instead." |
+| §4.1 row 3 | "Mode 1 blocked. Why: profile has no GPU kernel table — CUPTI not enabled or capture range missed GPU work. Fix: re-profile without `--capture-range`. Alternative: none." |
+| §4.1 row 7 | "Mode 8 blocked. Why: both paths resolve to the same file. Fix: provide two distinct profiles. Alternative: Mode 1 for single-profile analysis." |
+| §4.1 row 3 in Mode 8 | "Mode 8 blocked (before=`a.sqlite`, after=`b.sqlite`): `b.sqlite` has no kernel table. Fix: re-export or pick a valid profile." |
+| §4.3 row 1 | "Mode 5 requires a user choice. Why: no NVTX annotations. Fix: add `torch.cuda.nvtx.range` and re-profile. Alternative: Path B (kernel heuristics). Reply `B`, re-profile, or `stop`." |
+| §4.3 row 2 | "Mode 7 requires a user choice. Why: no GPU detected on this host. Fix: run on GPU-enabled host. Alternative: Modal backend, ~$<X> at H100 default (see M7_CUTRACER.md cost formula). Reply `modal`, `local-gpu-ready`, or `stop`." |
+
+---
+
+## §8 Error Handling (skill-level signals)
+
+| Error signal | Required action |
+|--------------|-----------------|
+| `MFU > 100%` | Recompute with narrower operation; explain the error |
+| `kernel_count = 0` | Corresponds to §4.1 row 3 |
+| `is_aligned=false` in diff | Warn; use global diff (no `--iteration`) |
+| `Hardware_Warning=true` | Thermal throttle likely; re-run before concluding |
+| `JIT_Compilation_Warning=true` | Skip iteration 0; use index ≥ 1 |
+| `iteration_count = 1` | Profile too short; ask user to re-profile with ≥ 3 iters |
+| GPU unknown in manifest | Ask user for peak TFLOPS (BF16, dense, no sparsity) |
+| SQLite error | Verify column names with `PRAGMA table_info` |
+
+---
+
+## §9 Performance Notes
+
+- **DuckDB + Parquet default.** First open exports SQLite → `<profile>.nsys-cache/`
+  ZSTD Parquet. Subsequent opens sub-second. Falls back to direct SQLite automatically.
+- **Large profiles** (>100 MB): narrow the window via `--trim START_S END_S` on `skill run`.
+  Best practice: profile 1–2 representative iterations, not the entire run.
+- **Costliest skills** on big files: `nvtx_kernel_map`, `nvtx_layer_breakdown`,
+  `gpu_idle_gaps`. Trim before running.
+- **Auto-indexing**: one-time ~30 s cost for 250 MB profiles; speeds up subsequent queries.
+
+---
+
+## §10 Acceptance Checklist
+
+After any mode completes, verify:
+
+- [ ] MFU values are between 0% and 100%
+- [ ] `theoretical_flops` came from the skill, not estimated
+- [ ] NVTX / kernel names came from a query, not guessed
+- [ ] Step time from a single representative iteration (not full profile span)
+- [ ] Mode 8 diff skipped iteration 0
+- [ ] Root-cause statement includes: cause + evidence field+value + recommendation
+- [ ] File:line fix when local source code accessible
+- [ ] No `SELECT *` used
+- [ ] Time values converted from ns (÷ 1e6 ms, ÷ 1e9 s)
+- [ ] §5 evidence step ran; `localhost:PORT` URL printed
+
+---
+
+## §11 Pin to Plan
+
+§4–§7 are pinned against `docs/claude-skill-plan.md`:
+- §4 mirrors plan §4 (CLI-level precondition catalogue)
+- §5 mirrors plan §5.10 (universal evidence step)
+- §6 mirrors plan §8.5 (device propagation)
+- §7 mirrors plan §7 (fail template)
+
+If the plan diverges, update this file in the same PR to keep them in sync.

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -61,7 +61,7 @@ use the §7 template but offer an alternative path (not a hard block).
 | 5 | Mode 7 tool chain incomplete | `cutracer/installer.py:70-117` (nvcc / g++ / make / git / libzstd-dev) | Show exact `apt-get install` from error; stop |
 | 6 | Mode 7 on host without GPU AND user declined Modal | `cutracer/runner.py` subprocess fails | Pre-check `nvidia-smi`; §4.3 row 2 first |
 | 7 | Mode 8 paths resolve to same inode | Not validated in `diff.py` | Plugin `os.stat().st_ino` compare; stop before `nsys-ai diff` |
-| 8 | Mode 9 empty `iteration_timing` | Skill returns `[]` when no NVTX step markers | Offer Mode 5 Path B (see §4.3 row 3) |
+| 8 | Mode 9 empty `iteration_timing` | Skill returns `[]` only after NVTX matching and kernel-gap heuristic fallback both fail, or required runtime tables are unavailable | Offer Mode 5 Path B (see §4.3 row 3) |
 
 ### §4.2 Auto-handled — plugin must NOT ask the user
 

--- a/skills/analyze/references/SKILLS_REF.md
+++ b/skills/analyze/references/SKILLS_REF.md
@@ -3,7 +3,7 @@
 **Always start with**: `profile_health_manifest` (one-shot triage, ~2 s, returns everything)
 
 **Token budget**: add `--max-rows N` to limit JSON output size.
-Default cap: 50 rows. Use 10–20 for large profiles.
+No default row cap is applied; use `--max-rows` explicitly if you want to truncate output. For large profiles, 10–20 rows is often a good starting point.
 
 **Trim**: add `--trim START_S END_S` or `--iteration N` to all skills.
 

--- a/skills/analyze/references/SKILLS_REF.md
+++ b/skills/analyze/references/SKILLS_REF.md
@@ -1,0 +1,131 @@
+# Skills Quick Reference
+
+**Always start with**: `profile_health_manifest` (one-shot triage, ~2 s, returns everything)
+
+**Token budget**: add `--max-rows N` to limit JSON output size.
+Default cap: 50 rows. Use 10–20 for large profiles.
+
+**Trim**: add `--trim START_S END_S` or `--iteration N` to all skills.
+
+**Run syntax**:
+```bash
+nsys-ai skill run <skill_name> <profile> --format json [-p key=value ...]
+```
+
+---
+
+## Utility (start here)
+
+| Skill | Description |
+|-------|-------------|
+| `profile_health_manifest` | One-shot: GPU, top-5 kernels, overlap %, NCCL summary, idle %, root causes, `suspected_bottleneck` |
+| `schema_inspect` | List all tables + columns (run if unsure about schema) |
+
+---
+
+## Kernels
+
+| Skill | Params | Description |
+|-------|--------|-------------|
+| `top_kernels` | `limit=15` | Heaviest kernels by total time |
+| `tensor_core_usage` | — | FP32 fallback detection — are tensor cores active? |
+| `kernel_instances` | `name=<kernel>` ✅ | Exact ns timestamps per kernel instance → use for findings.json |
+| `kernel_launch_overhead` | — | CPU dispatch latency per kernel |
+| `kernel_launch_pattern` | — | Per-stream burst density, sync-stall detection |
+| `stream_concurrency` | — | Multi-stream concurrency analysis |
+| `gpu_idle_gaps` | `min_gap_ns=1000000` | Idle gaps with CPU attribution |
+| `region_mfu` | `name` ✅, `theoretical_flops` ✅ | MFU for a named NVTX region |
+| `theoretical_flops` | `operation` ✅, `hidden_dim` ✅, `seq_len` ✅ | Exact FLOPs for transformer ops |
+| `arithmetic_intensity` | `theoretical_flops` ✅ | Roofline: compute-bound vs memory-bound |
+
+✅ = required parameter
+
+---
+
+## Communication
+
+| Skill | Description |
+|-------|-------------|
+| `nccl_breakdown` | NCCL ops by stream × collective (infer TP/PP/DP from stream) |
+| `overlap_breakdown` | Compute/NCCL overlap %. >60% = NCCL well-hidden |
+| `nccl_communicator_analysis` | Communicator-level NCCL efficiency (needs NVTX payload tables) |
+| `nccl_anomaly` | Outlier NCCL ops vs median [`threshold=3.0`] |
+| `kernel_overlap_matrix` | Pairwise overlap: comm×comm, comm×compute |
+
+---
+
+## Memory
+
+| Skill | Description |
+|-------|-------------|
+| `memory_bandwidth` | Per-direction throughput, peak vs sustained |
+| `memory_transfers` | H2D/D2H/D2D/P2P breakdown with counts |
+| `h2d_distribution` | H2D transfer pattern: init-heavy / spread-out / spike |
+
+---
+
+## NVTX / Code Attribution
+
+| Skill | Params | Description |
+|-------|--------|-------------|
+| `nvtx_layer_breakdown` | — | NVTX region GPU time breakdown with top kernels per region |
+| `nvtx_kernel_map` | — | NVTX annotation → GPU kernel mapping (source attribution) |
+| `iteration_timing` | `marker=sample_0` | Per-iteration timing |
+| `iteration_detail` | `iteration` ✅ | Kernel breakdown for one iteration |
+
+---
+
+## System
+
+| Skill | Description |
+|-------|-------------|
+| `cpu_gpu_pipeline` | CPU dispatch lead time, GPU starvation events |
+| `thread_utilization` | CPU % per thread (DataLoader / GIL detection) |
+
+---
+
+## Bottlenecks
+
+| Skill | Description |
+|-------|-------------|
+| `module_loading` | JIT compilation + cuModuleLoad stalls |
+| `gc_impact` | cudaMalloc/cudaFree stalls + Python GC events |
+| `sync_cost_analysis` | CPU-side sync density + blocking cost (cudaStreamSynchronize, etc.) |
+| `pipeline_bubble_metrics` | True GPU idle % (interval merge, O(n log n)) |
+
+---
+
+## Analysis
+
+| Skill | Params | Description |
+|-------|--------|-------------|
+| `root_cause_matcher` | — | Auto-detect 12+ anti-patterns with evidence + fix |
+| `speedup_estimator` | `iteration_ms` ✅ | What-if: idle→X speedup, perfect overlap→Y |
+| `cutracer_analysis` | `trace_dir` ✅ | Instruction-mix classifier (memory/compute/sync-bound) |
+
+---
+
+## Common patterns
+
+```bash
+# Full triage starting point
+nsys-ai skill run profile_health_manifest profile.sqlite --format json
+
+# Top kernels, budget 20 rows
+nsys-ai skill run top_kernels profile.sqlite --format json --max-rows 20
+
+# NCCL deep dive
+nsys-ai skill run nccl_breakdown profile.sqlite --format json
+nsys-ai skill run overlap_breakdown profile.sqlite --format json
+
+# NVTX attribution
+nsys-ai skill run nvtx_layer_breakdown profile.sqlite --format json
+nsys-ai skill run nvtx_kernel_map profile.sqlite --format json
+
+# Root cause auto-detect
+nsys-ai skill run root_cause_matcher profile.sqlite --format json
+
+# Speedup estimate (needs iteration_ms from iteration_timing first)
+nsys-ai skill run iteration_timing profile.sqlite --format json
+nsys-ai skill run speedup_estimator profile.sqlite --format json -p iteration_ms=<value>
+```

--- a/skills/analyze/references/SKILLS_REF.md
+++ b/skills/analyze/references/SKILLS_REF.md
@@ -29,7 +29,7 @@ nsys-ai skill run <skill_name> <profile> --format json [-p key=value ...]
 |-------|--------|-------------|
 | `top_kernels` | `limit=15` | Heaviest kernels by total time |
 | `tensor_core_usage` | — | FP32 fallback detection — are tensor cores active? |
-| `kernel_instances` | `name=<kernel>` ✅ | Exact ns timestamps per kernel instance → use for findings.json |
+| `kernel_instances` | `name=<kernel>` (optional; omit to get longest kernels across the profile) | Exact ns timestamps per kernel instance → use for findings.json |
 | `kernel_launch_overhead` | — | CPU dispatch latency per kernel |
 | `kernel_launch_pattern` | — | Per-stream burst density, sync-stall detection |
 | `stream_concurrency` | — | Multi-stream concurrency analysis |

--- a/skills/analyze/references/VARIANCE.md
+++ b/skills/analyze/references/VARIANCE.md
@@ -42,8 +42,13 @@ Step 2  Classify the variance pattern:
         └────────────────────────────────────────┴──────────────────────────────────────────┘
 
 Step 3  Zoom into one slow iteration to confirm:
-        [Use navigate tools to get to the slow iteration window]
+        [CLI — preferred for Claude Code plugin]
+        nsys-ai skill run iteration_detail <profile> --format json -p iteration=<slow iter index>
+        or: nsys-ai skill run top_kernels <profile> --format json --iteration <slow iter index>
+
+        [Interactive UI/tooling only — not available from plugin today]
         `fit_nvtx_range`(nvtx_name="<iteration name>", occurrence_index=<slow iter index>)
+        (This is a navigate/UI tool; use the CLI alternatives above in the Claude Code plugin.)
 
         Query kernels in that window:
         SELECT s.value AS name, COUNT(*) AS cnt, SUM([end]-start)/1e6 AS ms

--- a/skills/analyze/references/VARIANCE.md
+++ b/skills/analyze/references/VARIANCE.md
@@ -9,6 +9,14 @@ or the user says "the profile looks choppy" / "some iterations spike".
 
 ```
 Step 1  Get per-iteration timing (requires NVTX iteration markers):
+        Prefer the CLI skill which handles schema differences automatically:
+          nsys-ai skill run iteration_timing <profile> --format json
+
+        If using raw SQL, first check which columns NVTX_EVENTS has:
+          PRAGMA table_info(NVTX_EVENTS)
+        Then pick the appropriate query:
+
+        [NVTX_EVENTS has textId column]
         SELECT COALESCE(n.text, s.value) AS name,
                ([end]-start)/1e6 AS duration_ms,
                start/1e9 AS start_s
@@ -18,14 +26,19 @@ Step 1  Get per-iteration timing (requires NVTX iteration markers):
            OR COALESCE(n.text, s.value) LIKE '%iter%'
         ORDER BY start LIMIT 50
 
+        [NVTX_EVENTS has only text column]
+        SELECT text AS name, ([end]-start)/1e6 AS duration_ms, start/1e9 AS start_s
+        FROM NVTX_EVENTS
+        WHERE text LIKE '%sample%' OR text LIKE '%step%' OR text LIKE '%iter%'
+        ORDER BY start LIMIT 50
+
         Compute statistics:
-        SELECT MIN(n.[end]-n.start)/1e6 AS min_ms,
-               MAX(n.[end]-n.start)/1e6 AS max_ms,
-               AVG(n.[end]-n.start)/1e6 AS avg_ms,
+        SELECT MIN([end]-start)/1e6 AS min_ms,
+               MAX([end]-start)/1e6 AS max_ms,
+               AVG([end]-start)/1e6 AS avg_ms,
                COUNT(*) AS n_iters
-        FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId=s.id
-        WHERE COALESCE(n.text, s.value) LIKE '%sample%'
-           OR COALESCE(n.text, s.value) LIKE '%step%'
+        FROM NVTX_EVENTS
+        WHERE text LIKE '%sample%' OR text LIKE '%step%'
 
         [If max_ms < 1.5 × avg_ms] → variance is normal; no problem to investigate
 

--- a/skills/analyze/references/VARIANCE.md
+++ b/skills/analyze/references/VARIANCE.md
@@ -8,9 +8,13 @@ or the user says "the profile looks choppy" / "some iterations spike".
 ## Workflow 7: Variance Diagnosis
 
 ```
-Step 1  Get per-iteration timing (requires NVTX iteration markers):
+Step 1  Get per-iteration timing (NVTX iteration markers preferred for best accuracy):
         Prefer the CLI skill which handles schema differences automatically:
           nsys-ai skill run iteration_timing <profile> --format json
+
+        This works best with NVTX iteration markers. If markers are missing or do not match,
+        `iteration_timing` falls back to a kernel-gap heuristic — the inferred iteration
+        boundaries are approximate and may be less reliable for some workloads.
 
         If using raw SQL, first check which columns NVTX_EVENTS has:
           PRAGMA table_info(NVTX_EVENTS)
@@ -32,13 +36,25 @@ Step 1  Get per-iteration timing (requires NVTX iteration markers):
         WHERE text LIKE '%sample%' OR text LIKE '%step%' OR text LIKE '%iter%'
         ORDER BY start LIMIT 50
 
-        Compute statistics:
+        Compute statistics (branch on the same schema check as above):
+
+        [NVTX_EVENTS has textId column]
+        SELECT MIN([end]-start)/1e6 AS min_ms,
+               MAX([end]-start)/1e6 AS max_ms,
+               AVG([end]-start)/1e6 AS avg_ms,
+               COUNT(*) AS n_iters
+        FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId=s.id
+        WHERE COALESCE(n.text, s.value) LIKE '%sample%'
+           OR COALESCE(n.text, s.value) LIKE '%step%'
+           OR COALESCE(n.text, s.value) LIKE '%iter%'
+
+        [NVTX_EVENTS has only text column]
         SELECT MIN([end]-start)/1e6 AS min_ms,
                MAX([end]-start)/1e6 AS max_ms,
                AVG([end]-start)/1e6 AS avg_ms,
                COUNT(*) AS n_iters
         FROM NVTX_EVENTS
-        WHERE text LIKE '%sample%' OR text LIKE '%step%'
+        WHERE text LIKE '%sample%' OR text LIKE '%step%' OR text LIKE '%iter%'
 
         [If max_ms < 1.5 × avg_ms] → variance is normal; no problem to investigate
 

--- a/skills/analyze/references/VARIANCE.md
+++ b/skills/analyze/references/VARIANCE.md
@@ -1,0 +1,87 @@
+# Skill: Iteration Variance
+
+Read this when some training steps are much slower than others,
+or the user says "the profile looks choppy" / "some iterations spike".
+
+---
+
+## Workflow 7: Variance Diagnosis
+
+```
+Step 1  Get per-iteration timing (requires NVTX iteration markers):
+        SELECT COALESCE(n.text, s.value) AS name,
+               ([end]-start)/1e6 AS duration_ms,
+               start/1e9 AS start_s
+        FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId=s.id
+        WHERE COALESCE(n.text, s.value) LIKE '%sample%'
+           OR COALESCE(n.text, s.value) LIKE '%step%'
+           OR COALESCE(n.text, s.value) LIKE '%iter%'
+        ORDER BY start LIMIT 50
+
+        Compute statistics:
+        SELECT MIN(n.[end]-n.start)/1e6 AS min_ms,
+               MAX(n.[end]-n.start)/1e6 AS max_ms,
+               AVG(n.[end]-n.start)/1e6 AS avg_ms,
+               COUNT(*) AS n_iters
+        FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId=s.id
+        WHERE COALESCE(n.text, s.value) LIKE '%sample%'
+           OR COALESCE(n.text, s.value) LIKE '%step%'
+
+        [If max_ms < 1.5 × avg_ms] → variance is normal; no problem to investigate
+
+Step 2  Classify the variance pattern:
+        ┌────────────────────────────────────────┬──────────────────────────────────────────┐
+        │ Pattern                                │ Likely cause                             │
+        ├────────────────────────────────────────┼──────────────────────────────────────────┤
+        │ Every Nth iteration (e.g. every 4th)   │ Gradient accumulation / eval step        │
+        │ First 2–3 iterations slow, rest OK     │ JIT compilation / CUDA cache warmup      │
+        │ Random spikes, no fixed period         │ DataLoader I/O (disk latency variance)   │
+        │ Slow iterations align with NCCL spikes │ NCCL retry / network instability         │
+        │ Duration increases gradually over time │ GPU thermal throttle                     │
+        │ Alternating fast/slow pairs            │ Double buffering / prefetch pipeline      │
+        └────────────────────────────────────────┴──────────────────────────────────────────┘
+
+Step 3  Zoom into one slow iteration to confirm:
+        [Use navigate tools to get to the slow iteration window]
+        `fit_nvtx_range`(nvtx_name="<iteration name>", occurrence_index=<slow iter index>)
+
+        Query kernels in that window:
+        SELECT s.value AS name, COUNT(*) AS cnt, SUM([end]-start)/1e6 AS ms
+        FROM CUPTI_ACTIVITY_KIND_KERNEL k JOIN StringIds s ON k.shortName=s.id
+        WHERE k.start >= <slow_iter_start_ns> AND k.[end] <= <slow_iter_end_ns>
+        GROUP BY k.shortName ORDER BY ms DESC LIMIT 20
+
+        Compare to a normal iteration. Look for: extra kernels, longer kernel durations,
+        large gaps (idle time), or NCCL spikes.
+
+Step 4  Report:
+        - What fraction of iterations are outliers (e.g. 3 out of 12 = 25%)
+        - Is it expected (eval loop, gradient accumulation) or unexpected (I/O, GC)?
+        - Specific recommendation:
+          DataLoader I/O → prefetch_factor, num_workers, pin_memory
+          JIT → skip first N steps in benchmark; profile after warmup
+          Thermal → use nvidia-smi to check GPU clocks; reduce power limit
+          NCCL retry → check network stability; NCCL_DEBUG=INFO logs
+```
+
+---
+
+## CLI-Based Drill-Down
+
+After Step 1, use the CLI skills for faster iteration:
+
+```bash
+# Step 1: Get per-iteration timing
+nsys-ai skill run iteration_timing profile.sqlite --format json
+
+# Step 3: Drill into a slow iteration (e.g. iteration 3)
+nsys-ai skill run iteration_detail profile.sqlite --format json -p iteration=3
+
+# Alternative: Use --iteration to auto-trim any skill to that iteration
+nsys-ai skill run top_kernels profile.sqlite --format json --iteration 3
+nsys-ai skill run gpu_idle_gaps profile.sqlite --format json --iteration 3
+nsys-ai skill run kernel_instances profile.sqlite --format json --iteration 3
+
+# Get exact ns timestamps for evidence overlay
+nsys-ai skill run kernel_instances profile.sqlite --format json --iteration 3 -p name=flash
+```


### PR DESCRIPTION
 ## Summary      
                                                                                                                 
  Ships the initial **nsys-ai Claude Code plugin** with the `/analyze` slash command.                            
  Stage A lands **Mode 1 (auto triage)** as the live entry point; Modes 2–9 are wired                            
  into the menu with "coming Stage B1/B2/C1/C2" annotations and keyword fall-through                             
  to Mode 1.                                                                                                     
                                                                                                                 
  This turns any NVIDIA Nsight Systems profile (`.sqlite` / `.nsys-rep`) into a                                  
  **root cause + actionable fix + timeline URL** inside Claude Code — no CLI
  knowledge required.                                                                                            
                  
  ## What's included                                                                                             
                  
  **Plugin entry point**
  - `.claude-plugin/plugin.json` — plugin metadata
  - `skills/analyze/SKILL.md` (121 lines) — 9-mode menu + priority keyword routing                               
                                                                                                                 
  **Mode 1 (live)**                                                                                              
  - `references/M1_AUTO.md` — precondition gate, stages (incl. smart-trim + silent                               
    device-0 auto-retry), skills, `profile_health_manifest` field contract,                                      
    3-part delivery                                                                                              
                                                                                                                 
  **Shared rules (pinned to `docs/claude-skill-plan.md`)**                                                       
  - `references/PRINCIPLES.md`
    - §4 — 8 CLI-level break guards + 9 auto-handled + 3 user-choice fallbacks                                   
      (each row cites code line)                                                                                 
    - §5 — universal `evidence build` + `timeline-web` step                                                      
    - §6 — device propagation table (11 accepts / 12 uses trim / 10 non-scoped)                                  
    - §7 — precondition-fail UX template                                                                         
                                                                                                                 
  **Future-stage drops (Mode 2–9)**                                                                              
  - `references/{DIFF,DISTRIBUTED,MFU,SKILLS_REF,VARIANCE}.md`                                                   
                                                                                                                 
  **CI**
  - `scripts/smoke_test.sh` — validates 30 drill-down CLI commands + Mode 1 E2E                                  
    evidence pipeline                                                                                            
   
  **Docs**                                                                                                       
  - `docs/claude-plugin.md` — overview
  - `docs/claude-plugin-quickstart.md` — 2-minute walkthrough                                                    
                                                                                                                 
  ## How to try it                                                                                               
                                                                                                                 
  ```bash         
  pip install "nsys-ai[agent]"
  git clone <this-repo> ~/.claude/skills/nsys-ai                                                                 
  # In Claude Code:                                                                                              
  /analyze report.nsys-rep why is my training slow?                                                              
                                                                                                                 
  Test plan                                                                                                      
   
  - Smoke test green on megatron_distca.sqlite and nano_vllm_qwen3_4b.sqlite                                     
  - Stage A acceptance: 5/5 pass
  - Manual Mode 1 run on vLLM profile produces: framework=vLLM +                                                 
  CPU-starved-idle root cause + CUDA graphs fix + 10.64× speedup estimate +                                      
  timeline URL                                                                                                   
  - Full test suite: 604 passed, 135 skipped, 0 failed                                                           
  - ruff check src/ tests/ clean                                                                                 
  - Reviewer verifies /analyze launches in Claude Code after
  git clone ... ~/.claude/skills/nsys-ai                                                                         
                                                                                                                 
  Out of scope (future PRs)                                                                                      
                                                                                                                 
  - Stage B1 — Mode 2 (Comms) + Mode 6 (Idle/Sync)                                                               
  - Stage B2 — Mode 3 (Compute) + Mode 4 (Memory) + Mode 5 (NVTX)
  - Stage C1 — Mode 7 (CUTracer SASS)                                                                            
  - Stage C2 — Mode 8 (Diff) + Mode 9 (Variance)  