### PR TITLE
feat(plugin): Stage B2 — Mode 3/4/5 reference docs, ROOT_CAUSE matrix, smoke test field validation 

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -105,14 +105,15 @@ except Exception:
 # ── Profile capability detection ──────────────────────────────────────────────
 # Use the skill itself to probe NVTX — sqlite3 can't read DuckDB parquet caches.
 NVTX_PROBE_OUT="$(mktemp)"
-nsys-ai skill run nvtx_layer_breakdown "$NVTX_PROFILE" --format json --max-rows 1 \
+nsys-ai skill run nvtx_layer_breakdown "$NVTX_PROFILE" --format json --max-rows 2 \
   >"$NVTX_PROBE_OUT" 2>/dev/null || true
-# Detection succeeds when either real region rows or a _detection_meta row with layer_names exists
+# Detection succeeds when either real region rows or a _detection_meta row exists.
+# Probe two rows so a prepended metadata row does not hide the first real NVTX region row.
 HAS_NVTX=$(python3 -c "
 import json
 d = json.load(open('$NVTX_PROBE_OUT'))
 has_regions = any('nvtx_region' in r for r in d)
-has_meta = any(r.get('_detection_meta') and r.get('layer_names') for r in d)
+has_meta = any('_detection_meta' in r for r in d)
 print('1' if (has_regions or has_meta) else '0')
 " 2>/dev/null || echo 0)
 NVTX_ROWS="$HAS_NVTX"

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -19,7 +19,16 @@ if [[ -z "$PROFILE" || ! -f "$PROFILE" ]]; then
   echo "usage: $0 <profile.sqlite> [nvtx-profile.sqlite]" >&2
   exit 2
 fi
-NVTX_PROFILE="${2:-$PROFILE}"
+if [[ -n "${2:-}" ]]; then
+  if [[ ! -f "$2" ]]; then
+    echo "error: nvtx-profile.sqlite not found: $2" >&2
+    echo "usage: $0 <profile.sqlite> [nvtx-profile.sqlite]" >&2
+    exit 2
+  fi
+  NVTX_PROFILE="$2"
+else
+  NVTX_PROFILE="$PROFILE"
+fi
 
 FAIL=0
 

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -3,11 +3,11 @@
 # in skills/analyze/SKILL.md + M*.md still works with the installed nsys-ai version.
 #
 # Usage:  ./scripts/smoke_test.sh <profile.sqlite>
-# Exit 0 if all commands succeed, non-zero otherwise.
+# Exit 0 if all checks succeed, non-zero otherwise.
 #
-# Stage A extension: adds Mode 1 end-to-end dry-run covering the three CLI boundaries
-# that the plugin actually orchestrates (manifest → evidence → timeline). See
-# docs/claude-skill-plan.md §11 Stage A acceptance tests.
+# Stage A: Mode 1 end-to-end (manifest → evidence → timeline surface check)
+# Stage B1: Mode 2 + Mode 6 drill-down skills
+# Stage B2: Mode 3, Mode 4, Mode 5 drill-down skills + field-shape validation
 
 set -euo pipefail
 
@@ -18,9 +18,10 @@ if [[ -z "$PROFILE" || ! -f "$PROFILE" ]]; then
 fi
 
 FAIL=0
+
 run() {
   local label="$1"; shift
-  printf "  %-45s " "$label"
+  printf "  %-50s " "$label"
   if "$@" >/dev/null 2>&1; then
     echo "OK"
   else
@@ -30,10 +31,9 @@ run() {
 }
 
 run_capture() {
-  # Like run, but captures stdout to a temp file for subsequent regex checks.
   local label="$1"; shift
   local out="$1"; shift
-  printf "  %-45s " "$label"
+  printf "  %-50s " "$label"
   if "$@" >"$out" 2>/dev/null; then
     echo "OK"
   else
@@ -44,7 +44,7 @@ run_capture() {
 
 check_regex() {
   local label="$1"; local file="$2"; local pattern="$3"
-  printf "  %-45s " "$label"
+  printf "  %-50s " "$label"
   if grep -qE "$pattern" "$file" 2>/dev/null; then
     echo "OK"
   else
@@ -53,71 +53,178 @@ check_regex() {
   fi
 }
 
+check_json_key() {
+  # Verify a key path exists and is non-null in a JSON file.
+  # key_path uses dot notation: e.g. "nccl.collectives" or "idle.idle_pct"
+  local label="$1"; local file="$2"; local key_path="$3"
+  printf "  %-50s " "$label"
+  local py_expr
+  py_expr="import json,sys; d=json.load(open('$file')); d=d[0] if isinstance(d,list) else d"
+  for part in ${key_path//./ }; do
+    py_expr+="; d=d['$part']"
+  done
+  py_expr+="; sys.exit(0 if d is not None else 1)"
+  if python3 -c "$py_expr" 2>/dev/null; then
+    echo "OK"
+  else
+    echo "FAIL (key $key_path missing or null)"
+    FAIL=$((FAIL+1))
+  fi
+}
+
+# Detect profile capabilities once upfront
+HAS_NVTX=$(sqlite3 "$PROFILE" "SELECT COUNT(*) FROM sqlite_master WHERE name='NVTX_EVENTS';" 2>/dev/null || echo 0)
+HAS_NCCL=$(sqlite3 "$PROFILE" "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL';" 2>/dev/null || echo 0)
+
+MANIFEST_OUT="$(mktemp)"
+ITER_OUT="$(mktemp)"
+TC_OUT="$(mktemp)"
+MEM_XFER_OUT="$(mktemp)"
+H2D_OUT="$(mktemp)"
+trap 'rm -f "$MANIFEST_OUT" "$ITER_OUT" "$TC_OUT" "$MEM_XFER_OUT" "$H2D_OUT" /tmp/findings_smoke.json' EXIT
+
+# ── Top-level ─────────────────────────────────────────────────────────────────
 echo "== Top-level commands =="
-run "nsys-ai help"           nsys-ai --help
-run "nsys-ai skill list"     nsys-ai skill list
-# cutracer check exits non-zero if .so is not built — informational only
-printf "  %-45s " "nsys-ai cutracer check (info)"
+run "nsys-ai --help"             nsys-ai --help
+run "nsys-ai skill list"         nsys-ai skill list
+run "schema_inspect"             nsys-ai skill run schema_inspect "$PROFILE" --format json
+printf "  %-50s " "cutracer check (info)"
 if nsys-ai cutracer check >/dev/null 2>&1; then
   echo "OK (.so installed)"
 else
-  echo "SKIP (.so not built — expected for analysis-only installs)"
+  echo "SKIP (.so not built)"
 fi
 
-echo "== Mode 1 routing skills (profile_health_manifest + drill-down targets) =="
-MANIFEST_OUT="$(mktemp)"
-trap 'rm -f "$MANIFEST_OUT" /tmp/findings_smoke.json' EXIT
+# ── Mode 1: manifest + field validation ───────────────────────────────────────
+echo "== Mode 1 — profile_health_manifest + field validation =="
 run_capture "profile_health_manifest" "$MANIFEST_OUT" \
   nsys-ai skill run profile_health_manifest "$PROFILE" --format json
-check_regex "manifest has gpu field"         "$MANIFEST_OUT" '"gpu"'
-check_regex "manifest has profile_span_ms"   "$MANIFEST_OUT" '"profile_span_ms"'
-check_regex "manifest has suspected_bottleneck" "$MANIFEST_OUT" '"suspected_bottleneck"'
-# NVTX-dependent skills fail on profiles without an NVTX_EVENTS table.
-# Missing NVTX is a non-blocking scenario for the plugin (Mode 5 falls back to Path B),
-# so we skip rather than fail here.
-HAS_NVTX=$(sqlite3 "$PROFILE" "SELECT COUNT(*) FROM sqlite_master WHERE name='NVTX_EVENTS';" 2>/dev/null || echo 0)
-if [[ "$HAS_NVTX" -gt 0 ]]; then
-  run "nvtx_layer_breakdown"   nsys-ai skill run nvtx_layer_breakdown "$PROFILE" --format json --max-rows 1
+check_regex  "  manifest: gpu field"              "$MANIFEST_OUT" '"gpu"'
+check_regex  "  manifest: profile_span_ms"        "$MANIFEST_OUT" '"profile_span_ms"'
+check_regex  "  manifest: suspected_bottleneck"   "$MANIFEST_OUT" '"suspected_bottleneck"'
+check_json_key "  manifest: nccl.collectives"     "$MANIFEST_OUT" "nccl.collectives"
+check_json_key "  manifest: idle.idle_pct"        "$MANIFEST_OUT" "idle.idle_pct"
+# overlap.overlap_pct only present when device 0 has kernels; skip if overlap.error exists
+printf "  %-50s " "  manifest: overlap.overlap_pct"
+OVERLAP_ERR=$(python3 -c "import json; d=json.load(open('$MANIFEST_OUT')); d=d[0] if isinstance(d,list) else d; print('yes' if 'error' in d.get('overlap',{}) else 'no')" 2>/dev/null || echo "no")
+if [[ "$OVERLAP_ERR" == "yes" ]]; then
+  echo "SKIP (device 0 empty — overlap.error present; auto-retry needed)"
 else
-  printf "  %-45s " "nvtx_layer_breakdown"
-  echo "SKIP (no NVTX_EVENTS table)"
+  if python3 -c "import json,sys; d=json.load(open('$MANIFEST_OUT')); d=d[0] if isinstance(d,list) else d; assert d['overlap']['overlap_pct'] is not None" 2>/dev/null; then
+    echo "OK"
+  else
+    echo "FAIL (key overlap.overlap_pct missing or null)"
+    FAIL=$((FAIL+1))
+  fi
 fi
-run "root_cause_matcher"       nsys-ai skill run root_cause_matcher "$PROFILE" --format json
+run "root_cause_matcher"         nsys-ai skill run root_cause_matcher "$PROFILE" --format json
+if [[ "$HAS_NVTX" -gt 0 ]]; then
+  run "nvtx_layer_breakdown"     nsys-ai skill run nvtx_layer_breakdown "$PROFILE" --format json --max-rows 1
+else
+  printf "  %-50s " "nvtx_layer_breakdown"; echo "SKIP (no NVTX_EVENTS)"
+fi
 
-echo "== Mode 2 drill-down skills (comms) =="
-run "overlap_breakdown"        nsys-ai skill run overlap_breakdown "$PROFILE" --format json
-run "nccl_breakdown"           nsys-ai skill run nccl_breakdown "$PROFILE" --format json
-run "kernel_overlap_matrix"    nsys-ai skill run kernel_overlap_matrix "$PROFILE" --format json
+# ── Mode 2: comms ─────────────────────────────────────────────────────────────
+echo "== Mode 2 — comms (NCCL / overlap) =="
+run "overlap_breakdown"          nsys-ai skill run overlap_breakdown "$PROFILE" --format json
+run "nccl_breakdown"             nsys-ai skill run nccl_breakdown "$PROFILE" --format json
+run "kernel_overlap_matrix"      nsys-ai skill run kernel_overlap_matrix "$PROFILE" --format json
+run "nccl_anomaly"               nsys-ai skill run nccl_anomaly "$PROFILE" --format json -p threshold=3.0
 
-echo "== Mode 6 drill-down skills (idle / sync) =="
-run "gpu_idle_gaps"            nsys-ai skill run gpu_idle_gaps "$PROFILE" --format json -p min_gap_ns=1000000
-run "sync_cost_analysis"       nsys-ai skill run sync_cost_analysis "$PROFILE" --format json
-run "kernel_launch_overhead"   nsys-ai skill run kernel_launch_overhead "$PROFILE" --format json
-run "cpu_gpu_pipeline"         nsys-ai skill run cpu_gpu_pipeline "$PROFILE" --format json
-run "stream_concurrency"       nsys-ai skill run stream_concurrency "$PROFILE" --format json
-run "pipeline_bubble_metrics"  nsys-ai skill run pipeline_bubble_metrics "$PROFILE" --format json
+# ── Mode 3: compute ───────────────────────────────────────────────────────────
+echo "== Mode 3 — compute (kernels / tensor core / MFU) =="
+run_capture "tensor_core_usage" "$TC_OUT" \
+  nsys-ai skill run tensor_core_usage "$PROFILE" --format json
+check_regex "  tensor_core_usage: tc_achieved_pct field" "$TC_OUT" '"tc_achieved_pct"'
+run "top_kernels"                nsys-ai skill run top_kernels "$PROFILE" --format json --max-rows 5
+run "kernel_instances (longest)" nsys-ai skill run kernel_instances "$PROFILE" --format json --max-rows 3
+run "kernel_launch_pattern"      nsys-ai skill run kernel_launch_pattern "$PROFILE" --format json
+# arithmetic_intensity requires theoretical_flops — use a sentinel value (1e12 FLOPs)
+run "arithmetic_intensity"       nsys-ai skill run arithmetic_intensity "$PROFILE" --format json \
+  -p theoretical_flops=1000000000000
 
-echo "== Mode 3 drill-down skills (compute hotspot) =="
-run "top_kernels"              nsys-ai skill run top_kernels "$PROFILE" --format json --max-rows 5
-run "tensor_core_usage"        nsys-ai skill run tensor_core_usage "$PROFILE" --format json
-run "kernel_launch_pattern"    nsys-ai skill run kernel_launch_pattern "$PROFILE" --format json
+# ── Mode 4: memory ────────────────────────────────────────────────────────────
+echo "== Mode 4 — memory (H2D / D2H / bandwidth) =="
+run "memory_bandwidth"           nsys-ai skill run memory_bandwidth "$PROFILE" --format json
+run_capture "memory_transfers" "$MEM_XFER_OUT" \
+  nsys-ai skill run memory_transfers "$PROFILE" --format json
+check_regex "  memory_transfers: total_ms field" "$MEM_XFER_OUT" '"total_ms"'
+run_capture "h2d_distribution" "$H2D_OUT" \
+  nsys-ai skill run h2d_distribution "$PROFILE" --format json
+# h2d_distribution appends pattern metadata only when H2D transfers exist
+printf "  %-50s " "  h2d_distribution: pattern type"
+H2D_NONEMPTY=$(python3 -c "import json; d=json.load(open('$H2D_OUT')); print('yes' if d else 'no')" 2>/dev/null || echo "no")
+if [[ "$H2D_NONEMPTY" == "no" ]]; then
+  echo "SKIP (no H2D transfers in this profile)"
+else
+  if grep -qE '"type"' "$H2D_OUT" 2>/dev/null; then
+    echo "OK"
+  else
+    echo "FAIL (pattern /\"type\"/ not found)"
+    FAIL=$((FAIL+1))
+  fi
+fi
 
-echo "== Mode 4 drill-down skills (memory) =="
-run "memory_bandwidth"         nsys-ai skill run memory_bandwidth "$PROFILE" --format json
-run "memory_transfers"         nsys-ai skill run memory_transfers "$PROFILE" --format json
-run "h2d_distribution"         nsys-ai skill run h2d_distribution "$PROFILE" --format json
+# ── Mode 5: code mapping ──────────────────────────────────────────────────────
+echo "== Mode 5 — NVTX / code mapping =="
+run_capture "iteration_timing" "$ITER_OUT" \
+  nsys-ai skill run iteration_timing "$PROFILE" --format json
+if [[ "$HAS_NVTX" -gt 0 ]]; then
+  run "nvtx_kernel_map"          nsys-ai skill run nvtx_kernel_map "$PROFILE" --format json --max-rows 5
+  # iteration_detail: use iteration=1 (safe default)
+  run "iteration_detail iter=1"  nsys-ai skill run iteration_detail "$PROFILE" --format json -p iteration=1
+  # speedup_estimator: extract median_ms from iteration_timing output if available
+  ITER_MS=$(python3 -c "
+import json, sys
+rows=[r for r in json.load(open('$ITER_OUT')) if 'duration_ms' in r]
+if rows:
+    durs=[r['duration_ms'] for r in rows]
+    print(sorted(durs)[len(durs)//2])
+else:
+    print(100)
+" 2>/dev/null || echo 100)
+  run "speedup_estimator"        nsys-ai skill run speedup_estimator "$PROFILE" --format json \
+    -p iteration_ms="$ITER_MS"
+else
+  printf "  %-50s " "nvtx_kernel_map";        echo "SKIP (no NVTX_EVENTS)"
+  printf "  %-50s " "iteration_detail iter=1"; echo "SKIP (no NVTX_EVENTS)"
+  printf "  %-50s " "speedup_estimator";       echo "SKIP (no NVTX_EVENTS)"
+fi
 
-echo "== Mode 5 drill-down skills (code mapping) =="
-run "iteration_timing"         nsys-ai skill run iteration_timing "$PROFILE" --format json
+# ── Mode 6: idle / sync ───────────────────────────────────────────────────────
+echo "== Mode 6 — idle / sync =="
+run "gpu_idle_gaps"              nsys-ai skill run gpu_idle_gaps "$PROFILE" --format json -p min_gap_ns=1000000
+run "stream_concurrency"         nsys-ai skill run stream_concurrency "$PROFILE" --format json
+run "sync_cost_analysis"         nsys-ai skill run sync_cost_analysis "$PROFILE" --format json
+run "kernel_launch_overhead"     nsys-ai skill run kernel_launch_overhead "$PROFILE" --format json
+run "cpu_gpu_pipeline"           nsys-ai skill run cpu_gpu_pipeline "$PROFILE" --format json
+run "thread_utilization"         nsys-ai skill run thread_utilization "$PROFILE" --format json
+run "module_loading"             nsys-ai skill run module_loading "$PROFILE" --format json
+run "gc_impact"                  nsys-ai skill run gc_impact "$PROFILE" --format json
+run "pipeline_bubble_metrics"    nsys-ai skill run pipeline_bubble_metrics "$PROFILE" --format json
 
-echo "== Stage A Mode 1 smoke — evidence/timeline CLI surface =="
-# The plugin ends every mode with evidence build + timeline-web. In CI we only smoke
-# the CLI boundary here: build findings JSON, validate its shape, and verify the
-# timeline-web command is available. This does not start the HTTP server.
-run "evidence build"           nsys-ai evidence build "$PROFILE" --format json -o /tmp/findings_smoke.json
-run "findings JSON is valid"   bash -c "python3 -c 'import json,sys; json.load(open(\"/tmp/findings_smoke.json\"))'"
-run "findings has findings key" bash -c "python3 -c 'import json; assert \"findings\" in json.load(open(\"/tmp/findings_smoke.json\"))'"
-run "timeline-web --help"      nsys-ai timeline-web --help
+# ── Stage A evidence / timeline surface ───────────────────────────────────────
+echo "== Stage A — evidence build + timeline-web surface =="
+run "evidence build"             nsys-ai evidence build "$PROFILE" --format json -o /tmp/findings_smoke.json
+run "findings JSON valid"        bash -c "python3 -c 'import json; json.load(open(\"/tmp/findings_smoke.json\"))'"
+run "findings has findings key"  bash -c "python3 -c 'import json; assert \"findings\" in json.load(open(\"/tmp/findings_smoke.json\"))'"
+run "timeline-web --help"        nsys-ai timeline-web --help
+
+# ── /nsys-ai skill name check ─────────────────────────────────────────────────
+echo "== Plugin skill name (/nsys-ai) =="
+SKILL_NAME=$(python3 -c "
+import re, pathlib
+content = pathlib.Path('skills/analyze/SKILL.md').read_text()
+m = re.search(r'^name:\s*(\S+)', content, re.MULTILINE)
+print(m.group(1) if m else 'NOT_FOUND')
+" 2>/dev/null || echo NOT_FOUND)
+printf "  %-50s " "SKILL.md name == nsys-ai"
+if [[ "$SKILL_NAME" == "nsys-ai" ]]; then
+  echo "OK"
+else
+  echo "FAIL (got: $SKILL_NAME)"
+  FAIL=$((FAIL+1))
+fi
 
 echo ""
 if [[ $FAIL -eq 0 ]]; then

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -2,26 +2,30 @@
 # Smoke test for nsys-ai plugin — validates that every CLI command referenced
 # in skills/analyze/SKILL.md + M*.md still works with the installed nsys-ai version.
 #
-# Usage:  ./scripts/smoke_test.sh <profile.sqlite>
+# Usage:  ./scripts/smoke_test.sh <profile.sqlite> [nvtx-profile.sqlite]
+#   profile.sqlite      — any GPU profile (NCCL preferred for Mode 2 coverage)
+#   nvtx-profile.sqlite — profile with NVTX_EVENTS; enables Mode 5 skill checks
+#                         (optional; NVTX skills SKIP when omitted)
 # Exit 0 if all checks succeed, non-zero otherwise.
 #
-# Stage A: Mode 1 end-to-end (manifest → evidence → timeline surface check)
-# Stage B1: Mode 2 + Mode 6 drill-down skills
+# Stage A:  Mode 1 end-to-end (manifest → evidence → timeline surface check)
+# Stage B1: Mode 2 + Mode 6 drill-down skills + field-shape validation
 # Stage B2: Mode 3, Mode 4, Mode 5 drill-down skills + field-shape validation
 
 set -euo pipefail
 
 PROFILE="${1:-}"
 if [[ -z "$PROFILE" || ! -f "$PROFILE" ]]; then
-  echo "usage: $0 <profile.sqlite>" >&2
+  echo "usage: $0 <profile.sqlite> [nvtx-profile.sqlite]" >&2
   exit 2
 fi
+NVTX_PROFILE="${2:-$PROFILE}"
 
 FAIL=0
 
 run() {
   local label="$1"; shift
-  printf "  %-50s " "$label"
+  printf "  %-55s " "$label"
   if "$@" >/dev/null 2>&1; then
     echo "OK"
   else
@@ -33,7 +37,7 @@ run() {
 run_capture() {
   local label="$1"; shift
   local out="$1"; shift
-  printf "  %-50s " "$label"
+  printf "  %-55s " "$label"
   if "$@" >"$out" 2>/dev/null; then
     echo "OK"
   else
@@ -44,7 +48,7 @@ run_capture() {
 
 check_regex() {
   local label="$1"; local file="$2"; local pattern="$3"
-  printf "  %-50s " "$label"
+  printf "  %-55s " "$label"
   if grep -qE "$pattern" "$file" 2>/dev/null; then
     echo "OK"
   else
@@ -57,7 +61,7 @@ check_json_key() {
   # Verify a key path exists and is non-null in a JSON file.
   # key_path uses dot notation: e.g. "nccl.collectives" or "idle.idle_pct"
   local label="$1"; local file="$2"; local key_path="$3"
-  printf "  %-50s " "$label"
+  printf "  %-55s " "$label"
   local py_expr
   py_expr="import json,sys; d=json.load(open('$file')); d=d[0] if isinstance(d,list) else d"
   for part in ${key_path//./ }; do
@@ -72,23 +76,83 @@ check_json_key() {
   fi
 }
 
-# Detect profile capabilities once upfront
-HAS_NVTX=$(sqlite3 "$PROFILE" "SELECT COUNT(*) FROM sqlite_master WHERE name='NVTX_EVENTS';" 2>/dev/null || echo 0)
-HAS_NCCL=$(sqlite3 "$PROFILE" "SELECT COUNT(*) FROM sqlite_master WHERE name LIKE 'CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL';" 2>/dev/null || echo 0)
+check_field_conditional() {
+  # Run check_regex but SKIP when JSON has no real data rows.
+  # Skips rows with: empty list, _metadata, _summary, _diagnostic, or top-level 'error' key.
+  local label="$1"; local file="$2"; local pattern="$3"; local skip_msg="$4"
+  printf "  %-55s " "$label"
+  EMPTY=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open('$file'))
+    rows = d if isinstance(d, list) else [d]
+    data = [r for r in rows if not r.get('_metadata') and not r.get('_summary')
+            and not r.get('_diagnostic') and 'error' not in r]
+    print('yes' if not data else 'no')
+except Exception:
+    print('yes')
+" 2>/dev/null || echo "yes")
+  if [[ "$EMPTY" == "yes" ]]; then
+    echo "SKIP ($skip_msg)"
+  elif grep -qE "$pattern" "$file" 2>/dev/null; then
+    echo "OK"
+  else
+    echo "FAIL (pattern /$pattern/ not found)"
+    FAIL=$((FAIL+1))
+  fi
+}
 
+# ── Profile capability detection ──────────────────────────────────────────────
+# Use the skill itself to probe NVTX — sqlite3 can't read DuckDB parquet caches.
+NVTX_PROBE_OUT="$(mktemp)"
+nsys-ai skill run nvtx_layer_breakdown "$NVTX_PROFILE" --format json --max-rows 1 \
+  >"$NVTX_PROBE_OUT" 2>/dev/null || true
+# Detection succeeds when either real region rows or a _detection_meta row with layer_names exists
+HAS_NVTX=$(python3 -c "
+import json
+d = json.load(open('$NVTX_PROBE_OUT'))
+has_regions = any('nvtx_region' in r for r in d)
+has_meta = any(r.get('_detection_meta') and r.get('layer_names') for r in d)
+print('1' if (has_regions or has_meta) else '0')
+" 2>/dev/null || echo 0)
+NVTX_ROWS="$HAS_NVTX"
+
+# Temp files
 MANIFEST_OUT="$(mktemp)"
-ITER_OUT="$(mktemp)"
+OVL_OUT="$(mktemp)"
+NCCL_BD_OUT="$(mktemp)"
+NCCL_AN_OUT="$(mktemp)"
+NCCL_COMM_OUT="$(mktemp)"
 TC_OUT="$(mktemp)"
+TK_OUT="$(mktemp)"
+KLP_OUT="$(mktemp)"
+AI_OUT="$(mktemp)"
+MEM_BW_OUT="$(mktemp)"
 MEM_XFER_OUT="$(mktemp)"
 H2D_OUT="$(mktemp)"
-trap 'rm -f "$MANIFEST_OUT" "$ITER_OUT" "$TC_OUT" "$MEM_XFER_OUT" "$H2D_OUT" /tmp/findings_smoke.json' EXIT
+GAPS_OUT="$(mktemp)"
+SYNC_OUT="$(mktemp)"
+CPU_GPU_OUT="$(mktemp)"
+ITER_OUT="$(mktemp)"
+NLB_OUT="$(mktemp)"
+NKM_OUT="$(mktemp)"
+SE_OUT="$(mktemp)"
+_cleanup() {
+  rm -f "$MANIFEST_OUT" "$OVL_OUT" "$NCCL_BD_OUT" "$NCCL_AN_OUT" "$NCCL_COMM_OUT" \
+        "$TC_OUT" "$TK_OUT" "$KLP_OUT" "$AI_OUT" \
+        "$MEM_BW_OUT" "$MEM_XFER_OUT" "$H2D_OUT" \
+        "$GAPS_OUT" "$SYNC_OUT" "$CPU_GPU_OUT" \
+        "$ITER_OUT" "$NLB_OUT" "$NKM_OUT" "$SE_OUT" "$NVTX_PROBE_OUT" \
+        /tmp/findings_smoke.json
+}
+trap _cleanup EXIT
 
 # ── Top-level ─────────────────────────────────────────────────────────────────
 echo "== Top-level commands =="
 run "nsys-ai --help"             nsys-ai --help
 run "nsys-ai skill list"         nsys-ai skill list
 run "schema_inspect"             nsys-ai skill run schema_inspect "$PROFILE" --format json
-printf "  %-50s " "cutracer check (info)"
+printf "  %-55s " "cutracer check (info)"
 if nsys-ai cutracer check >/dev/null 2>&1; then
   echo "OK (.so installed)"
 else
@@ -99,18 +163,26 @@ fi
 echo "== Mode 1 — profile_health_manifest + field validation =="
 run_capture "profile_health_manifest" "$MANIFEST_OUT" \
   nsys-ai skill run profile_health_manifest "$PROFILE" --format json
-check_regex  "  manifest: gpu field"              "$MANIFEST_OUT" '"gpu"'
-check_regex  "  manifest: profile_span_ms"        "$MANIFEST_OUT" '"profile_span_ms"'
-check_regex  "  manifest: suspected_bottleneck"   "$MANIFEST_OUT" '"suspected_bottleneck"'
-check_json_key "  manifest: nccl.collectives"     "$MANIFEST_OUT" "nccl.collectives"
-check_json_key "  manifest: idle.idle_pct"        "$MANIFEST_OUT" "idle.idle_pct"
-# overlap.overlap_pct only present when device 0 has kernels; skip if overlap.error exists
-printf "  %-50s " "  manifest: overlap.overlap_pct"
-OVERLAP_ERR=$(python3 -c "import json; d=json.load(open('$MANIFEST_OUT')); d=d[0] if isinstance(d,list) else d; print('yes' if 'error' in d.get('overlap',{}) else 'no')" 2>/dev/null || echo "no")
+check_regex    "  manifest: gpu field"              "$MANIFEST_OUT" '"gpu"'
+check_regex    "  manifest: profile_span_ms"        "$MANIFEST_OUT" '"profile_span_ms"'
+check_regex    "  manifest: suspected_bottleneck"   "$MANIFEST_OUT" '"suspected_bottleneck"'
+check_json_key "  manifest: nccl.collectives"       "$MANIFEST_OUT" "nccl.collectives"
+check_json_key "  manifest: idle.idle_pct"          "$MANIFEST_OUT" "idle.idle_pct"
+# overlap.overlap_pct absent when device 0 has no kernels (overlap.error present instead)
+printf "  %-55s " "  manifest: overlap.overlap_pct"
+OVERLAP_ERR=$(python3 -c "
+import json; d=json.load(open('$MANIFEST_OUT'))
+d=d[0] if isinstance(d,list) else d
+print('yes' if 'error' in d.get('overlap',{}) else 'no')
+" 2>/dev/null || echo "no")
 if [[ "$OVERLAP_ERR" == "yes" ]]; then
   echo "SKIP (device 0 empty — overlap.error present; auto-retry needed)"
 else
-  if python3 -c "import json,sys; d=json.load(open('$MANIFEST_OUT')); d=d[0] if isinstance(d,list) else d; assert d['overlap']['overlap_pct'] is not None" 2>/dev/null; then
+  if python3 -c "
+import json,sys; d=json.load(open('$MANIFEST_OUT'))
+d=d[0] if isinstance(d,list) else d
+assert d['overlap']['overlap_pct'] is not None
+" 2>/dev/null; then
     echo "OK"
   else
     echo "FAIL (key overlap.overlap_pct missing or null)"
@@ -118,42 +190,109 @@ else
   fi
 fi
 run "root_cause_matcher"         nsys-ai skill run root_cause_matcher "$PROFILE" --format json
-if [[ "$HAS_NVTX" -gt 0 ]]; then
-  run "nvtx_layer_breakdown"     nsys-ai skill run nvtx_layer_breakdown "$PROFILE" --format json --max-rows 1
+if [[ "$HAS_NVTX" -gt 0 && "$NVTX_ROWS" -gt 0 ]]; then
+  run "nvtx_layer_breakdown (probe)" nsys-ai skill run nvtx_layer_breakdown "$NVTX_PROFILE" --format json --max-rows 1
 else
-  printf "  %-50s " "nvtx_layer_breakdown"; echo "SKIP (no NVTX_EVENTS)"
+  printf "  %-55s " "nvtx_layer_breakdown (probe)"; echo "SKIP (no NVTX_EVENTS)"
 fi
 
 # ── Mode 2: comms ─────────────────────────────────────────────────────────────
 echo "== Mode 2 — comms (NCCL / overlap) =="
-run "overlap_breakdown"          nsys-ai skill run overlap_breakdown "$PROFILE" --format json
-run "nccl_breakdown"             nsys-ai skill run nccl_breakdown "$PROFILE" --format json
+run_capture "overlap_breakdown" "$OVL_OUT" \
+  nsys-ai skill run overlap_breakdown "$PROFILE" --format json
+# overlap_pct absent when device 0 has no kernels (error key present instead)
+OVL_ERR=$(python3 -c "
+import json; d=json.load(open('$OVL_OUT'))
+d=d[0] if isinstance(d,list) else d
+print('yes' if 'error' in d else 'no')
+" 2>/dev/null || echo "no")
+printf "  %-55s " "  overlap_breakdown: overlap_pct field"
+if [[ "$OVL_ERR" == "yes" ]]; then
+  echo "SKIP (device error — no overlap data on device 0)"
+else
+  if grep -qE '"overlap_pct"' "$OVL_OUT" 2>/dev/null; then echo "OK"
+  else echo "FAIL (overlap_pct missing)"; FAIL=$((FAIL+1)); fi
+fi
+
+run_capture "nccl_breakdown" "$NCCL_BD_OUT" \
+  nsys-ai skill run nccl_breakdown "$PROFILE" --format json
+check_field_conditional \
+  "  nccl_breakdown: total_ms field" "$NCCL_BD_OUT" '"total_ms"' "no NCCL data on this profile"
+
 run "kernel_overlap_matrix"      nsys-ai skill run kernel_overlap_matrix "$PROFILE" --format json
-run "nccl_anomaly"               nsys-ai skill run nccl_anomaly "$PROFILE" --format json -p threshold=3.0
+
+run_capture "nccl_anomaly" "$NCCL_AN_OUT" \
+  nsys-ai skill run nccl_anomaly "$PROFILE" --format json -p threshold=3.0
+check_field_conditional \
+  "  nccl_anomaly: ratio_to_avg field" "$NCCL_AN_OUT" '"ratio_to_avg"' "no anomalies detected"
+
+run_capture "nccl_communicator_analysis" "$NCCL_COMM_OUT" \
+  nsys-ai skill run nccl_communicator_analysis "$PROFILE" --format json
+check_field_conditional \
+  "  nccl_communicator_analysis: communicator_id" "$NCCL_COMM_OUT" '"communicator_id"' \
+  "no communicator blobs (re-export with --include-blobs=true)"
 
 # ── Mode 3: compute ───────────────────────────────────────────────────────────
 echo "== Mode 3 — compute (kernels / tensor core / MFU) =="
 run_capture "tensor_core_usage" "$TC_OUT" \
   nsys-ai skill run tensor_core_usage "$PROFILE" --format json
-check_regex "  tensor_core_usage: tc_achieved_pct field" "$TC_OUT" '"tc_achieved_pct"'
-run "top_kernels"                nsys-ai skill run top_kernels "$PROFILE" --format json --max-rows 5
-run "kernel_instances (longest)" nsys-ai skill run kernel_instances "$PROFILE" --format json --max-rows 3
-run "kernel_launch_pattern"      nsys-ai skill run kernel_launch_pattern "$PROFILE" --format json
+check_regex "  tensor_core_usage: tc_achieved_pct" "$TC_OUT" '"tc_achieved_pct"'
+
+run_capture "top_kernels" "$TK_OUT" \
+  nsys-ai skill run top_kernels "$PROFILE" --format json --max-rows 5
+check_regex "  top_kernels: total_ms field"        "$TK_OUT" '"total_ms"'
+
+# kernel_instances: default (longest) + specific-kernel sub-focus
+run "kernel_instances (longest)"  nsys-ai skill run kernel_instances "$PROFILE" --format json --max-rows 3
+KERNEL_NAME=$(python3 -c "
+import json
+d = json.load(open('$TK_OUT'))
+if d: print(d[0]['kernel_name'])
+" 2>/dev/null || echo "")
+printf "  %-55s " "kernel_instances (by name)"
+if [[ -n "$KERNEL_NAME" ]]; then
+  if nsys-ai skill run kernel_instances "$PROFILE" --format json -p name="$KERNEL_NAME" --max-rows 3 >/dev/null 2>&1; then
+    echo "OK"
+  else
+    echo "FAIL"
+    FAIL=$((FAIL+1))
+  fi
+else
+  echo "SKIP (no kernel name from top_kernels)"
+fi
+
+run_capture "kernel_launch_pattern" "$KLP_OUT" \
+  nsys-ai skill run kernel_launch_pattern "$PROFILE" --format json
+check_regex "  kernel_launch_pattern: sync_stalls"  "$KLP_OUT" '"sync_stalls"'
+
 # arithmetic_intensity requires theoretical_flops — use a sentinel value (1e12 FLOPs)
-run "arithmetic_intensity"       nsys-ai skill run arithmetic_intensity "$PROFILE" --format json \
+run_capture "arithmetic_intensity" "$AI_OUT" \
+  nsys-ai skill run arithmetic_intensity "$PROFILE" --format json \
   -p theoretical_flops=1000000000000
+check_field_conditional \
+  "  arithmetic_intensity: classification" "$AI_OUT" '"classification"' \
+  "GPU not in hardware specs — roofline unavailable"
 
 # ── Mode 4: memory ────────────────────────────────────────────────────────────
 echo "== Mode 4 — memory (H2D / D2H / bandwidth) =="
-run "memory_bandwidth"           nsys-ai skill run memory_bandwidth "$PROFILE" --format json
+run_capture "memory_bandwidth" "$MEM_BW_OUT" \
+  nsys-ai skill run memory_bandwidth "$PROFILE" --format json
+check_field_conditional \
+  "  memory_bandwidth: avg_bandwidth_gbps" "$MEM_BW_OUT" '"avg_bandwidth_gbps"' \
+  "no CUDA memory copies in this profile"
+
 run_capture "memory_transfers" "$MEM_XFER_OUT" \
   nsys-ai skill run memory_transfers "$PROFILE" --format json
-check_regex "  memory_transfers: total_ms field" "$MEM_XFER_OUT" '"total_ms"'
+check_regex "  memory_transfers: total_ms field"   "$MEM_XFER_OUT" '"total_ms"'
+
 run_capture "h2d_distribution" "$H2D_OUT" \
   nsys-ai skill run h2d_distribution "$PROFILE" --format json
-# h2d_distribution appends pattern metadata only when H2D transfers exist
-printf "  %-50s " "  h2d_distribution: pattern type"
-H2D_NONEMPTY=$(python3 -c "import json; d=json.load(open('$H2D_OUT')); print('yes' if d else 'no')" 2>/dev/null || echo "no")
+# pattern metadata row only appended when H2D data rows exist
+printf "  %-55s " "  h2d_distribution: pattern type"
+H2D_NONEMPTY=$(python3 -c "
+import json; d=json.load(open('$H2D_OUT'))
+print('yes' if d else 'no')
+" 2>/dev/null || echo "no")
 if [[ "$H2D_NONEMPTY" == "no" ]]; then
   echo "SKIP (no H2D transfers in this profile)"
 else
@@ -165,17 +304,34 @@ else
   fi
 fi
 
-# ── Mode 5: code mapping ──────────────────────────────────────────────────────
+# ── Mode 5: NVTX / code mapping ──────────────────────────────────────────────
 echo "== Mode 5 — NVTX / code mapping =="
 run_capture "iteration_timing" "$ITER_OUT" \
-  nsys-ai skill run iteration_timing "$PROFILE" --format json
-if [[ "$HAS_NVTX" -gt 0 ]]; then
-  run "nvtx_kernel_map"          nsys-ai skill run nvtx_kernel_map "$PROFILE" --format json --max-rows 5
+  nsys-ai skill run iteration_timing "$NVTX_PROFILE" --format json
+check_field_conditional \
+  "  iteration_timing: duration_ms field" "$ITER_OUT" '"duration_ms"' \
+  "no iterations detected"
+
+if [[ "$HAS_NVTX" -gt 0 && "$NVTX_ROWS" -gt 0 ]]; then
+  run_capture "nvtx_layer_breakdown" "$NLB_OUT" \
+    nsys-ai skill run nvtx_layer_breakdown "$NVTX_PROFILE" --format json --max-rows 20
+  check_field_conditional \
+    "  nvtx_layer_breakdown: total_gpu_ms"  "$NLB_OUT" '"total_gpu_ms"' "no NVTX regions found"
+  check_field_conditional \
+    "  nvtx_layer_breakdown: tc_achieved_pct" "$NLB_OUT" '"tc_achieved_pct"' "no NVTX regions found"
+
+  run_capture "nvtx_kernel_map" "$NKM_OUT" \
+    nsys-ai skill run nvtx_kernel_map "$NVTX_PROFILE" --format json --max-rows 5
+  check_field_conditional \
+    "  nvtx_kernel_map: kernel_name field"  "$NKM_OUT" '"kernel_name"' "no NVTX→kernel mappings"
+
   # iteration_detail: use iteration=1 (safe default)
-  run "iteration_detail iter=1"  nsys-ai skill run iteration_detail "$PROFILE" --format json -p iteration=1
-  # speedup_estimator: extract median_ms from iteration_timing output if available
+  run "iteration_detail iter=1" \
+    nsys-ai skill run iteration_detail "$NVTX_PROFILE" --format json -p iteration=1
+
+  # speedup_estimator: extract median_ms from iteration_timing
   ITER_MS=$(python3 -c "
-import json, sys
+import json
 rows=[r for r in json.load(open('$ITER_OUT')) if 'duration_ms' in r]
 if rows:
     durs=[r['duration_ms'] for r in rows]
@@ -183,34 +339,68 @@ if rows:
 else:
     print(100)
 " 2>/dev/null || echo 100)
-  run "speedup_estimator"        nsys-ai skill run speedup_estimator "$PROFILE" --format json \
+  run_capture "speedup_estimator" "$SE_OUT" \
+    nsys-ai skill run speedup_estimator "$NVTX_PROFILE" --format json \
     -p iteration_ms="$ITER_MS"
+  check_field_conditional \
+    "  speedup_estimator: speedup field"    "$SE_OUT" '"speedup"' "no speedup opportunities found"
 else
-  printf "  %-50s " "nvtx_kernel_map";        echo "SKIP (no NVTX_EVENTS)"
-  printf "  %-50s " "iteration_detail iter=1"; echo "SKIP (no NVTX_EVENTS)"
-  printf "  %-50s " "speedup_estimator";       echo "SKIP (no NVTX_EVENTS)"
+  printf "  %-55s " "nvtx_layer_breakdown";   echo "SKIP (no NVTX_EVENTS — pass nvtx-profile as \$2)"
+  printf "  %-55s " "nvtx_kernel_map";        echo "SKIP (no NVTX_EVENTS)"
+  printf "  %-55s " "iteration_detail iter=1"; echo "SKIP (no NVTX_EVENTS)"
+  printf "  %-55s " "speedup_estimator";       echo "SKIP (no NVTX_EVENTS)"
 fi
 
 # ── Mode 6: idle / sync ───────────────────────────────────────────────────────
 echo "== Mode 6 — idle / sync =="
-run "gpu_idle_gaps"              nsys-ai skill run gpu_idle_gaps "$PROFILE" --format json -p min_gap_ns=1000000
-run "stream_concurrency"         nsys-ai skill run stream_concurrency "$PROFILE" --format json
-run "sync_cost_analysis"         nsys-ai skill run sync_cost_analysis "$PROFILE" --format json
-run "kernel_launch_overhead"     nsys-ai skill run kernel_launch_overhead "$PROFILE" --format json
-run "cpu_gpu_pipeline"           nsys-ai skill run cpu_gpu_pipeline "$PROFILE" --format json
-run "thread_utilization"         nsys-ai skill run thread_utilization "$PROFILE" --format json
-run "module_loading"             nsys-ai skill run module_loading "$PROFILE" --format json
-run "gc_impact"                  nsys-ai skill run gc_impact "$PROFILE" --format json
-run "pipeline_bubble_metrics"    nsys-ai skill run pipeline_bubble_metrics "$PROFILE" --format json
+run_capture "gpu_idle_gaps" "$GAPS_OUT" \
+  nsys-ai skill run gpu_idle_gaps "$PROFILE" --format json -p min_gap_ns=1000000
+# attribution only present on top 5 gaps; check conditionally
+printf "  %-55s " "  gpu_idle_gaps: attribution field"
+ATTR_ROWS=$(python3 -c "
+import json
+d=json.load(open('$GAPS_OUT'))
+rows=[r for r in d if not r.get('_summary') and r.get('attribution')]
+print('yes' if rows else 'no')
+" 2>/dev/null || echo "no")
+if [[ "$ATTR_ROWS" == "yes" ]]; then
+  if grep -qE '"description"' "$GAPS_OUT" 2>/dev/null; then
+    echo "OK"
+  else
+    echo "FAIL (attribution.description missing)"
+    FAIL=$((FAIL+1))
+  fi
+else
+  echo "SKIP (no gaps large enough for CPU attribution)"
+fi
+
+run "stream_concurrency"   nsys-ai skill run stream_concurrency "$PROFILE" --format json
+
+run_capture "sync_cost_analysis" "$SYNC_OUT" \
+  nsys-ai skill run sync_cost_analysis "$PROFILE" --format json
+check_regex "  sync_cost_analysis: sync_density_pct" "$SYNC_OUT" '"sync_density_pct"'
+
+run "kernel_launch_overhead" nsys-ai skill run kernel_launch_overhead "$PROFILE" --format json
+
+run_capture "cpu_gpu_pipeline" "$CPU_GPU_OUT" \
+  nsys-ai skill run cpu_gpu_pipeline "$PROFILE" --format json
+check_field_conditional \
+  "  cpu_gpu_pipeline: starvation_events"  "$CPU_GPU_OUT" '"starvation_events"' \
+  "no dispatch data"
+
+run "thread_utilization"   nsys-ai skill run thread_utilization "$PROFILE" --format json
+run "module_loading"       nsys-ai skill run module_loading "$PROFILE" --format json
+run "gc_impact"            nsys-ai skill run gc_impact "$PROFILE" --format json
+run "pipeline_bubble_metrics" nsys-ai skill run pipeline_bubble_metrics "$PROFILE" --format json
 
 # ── Stage A evidence / timeline surface ───────────────────────────────────────
 echo "== Stage A — evidence build + timeline-web surface =="
-run "evidence build"             nsys-ai evidence build "$PROFILE" --format json -o /tmp/findings_smoke.json
-run "findings JSON valid"        bash -c "python3 -c 'import json; json.load(open(\"/tmp/findings_smoke.json\"))'"
-run "findings has findings key"  bash -c "python3 -c 'import json; assert \"findings\" in json.load(open(\"/tmp/findings_smoke.json\"))'"
-run "timeline-web --help"        nsys-ai timeline-web --help
+run "evidence build"          nsys-ai evidence build "$PROFILE" --format json -o /tmp/findings_smoke.json
+run "findings JSON valid"     bash -c "python3 -c 'import json; json.load(open(\"/tmp/findings_smoke.json\"))'"
+run "findings has findings key" bash -c "python3 -c 'import json; assert \"findings\" in json.load(open(\"/tmp/findings_smoke.json\"))'"
+run "timeline-web --help"     nsys-ai timeline-web --help
 
-# ── /nsys-ai skill name check ─────────────────────────────────────────────────
+# ── Plugin skill name check ───────────────────────────────────────────────────
 echo "== Plugin skill name (/nsys-ai) =="
 SKILL_NAME=$(python3 -c "
 import re, pathlib
@@ -218,7 +408,7 @@ content = pathlib.Path('skills/analyze/SKILL.md').read_text()
 m = re.search(r'^name:\s*(\S+)', content, re.MULTILINE)
 print(m.group(1) if m else 'NOT_FOUND')
 " 2>/dev/null || echo NOT_FOUND)
-printf "  %-50s " "SKILL.md name == nsys-ai"
+printf "  %-55s " "SKILL.md name == nsys-ai"
 if [[ "$SKILL_NAME" == "nsys-ai" ]]; then
   echo "OK"
 else

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -293,7 +293,9 @@ check_field_conditional \
 
 run_capture "memory_transfers" "$MEM_XFER_OUT" \
   nsys-ai skill run memory_transfers "$PROFILE" --format json
-check_regex "  memory_transfers: total_ms field"   "$MEM_XFER_OUT" '"total_ms"'
+check_field_conditional \
+  "  memory_transfers: total_ms field" "$MEM_XFER_OUT" '"total_ms"' \
+  "No memory transfers found"
 
 run_capture "h2d_distribution" "$H2D_OUT" \
   nsys-ai skill run h2d_distribution "$PROFILE" --format json

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -91,8 +91,9 @@ For priorities not yet implemented (marked "(coming Stage C1/C2)" in the menu ab
 
 > "Specialist Mode <N> coming in Stage <C1/C2>. Running auto-triage (Mode 1) now."
 
-Priorities 1–8 are live for modes 1–6; priorities 1 (cutracer), 2 (diff), 3 (variance)
-still fall through until C1/C2.
+Priorities 4–9 are currently live because they route to modes 1–6; priorities 1
+(cutracer), 2 (diff), and 3 (variance) route to modes 7–9 and still fall through until
+C1/C2.
 
 ---
 

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -1,10 +1,10 @@
 ---
-name: analyze
+name: nsys-ai
 description: >
   GPU performance analysis for NVIDIA Nsight Systems profiles (.sqlite or .nsys-rep files).
   Activates when the user opens a .sqlite/.nsys-rep profile, asks about GPU bottlenecks,
   mentions NCCL / distributed slowdown, asks for MFU / efficiency, wants to compare two
-  runs, mentions CUTracer / SASS, asks about variance / spikes, or types /analyze,
+  runs, mentions CUTracer / SASS, asks about variance / spikes, or types /nsys-ai,
   /nsys-analyze, /gpu-profile, /profile-analysis.
 ---
 
@@ -50,9 +50,9 @@ What would you like to analyze?
 
   1. Auto triage      — not sure where to start                  [default]
   2. Comms            — NCCL / overlap / multi-GPU
-  3. Compute          — top kernels / tensor core / MFU          (coming Stage B2)
-  4. Memory           — H2D / D2H / bandwidth                    (coming Stage B2)
-  5. NVTX / code map  — which layer / step consumes time         (coming Stage B2)
+  3. Compute          — top kernels / tensor core / MFU
+  4. Memory           — H2D / D2H / bandwidth
+  5. NVTX / code map  — which layer / step consumes time
   6. Idle / sync      — GPU gaps, CPU stalls, launch overhead
   7. CUTracer         — SASS-level (requires re-run)             (coming Stage C1)
   8. Diff             — compare two profiles                     (coming Stage C2)
@@ -86,10 +86,13 @@ position).
 > escapes only. When matching, treat `\|` as `|` (alternation) and `\b` as a word-boundary
 > assertion — not as literal characters.
 
-For priorities not yet implemented (marked "(coming Stage …)" in the menu above), fall
-through to Mode 1 with a one-line notice:
+For priorities not yet implemented (marked "(coming Stage C1/C2)" in the menu above — modes
+7, 8, 9), fall through to Mode 1 with a one-line notice:
 
-> "Specialist Mode <N> coming in Stage <B1/B2/C1/C2>. Running auto-triage (Mode 1) now."
+> "Specialist Mode <N> coming in Stage <C1/C2>. Running auto-triage (Mode 1) now."
+
+Priorities 1–8 are live for modes 1–6; priorities 1 (cutracer), 2 (diff), 3 (variance)
+still fall through until C1/C2.
 
 ---
 
@@ -99,9 +102,9 @@ through to Mode 1 with a one-line notice:
 |------|-----------|----------------------|--------|
 | 1 Auto | `references/M1_AUTO.md` | — | Stage A (live) |
 | 2 Comms | `references/M2_COMMS.md` | `references/DISTRIBUTED.md` (deeper topology ref) | Stage B1 (live) |
-| 3 Compute | `references/M3_COMPUTE.md` *(not yet present)* | `references/MFU.md` | Stage B2 planned |
-| 4 Memory | `references/M4_MEMORY.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage B2 planned |
-| 5 NVTX | `references/M5_NVTX.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage B2 planned |
+| 3 Compute | `references/M3_COMPUTE.md` | `references/MFU.md` (MFU math) | Stage B2 (live) |
+| 4 Memory | `references/M4_MEMORY.md` | — | Stage B2 (live) |
+| 5 NVTX | `references/M5_NVTX.md` | — | Stage B2 (live) |
 | 6 Idle | `references/M6_IDLE.md` | — | Stage B1 (live) |
 | 7 CUTracer | `references/M7_CUTRACER.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage C1 planned |
 | 8 Diff | `references/M8_DIFF.md` *(not yet present)* | `references/DIFF.md` | Stage C2 planned |

--- a/skills/analyze/references/M1_AUTO.md
+++ b/skills/analyze/references/M1_AUTO.md
@@ -1,163 +1,94 @@
 # Mode 1 — Auto Triage
 
-Reference for `/analyze` Mode 1 (auto triage). **Read `PRINCIPLES.md` first** — in particular
-§4 (guards), §5 (evidence), §7 (fail template), §10 (acceptance checklist).
-
----
+Reference for `/nsys-ai` Mode 1. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+§7 fail template, §10 checklist.
 
 ## 1. Precondition gate
 
-§4.1 rows 1–4 (see PRINCIPLES.md). If any fail, render via §7 template and abort.
-
----
+§4.1 rows 1–4 (PRINCIPLES.md). Any fail → render §7 template and abort.
 
 ## 2. Stages
 
 | # | Question | Condition |
 |---|----------|-----------|
-| 1 | Profile path | Only if not supplied in invocation |
-| 2 | "Is this training or inference?" | Only if framework ambiguous — see §2.1 |
-| 3 | "Detected N iterations. Analyze iterations 2 to N-1? (skips JIT warmup + teardown)" | Only if `iteration_timing` reports ≥3 iterations |
+| 1 | Profile path | Only if not supplied |
+| 2 | "Training or inference?" | Only if `fingerprint.framework == "Generic CUDA"` AND no top-10 kernel matches `ncclDevKernel*`, `flash_*`, `ampere_*gemm*`, `volta_*gemm*`, `cutlass_*`, `sm80_*`, `sm90_*`, `void at::*` |
+| 3 | "Detected N iterations. Analyze 2 to N-1? (skips JIT warmup)" | Only if `iteration_timing` reports ≥3 iterations |
 
-### 2.1 Framework ambiguous definition
+Stage 2 answer overrides `fingerprint.framework` for session only ("inference" → ms/token
+framing; "training" → look for `_bwd`/`wgrad`/`dgrad`). No file writes.
 
-Ambiguous = `fingerprint.framework == "Generic CUDA"` AND no top-10 kernel name matches any
-of: `ncclDevKernel*`, `flash_*`, `ampere_*gemm*`, `volta_*gemm*`, `cutlass_*`, `sm80_*`,
-`sm90_*`, `void at::*`. Otherwise skip Stage 2.
-
-User's answer overrides `fingerprint.framework` for the session only. "inference" →
-ms/token framing; "training" → look for `_bwd`/`wgrad`/`dgrad` kernels and DataLoader
-signals. No file writes.
-
-### 2.2 Device 0 auto-retry (silent — NOT a user stage)
-
-After Stage 1 runs `profile_health_manifest`, if the response has:
-- `overlap.error == "no kernels found"` AND
-- `overlap.available_devices` is non-empty
-
-…then plugin picks the first numeric key (lowest device id) and re-runs manifest with
-`-p device=N`. Tell user once: `"Detected active GPU: device N"`. No user question.
-
----
+**Device 0 auto-retry** (silent, NOT a stage): if `overlap.error == "no kernels found"` AND
+`overlap.available_devices` non-empty, re-run manifest with `-p device=N` (lowest available).
+Tell user once: `"Detected active GPU: device N"`.
 
 ## 3. Skills
 
-### 3.1 Primary
+Primary: `nsys-ai skill run profile_health_manifest <profile> --format json`
+→ follow §4 routing from `suspected_bottleneck`.
 
-```bash
-nsys-ai skill run profile_health_manifest <profile> --format json
-```
+Fallback (if `suspected_bottleneck` empty AND `root_causes[]` empty):
+`nsys-ai skill run root_cause_matcher <profile> --format json`
+→ re-route via §4 if patterns found; still empty → offer menu 2/3/4/6.
 
-Then follow `suspected_bottleneck` routing (§4 below).
-
-### 3.2 Fallback
-
-If `suspected_bottleneck` is empty/"None" AND `root_causes[]` is empty:
-
-```bash
-nsys-ai skill run root_cause_matcher <profile> --format json
-```
-
-If returns patterns, re-route via §4 keyword logic. If still empty, offer menu 2/3/4/6.
-
-### 3.3 Device propagation
-
-If §2.2 auto-retry selected device N, every subsequent skill in the drill-down that accepts
-device must receive `-p device=N`. See PRINCIPLES.md §6 for the 13 / 1 / 9 / 10 partition.
-
----
+Device propagation: if auto-retry picked device N, pass `-p device=N` to all subsequent
+device-scoped skills (see PRINCIPLES.md §6 for the 13/1/9/10 partition).
 
 ## 4. Signals — routing from `suspected_bottleneck`
 
-| Keyword match (case-insensitive) | Drill into | Skills invoked |
-|----------------------------------|------------|----------------|
-| `nccl` / `comm` | Mode 2 subroutine | `overlap_breakdown`, `nccl_breakdown`, `kernel_overlap_matrix` |
-| `sync` / `idle` / `bubble` | Mode 6 subroutine | `gpu_idle_gaps`, `sync_cost_analysis`, `kernel_launch_overhead`, `cpu_gpu_pipeline` (+ `pipeline_bubble_metrics` if `nccl.collectives > 0`) |
-| `hotspot` / `kernel` | Mode 3 subroutine | `top_kernels`, `kernel_launch_pattern`, `tensor_core_usage` |
-| `h2d` / `transfer` | Mode 4 subroutine | `memory_bandwidth`, `memory_transfers`, `h2d_distribution` |
+| Keyword match | Drill into | Skills invoked |
+|---------------|------------|----------------|
+| `nccl` / `comm` | Mode 2 | `overlap_breakdown`, `nccl_breakdown`, `kernel_overlap_matrix` |
+| `sync` / `idle` / `bubble` | Mode 6 | `gpu_idle_gaps`, `sync_cost_analysis`, `kernel_launch_overhead`, `cpu_gpu_pipeline` (+`pipeline_bubble_metrics` if NCCL) |
+| `hotspot` / `kernel` | Mode 3 | `top_kernels`, `kernel_launch_pattern`, `tensor_core_usage` |
+| `h2d` / `transfer` | Mode 4 | `memory_bandwidth`, `memory_transfers`, `h2d_distribution` |
 
-### 4.1 CLI-field schema contract (source of truth for every mode ref)
-
-Pinned against `profile_health_manifest`. Do NOT restate this table in other mode refs —
-they reference `M1_AUTO.md §4.1`.
+### 4.1 CLI-field schema contract (source of truth — do NOT restate in other mode refs)
 
 | Field | Type | Meaning |
 |-------|------|---------|
 | `gpu` | str | GPU name (not `gpu_name`) |
-| `profile_span_ms` | float | Total span in ms (not seconds) |
+| `profile_span_ms` | float | Total span in ms |
 | `fingerprint.framework` | str | "vLLM" / "Megatron-LM" / "Generic CUDA" / … |
 | `fingerprint.distributed` | bool | **Unreliable alone** — also check `nccl.collectives` |
-| `nccl.collectives` | int | >0 means multi-GPU workload |
-| `top_kernels[]` | list | `{name, total_ms, count}` (no `device` field — filter via manifest's `-p device=N` if needed) |
-| `top_kernels[].name` | str | First `ncclDevKernel*` ⇒ multi-GPU |
-| `overlap.overlap_pct` | float | <30% with NCCL ⇒ comm-bound (Mode 2) |
-| `overlap.error` | str | "no kernels found" → §2.2 auto-retry trigger |
-| `overlap.available_devices` | dict | `{N: kernel_count}` — §2.2 retry target |
+| `nccl.collectives` | int | >0 = multi-GPU workload |
+| `top_kernels[]` | list | `{name, total_ms, count}` |
+| `overlap.overlap_pct` | float | <30% with NCCL → comm-bound (Mode 2) |
+| `overlap.error` | str | "no kernels found" → device auto-retry |
+| `overlap.available_devices` | dict | `{N: kernel_count}` — retry target |
 | `idle.idle_pct` | float | >15% → Mode 6 |
 | `sync.sync_density_pct` | float | >20% → Mode 6 |
-| `root_causes[].pattern` | str | Label (e.g. "NCCL Serialization") |
+| `root_causes[].pattern` | str | e.g. "NCCL Serialization" |
 | `root_causes[].severity` | str | `critical` / `warning` / `info` |
-| `suspected_bottleneck` | str | **Free-form** — keyword-match per §4 routing |
+| `suspected_bottleneck` | str | Free-form — keyword-match per §4 |
 | `data_quality.overhead_pct` | float | >1% → surface note (not a block) |
-
----
 
 ## 5. Cross-mode exits
 
-After Mode 1 delivery, suggest specialist mode only if a second critical finding exists.
-**Cap 2 chains per session** (UX invariant 7).
+Suggest specialist mode after delivery only if a second critical finding exists (soft cap:
+≤2 suggestions per delivery message — UX invariant 7).
 
-> **Mode 2 — Comms (NCCL / overlap)**: see `M2_COMMS.md` (Stage B1, live). Also: `DISTRIBUTED.md` for deeper NCCL topology.
-> **Mode 3 — Compute (kernels / MFU)**: coming Stage B2 as `M3_COMPUTE.md`. Today: see `MFU.md`.
-> **Mode 4 — Memory (H2D / bandwidth)**: coming Stage B2 as `M4_MEMORY.md`. Today: no fallback ref — use Mode 1 auto-triage.
-> **Mode 5 — NVTX / code mapping**: coming Stage B2 as `M5_NVTX.md`. Today: no fallback ref — use Mode 1 auto-triage.
-> **Mode 6 — Idle / sync**: see `M6_IDLE.md` (Stage B1, live).
-> **Mode 7 — CUTracer (SASS)**: coming Stage C1 as `M7_CUTRACER.md`. Today: no fallback ref — use Mode 1 auto-triage.
-> **Mode 8 — Diff**: coming Stage C2 as `M8_DIFF.md`. Today: see `DIFF.md`.
-> **Mode 9 — Variance**: coming Stage C2 as `M9_VARIANCE.md`. Today: see `VARIANCE.md`.
-
----
+| Mode | Reference | When to suggest |
+|------|-----------|----------------|
+| 2 | `M2_COMMS.md` | `nccl`/`comm` bottleneck |
+| 3 | `M3_COMPUTE.md` | `hotspot`/`kernel` bottleneck |
+| 4 | `M4_MEMORY.md` | `h2d`/`transfer` bottleneck |
+| 5 | `M5_NVTX.md` | layer attribution needed |
+| 6 | `M6_IDLE.md` | `sync`/`idle`/`bubble` bottleneck |
+| 7 | `M7_CUTRACER.md` (C1) | top kernel > 60%, custom/Triton |
+| 8 | `M8_DIFF.md` (C2) | regression analysis requested |
+| 9 | `M9_VARIANCE.md` (C2) | iteration spikes detected |
 
 ## 6. Delivery
 
-Follow `PRINCIPLES.md` §5 (universal evidence + timeline step). Then the 3-part summary
-framed for Mode 1.
+Follow `PRINCIPLES.md §5` for evidence + timeline URL. Then 3-part summary:
 
-### 6.1 Evidence CLI
+1. **Root cause** — bottleneck + quantified impact (see `ROOT_CAUSE.md §2` for examples).
+2. **Specific fix** — code example (see `ROOT_CAUSE.md §1` matrix).
+3. **Expected gain** — `speedup_estimator` if NVTX present; omit otherwise.
 
-Follow `PRINCIPLES.md §5` for the canonical evidence/timeline sequence, including:
+**Inference framing**: `fingerprint.framework ∈ {vLLM, SGLang, TensorRT}` OR no
+`_bwd`/`wgrad`/`dgrad` in top-10 → metrics in ms/token; label "inference workload".
 
-- the `nsys-ai evidence build` and `nsys-ai timeline-web` commands,
-- printing the exact URL emitted by `timeline-web` (typically `http://127.0.0.1:PORT`),
-- WSL2/browser behavior, and
-- fail-soft handling when findings are empty or evidence generation fails.
-
-Do not restate or modify that procedure here; treat `PRINCIPLES.md §5` as the single source
-of truth.
-
-### 6.2 3-part summary (Mode 1 framing)
-
-1. **Root cause** — one sentence citing the dominant bottleneck + quantified impact:
-   > "Your NCCL AllReduce is serialized with compute (overlap = 18%). This wastes
-   > approximately 3.2 s of every 8.4 s training step."
-
-2. **Specific fix** — code example (ideally file:line if source present):
-   ```python
-   model = DDP(model, bucket_cap_mb=256)
-   ```
-
-3. **Expected gain** — from `speedup_estimator` if NVTX present; **omit** the line otherwise:
-   > "speedup_estimator: this fix → ≈ 1.4× faster per step."
-
-### 6.3 Inference framing
-
-`fingerprint.framework ∈ {vLLM, SGLang, TensorRT}` OR no `_bwd`/`wgrad`/`dgrad` in top-10
-→ reframe metrics as ms/token and label "inference workload".
-
-### 6.4 Optional text report
-
-On explicit user request only: see PRINCIPLES.md §5.4 for the `nsys-ai report` CLI.
-
-### 6.5 Required output checklist
-
-See PRINCIPLES.md §10 — run that checklist before ending the turn.
+Optional text report (on explicit request): `PRINCIPLES.md §5.4`.
+Required output checklist: `PRINCIPLES.md §10` — run before ending the turn.

--- a/skills/analyze/references/M2_COMMS.md
+++ b/skills/analyze/references/M2_COMMS.md
@@ -1,6 +1,6 @@
 # Mode 2 — Comms (NCCL / overlap)
 
-Reference for `/analyze` Mode 2. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+Reference for `/nsys-ai` Mode 2. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
 §7 fail template, §10 checklist.
 
 ---

--- a/skills/analyze/references/M3_COMPUTE.md
+++ b/skills/analyze/references/M3_COMPUTE.md
@@ -35,8 +35,8 @@ per head; `sm90_xmma_gemm_*_4096x` → H=4096). Ask only when kernel names give 
 
 | Sub-focus | Skills (in order) |
 |-----------|-------------------|
-| `top-n` (default) | `top_kernels --max-rows 20` → `kernel_launch_pattern` |
-| `tensor-core` | `tensor_core_usage` → `top_kernels --max-rows 10` |
+| `top-n` (default) | `top_kernels -p limit=20` → `kernel_launch_pattern` |
+| `tensor-core` | `tensor_core_usage` → `top_kernels -p limit=10` |
 | `mfu` | `theoretical_flops -p operation=<op> -p hidden_dim=<H> -p seq_len=<S>` → `region_mfu -p name=<region> -p theoretical_flops=<N>` → `arithmetic_intensity -p theoretical_flops=<N>` |
 | `specific-kernel` | `kernel_instances -p name=<name>` |
 

--- a/skills/analyze/references/M3_COMPUTE.md
+++ b/skills/analyze/references/M3_COMPUTE.md
@@ -1,0 +1,98 @@
+# Mode 3 — Compute (kernels / tensor core / MFU)
+
+Reference for `/nsys-ai` Mode 3. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+§7 fail template, §10 checklist.
+
+---
+
+## 1. Precondition gate
+
+§4.1 row 3 is the global guard (no kernel table → abort before any mode). No additional gate
+for Mode 3. Soft note if `profile_health_manifest` `nccl.collectives > 0` AND
+`overlap.overlap_pct < 30`: "NCCL overlap is critical — Mode 2 may address more time than
+compute tuning. Proceed with Mode 3 or switch? Reply `mode2` or press on."
+
+MFU sub-focus additionally needs an NVTX region name. If `nvtx_layer_breakdown` returns empty,
+print: "MFU sub-focus needs an NVTX region name; falling back to `arithmetic_intensity` for a
+roofline estimate (no per-region breakdown)."
+
+---
+
+## 2. Stages
+
+| # | Question | Condition/Default |
+|---|----------|-------------------|
+| 1 | Profile path | Only if not supplied |
+| 2 | Sub-focus: `top-n` / `tensor-core` / `mfu` / `specific-kernel` | Optional; default `top-n` |
+| 3 | Model arch (llama-7b / llama-13b / llama-70b / mistral-7b / gpt3-175b) OR raw `hidden_dim seq_len` | **Only if sub-focus = `mfu`** AND arch is ambiguous from kernel names |
+
+Skip Stage 3 if arch is already clear from top kernel names (e.g. `flash_fwd_hdim128` → H=128
+per head; `sm90_xmma_gemm_*_4096x` → H=4096). Ask only when kernel names give no signal.
+
+---
+
+## 3. Skills
+
+| Sub-focus | Skills (in order) |
+|-----------|-------------------|
+| `top-n` (default) | `top_kernels --max-rows 20` → `kernel_launch_pattern` |
+| `tensor-core` | `tensor_core_usage` → `top_kernels --max-rows 10` |
+| `mfu` | `theoretical_flops -p operation=<op> -p hidden_dim=<H> -p seq_len=<S>` → `region_mfu -p name=<region> -p theoretical_flops=<N>` → `arithmetic_intensity -p theoretical_flops=<N>` |
+| `specific-kernel` | `kernel_instances -p name=<name>` |
+
+Device propagation: `region_mfu` uses **`-p device_id=N`** (NOT `-p device=N`).
+`top_kernels`, `tensor_core_usage`, `kernel_launch_pattern`, `arithmetic_intensity` do not
+accept device. `kernel_instances` accepts `-p device=N`. See PRINCIPLES.md §6.
+
+Mode 3 is the **sole caller of `MFU.md`**. Never call `region_mfu` from Mode 1 — always
+redirect via "want an MFU number? → Mode 3 mfu sub-focus". See `MFU.md` for FLOPs formulas
+and model architecture table.
+
+---
+
+## 4. Signals
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| `top_kernels[0].total_ms` / `profile_span_ms` > 60% | Single hotspot dominates | tune or replace that kernel |
+| `tensor_core_usage[*].tc_achieved_pct` = 0 for eligible kernels | Tensor cores inactive (FP32 fallback) | force BF16 / TF32; check `torch.set_default_dtype` |
+| `tensor_core_usage[*].is_outlier` = true | Kernel has < 50% TC time (FP32 fallback) | inspect matmul shape; pad to multiple of 8/16 |
+| `region_mfu.mfu.mfu_pct < 30` | Severely underutilizing GPU | widen batch; improve memory access pattern |
+| `region_mfu.mfu.mfu_pct > 100` | FLOPs scope too broad — **always wrong** | narrow `operation` to match the actual kernel target (see MFU.md) |
+| `arithmetic_intensity.classification` starts with `"Memory-bound"` | Below ridge point | fuse ops; increase tile sizes; reduce redundant loads |
+| `arithmetic_intensity.classification` starts with `"Compute-bound"` with low MFU | Above ridge but inefficient | occupancy issue; check register pressure / block size |
+| `kernel_launch_pattern.sync_stalls` > 0 on a stream | CPU dispatch bottleneck | use CUDA graphs; batch launches |
+| `top_kernels[0]` is custom / Triton AND > 60% | SASS-level investigation warranted | suggest Mode 7 (coming Stage C1) |
+
+---
+
+## 5. Cross-mode exits
+
+After delivery, suggest a second mode only if a distinct critical finding exists.
+Soft cap: avoid suggesting >2 modes in one delivery.
+
+- Top custom/Triton kernel > 60% AND `tensor_core_usage` / `arithmetic_intensity` ambiguous
+  → suggest **Mode 7** (coming Stage C1; fall through to Mode 1 until then)
+- Per-layer attribution needed to identify which model component owns the hotspot
+  → suggest **Mode 5** (`layer` sub-focus)
+
+---
+
+## 6. Delivery
+
+Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+
+1. **Root cause** — hotspot identity + quantified share:
+   > "Top kernel `ampere_bf16_s16816gemm_bf16_128x128x32_ldg8_f2f_stages_32x3_nn`
+   > accounts for 68% of GPU time. Tensor core utilization is 91% — compute is the bottleneck,
+   > not memory."
+
+2. **Specific fix** — matching the finding:
+   - FP32 fallback: `model = model.to(torch.bfloat16)` or `torch.set_float32_matmul_precision('high')`
+   - Low MFU, memory-bound: increase batch size; fuse attention via `scaled_dot_product_attention`
+   - Custom kernel: profiling alone can't fix — suggest Mode 7 for SASS-level diagnosis
+   - Small matmul shapes: pad sequence length / batch to GEMM-friendly multiples (128, 256)
+
+3. **Expected gain** — MFU % if computed; `speedup_estimator` if NVTX present; omit otherwise.
+
+See `ROOT_CAUSE.md §1` for the cross-mode cause→fix matrix.

--- a/skills/analyze/references/M3_COMPUTE.md
+++ b/skills/analyze/references/M3_COMPUTE.md
@@ -41,8 +41,8 @@ per head; `sm90_xmma_gemm_*_4096x` → H=4096). Ask only when kernel names give 
 | `specific-kernel` | `kernel_instances -p name=<name>` |
 
 Device propagation: `region_mfu` uses **`-p device_id=N`** (NOT `-p device=N`).
-`top_kernels`, `tensor_core_usage`, `kernel_launch_pattern`, `arithmetic_intensity` do not
-accept device. `kernel_instances` accepts `-p device=N`. See PRINCIPLES.md §6.
+`top_kernels`, `tensor_core_usage`, and `kernel_launch_pattern` do not accept device.
+`arithmetic_intensity` and `kernel_instances` accept `-p device=N`. See PRINCIPLES.md §6.
 
 Mode 3 is the **sole caller of `MFU.md`**. Never call `region_mfu` from Mode 1 — always
 redirect via "want an MFU number? → Mode 3 mfu sub-focus". See `MFU.md` for FLOPs formulas

--- a/skills/analyze/references/M4_MEMORY.md
+++ b/skills/analyze/references/M4_MEMORY.md
@@ -1,0 +1,98 @@
+# Mode 4 — Memory (H2D / D2H / bandwidth)
+
+Reference for `/nsys-ai` Mode 4. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+§7 fail template, §10 checklist.
+
+---
+
+## 1. Precondition gate
+
+No hard gate beyond §4.1 row 3 (global kernel-table check). Soft note if `memory_bandwidth`
+returns empty (no memcpy table in profile): "No CUDA memory copies detected — profile may
+have been captured without memory tracing. Mode 3 (compute) or Mode 6 (idle) may be more
+relevant."
+
+---
+
+## 2. Stages
+
+| # | Question | Condition/Default |
+|---|----------|-------------------|
+| 1 | Profile path | Only if not supplied |
+
+No sub-menu. Runs all three memory skills in sequence; classifies the transfer pattern.
+
+---
+
+## 3. Skills
+
+Run in order:
+
+```bash
+nsys-ai skill run memory_bandwidth <profile> --format json
+nsys-ai skill run memory_transfers <profile> --format json
+nsys-ai skill run h2d_distribution <profile> --format json
+```
+
+No device propagation for these three skills — they do not accept `-p device=N`.
+See PRINCIPLES.md §6 (device-not-scoped list).
+
+---
+
+## 4. Signals
+
+**From `memory_bandwidth`** (per-row fields: `copyKind`, `op_count`, `total_mb`,
+`total_dur_ms`, `avg_bandwidth_gbps`, `peak_bandwidth_gbps`; also `_metadata.anomalies`):
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| H2D `total_dur_ms` / `profile_span_ms` > 15% | Memory-bound critical path | pin memory; pre-stage data on GPU |
+| `avg_bandwidth_gbps` << `peak_bandwidth_gbps` | Many small transfers (low efficiency) | batch transfers; use `torch.Tensor.pin_memory()` |
+| D2H large with high `op_count` | Metric logging overhead (`.item()` / `.numpy()` in loop) | log only every N steps; avoid `.item()` in hot loop |
+| `_metadata.anomalies` non-empty (transfers > 10 MB) | Single large blocking copy | check timeline; consider async copy |
+
+**From `memory_transfers`** (per-row fields: `copyKind`, `count`, `total_mb`, `total_ms`):
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| P2P `total_mb` large | Cross-device tensor copies not hidden by NCCL | check tensor placement; overlap with comm |
+| H2D `count` >> other directions | Repeated small copies every step | accumulate on CPU then single large H2D; or keep tensor on GPU |
+
+**From `h2d_distribution`** (pattern metadata: `type`, `detail`, `spike_seconds`, `spikes`):
+
+| `type` value | Diagnosis | Action |
+|-------------|-----------|--------|
+| `init_heavy` | Model weight loading — normal | no action required |
+| `spread_out` | Every step copies data to GPU | `pin_memory=True`, `num_workers ≥ 4`, `prefetch_factor=2` |
+| `spike` | Sudden H2D burst mid-training | check `spike_seconds` timestamps; likely `.cpu()` + back to GPU in loop |
+
+---
+
+## 5. Cross-mode exits
+
+After delivery, suggest a second mode only if a distinct critical finding exists.
+
+- H2D spike at specific `spike_seconds` → suggest **Mode 5** (`kernel-attribution` sub-focus
+  to locate the NVTX region responsible)
+- P2P large AND `nccl.collectives > 0` → suggest **Mode 2** (NCCL may be using P2P unnecessarily)
+
+---
+
+## 6. Delivery
+
+Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+
+1. **Root cause** — transfer class + direction + quantified waste:
+   > "H2D transfers account for 22% of profile time. `h2d_distribution` shows a `spread_out`
+   > pattern — every training step copies a fresh batch of tensors from CPU to GPU, preventing
+   > GPU from staying fully occupied."
+
+2. **Specific fix** — matching the transfer class:
+   - Spread-out: `DataLoader(..., pin_memory=True, num_workers=8, prefetch_factor=4, persistent_workers=True)`
+   - Spike (rogue `.item()` or `.cpu()`): locate the call via Mode 5; remove from inner loop
+   - D2H metric logging: `if step % 100 == 0: loss_val = loss.item()`
+   - Large one-time copy: `model.cuda()` before training loop, not inside
+
+3. **Expected gain** — `speedup_estimator` if NVTX present; omit otherwise.
+
+See `ROOT_CAUSE.md §1` for the cross-mode cause→fix matrix.

--- a/skills/analyze/references/M4_MEMORY.md
+++ b/skills/analyze/references/M4_MEMORY.md
@@ -34,8 +34,8 @@ nsys-ai skill run memory_transfers <profile> --format json
 nsys-ai skill run h2d_distribution <profile> --format json
 ```
 
-No device propagation for these three skills — they do not accept `-p device=N`.
-See PRINCIPLES.md §6 (device-not-scoped list).
+Device propagation: `memory_bandwidth` and `h2d_distribution` accept `-p device=N`;
+`memory_transfers` does not. See PRINCIPLES.md §6.
 
 ---
 

--- a/skills/analyze/references/M5_NVTX.md
+++ b/skills/analyze/references/M5_NVTX.md
@@ -56,7 +56,7 @@ device. `kernel_instances` accepts `-p device=N`. See PRINCIPLES.md §6.
 **Path B** (no NVTX — fallback):
 
 ```bash
-nsys-ai skill run top_kernels <profile> --format json --max-rows 30
+nsys-ai skill run top_kernels <profile> -p limit=30 --format json --max-rows 30
 nsys-ai skill run kernel_launch_pattern <profile> --format json
 ```
 
@@ -72,7 +72,8 @@ Apply kernel→source heuristic to attribute kernels to model components:
 | `elementwise_kernel*` | Elementwise op (activation, dropout) |
 | `reduce_kernel*` | Reduction (layer norm, softmax) |
 
-`speedup_estimator` is **NOT available** in Path B (requires iteration detection via NVTX).
+`speedup_estimator` is less reliable in Path B without NVTX markers; it may still be used if
+heuristic iteration detection succeeds or if `iteration_ms` is provided manually.
 
 ---
 

--- a/skills/analyze/references/M5_NVTX.md
+++ b/skills/analyze/references/M5_NVTX.md
@@ -1,0 +1,134 @@
+# Mode 5 — NVTX / code mapping
+
+Reference for `/nsys-ai` Mode 5. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+§7 fail template, §10 checklist.
+
+---
+
+## 1. Precondition gate
+
+Run a single-row probe first:
+
+```bash
+nsys-ai skill run nvtx_layer_breakdown <profile> --format json --max-rows 1
+```
+
+If empty, render the §7 template:
+
+```
+Mode 5 requires a user choice.
+
+Why: no NVTX annotations found in this profile.
+Fix: add `with torch.cuda.nvtx.range("layer_name"):` around key regions and re-profile.
+Alternative: Path B uses kernel-name heuristics (no per-layer attribution).
+
+Reply with: "B", "stop", or re-profile with annotations.
+```
+
+If user replies "B" → Path B fallback (§3). Otherwise proceed normally.
+
+---
+
+## 2. Stages
+
+| # | Question | Condition/Default |
+|---|----------|-------------------|
+| 1 | Profile path | Only if not supplied |
+| 2 | Sub-focus: `layer` / `iteration` / `kernel-attribution` | Optional; default `layer` |
+
+Skip Stage 2 if keyword already maps to a sub-focus (e.g. "which layer" → `layer`,
+"slow iterations" → `iteration`, "what kernel runs in attention" → `kernel-attribution`).
+
+---
+
+## 3. Skills
+
+| Sub-focus | Skills (in order) |
+|-----------|-------------------|
+| `layer` (default) | `nvtx_layer_breakdown --max-rows 20` → `nvtx_kernel_map` |
+| `iteration` | `iteration_timing` → `iteration_detail -p iteration=<slow_N>` → `speedup_estimator -p iteration_ms=<median_ms>` |
+| `kernel-attribution` | `nvtx_kernel_map` → `kernel_instances -p name=<name>` |
+
+Device propagation: `iteration_timing` accepts `-p device=N` (param name `device`, not
+`device_id`). `nvtx_layer_breakdown`, `nvtx_kernel_map`, `speedup_estimator` do not accept
+device. `kernel_instances` accepts `-p device=N`. See PRINCIPLES.md §6.
+
+**Path B** (no NVTX — fallback):
+
+```bash
+nsys-ai skill run top_kernels <profile> --format json --max-rows 30
+nsys-ai skill run kernel_launch_pattern <profile> --format json
+```
+
+Apply kernel→source heuristic to attribute kernels to model components:
+
+| Kernel name pattern | Likely source |
+|--------------------|--------------|
+| `ampere_sgemm*` / `volta_sgemm*` / `sm80_xmma_gemm*` | `nn.Linear` (FP32/BF16 dense matmul) |
+| `flash_fwd*` / `flash_bwd*` / `flash_attn_*` | `scaled_dot_product_attention` / FlashAttention |
+| `cunn_*` / `cudnn_*` | cuDNN op (conv, BN, RNN) |
+| `ncclDevKernel*` | `dist.all_reduce` / `dist.reduce_scatter` / NCCL collective |
+| `void at::native::*` | PyTorch native CUDA kernel |
+| `elementwise_kernel*` | Elementwise op (activation, dropout) |
+| `reduce_kernel*` | Reduction (layer norm, softmax) |
+
+`speedup_estimator` is **NOT available** in Path B (requires iteration detection via NVTX).
+
+---
+
+## 4. Signals
+
+**From `nvtx_layer_breakdown`** (per-region fields: `nvtx_region`, `nvtx_path`,
+`total_gpu_ms`, `compute_ms`, `nccl_ms`, `nccl_pct`, `tc_achieved_pct`,
+`kernel_count`, `avg_kernel_ms`; embedded `top_kernels[].{kernel_name, total_ms}`):
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| One region `total_gpu_ms` >> all others | Slow layer — compute or NCCL | drill into `nvtx_kernel_map` for that region |
+| Region `nccl_pct > 50` | NCCL inside this layer dominates | Mode 2 for NCCL analysis |
+| Region `tc_achieved_pct < 20` | Poor tensor core usage in this layer | check dtype; is it a custom op? |
+| `avg_kernel_ms` high but `kernel_count` low | Few, slow kernels | consider operator fusion |
+
+**From `iteration_timing`** (per-iteration fields: `iteration`, `duration_ms`,
+`kernel_count`, `nccl_count`, `compute_ms`):
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| `duration_ms` p99/p50 > 1.5 | Iteration spikes → suggest Mode 9 | check GC / DataLoader |
+| `nccl_count` spikes in slow iteration | NCCL retry or timeout | Mode 2 with per-rank-variance |
+| `kernel_count` spikes in slow iteration | Recomputation / gradient checkpointing stall | check activation checkpoint strategy |
+
+**From `speedup_estimator`** (per-optimization fields: `optimization`, `speedup`,
+`new_iteration_ms`, `current_ms`, `saved_ms`):
+
+Use `speedup` value directly in delivery: "fixing idle gaps → estimated `N`× speedup per step."
+
+---
+
+## 5. Cross-mode exits
+
+After delivery, suggest a second mode only if a distinct critical finding exists.
+
+- Hot layer's top kernel is custom/Triton AND > 60% of that region's time → suggest **Mode 3**
+  (`specific-kernel` sub-focus with that kernel name)
+- `iteration_timing` shows spikes (p99/p50 > 1.5) → suggest **Mode 9** (variance analysis)
+
+---
+
+## 6. Delivery
+
+Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+
+1. **Root cause** — layer name + quantified % + mechanism:
+   > "The `TransformerLayer.12.attn_fwd` region accounts for 34% of GPU time. Top kernel is
+   > `flash_fwd_hdim128_bf16_sm80` — attention computation is the bottleneck, not NCCL."
+
+2. **Specific fix** — matching the attribution:
+   - Slow attention layer: upgrade to `torch.nn.functional.scaled_dot_product_attention` (2–4×)
+   - Slow FFN: fuse with `torch.compile(mode='reduce-overhead')`; try INT8 quantization
+   - Slow backward pass only: gradient checkpointing trade-off; recompute fewer activations
+   - Path B (heuristic): "attribution is approximate — re-profile with NVTX for accuracy"
+
+3. **Expected gain** — from `speedup_estimator` if NVTX present; omit in Path B.
+
+See `ROOT_CAUSE.md §1` for the cross-mode cause→fix matrix.

--- a/skills/analyze/references/M6_IDLE.md
+++ b/skills/analyze/references/M6_IDLE.md
@@ -1,6 +1,6 @@
 # Mode 6 — Idle / Sync
 
-Reference for `/analyze` Mode 6. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+Reference for `/nsys-ai` Mode 6. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
 §7 fail template, §10 checklist.
 
 ---

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -1,6 +1,6 @@
 # nsys-ai Plugin Principles
 
-Source of truth for all `/analyze` modes. **Read this file before any mode runs.**
+Source of truth for all `/nsys-ai` modes. **Read this file before any mode runs.**
 Sections §4–§7 are pinned against `docs/claude-skill-plan.md` (§4 catalogue, §5.10 evidence,
 §8.5 device propagation, §7 fail template). Do not duplicate this content in mode refs.
 
@@ -8,7 +8,7 @@ Sections §4–§7 are pinned against `docs/claude-skill-plan.md` (§4 catalogue
 
 ## §1 Identity
 
-You are a **CUDA ML Systems Performance Expert** invoked via the `/analyze` slash command
+You are a **CUDA ML Systems Performance Expert** invoked via the `/nsys-ai` slash command
 (see `../SKILL.md`). Your job: turn an NVIDIA Nsight Systems profile (`.sqlite` or
 `.nsys-rep`) into one root cause + one actionable fix within each mode's turn budget.
 

--- a/skills/analyze/references/ROOT_CAUSE.md
+++ b/skills/analyze/references/ROOT_CAUSE.md
@@ -1,0 +1,67 @@
+# Root Cause Reference
+
+Cross-mode cause→fix matrix. Loaded on demand (Layer 3) — referenced by M*.md §6 Delivery
+when a mode needs delivery framing beyond its own §6 section.
+
+---
+
+## 1. Cross-mode cause→fix matrix
+
+| Pattern | Primary mode | Fix | Typical speedup |
+|---------|-------------|-----|----------------|
+| NCCL serialized with compute (`overlap_pct < 30`) | 2 | `DDP(model, bucket_cap_mb=256)` or `FSDP(..., forward_prefetch=True)` | 1.2–1.8× |
+| Single straggler GPU (one rank slow) | 2 | rebalance dataset sharding; check NIC / switch port; `NCCL_DEBUG=INFO` | 1.05–1.2× |
+| GPU idle > 15% (DataLoader starvation) | 6 | `DataLoader(..., num_workers=8, pin_memory=True, prefetch_factor=4, persistent_workers=True)` | 1.1–1.4× |
+| Excessive CPU→GPU syncs (`.item()` loop) | 6 | accumulate loss as tensor; call `.item()` once outside loop | 1.05–1.15× |
+| PP micro-batch bubble > 10% | 6 | `num_micro_batches = 2 × pipeline_stages` (1F1B schedule) | 1.1–1.3× |
+| Compute hotspot (single kernel > 60%) | 3 | BF16 / TF32 dtype; fuse ops; replace with library kernel | varies |
+| Tensor cores inactive (FP32 fallback) | 3 | `model.to(torch.bfloat16)` or `torch.set_float32_matmul_precision('high')` | 1.3–2.5× |
+| H2D spread-out (every step copies data) | 4 | `pin_memory=True`, `num_workers ≥ 4`, `prefetch_factor=2` | 1.05–1.2× |
+| H2D spike (rogue `.cpu()` in loop) | 4→5 | remove scalar sync from inner loop; locate via Mode 5 layer attribution | 1.05–1.15× |
+| Slow model layer (NVTX) | 5 | op-level: fuse attention; quantize; `torch.compile` | varies |
+| Iteration spikes (GC / DataLoader) | 9 | `gc.freeze()` before training; fix DataLoader randomness | 1.02–1.1× |
+| JIT / cuModuleLoad stall at step 0 | 6 | pre-warm with 1 dummy forward pass before profiling window | n/a |
+
+---
+
+## 2. Root cause framing examples
+
+One 3-part example per bottleneck class. Use these as delivery templates in Mode 1.
+
+**NCCL serialized**:
+> Root cause: "NCCL AllReduce is serialized with compute (overlap = 18%, DDP default bucket
+> 25 MB). Estimated 3.4 s of every 8.1 s step is blocked waiting for gradient sync."
+> Fix: `model = DDP(model, bucket_cap_mb=256)`
+> Gain: `speedup_estimator: ≈ 1.5× faster per step`
+
+**GPU idle / DataLoader**:
+> Root cause: "GPU is idle 23% of profile time. `gpu_idle_gaps` attributes 78% of gaps to
+> DataLoader workers — CPU cannot prefetch fast enough."
+> Fix: `DataLoader(..., num_workers=8, pin_memory=True, prefetch_factor=4, persistent_workers=True)`
+> Gain: `speedup_estimator: ≈ 1.3× faster per step`
+
+**H2D spread-out**:
+> Root cause: "H2D transfers account for 22% of span. Every step copies a fresh batch from
+> CPU — GPU stalls waiting for data to arrive."
+> Fix: `DataLoader(..., pin_memory=True, num_workers=8, prefetch_factor=4)`
+> Gain: `speedup_estimator: ≈ 1.2× faster per step`
+
+**Slow layer (NVTX)**:
+> Root cause: "`TransformerLayer.12.attn_fwd` accounts for 34% of GPU time — attention
+> is the bottleneck, not NCCL or idle."
+> Fix: `nn.functional.scaled_dot_product_attention` (replaces manual QKV + softmax)
+> Gain: "2–4× attention speedup typical on A100/H100 with FlashAttention backend"
+
+**Compute hotspot**:
+> Root cause: "Top kernel accounts for 68% of GPU time. Tensor cores are inactive (FP32
+> fallback) — peak throughput is 16× lower than BF16."
+> Fix: `model.to(torch.bfloat16)` + `torch.set_float32_matmul_precision('high')`
+> Gain: `speedup_estimator: ≈ 2.1× faster per step`
+
+---
+
+## 3. Pointers
+
+- Deeper NCCL topology (communicator tables, per-GPU imbalance): see `DISTRIBUTED.md`
+- MFU math and model FLOPs formulas: see `MFU.md`
+- Inference framing (ms/token metrics): see `M1_AUTO.md §6.3`

--- a/skills/analyze/references/ROOT_CAUSE.md
+++ b/skills/analyze/references/ROOT_CAUSE.md
@@ -64,4 +64,4 @@ One 3-part example per bottleneck class. Use these as delivery templates in Mode
 
 - Deeper NCCL topology (communicator tables, per-GPU imbalance): see `DISTRIBUTED.md`
 - MFU math and model FLOPs formulas: see `MFU.md`
-- Inference framing (ms/token metrics): see `M1_AUTO.md §6.3`
+- Inference framing (ms/token metrics): see `M1_AUTO.md` §6 "Inference framing"


### PR DESCRIPTION
  ## Summary                                                                                                                                   
                                                            
  - **3 new mode reference files**: `M3_COMPUTE.md`, `M4_MEMORY.md`, `M5_NVTX.md` — each follows the six-section template (Precondition /      
  Stages / Skills / Signals / Cross-mode exits / Delivery)
  - **`ROOT_CAUSE.md`**: 12-row cross-mode cause→fix matrix + 5 delivery framing examples, shared by all modes                                 
  - **`M1_AUTO.md` trimmed** from 163 → 94 lines; verbose cross-ref list replaced with compact table, §6 condensed to pointers                 
  - **Slash command renamed** `/analyze` → `/nsys-ai` across all plugin files (`SKILL.md`, `PRINCIPLES.md`, `M1`–`M6`)                         
  - **`scripts/smoke_test.sh` major expansion**: 130 → 260 lines; adds per-skill field-shape validation, NVTX-profile support as `$2`,         
  `check_field_conditional` helper, `nccl_communicator_analysis`, `kernel_instances -p name=<kernel>` (specific-kernel sub-focus), and 15 new  
  field checks across all 6 modes                                                                                                              
                                                                                                                                               
  ## New mode coverage                                      

  **M3_COMPUTE.md** — top-n / tensor-core / mfu / specific-kernel sub-focus routing. Key guards: `region_mfu` uses `-p device_id=N` (not 
  `device`); `arithmetic_intensity.classification` starts with `"Memory-bound"` / `"Compute-bound"` (not a short enum). Mode 3 is the sole     
                     
  **M4_MEMORY.md** — runs `memory_bandwidth` → `memory_transfers` → `h2d_distribution` in sequence. Covers `_metadata.anomalies` from bandwidth
   skill and the three H2D pattern types (`init_heavy`, `spread_out`, `spike`) with `spike_seconds` timestamps.                                
                                                                                                                                               
  **M5_NVTX.md** — layer / iteration / kernel-attribution sub-focus. §7 precondition-fail template with Path B fallback (kernel-name heuristics
   when no NVTX). Clarifies `iteration_timing` uses `-p device=N` while `region_mfu` uses `-p device_id=N`.                                    
                                                                                                                                               
  ## Bugs fixed during self-review (all in M3_COMPUTE.md)
                                                                                                                                               
  | Field / reference | Bug | Fix |                                                                                                            
  |-------------------|-----|-----|
  | `kernel_launch_pattern.Stalls` | Display header, not the JSON key | → `sync_stalls` |                                                      
  | `arithmetic_intensity.classification = "memory_bound"` | Wrong exact string — actual is `"Memory-bound (AI=X < Ridge=Y)"` | → `starts with 
  "Memory-bound"` |                                                                                                                            
  | `tensor_core_usage.is_outlier = true` described as "below median" | Threshold is hardcoded 50%, not median | → `"< 50% TC time (FP32       
  fallback)"` |                                                                                                                                
  | `"§5.7 in plan"` / `"PRINCIPLES.md §4 Mode 7 block"` | Internal plan refs, nonexistent in mode files | → `"coming Stage C1"` |             
                                                                                                                                  
  ## Smoke test — what's now validated                                                                                                         
                                                            
  | Skill | Previously | Now |                                                                                                                 
  |-------|-----------|-----|                               
  | `overlap_breakdown` | run only | `overlap_pct` field checked |                                                                             
  | `nccl_breakdown` | run only | `total_ms` field checked |      
  | `nccl_anomaly` | run only | `ratio_to_avg` field checked |                                                                                 
  | `nccl_communicator_analysis` | not tested | run + `communicator_id` checked |                                                              
  | `top_kernels` | run only | `total_ms` field checked |                                                                                      
  | `kernel_instances` | `--max-rows 3` only | adds `-p name=<kernel>` specific-kernel path |                                                  
  | `kernel_launch_pattern` | run only | `sync_stalls` field checked |                                                                         
  | `arithmetic_intensity` | run only | `classification` field checked |                                                                       
  | `memory_bandwidth` | run only | `avg_bandwidth_gbps` field checked |                                                                       
  | `gpu_idle_gaps` | run only | `attribution.description` field checked |                                                                     
  | `sync_cost_analysis` | run only | `sync_density_pct` field checked |  
  | `cpu_gpu_pipeline` | run only | `starvation_events` field checked |                                                                        
  | `nvtx_layer_breakdown` | always SKIP | `total_gpu_ms` + `tc_achieved_pct` checked (with `$2`) |                                            
  | `nvtx_kernel_map` | always SKIP | `kernel_name` field checked (with `$2`) |                                                                
  | `speedup_estimator` | always SKIP | `speedup` field checked (with `$2`) |                                                                  
  | `iteration_timing` | run only | `duration_ms` field checked |                                                                              
                                                                                                                                               
  NVTX skills activate when a profile with NVTX data is passed as the optional second argument:                                                
  ```bash                                                                                                                                      
  ./scripts/smoke_test.sh <primary.sqlite> <nvtx-profile.sqlite>                                                                               
                                                                
  Tested on: fastvideo/trace_20260223, distca-0/baseline.with-blobs, fastvideo/trace_20260202 (all pass); mfu_training_latest.sqlite as NVTX   
  profile (Mode 5 fully exercised).  