### PR TITLE
feat(plugin): Stage C1 — Mode 7 (CUTracer/SASS) reference doc + smoke test coverage

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -424,7 +424,8 @@ else
   echo "SKIP (cutracer Python package not installed)"
 fi
 rm -f "$CUTRACER_CHECK_OUT"
-# cutracer plan --top-n 3: should return JSON with up to 3 kernel entries
+# cutracer plan --top-n 3: default output is a human-readable table/summary;
+# validate that the table header includes the Kernel column.
 run_capture "cutracer plan --top-n 3" "$CUPLAN_OUT" \
   nsys-ai cutracer plan "$PROFILE" --top-n 3
 check_regex "  cutracer plan: Kernel column present" "$CUPLAN_OUT" 'Kernel'

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -11,6 +11,7 @@
 # Stage A:  Mode 1 end-to-end (manifest → evidence → timeline surface check)
 # Stage B1: Mode 2 + Mode 6 drill-down skills + field-shape validation
 # Stage B2: Mode 3, Mode 4, Mode 5 drill-down skills + field-shape validation
+# Stage C1: Mode 7 CUTracer plan + script generation
 
 set -euo pipefail
 
@@ -147,12 +148,15 @@ ITER_OUT="$(mktemp)"
 NLB_OUT="$(mktemp)"
 NKM_OUT="$(mktemp)"
 SE_OUT="$(mktemp)"
+CUPLAN_OUT="$(mktemp)"
+CUPLAN_SCRIPT_OUT="$(mktemp)"
 _cleanup() {
   rm -f "$MANIFEST_OUT" "$OVL_OUT" "$NCCL_BD_OUT" "$NCCL_AN_OUT" "$NCCL_COMM_OUT" \
         "$TC_OUT" "$TK_OUT" "$KLP_OUT" "$AI_OUT" \
         "$MEM_BW_OUT" "$MEM_XFER_OUT" "$H2D_OUT" \
         "$GAPS_OUT" "$SYNC_OUT" "$CPU_GPU_OUT" \
         "$ITER_OUT" "$NLB_OUT" "$NKM_OUT" "$SE_OUT" "$NVTX_PROBE_OUT" \
+        "$CUPLAN_OUT" "$CUPLAN_SCRIPT_OUT" \
         /tmp/findings_smoke.json
 }
 trap _cleanup EXIT
@@ -162,12 +166,6 @@ echo "== Top-level commands =="
 run "nsys-ai --help"             nsys-ai --help
 run "nsys-ai skill list"         nsys-ai skill list
 run "schema_inspect"             nsys-ai skill run schema_inspect "$PROFILE" --format json
-printf "  %-55s " "cutracer check (info)"
-if nsys-ai cutracer check >/dev/null 2>&1; then
-  echo "OK (.so installed)"
-else
-  echo "SKIP (.so not built)"
-fi
 
 # ── Mode 1: manifest + field validation ───────────────────────────────────────
 echo "== Mode 1 — profile_health_manifest + field validation =="
@@ -411,6 +409,29 @@ run "evidence build"          nsys-ai evidence build "$PROFILE" --format json -o
 run "findings JSON valid"     bash -c "python3 -c 'import json; json.load(open(\"/tmp/findings_smoke.json\"))'"
 run "findings has findings key" bash -c "python3 -c 'import json; assert \"findings\" in json.load(open(\"/tmp/findings_smoke.json\"))'"
 run "timeline-web --help"     nsys-ai timeline-web --help
+
+# ── Mode 7: CUTracer ─────────────────────────────────────────────────────────
+echo "== Mode 7 — CUTracer (SASS) =="
+# cutracer check: exit 0 = full SASS mode; exit 1 = .so missing (kernel-launch-logger fallback)
+# or Python package missing (hard block). Both cases are valid smoke outcomes.
+printf "  %-55s " "cutracer check"
+CUTRACER_CHECK_OUT="$(mktemp)"
+if nsys-ai cutracer check >"$CUTRACER_CHECK_OUT" 2>&1; then
+  echo "OK (full SASS mode)"
+elif grep -q "Python package.*OK" "$CUTRACER_CHECK_OUT" 2>/dev/null; then
+  echo "SKIP (.so not built — kernel-launch-logger fallback available)"
+else
+  echo "SKIP (cutracer Python package not installed)"
+fi
+rm -f "$CUTRACER_CHECK_OUT"
+# cutracer plan --top-n 3: should return JSON with up to 3 kernel entries
+run_capture "cutracer plan --top-n 3" "$CUPLAN_OUT" \
+  nsys-ai cutracer plan "$PROFILE" --top-n 3
+check_regex "  cutracer plan: Kernel column present" "$CUPLAN_OUT" 'Kernel'
+# cutracer plan --script: should emit a bash script containing cutracer reference
+run_capture "cutracer plan --script" "$CUPLAN_SCRIPT_OUT" \
+  nsys-ai cutracer plan "$PROFILE" --script --launch-cmd 'echo test'
+check_regex "  cutracer plan script: cutracer ref" "$CUPLAN_SCRIPT_OUT" 'cutracer'
 
 # ── Plugin skill name check ───────────────────────────────────────────────────
 echo "== Plugin skill name (/nsys-ai) =="

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -54,7 +54,7 @@ What would you like to analyze?
   4. Memory           — H2D / D2H / bandwidth
   5. NVTX / code map  — which layer / step consumes time
   6. Idle / sync      — GPU gaps, CPU stalls, launch overhead
-  7. CUTracer         — SASS-level (requires re-run)             (coming Stage C1)
+  7. CUTracer         — SASS-level (requires re-run)
   8. Diff             — compare two profiles                     (coming Stage C2)
   9. Variance         — some iterations much slower than others  (coming Stage C2)
 
@@ -86,14 +86,13 @@ position).
 > escapes only. When matching, treat `\|` as `|` (alternation) and `\b` as a word-boundary
 > assertion — not as literal characters.
 
-For priorities not yet implemented (marked "(coming Stage C1/C2)" in the menu above — modes
-7, 8, 9), fall through to Mode 1 with a one-line notice:
+For priorities not yet implemented (marked "(coming Stage C2)" in the menu above — modes
+8, 9), fall through to Mode 1 with a one-line notice:
 
-> "Specialist Mode <N> coming in Stage <C1/C2>. Running auto-triage (Mode 1) now."
+> "Specialist Mode <N> coming in Stage C2. Running auto-triage (Mode 1) now."
 
-Priorities 4–9 are currently live because they route to modes 1–6; priorities 1
-(cutracer), 2 (diff), and 3 (variance) route to modes 7–9 and still fall through until
-C1/C2.
+Priorities 1–9 are all handled: priorities 1–6 route directly; priorities 2 (diff) and
+3 (variance) still fall through until C2. Priority 1 (cutracer) routes to Mode 7 (live).
 
 ---
 
@@ -107,7 +106,7 @@ C1/C2.
 | 4 Memory | `references/M4_MEMORY.md` | — | Stage B2 (live) |
 | 5 NVTX | `references/M5_NVTX.md` | — | Stage B2 (live) |
 | 6 Idle | `references/M6_IDLE.md` | — | Stage B1 (live) |
-| 7 CUTracer | `references/M7_CUTRACER.md` *(not yet present)* | — (use Mode 1 auto-triage) | Stage C1 planned |
+| 7 CUTracer | `references/M7_CUTRACER.md` | — | Stage C1 (live) |
 | 8 Diff | `references/M8_DIFF.md` *(not yet present)* | `references/DIFF.md` | Stage C2 planned |
 | 9 Variance | `references/M9_VARIANCE.md` *(not yet present)* | `references/VARIANCE.md` | Stage C2 planned |
 

--- a/skills/analyze/references/M1_AUTO.md
+++ b/skills/analyze/references/M1_AUTO.md
@@ -75,7 +75,7 @@ Suggest specialist mode after delivery only if a second critical finding exists 
 | 4 | `M4_MEMORY.md` | `h2d`/`transfer` bottleneck |
 | 5 | `M5_NVTX.md` | layer attribution needed |
 | 6 | `M6_IDLE.md` | `sync`/`idle`/`bubble` bottleneck |
-| 7 | `M7_CUTRACER.md` (C1) | top kernel > 60%, custom/Triton |
+| 7 | `M7_CUTRACER.md` | top kernel > 60%, custom/Triton |
 | 8 | `M8_DIFF.md` (C2) | regression analysis requested |
 | 9 | `M9_VARIANCE.md` (C2) | iteration spikes detected |
 

--- a/skills/analyze/references/M7_CUTRACER.md
+++ b/skills/analyze/references/M7_CUTRACER.md
@@ -1,0 +1,150 @@
+# Mode 7 — CUTracer (SASS analysis)
+
+Reference for `/nsys-ai` Mode 7. **Read `PRINCIPLES.md` first** — §4 guards, §7 fail
+template, §10 checklist. **Evidence exception**: Mode 7 skips `evidence build` — see
+PRINCIPLES.md §5.5.
+
+---
+
+## 1. Precondition gate
+
+Three checks in sequence — any failure aborts via §7 template:
+
+1. **Tool chain**: `nsys-ai cutracer check` — §4.1 row 5.
+   - Exits 0 only when Python package AND `.so` are both present (full SASS mode).
+   - Exits 1 with "Python package : NOT FOUND" → hard block; direct user to `pip install cutracer`.
+   - Exits 1 with ".so : NOT FOUND" → soft note only; plugin proceeds in kernel-launch-logger
+     mode (launch counts + warp dims, no SASS mix). Full SASS requires `nsys-ai cutracer install`
+     (needs nvcc / g++ / make / git / libzstd-dev — §4.2 auto-handled at run time).
+
+2. **GPU available**: `nvidia-smi` exits 0, **or** user already chose Modal in Stage 4.
+   If no GPU: §4.3 row 2 — "Mode 7 requires a user choice. Why: no GPU on this host.
+   Fix: run on GPU-enabled host. Alternative: Modal backend (`--backend modal`),
+   ~$`<X>` at H100 default (see cost formula in §2). Reply `modal`, `local-gpu-ready`, or `stop`."
+
+3. **Launch command**: user supplies a reproducible launch command (Stage 2). No default.
+   Hint: `nsys-ai skill run schema_inspect <profile>` may surface the stored script name from
+   profile metadata (only if captured via `nsys profile python train.py …`).
+
+**Entry from Mode 3** — never auto-enter. All four must be true:
+1. Hotspot kernel > 60% of total GPU time
+2. Kernel is custom / Triton — NOT cuBLAS / cuDNN / FlashAttention
+3. `tensor_core_usage` OR `arithmetic_intensity` is ambiguous for that kernel
+4. User explicitly confirms re-run is acceptable
+
+---
+
+## 2. Stages
+
+| # | Question | Condition / Default |
+|---|----------|--------------------|
+| 1 | Profile path | **Required** — positional arg for `cutracer run`/`plan`. If user gives only a kernel name with no profile: "Profile the workload first via Mode 1, then return here." |
+| 2 | Launch command (`--launch-cmd`) | No default; try `schema_inspect` hint first |
+| 3 | Output directory | `./cutracer_out` |
+| 4 | Backend: `local` / `modal` / `modal-run` | `local` if `nvidia-smi` OK; else prompt |
+| 5 | Cost confirmation | Must reply `yes` — compute and display before asking |
+
+**Stage 5 cost display** (render computed values — do NOT echo the formula):
+
+```
+Cost estimate (profile span ≈ <span_s> s, 1.5× instrumentation overhead):
+  local run:    ≈ <local_s> s of GPU time
+  modal H100:   ≈ $<X.XX>   (default --modal-gpu H100; ~$4.56/hr)
+  modal A100:   ≈ $<X.XX>   (~$2.55/hr)
+  modal A10:    ≈ $<X.XX>   (~$1.10/hr)
+
+Proceed with local backend? Reply "yes" to continue, "modal" to switch, "stop" to abort.
+```
+
+**Cost formula** (`span_ms` from `profile_health_manifest`):
+```
+local_run_seconds = span_ms / 1000 × 1.5
+modal_usd = local_run_seconds × rate
+  rates (2026-04): H100 $0.00127/s · A100 $0.00071/s · A10 $0.00031/s
+```
+Round seconds to 1 decimal; USD to 2 decimals.
+
+---
+
+## 3. Commands
+
+```bash
+# 1. Verify tool chain
+nsys-ai cutracer check
+
+# 2. Inspect candidate kernels
+nsys-ai cutracer plan <profile> --top-n 3
+
+# 3. Generate instrumentation script (confirm launch-cmd with user first)
+nsys-ai cutracer plan <profile> --script --launch-cmd '<cmd>' --save run_cutracer.sh
+
+# 4a. Run locally (after cost confirm)
+bash run_cutracer.sh ./cutracer_out
+
+# 4b. OR: Modal backend
+nsys-ai cutracer run <profile> --launch-cmd '<cmd>' --backend modal --modal-gpu H100
+
+# 5. Analyze results
+nsys-ai cutracer analyze <profile> ./cutracer_out --format json
+```
+
+---
+
+## 4. Signals
+
+From `nsys-ai cutracer analyze <profile> <outdir> --format json` (per-kernel fields:
+`kernel_name`, `pct_of_gpu`, `total_instructions`, `instruction_mix_pct`,
+`tensor_core_active`, `bottleneck`, `bank_conflict_hint`, `achieved_warps`, `top_stalls[]`):
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| `bottleneck = "memory"` | Memory-bound (LDG/STG stalls > 25% or `instruction_mix_pct.memory > 30%`) | Tile into shared memory; use `__ldg` / `cp.async`; reduce redundant loads |
+| `bottleneck = "compute"` | Compute-bound (`instruction_mix_pct.compute + .tensor > 60%`) | Tune register reuse; increase tile size; try `torch.compile` |
+| `bottleneck = "sync"` | Sync-bound (`instruction_mix_pct.sync > 15%`) | Replace `__syncthreads` with `__syncwarp`; reduce barrier frequency |
+| `bank_conflict_hint = true` | Shared memory bank conflicts (high LDS/STS stall) | Pad shared memory arrays by 1 element per row |
+| `tensor_core_active = false` AND eligible kernel | Tensor cores inactive | Force BF16/TF32; check matmul shape — pad to multiple of 8/16 |
+| `top_stalls[0].stall_score > 0.3` | One opcode dominates stall cycles | Focus on that instruction; see mnemonic for LDG/STG/FFMA/BAR diagnosis |
+| `bottleneck = "unknown"` AND `total_instructions = 0` | `.so` not installed — launch-logger mode only | Run `nsys-ai cutracer install` then re-run for SASS mix |
+
+**Kernel-launch-logger fallback** (when `.so` absent): `cutracer analyze` still reports
+`pct_of_gpu` and `achieved_warps` but `instruction_mix_pct` will be empty and `bottleneck`
+null. Surface the launch-count data; advise building the `.so` for full SASS analysis.
+
+---
+
+## 5. Cross-mode exits
+
+Mode 7 is **terminal** — no chained mode suggestions.
+
+If `bottleneck = null` due to missing `.so`:
+> "Full SASS analysis requires the CUTracer `.so`. Run `nsys-ai cutracer install`
+> (requires CUDA toolkit + g++) then repeat Mode 7."
+
+---
+
+## 6. Delivery
+
+**Evidence**: Mode 7 skips `evidence build`. Open an unannotated timeline for context:
+```bash
+nsys-ai timeline-web <profile>
+```
+Print the URL emitted by `timeline-web` (`http://127.0.0.1:PORT`). No `--findings` flag.
+
+Then 3-part summary:
+
+1. **Root cause** — SASS verdict + kernel share:
+   > "`my_triton_kernel` accounts for 68% of GPU time. SASS bottleneck: MEMORY-BOUND.
+   > Top stall opcode is `LDG` (stall score 0.41) — global memory latency dominates."
+
+2. **Specific fix** — matching `bottleneck`:
+   - `memory`: tile into shared memory; use `cp.async` prefetch; reduce redundant global loads
+   - `compute`: increase register reuse; tile size tuning; `torch.compile(mode='max-autotune')`
+   - `sync`: replace `__syncthreads` with `__syncwarp`; fuse loops to reduce barrier count
+   - `bank_conflict`: pad shared memory arrays (`__shared__ float s[32][33]`)
+   - `.so` missing: "Build `.so` via `nsys-ai cutracer install` for SASS-level breakdown"
+
+3. **Expected gain** — qualitative only (`speedup_estimator` not applicable in Mode 7):
+   > "Eliminating LDG stalls typically yields 1.5–2× speedup for memory-bound CUDA kernels."
+
+**Always note** that Mode 7 required a re-run of the workload: "Note: CUTracer analysis
+required re-running the workload with instrumentation overhead (~1.5×)."

--- a/skills/analyze/references/M7_CUTRACER.md
+++ b/skills/analyze/references/M7_CUTRACER.md
@@ -12,8 +12,8 @@ Three checks in sequence — any failure aborts via §7 template:
 
 1. **Tool chain**: `nsys-ai cutracer check` — §4.1 row 5.
    - Exits 0 only when Python package AND `.so` are both present (full SASS mode).
-   - Exits 1 with "Python package : NOT FOUND" → hard block; direct user to `pip install cutracer`.
-   - Exits 1 with ".so : NOT FOUND" → soft note only; plugin proceeds in kernel-launch-logger
+   - Exits 1 with "cutracer Python package : NOT FOUND" → hard block; direct user to `pip install cutracer`.
+   - Exits 1 with "cutracer.so             : NOT FOUND" → soft note only; plugin proceeds in kernel-launch-logger
      mode (launch counts + warp dims, no SASS mix). Full SASS requires `nsys-ai cutracer install`
      (needs nvcc / g++ / make / git / libzstd-dev — §4.2 auto-handled at run time).
 
@@ -99,7 +99,7 @@ From `nsys-ai cutracer analyze <profile> <outdir> --format json` (per-kernel fie
 | Field / condition | Diagnosis | Action |
 |-------------------|-----------|--------|
 | `bottleneck = "memory"` | Memory-bound (LDG/STG stalls > 25% or `instruction_mix_pct.memory > 30%`) | Tile into shared memory; use `__ldg` / `cp.async`; reduce redundant loads |
-| `bottleneck = "compute"` | Compute-bound (`instruction_mix_pct.compute + .tensor > 60%`) | Tune register reuse; increase tile size; try `torch.compile` |
+| `bottleneck = "compute"` | Compute-bound (`instruction_mix_pct.compute + instruction_mix_pct.tensor > 60%`) | Tune register reuse; increase tile size; try `torch.compile` |
 | `bottleneck = "sync"` | Sync-bound (`instruction_mix_pct.sync > 15%`) | Replace `__syncthreads` with `__syncwarp`; reduce barrier frequency |
 | `bank_conflict_hint = true` | Shared memory bank conflicts (high LDS/STS stall) | Pad shared memory arrays by 1 element per row |
 | `tensor_core_active = false` AND eligible kernel | Tensor cores inactive | Force BF16/TF32; check matmul shape — pad to multiple of 8/16 |

--- a/skills/analyze/references/M7_CUTRACER.md
+++ b/skills/analyze/references/M7_CUTRACER.md
@@ -108,7 +108,7 @@ From `nsys-ai cutracer analyze <profile> <outdir> --format json` (per-kernel fie
 
 **Kernel-launch-logger fallback** (when `.so` absent): `cutracer analyze` still reports
 `pct_of_gpu` and `achieved_warps` but `instruction_mix_pct` will be empty and `bottleneck`
-null. Surface the launch-count data; advise building the `.so` for full SASS analysis.
+will be `"unknown"`. Surface the launch-count data; advise building the `.so` for full SASS analysis.
 
 ---
 
@@ -116,7 +116,7 @@ null. Surface the launch-count data; advise building the `.so` for full SASS ana
 
 Mode 7 is **terminal** — no chained mode suggestions.
 
-If `bottleneck = null` due to missing `.so`:
+If `bottleneck = "unknown"` due to missing `.so`:
 > "Full SASS analysis requires the CUTracer `.so`. Run `nsys-ai cutracer install`
 > (requires CUDA toolkit + g++) then repeat Mode 7."
 

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -136,6 +136,15 @@ supplies from manifest: `gpu` = first device in `overlap.available_devices` or 0
 = smart-trim iteration range (if Mode 1 Stage 3 was taken) else
 `0 profile_span_ms/1000`. Slow on large profiles — confirm before running.
 
+### §5.5 Mode 7 evidence exception
+
+Mode 7 (CUTracer) **skips `evidence build` entirely** — `cutracer analyze` output is the
+evidence layer. Open `timeline-web` without `--findings` for unannotated context only:
+
+```bash
+nsys-ai timeline-web <profile>
+```
+
 ---
 
 ## §6 Device Propagation Table


### PR DESCRIPTION
### Summary                                                   

  - M7_CUTRACER.md (NEW, 150 lines) — Full 6-section Mode 7 reference: sequential precondition gate (tool chain → GPU → launch command), 5     
  stages with cost formula and rendered display template, all verified CLI commands (check / plan / run / analyze), signal table with
  source-verified field names (bottleneck, instruction_mix_pct, top_stalls, bank_conflict_hint, tensor_core_active, achieved_warps), terminal  
  cross-mode exit, and Mode 7 evidence exception (skips evidence build, opens unannotated timeline-web).
  - PRINCIPLES.md — Added §5.5 documenting the Mode 7 evidence exception in the universal evidence section (skips evidence build entirely;
  cutracer analyze is the evidence layer).                                                                                                     
  - SKILL.md — Mode 7 menu row unlocked (removed "(coming Stage C1)"); fall-through paragraph updated (priorities 8/9 still fall through until
  C2, priority 1 now routes live); Mode routing table status updated to "Stage C1 (live)".                                                     
  - M1_AUTO.md — Removed "(C1)" marker from Mode 7 cross-reference table.
  - smoke_test.sh — Added Stage C1 Mode 7 section: cutracer check with three-outcome detection (full SASS / .so missing / Python package       
  missing), cutracer plan --top-n 3 with Kernel column validation, cutracer plan --script with cutracer reference check. Header updated to     
  document Stage C1 scope.                                                                                                                     
                                                                                                                                               
### Signal field verification                                 

  All cutracer analyze --format json field names and bottleneck thresholds were source-verified against src/nsys_ai/cutracer/report.py and     
  manually confirmed against fixture CSVs in tests/fixtures/cutracer/:
                                                                                                                                               
  - cutlass_gemm_s8: 74.9% tensor (IMMA), mem_stall=0.062 < 0.25 → bottleneck="compute" ✅                                                     
  - volta_h16gemm: LDG actual=80 cycles vs ideal=30 → stall_score=0.625 > 0.25 → bottleneck="memory" ✅ (correctly overrides 74.9%
  compute+tensor instruction mix)                                                                                                              
  - bottleneck="unknown" (not null) when .so absent and total_instructions=0 ✅
                                                                                                                                               
### Smoke test results                                        
                                                                                                                                               
  All 3 hero profiles pass with 0 FAILs:                                                                                                       
  - fastvideo/trace_20260223_213127.sqlite
  - distca-0/baseline.t128k.with-blobs.sqlite                                                                                                  
  - fastvideo/trace_20260202_055418.sqlite