### PR TITLE
 feat(plugin): Stage B1 — ship Mode 2 (Comms/NCCL) and Mode 6 (Idle/Sync) reference docs

### DIFF
--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -49,11 +49,11 @@ Otherwise, render the menu **once per session**:
 What would you like to analyze?
 
   1. Auto triage      — not sure where to start                  [default]
-  2. Comms            — NCCL / overlap / multi-GPU               (coming Stage B1)
+  2. Comms            — NCCL / overlap / multi-GPU
   3. Compute          — top kernels / tensor core / MFU          (coming Stage B2)
   4. Memory           — H2D / D2H / bandwidth                    (coming Stage B2)
   5. NVTX / code map  — which layer / step consumes time         (coming Stage B2)
-  6. Idle / sync      — GPU gaps, CPU stalls, launch overhead    (coming Stage B1)
+  6. Idle / sync      — GPU gaps, CPU stalls, launch overhead
   7. CUTracer         — SASS-level (requires re-run)             (coming Stage C1)
   8. Diff             — compare two profiles                     (coming Stage C2)
   9. Variance         — some iterations much slower than others  (coming Stage C2)
@@ -98,11 +98,11 @@ through to Mode 1 with a one-line notice:
 | Mode | Reference | Fallback ref (today) | Status |
 |------|-----------|----------------------|--------|
 | 1 Auto | `references/M1_AUTO.md` | — | Stage A (live) |
-| 2 Comms | `references/M2_COMMS.md` *(not yet present)* | `references/DISTRIBUTED.md` | Stage B1 planned |
+| 2 Comms | `references/M2_COMMS.md` | `references/DISTRIBUTED.md` (deeper topology ref) | Stage B1 (live) |
 | 3 Compute | `references/M3_COMPUTE.md` *(not yet present)* | `references/MFU.md` | Stage B2 planned |
 | 4 Memory | `references/M4_MEMORY.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage B2 planned |
 | 5 NVTX | `references/M5_NVTX.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage B2 planned |
-| 6 Idle | `references/M6_IDLE.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage B1 planned |
+| 6 Idle | `references/M6_IDLE.md` | — | Stage B1 (live) |
 | 7 CUTracer | `references/M7_CUTRACER.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage C1 planned |
 | 8 Diff | `references/M8_DIFF.md` *(not yet present)* | `references/DIFF.md` | Stage C2 planned |
 | 9 Variance | `references/M9_VARIANCE.md` *(not yet present)* | `references/VARIANCE.md` | Stage C2 planned |

--- a/skills/analyze/references/M1_AUTO.md
+++ b/skills/analyze/references/M1_AUTO.md
@@ -102,22 +102,19 @@ they reference `M1_AUTO.md §4.1`.
 
 ---
 
-## 5. Cross-mode exits (placeholders for B/C stages)
+## 5. Cross-mode exits
 
 After Mode 1 delivery, suggest specialist mode only if a second critical finding exists.
 **Cap 2 chains per session** (UX invariant 7).
 
-> **Mode 2 — Comms (NCCL / overlap)**: coming Stage B1 as `M2_COMMS.md`. Today: see `DISTRIBUTED.md`.
+> **Mode 2 — Comms (NCCL / overlap)**: see `M2_COMMS.md` (Stage B1, live). Also: `DISTRIBUTED.md` for deeper NCCL topology.
 > **Mode 3 — Compute (kernels / MFU)**: coming Stage B2 as `M3_COMPUTE.md`. Today: see `MFU.md`.
 > **Mode 4 — Memory (H2D / bandwidth)**: coming Stage B2 as `M4_MEMORY.md`. Today: no fallback ref — use Mode 1 auto-triage.
 > **Mode 5 — NVTX / code mapping**: coming Stage B2 as `M5_NVTX.md`. Today: no fallback ref — use Mode 1 auto-triage.
-> **Mode 6 — Idle / sync**: coming Stage B1 as `M6_IDLE.md`. Today: no fallback ref — use Mode 1 auto-triage.
+> **Mode 6 — Idle / sync**: see `M6_IDLE.md` (Stage B1, live).
 > **Mode 7 — CUTracer (SASS)**: coming Stage C1 as `M7_CUTRACER.md`. Today: no fallback ref — use Mode 1 auto-triage.
 > **Mode 8 — Diff**: coming Stage C2 as `M8_DIFF.md`. Today: see `DIFF.md`.
 > **Mode 9 — Variance**: coming Stage C2 as `M9_VARIANCE.md`. Today: see `VARIANCE.md`.
-
-During Stage A (only Mode 1 lives), after auto-triage completes, emit the 3-part summary
-directly — no chain prompt until Stage B1 lands.
 
 ---
 

--- a/skills/analyze/references/M2_COMMS.md
+++ b/skills/analyze/references/M2_COMMS.md
@@ -1,0 +1,102 @@
+# Mode 2 — Comms (NCCL / overlap)
+
+Reference for `/analyze` Mode 2. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+§7 fail template, §10 checklist.
+
+---
+
+## 1. Precondition gate
+
+Check `nccl.collectives` from `profile_health_manifest`:
+
+```
+if nccl.collectives == 0:
+    "Mode 2 blocked. Why: single-GPU profile — no NCCL activity recorded.
+    Fix: run with multi-GPU workload. Alternative: Mode 1 or Mode 6 for single-GPU."
+```
+
+---
+
+## 2. Stages
+
+| # | Question | Condition/Default |
+|---|----------|-------------------|
+| 1 | Profile path | Only if not supplied |
+| 2 | Sub-focus: `overlap` / `outlier` / `topology` / `per-rank-variance` | Optional; default `overlap` |
+
+Skip Stage 2 if user provided a keyword that maps to a sub-focus
+(e.g. "straggler" → `per-rank-variance`, "communicator" → `topology`).
+
+---
+
+## 3. Skills
+
+| Sub-focus | Skills (in order) |
+|-----------|-------------------|
+| `overlap` (default) | `overlap_breakdown` → `kernel_overlap_matrix` |
+| `outlier` | `nccl_anomaly -p threshold=3.0` → `nccl_breakdown` |
+| `topology` | `nccl_communicator_analysis` → `nccl_breakdown` (requires profile exported with `nsys export --include-blobs=true`; returns diagnostic if blobs missing) |
+| `per-rank-variance` | `nccl_breakdown` (all devices) → `nccl_anomaly -p threshold=3.0` |
+
+Device propagation: if Mode 1 auto-retry selected device N, pass `-p device=N` to
+`overlap_breakdown`, `kernel_overlap_matrix`, `nccl_breakdown`, and
+`nccl_communicator_analysis`. `nccl_anomaly` is not device-scoped. See PRINCIPLES.md §6.
+
+**Collective type → parallelism strategy** (from `nccl_breakdown` stream grouping):
+
+| Dominant collective | Strategy |
+|--------------------|----------|
+| AllReduce | DDP gradient sync |
+| ReduceScatter + AllGather | FSDP / ZeRO-2/3 sharded params |
+| AllGather (forward only) | Tensor Parallelism or FSDP inference |
+| SendRecv | Pipeline Parallelism (P2P) |
+| Broadcast | Checkpoint sync / param broadcast at init |
+
+---
+
+## 4. Signals
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| `overlap_pct < 30` (from `overlap_breakdown`) | NCCL serialized with compute | critical; DDP bucket or FSDP fix |
+| `overlap_pct` 30–60 | Partial pipelining | warning; tune prefetch |
+| `overlap_pct > 60` | NCCL well-hidden | info; not the bottleneck |
+| `nccl_anomaly.ratio_to_avg > 3` | Straggler NCCL op or rank | check NIC / dataset imbalance |
+| One device `total_ms >> others` (from `nccl_breakdown -p device=N`) | Single straggler GPU | NCCL_DEBUG=INFO; check switch port |
+| All devices `total_ms` up uniformly (from `nccl_breakdown`) | Cross-node congestion | NCCL_SOCKET_IFNAME; check IB/RoCE |
+| `overlap_breakdown.idle_ms` up across devices, `nccl_breakdown.total_ms` flat | CPU launch overhead → Mode 6 | check kernel dispatch latency |
+
+**Overlap thresholds are not hard boundaries** — FSDP/ZeRO-3 with prefetch typically
+reaches 50–70%; DDP without bucketing often stays below 20%.
+
+---
+
+## 5. Cross-mode exits
+
+After delivery, suggest a second mode only if a distinct critical finding exists. Cap 2 chains.
+
+- `overlap_pct < 30` AND `idle.idle_pct > 15` → suggest **Mode 6** (idle underlies NCCL gap)
+- `nccl_anomaly.ratio_to_avg > 3` across iterations → suggest **Mode 9** (variance / straggler)
+- `nccl.collectives > 0` → run `pipeline_bubble_metrics` inline; if `bubble_pct > 10`,
+  report PP bubble % in delivery
+
+---
+
+## 6. Delivery
+
+Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+
+1. **Root cause** — NCCL class + quantified waste:
+   > "NCCL AllReduce is serialized with compute (overlap = 18%, DDP default bucket 25 MB).
+   > Estimated 3.4 s of every 8.1 s step is blocked waiting for gradient sync."
+
+2. **Specific fix** — matching the collective type:
+   - DDP serialized: `model = DDP(model, bucket_cap_mb=256)`
+   - FSDP slow prefetch: `FSDP(..., forward_prefetch=True, limit_all_gathers=True)`
+   - Straggler rank: check NIC on node; rebalance dataset sharding
+   - Cross-node: `NCCL_SOCKET_IFNAME=eth0 NCCL_IB_DISABLE=0`
+
+3. **Expected gain** — from `speedup_estimator` if NVTX present; omit otherwise.
+
+See `DISTRIBUTED.md` for deeper NCCL topology reference (communicator tables, kernel name
+patterns, per-GPU imbalance SQL).

--- a/skills/analyze/references/M2_COMMS.md
+++ b/skills/analyze/references/M2_COMMS.md
@@ -37,7 +37,7 @@ Skip Stage 2 if user provided a keyword that maps to a sub-focus
 | `overlap` (default) | `overlap_breakdown` → `kernel_overlap_matrix` |
 | `outlier` | `nccl_anomaly -p threshold=3.0` → `nccl_breakdown` |
 | `topology` | `nccl_communicator_analysis` → `nccl_breakdown` (requires profile exported with `nsys export --include-blobs=true`; returns diagnostic if blobs missing) |
-| `per-rank-variance` | `nccl_breakdown -p device=N` once per device, compare `total_ms` across devices → `nccl_anomaly -p threshold=3.0` |
+| `per-rank-variance` | `nccl_breakdown -p device=N` once per device, sum `total_ms` across all rows for each device, compare per-device aggregates → `nccl_anomaly -p threshold=3.0` |
 
 Device propagation: if Mode 1 auto-retry selected device N, pass `-p device=N` to
 `overlap_breakdown`, `kernel_overlap_matrix`, `nccl_breakdown`, and
@@ -63,9 +63,9 @@ Device propagation: if Mode 1 auto-retry selected device N, pass `-p device=N` t
 | `overlap_pct` 30–60 | Partial pipelining | warning; tune prefetch |
 | `overlap_pct > 60` | NCCL well-hidden | info; not the bottleneck |
 | `nccl_anomaly.ratio_to_avg > 3` | Straggler NCCL op or rank | check NIC / dataset imbalance |
-| One device `total_ms >> others` (from `nccl_breakdown -p device=N`) | Single straggler GPU | NCCL_DEBUG=INFO; check switch port |
-| All devices `total_ms` up uniformly (from `nccl_breakdown`) | Cross-node congestion | NCCL_SOCKET_IFNAME; check IB/RoCE |
-| `overlap_breakdown.idle_ms` up across devices, `nccl_breakdown.total_ms` flat | CPU launch overhead → Mode 6 | check kernel dispatch latency |
+| One device `sum(total_ms)` across `nccl_breakdown -p device=N` rows `>>` others | Single straggler GPU | NCCL_DEBUG=INFO; check switch port |
+| All devices `sum(total_ms)` across `nccl_breakdown -p device=N` rows up uniformly | Cross-node congestion | NCCL_SOCKET_IFNAME; check IB/RoCE |
+| `overlap_breakdown.idle_ms` up across devices, per-device `sum(nccl_breakdown.total_ms)` flat | CPU launch overhead → Mode 6 | check kernel dispatch latency |
 
 **Overlap thresholds are not hard boundaries** — FSDP/ZeRO-3 with prefetch typically
 reaches 50–70%; DDP without bucketing often stays below 20%.

--- a/skills/analyze/references/M2_COMMS.md
+++ b/skills/analyze/references/M2_COMMS.md
@@ -12,7 +12,8 @@ Check `nccl.collectives` from `profile_health_manifest`:
 ```
 if nccl.collectives == 0:
     "Mode 2 blocked. Why: single-GPU profile — no NCCL activity recorded.
-    Fix: run with multi-GPU workload. Alternative: Mode 1 or Mode 6 for single-GPU."
+    Fix: run with multi-GPU workload. Alternative: Mode 1 or Mode 6 for single-GPU.
+    Reply with: 'mode1', 'mode6', or 'stop'."
 ```
 
 ---
@@ -36,7 +37,7 @@ Skip Stage 2 if user provided a keyword that maps to a sub-focus
 | `overlap` (default) | `overlap_breakdown` → `kernel_overlap_matrix` |
 | `outlier` | `nccl_anomaly -p threshold=3.0` → `nccl_breakdown` |
 | `topology` | `nccl_communicator_analysis` → `nccl_breakdown` (requires profile exported with `nsys export --include-blobs=true`; returns diagnostic if blobs missing) |
-| `per-rank-variance` | `nccl_breakdown` (all devices) → `nccl_anomaly -p threshold=3.0` |
+| `per-rank-variance` | `nccl_breakdown -p device=N` once per device, compare `total_ms` across devices → `nccl_anomaly -p threshold=3.0` |
 
 Device propagation: if Mode 1 auto-retry selected device N, pass `-p device=N` to
 `overlap_breakdown`, `kernel_overlap_matrix`, `nccl_breakdown`, and

--- a/skills/analyze/references/M6_IDLE.md
+++ b/skills/analyze/references/M6_IDLE.md
@@ -1,0 +1,91 @@
+# Mode 6 — Idle / Sync
+
+Reference for `/analyze` Mode 6. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+§7 fail template, §10 checklist.
+
+---
+
+## 1. Precondition gate
+
+No hard precondition. Mode 6 runs on any profile with kernel activity (PRINCIPLES.md §4.1
+row 3 is a global guard — reaching Mode 6 guarantees at least one kernel is present). If
+manifest `idle.idle_pct < 5` AND `sync.sync_density_pct < 5`,
+note: "GPU appears busy — idle/sync overhead is low; Mode 3 or Mode 2 may be more relevant."
+Do not block.
+
+---
+
+## 2. Stages
+
+| # | Question | Condition/Default |
+|---|----------|-------------------|
+| 1 | Profile path | Only if not supplied |
+| 2 | Sub-focus: `gaps` / `sync` / `launch` / `cpu-pipeline` / `all` | Optional; default `all` |
+
+Skip Stage 2 if keyword already implies sub-focus (e.g. "dataloader" → `cpu-pipeline`,
+"cudaStreamSynchronize" → `sync`, "launch overhead" → `launch`).
+
+---
+
+## 3. Skills
+
+| Sub-focus | Skills (in order) |
+|-----------|-------------------|
+| `gaps` | `gpu_idle_gaps -p min_gap_ns=1000000` → `stream_concurrency` |
+| `sync` | `sync_cost_analysis` |
+| `launch` | `kernel_launch_overhead` |
+| `cpu-pipeline` | `cpu_gpu_pipeline` → `thread_utilization` |
+| `all` (default) | `gpu_idle_gaps` → `stream_concurrency` → `sync_cost_analysis` → `kernel_launch_overhead` → `cpu_gpu_pipeline` → `thread_utilization` → `module_loading` → `gc_impact` (if `starvation_events > 0`) → `pipeline_bubble_metrics` (if `nccl.collectives > 0`) |
+
+Device propagation: `gpu_idle_gaps` accepts `-p device=N`. `stream_concurrency`,
+`sync_cost_analysis`, `kernel_launch_overhead`, `cpu_gpu_pipeline` do not accept device.
+See PRINCIPLES.md §6.
+
+---
+
+## 4. Signals
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| manifest `idle.idle_pct > 15` OR `pipeline_bubble_metrics.bubble_pct > 15` | GPU starved | check DataLoader / CPU dispatch |
+| `sync_cost_analysis.sync_density_pct > 20` | Excessive CPU→GPU syncs | remove `.item()` / `.cpu()` in loop |
+| `kernel_launch_overhead.overhead_us` dominated by one caller | High CPU dispatch latency | async launch; reduce Python overhead |
+| `cpu_gpu_pipeline.starvation_events > 0` | CPU can't feed GPU fast enough | `num_workers`, `pin_memory`, `prefetch_factor` |
+| `thread_utilization` GIL contention (non-empty result) | DataLoader threads blocking | `persistent_workers=True`, reduce workers |
+| `module_loading` stalls on step 0 | JIT compilation | pre-warm; skip step 0 in benchmarks |
+| `gc_impact` `cudaMalloc/Free` spikes | Python GC stalls GPU | `torch.cuda.empty_cache()` placement |
+| `pipeline_bubble_metrics.bubble_pct > 10` | PP micro-batch bubble | increase `num_micro_batches`; check schedule |
+| `stream_concurrency` low despite multi-stream | Kernel serialization | check stream assignment / dependencies |
+
+**Idle gap attribution**: `gpu_idle_gaps` attributes each gap via `attribution.description`
+and `attribution.top_apis[].name`. Look for `DataLoader` / `cudaMemcpyAsync` /
+`cudaStreamSynchronize` in those fields.
+
+---
+
+## 5. Cross-mode exits
+
+After delivery, suggest a second mode only if a distinct critical finding exists. Cap 2 chains.
+
+- Large idle gaps attributed to NVTX region → suggest **Mode 5** (layer attribution)
+- `nccl.collectives > 0` AND idle gaps correlate with NCCL timeline → suggest **Mode 2**
+- Idle gap after step 0 only (JIT) → note: re-profile with `torch.cuda.nvtx.range` to verify
+
+---
+
+## 6. Delivery
+
+Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+
+1. **Root cause** — stall class + quantified waste:
+   > "GPU is idle 23% of profile time. `gpu_idle_gaps` attributes 78% of gaps to
+   > DataLoader workers — the CPU cannot prefetch fast enough to keep the GPU busy."
+
+2. **Specific fix** — matching the stall class:
+   - DataLoader starvation: `DataLoader(..., num_workers=8, pin_memory=True, prefetch_factor=4, persistent_workers=True)`
+   - `.item()` sync loop: remove from inner loop; accumulate as tensor, call once outside
+   - Launch overhead: batch small kernel launches; use CUDA graphs for repeated patterns
+   - GC stall: `torch.backends.cuda.matmul.allow_tf32 = True` + `gc.disable()` in training loop
+   - PP bubble: `num_micro_batches = pipeline_stages * 2` (1F1B schedule)
+
+3. **Expected gain** — from `speedup_estimator` if NVTX present; omit otherwise.

--- a/skills/analyze/references/M6_IDLE.md
+++ b/skills/analyze/references/M6_IDLE.md
@@ -67,7 +67,7 @@ and `attribution.top_apis[].name`. Look for `DataLoader` / `cudaMemcpyAsync` /
 
 After delivery, suggest a second mode only if a distinct critical finding exists. Cap 2 chains.
 
-- Large idle gaps attributed to NVTX region → suggest **Mode 5** (layer attribution)
+- Large idle gaps align with a specific NVTX region in the timeline → suggest **Mode 5** (layer attribution)
 - `nccl.collectives > 0` AND idle gaps correlate with NCCL timeline → suggest **Mode 2**
 - Idle gap after step 0 only (JIT) → note: re-profile with `torch.cuda.nvtx.range` to verify
 

--- a/skills/analyze/references/M6_IDLE.md
+++ b/skills/analyze/references/M6_IDLE.md
@@ -49,10 +49,10 @@ See PRINCIPLES.md §6.
 |-------------------|-----------|--------|
 | manifest `idle.idle_pct > 15` OR `pipeline_bubble_metrics.bubble_pct > 15` | GPU starved | check DataLoader / CPU dispatch |
 | `sync_cost_analysis.sync_density_pct > 20` | Excessive CPU→GPU syncs | remove `.item()` / `.cpu()` in loop |
-| `kernel_launch_overhead.overhead_us` dominated by one caller | High CPU dispatch latency | async launch; reduce Python overhead |
-| `cpu_gpu_pipeline.starvation_events > 0` | CPU can't feed GPU fast enough | `num_workers`, `pin_memory`, `prefetch_factor` |
-| `thread_utilization` GIL contention (non-empty result) | DataLoader threads blocking | `persistent_workers=True`, reduce workers |
-| `module_loading` stalls on step 0 | JIT compilation | pre-warm; skip step 0 in benchmarks |
+| `kernel_launch_overhead.overhead_us` concentrated in the top `kernel_name` | High CPU dispatch latency | async launch; reduce Python overhead |
+| any `cpu_gpu_pipeline` row has `starvation_events > 0` | CPU can't feed GPU fast enough | `num_workers`, `pin_memory`, `prefetch_factor` |
+| `thread_utilization` non-empty: one Python/DataLoader thread dominating CPU utilization | CPU thread saturation / imbalance | `persistent_workers=True`, tune/reduce workers |
+| significant `module_loading` `cuModuleLoad` / `CompilePTX` total time | Startup / JIT compilation overhead | pre-warm; confirm warmup-only via timeline before treating as step 0 |
 | `gc_impact` `cudaMalloc/Free` spikes | Python GC stalls GPU | `torch.cuda.empty_cache()` placement |
 | `pipeline_bubble_metrics.bubble_pct > 10` | PP micro-batch bubble | increase `num_micro_batches`; check schedule |
 | `stream_concurrency` low despite multi-stream | Kernel serialization | check stream assignment / dependencies |
@@ -85,7 +85,7 @@ Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summar
    - DataLoader starvation: `DataLoader(..., num_workers=8, pin_memory=True, prefetch_factor=4, persistent_workers=True)`
    - `.item()` sync loop: remove from inner loop; accumulate as tensor, call once outside
    - Launch overhead: batch small kernel launches; use CUDA graphs for repeated patterns
-   - GC stall: `torch.backends.cuda.matmul.allow_tf32 = True` + `gc.disable()` in training loop
+   - GC stall: reduce allocation churn; reuse tensors/buffers; avoid frequent allocate/free cycles; `gc.disable()` only with explicit memory-safety caveat
    - PP bubble: `num_micro_batches = pipeline_stages * 2` (1F1B schedule)
 
 3. **Expected gain** — from `speedup_estimator` if NVTX present; omit otherwise.


### PR DESCRIPTION
## Summary

  - Add skills/analyze/references/M2_COMMS.md — full 6-section reference for Mode 2 (NCCL / overlap analysis). Covers four sub-focuses         
  (overlap, outlier, topology, per-rank-variance), collective-type → parallelism-strategy table, verified signal field names (overlap_pct,
  ratio_to_avg, total_ms, idle_ms), and complete device propagation for all four device-accepting skills in the mode.                          
  - Add skills/analyze/references/M6_IDLE.md — full 6-section reference for Mode 6 (idle/sync/launch). Covers five sub-focuses (gaps, sync,
  launch, cpu-pipeline, all), verified signal field names (bubble_pct, sync_density_pct, overhead_us, starvation_events,                       
  attribution.description), and the full 9-skill all chain including stream_concurrency.
  - Update SKILL.md — remove (coming Stage B1) from menu rows 2 and 6; mark both as live in the mode routing table.                            
  - Update M1_AUTO.md — update §5 cross-mode exit pointers from placeholder text to live references (M2_COMMS.md, M6_IDLE.md); remove stale    
  Stage A closing paragraph.                                                                                                                   
                                                                                                                                               
## Test plan                                                                                                                                    
                                                            
  - scripts/smoke_test.sh passes on both trace_20260223_213127.sqlite (multi-GPU FastVideo) and nano_vllm_qwen3_4b.sqlite (vLLM inference)     
  - All signal field names in M2/M6 verified against real nsys-ai skill run output
  - PRINCIPLES.md §6 device partition cross-checked against every skill referenced in M2 and M6                                                
  - Automated cross-consistency check across all 4 modified/added files passes   