### PR TITLE
feat(plugin): Stage C2 — Mode 8 (Diff) + Mode 9 (Variance) reference docs, smoke test coverage, and diff GROUP BY bugfix

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -2,16 +2,19 @@
 # Smoke test for nsys-ai plugin — validates that every CLI command referenced
 # in skills/analyze/SKILL.md + M*.md still works with the installed nsys-ai version.
 #
-# Usage:  ./scripts/smoke_test.sh <profile.sqlite> [nvtx-profile.sqlite]
+# Usage:  ./scripts/smoke_test.sh <profile.sqlite> [nvtx-profile.sqlite] [before.sqlite] [after.sqlite]
 #   profile.sqlite      — any GPU profile (NCCL preferred for Mode 2 coverage)
-#   nvtx-profile.sqlite — profile with NVTX_EVENTS; enables Mode 5 skill checks
+#   nvtx-profile.sqlite — profile with NVTX_EVENTS; enables Mode 5/9 skill checks
 #                         (optional; NVTX skills SKIP when omitted)
+#   before.sqlite       — baseline profile for Mode 8 Diff (optional; falls back to profile × profile)
+#   after.sqlite        — candidate profile for Mode 8 Diff (optional; same fallback)
 # Exit 0 if all checks succeed, non-zero otherwise.
 #
 # Stage A:  Mode 1 end-to-end (manifest → evidence → timeline surface check)
 # Stage B1: Mode 2 + Mode 6 drill-down skills + field-shape validation
 # Stage B2: Mode 3, Mode 4, Mode 5 drill-down skills + field-shape validation
 # Stage C1: Mode 7 CUTracer plan + script generation
+# Stage C2: Mode 8 Diff + Mode 9 Variance/iteration skills
 
 set -euo pipefail
 
@@ -23,12 +26,22 @@ fi
 if [[ -n "${2:-}" ]]; then
   if [[ ! -f "$2" ]]; then
     echo "error: nvtx-profile.sqlite not found: $2" >&2
-    echo "usage: $0 <profile.sqlite> [nvtx-profile.sqlite]" >&2
+    echo "usage: $0 <profile.sqlite> [nvtx-profile.sqlite] [before.sqlite] [after.sqlite]" >&2
     exit 2
   fi
   NVTX_PROFILE="$2"
 else
   NVTX_PROFILE="$PROFILE"
+fi
+
+# Mode 8 Diff: use dedicated before/after pair when supplied; otherwise same-file fallback.
+DIFF_BEFORE="${3:-$PROFILE}"
+DIFF_AFTER="${4:-$PROFILE}"
+if [[ -n "${3:-}" && ! -f "$3" ]]; then
+  echo "error: before.sqlite not found: $3" >&2; exit 2
+fi
+if [[ -n "${4:-}" && ! -f "$4" ]]; then
+  echo "error: after.sqlite not found: $4" >&2; exit 2
 fi
 
 FAIL=0
@@ -433,6 +446,97 @@ check_regex "  cutracer plan: Kernel column present" "$CUPLAN_OUT" 'Kernel'
 run_capture "cutracer plan --script" "$CUPLAN_SCRIPT_OUT" \
   nsys-ai cutracer plan "$PROFILE" --script --launch-cmd 'echo test'
 check_regex "  cutracer plan script: cutracer ref" "$CUPLAN_SCRIPT_OUT" 'cutracer'
+
+# ── Mode 8: Diff ──────────────────────────────────────────────────────────────
+echo "== Mode 8 — Diff =="
+DIFF_OUT="$(mktemp)"
+
+# 8a. Global diff — check all M8_DIFF.md top-level JSON keys
+run_capture "diff global --format json" "$DIFF_OUT" \
+  nsys-ai diff "$DIFF_BEFORE" "$DIFF_AFTER" --format json
+check_json_key "  diff: top_regressions key"   "$DIFF_OUT" 'top_regressions'
+check_json_key "  diff: top_improvements key"  "$DIFF_OUT" 'top_improvements'
+check_json_key "  diff: nvtx_regressions key"  "$DIFF_OUT" 'nvtx_regressions'
+check_json_key "  diff: nvtx_improvements key" "$DIFF_OUT" 'nvtx_improvements'
+check_json_key "  diff: overlap key"           "$DIFF_OUT" 'overlap'
+check_json_key "  diff: warnings key"          "$DIFF_OUT" 'warnings'
+
+# 8b. Same-file path: regressions and improvements must both be empty (comparing a
+#     profile to itself should yield zero kernel changes — §C2 acceptance test 2 CLI side).
+#     The same-inode warning is surfaced by the AI skill layer, not the CLI.
+DIFF_SAME_OUT="$(mktemp)"
+run_capture "diff same-file --format json" "$DIFF_SAME_OUT" \
+  nsys-ai diff "$PROFILE" "$PROFILE" --format json
+printf "  %-55s " "diff same-file: zero regressions + improvements"
+SAME_CHANGES=$(python3 -c "
+import json; d=json.load(open('$DIFF_SAME_OUT'))
+print(len(d.get('top_regressions',[])) + len(d.get('top_improvements',[])))
+" 2>/dev/null || echo 1)
+if [[ "$SAME_CHANGES" -eq 0 ]]; then echo "OK"; else echo "FAIL (expected 0 changes, got $SAME_CHANGES)"; FAIL=$((FAIL+1)); fi
+rm -f "$DIFF_SAME_OUT"
+
+# 8c. diff --gpu 0 (GPU-scoped diff — M8_DIFF.md §3 command 2c)
+DIFF_GPU_OUT="$(mktemp)"
+run_capture "diff --gpu 0 --format json" "$DIFF_GPU_OUT" \
+  nsys-ai diff "$DIFF_BEFORE" "$DIFF_AFTER" --format json --gpu 0
+check_json_key "  diff --gpu 0: top_regressions key" "$DIFF_GPU_OUT" 'top_regressions'
+rm -f "$DIFF_GPU_OUT"
+
+# 8d. diff --iteration 1 (iteration-scoped — M8_DIFF.md §3 command 2b)
+DIFF_ITER_OUT="$(mktemp)"
+run_capture "diff --iteration 1 --format json" "$DIFF_ITER_OUT" \
+  nsys-ai diff "$DIFF_BEFORE" "$DIFF_AFTER" --format json --iteration 1
+check_json_key "  diff --iteration 1: top_regressions key" "$DIFF_ITER_OUT" 'top_regressions'
+rm -f "$DIFF_ITER_OUT"
+
+# 8e. search --type nvtx (M8_DIFF.md §3 command 3 — discover NVTX names before drilling)
+SEARCH_OUT="$(mktemp)"
+if [[ "$NVTX_PROFILE" != "$PROFILE" ]] || nsys-ai search "$NVTX_PROFILE" --query '' --type nvtx --limit 1 >/dev/null 2>&1; then
+  run_capture "search --type nvtx --query '' --limit 5" "$SEARCH_OUT" \
+    nsys-ai search "$NVTX_PROFILE" --query '' --type nvtx --limit 5
+  printf "  %-55s " "search nvtx: non-empty output"
+  if [[ -s "$SEARCH_OUT" ]]; then echo "OK"; else echo "SKIP (no NVTX events)"; fi
+fi
+rm -f "$SEARCH_OUT"
+rm -f "$DIFF_OUT"
+
+# ── Mode 9: Variance ──────────────────────────────────────────────────────────
+echo "== Mode 9 — Variance =="
+
+# 9a. iteration_timing (precondition gate — M9_DIFF.md §1)
+ITER_TIMING_OUT="$(mktemp)"
+run_capture "skill iteration_timing --format json" "$ITER_TIMING_OUT" \
+  nsys-ai skill run iteration_timing "$NVTX_PROFILE" --format json
+printf "  %-55s " "iteration_timing: returns list"
+ITER_TYPE=$(python3 -c "import json,sys; d=json.load(open('$ITER_TIMING_OUT')); print('list' if isinstance(d,list) else 'other')" 2>/dev/null || echo other)
+if [[ "$ITER_TYPE" == "list" ]]; then echo "OK"; else echo "FAIL (expected list)"; FAIL=$((FAIL+1)); fi
+
+# 9b. iteration_detail on iteration 1 (skip index 0 per M9_VARIANCE.md §4)
+ITER_DETAIL_OUT="$(mktemp)"
+ITER_COUNT=$(python3 -c "import json; rows=json.load(open('$ITER_TIMING_OUT')); print(len(rows))" 2>/dev/null || echo 0)
+if [[ "$ITER_COUNT" -ge 2 ]]; then
+  run_capture "skill iteration_detail -p iteration=1 --format json" "$ITER_DETAIL_OUT" \
+    nsys-ai skill run iteration_detail "$NVTX_PROFILE" --format json -p iteration=1
+  printf "  %-55s " "iteration_detail: has duration_ms field"
+  DET_FIELDS=$(python3 -c "
+import json; d=json.load(open('$ITER_DETAIL_OUT'))
+rows = d if isinstance(d,list) else [d]
+print('ok' if rows and 'duration_ms' in rows[0] else 'missing')
+" 2>/dev/null || echo missing)
+  if [[ "$DET_FIELDS" == "ok" ]]; then echo "OK"; else echo "FAIL"; FAIL=$((FAIL+1)); fi
+else
+  printf "  %-55s SKIP (< 2 iterations detected)\n" "skill iteration_detail"
+fi
+rm -f "$ITER_DETAIL_OUT"
+
+# 9c. nccl_anomaly (Mode 9 NCCL straggler check — M9_VARIANCE.md §3 command 6)
+NCCL_ANOM_OUT="$(mktemp)"
+run_capture "skill nccl_anomaly --format json" "$NCCL_ANOM_OUT" \
+  nsys-ai skill run nccl_anomaly "$NVTX_PROFILE" --format json
+printf "  %-55s " "nccl_anomaly: returns list"
+NCCL_TYPE=$(python3 -c "import json; d=json.load(open('$NCCL_ANOM_OUT')); print('list' if isinstance(d,list) else 'other')" 2>/dev/null || echo other)
+if [[ "$NCCL_TYPE" == "list" ]]; then echo "OK"; else echo "FAIL"; FAIL=$((FAIL+1)); fi
+rm -f "$NCCL_ANOM_OUT" "$ITER_TIMING_OUT"
 
 # ── Plugin skill name check ───────────────────────────────────────────────────
 echo "== Plugin skill name (/nsys-ai) =="

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 PROFILE="${1:-}"
 if [[ -z "$PROFILE" || ! -f "$PROFILE" ]]; then
-  echo "usage: $0 <profile.sqlite> [nvtx-profile.sqlite]" >&2
+  echo "usage: $0 <profile.sqlite> [nvtx-profile.sqlite] [before.sqlite] [after.sqlite]" >&2
   exit 2
 fi
 if [[ -n "${2:-}" ]]; then
@@ -503,7 +503,7 @@ rm -f "$DIFF_OUT"
 # ── Mode 9: Variance ──────────────────────────────────────────────────────────
 echo "== Mode 9 — Variance =="
 
-# 9a. iteration_timing (precondition gate — M9_DIFF.md §1)
+# 9a. iteration_timing (precondition gate — M9_VARIANCE.md §1)
 ITER_TIMING_OUT="$(mktemp)"
 run_capture "skill iteration_timing --format json" "$ITER_TIMING_OUT" \
   nsys-ai skill run iteration_timing "$NVTX_PROFILE" --format json

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -483,19 +483,35 @@ check_json_key "  diff --gpu 0: top_regressions key" "$DIFF_GPU_OUT" 'top_regres
 rm -f "$DIFF_GPU_OUT"
 
 # 8d. diff --iteration 1 (iteration-scoped — M8_DIFF.md §3 command 2b)
+#     Only run when both profiles have ≥ 2 iterations; otherwise the command
+#     exits without JSON and check_json_key would false-fail.
 DIFF_ITER_OUT="$(mktemp)"
-run_capture "diff --iteration 1 --format json" "$DIFF_ITER_OUT" \
-  nsys-ai diff "$DIFF_BEFORE" "$DIFF_AFTER" --format json --iteration 1
-check_json_key "  diff --iteration 1: top_regressions key" "$DIFF_ITER_OUT" 'top_regressions'
+BEFORE_ITERS=$(nsys-ai skill run iteration_timing "$DIFF_BEFORE" --format json 2>/dev/null \
+  | python3 -c "import json,sys; rows=json.load(sys.stdin); print(len(rows))" 2>/dev/null || echo 0)
+AFTER_ITERS=$(nsys-ai skill run iteration_timing "$DIFF_AFTER" --format json 2>/dev/null \
+  | python3 -c "import json,sys; rows=json.load(sys.stdin); print(len(rows))" 2>/dev/null || echo 0)
+printf "  %-55s " "diff --iteration 1 --format json"
+if [[ "$BEFORE_ITERS" -ge 2 && "$AFTER_ITERS" -ge 2 ]]; then
+  run_capture "diff --iteration 1 --format json" "$DIFF_ITER_OUT" \
+    nsys-ai diff "$DIFF_BEFORE" "$DIFF_AFTER" --format json --iteration 1
+  check_json_key "  diff --iteration 1: top_regressions key" "$DIFF_ITER_OUT" 'top_regressions'
+else
+  echo "SKIP (iterations unavailable: before=$BEFORE_ITERS after=$AFTER_ITERS)"
+fi
 rm -f "$DIFF_ITER_OUT"
 
 # 8e. search --type nvtx (M8_DIFF.md §3 command 3 — discover NVTX names before drilling)
+#     Gate on HAS_NVTX: "No results found." is non-empty so -s alone is not sufficient.
 SEARCH_OUT="$(mktemp)"
-if [[ "$NVTX_PROFILE" != "$PROFILE" ]] || nsys-ai search "$NVTX_PROFILE" --query '' --type nvtx --limit 1 >/dev/null 2>&1; then
-  run_capture "search --type nvtx --query '' --limit 5" "$SEARCH_OUT" \
-    nsys-ai search "$NVTX_PROFILE" --query '' --type nvtx --limit 5
-  printf "  %-55s " "search nvtx: non-empty output"
-  if [[ -s "$SEARCH_OUT" ]]; then echo "OK"; else echo "SKIP (no NVTX events)"; fi
+printf "  %-55s " "search --type nvtx --query '' --limit 5"
+if [[ "${HAS_NVTX:-0}" == "1" ]]; then
+  if nsys-ai search "$NVTX_PROFILE" --query '' --type nvtx --limit 5 >"$SEARCH_OUT" 2>/dev/null; then
+    echo "OK"
+  else
+    echo "FAIL"; FAIL=$((FAIL+1))
+  fi
+else
+  echo "SKIP (no NVTX events in profile)"
 fi
 rm -f "$SEARCH_OUT"
 rm -f "$DIFF_OUT"

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -55,8 +55,8 @@ What would you like to analyze?
   5. NVTX / code map  — which layer / step consumes time
   6. Idle / sync      — GPU gaps, CPU stalls, launch overhead
   7. CUTracer         — SASS-level (requires re-run)
-  8. Diff             — compare two profiles                     (coming Stage C2)
-  9. Variance         — some iterations much slower than others  (coming Stage C2)
+  8. Diff             — compare two profiles
+  9. Variance         — some iterations much slower than others
 
 Reply with a number, or ask a question directly — keywords auto-route.
 ```
@@ -86,13 +86,7 @@ position).
 > escapes only. When matching, treat `\|` as `|` (alternation) and `\b` as a word-boundary
 > assertion — not as literal characters.
 
-For priorities not yet implemented (marked "(coming Stage C2)" in the menu above — modes
-8, 9), fall through to Mode 1 with a one-line notice:
-
-> "Specialist Mode <N> coming in Stage C2. Running auto-triage (Mode 1) now."
-
-Priorities 1–9 are all handled: priorities 1–6 route directly; priorities 2 (diff) and
-3 (variance) still fall through until C2. Priority 1 (cutracer) routes to Mode 7 (live).
+All 9 priorities are live. Priorities 1–9 route directly to their modes.
 
 ---
 
@@ -107,8 +101,8 @@ Priorities 1–9 are all handled: priorities 1–6 route directly; priorities 2 
 | 5 NVTX | `references/M5_NVTX.md` | — | Stage B2 (live) |
 | 6 Idle | `references/M6_IDLE.md` | — | Stage B1 (live) |
 | 7 CUTracer | `references/M7_CUTRACER.md` | — | Stage C1 (live) |
-| 8 Diff | `references/M8_DIFF.md` *(not yet present)* | `references/DIFF.md` | Stage C2 planned |
-| 9 Variance | `references/M9_VARIANCE.md` *(not yet present)* | `references/VARIANCE.md` | Stage C2 planned |
+| 8 Diff | `references/M8_DIFF.md` | `references/DIFF.md` (legacy) | Stage C2 (live) |
+| 9 Variance | `references/M9_VARIANCE.md` | `references/VARIANCE.md` (legacy) | Stage C2 (live) |
 
 After mode pick: load the Mode ref if it exists; otherwise load the fallback ref if listed;
 otherwise fall through to Mode 1. For any loaded ref, follow its six sections

--- a/skills/analyze/references/M8_DIFF.md
+++ b/skills/analyze/references/M8_DIFF.md
@@ -33,7 +33,8 @@ Three checks; any failure → §7 template and abort:
 
 | iters result | Action |
 |-------------|--------|
-| ≥ 3 on both | Use `--iteration 1` (skip JIT iteration 0) |
+| ≥ 3 on both AND median `duration_ms > 10` | Use `--iteration 1` (skip JIT iteration 0) |
+| ≥ 3 on both but median `duration_ms ≤ 10` | Global diff; note iterations are heuristic noise |
 | 2 on either | Use `--iteration 1`; note single-iteration caveat |
 | 1 on either | Global diff (no `--iteration`); note profile too short |
 | Counts differ | Global diff; surface "iteration count mismatch" warning first |

--- a/skills/analyze/references/M8_DIFF.md
+++ b/skills/analyze/references/M8_DIFF.md
@@ -1,0 +1,130 @@
+# Mode 8 — Diff (before vs after)
+
+Reference for `/nsys-ai` Mode 8. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+§7 fail template, §10 checklist.
+
+---
+
+## 1. Precondition gate
+
+Three checks; any failure → §7 template and abort:
+
+1. **Both profiles pass §4.1 rows 1–4** — exists, has kernel table. If one fails:
+   "Mode 8 blocked (before=`<a>` after=`<b>`): `<which>` has no kernel table.
+   Fix: re-export or pick a valid profile."
+2. **Same-inode guard** (§4.1 row 7): `os.stat(before).st_ino != os.stat(after).st_ino`.
+   If equal: "Mode 8 blocked. Why: both paths resolve to the same file.
+   Fix: provide two distinct profiles. Alternative: Mode 1 for single-profile analysis."
+3. **Workload check**: after running diff, if `warnings[]` is non-empty surface each string
+   before proceeding — do NOT block on warnings, but note them prominently. If both
+   `top_regressions` and `top_improvements` are empty, warn "No kernel changes detected."
+
+---
+
+## 2. Stages
+
+| # | Question | Condition / Default |
+|---|----------|--------------------|
+| 1 | Baseline profile path (before) | Required if not supplied |
+| 2 | Candidate profile path (after) | Required if not supplied |
+| 3 | Iteration anchor: `auto` / `N` | Optional; default `auto` (global diff) |
+
+**Stage 3 auto strategy** — run `nsys-ai iters` on each side first:
+
+| iters result | Action |
+|-------------|--------|
+| ≥ 3 on both | Use `--iteration 1` (skip JIT iteration 0) |
+| 2 on either | Use `--iteration 1`; note single-iteration caveat |
+| 1 on either | Global diff (no `--iteration`); note profile too short |
+| Counts differ | Global diff; surface "iteration count mismatch" warning first |
+
+---
+
+## 3. Commands
+
+```bash
+# 1. Check iteration counts for Stage 3 decision
+nsys-ai iters <before>
+nsys-ai iters <after>
+
+# 2a. Global diff (default — no --iteration)
+nsys-ai diff <before> <after> --format json
+
+# 2b. Iteration-scoped diff (after iters confirm alignment)
+nsys-ai diff <before> <after> --iteration 1 --format json
+
+# 2c. GPU-scoped diff (multi-GPU; focus on one device)
+nsys-ai diff <before> <after> --gpu 0 --format json
+
+# 3. Search for NVTX region name before drilling (PRINCIPLES §3 rule 1: never guess)
+nsys-ai search <before> --query <keyword> --type nvtx
+nsys-ai search <after>  --query <keyword> --type nvtx
+
+# 4. Visual diff timeline
+nsys-ai diff-web <before> <after>
+```
+
+---
+
+## 4. Signals
+
+From `nsys-ai diff --format json` (top-level keys: `warnings[]`, `top_regressions[]`,
+`top_improvements[]`, `nvtx_regressions[]`, `nvtx_improvements[]`, `overlap`; per-kernel
+fields: `name`, `demangled`, `delta_ns`, `before_share`, `after_share`, `classification`):
+
+| Field / condition | Diagnosis | Action |
+|-------------------|-----------|--------|
+| `warnings[]` non-empty | Mismatch: schema diff, very different kernel sets, or missing overlap data | Surface each string; skip per-kernel conclusions if workloads differ |
+| `top_regressions[0].delta_ns / 1e6 > 10` | Kernel regression ≥ 10 ms | Examine `name`, `before_share` vs `after_share`; correlate with code change |
+| `top_regressions[0].classification = "new"` | Kernel appeared after change | New op introduced; `demangled` for source hint; ask user what changed |
+| `nvtx_regressions[0].delta_ns > 0` AND `top_regressions` small | NVTX-level slowdown without kernel cause | CPU starvation, DataLoader, or GIL — cross into Mode 6 |
+| `overlap.after.overlap_pct < overlap.before.overlap_pct - 10` | Lost compute/NCCL pipeline overlap (≥ 10 pp) | NCCL config changed; bucket size reduced; cross into Mode 2 |
+| Both `top_regressions` and `top_improvements` empty | No kernel change detected | Verify profiles are different; re-run global diff without `--iteration` |
+
+**Skip iteration 0** in any `--iteration` diff — JIT warmup inflates it (PRINCIPLES §3 rule 4).
+
+---
+
+## 5. Cross-mode exits
+
+| Mode | When to suggest |
+|------|----------------|
+| 5 (NVTX) | `nvtx_regressions` non-empty — attribute regression to specific layer |
+| 2 (Comms) | `overlap.after.overlap_pct` drops > 10 pp vs `overlap.before.overlap_pct` |
+| 6 (Idle) | `nvtx_regressions` spike with `top_regressions` small — CPU/DataLoader |
+
+---
+
+## 6. Delivery
+
+**Evidence**: PRINCIPLES §5.10 Mode 8 adaptation — run `evidence build <after>` only.
+Craft a findings JSON with regression labels, then serve the after-profile timeline:
+
+```bash
+nsys-ai skill run kernel_instances <after> --format json -p name=<hot_kernel>
+# Use start_ns / end_ns from output to build findings:
+nsys-ai timeline-web <after> --findings /tmp/findings.json
+```
+
+`findings.json` shape:
+```json
+{"findings": [{"type": "regression", "label": "<name> +<delta_ms>ms",
+  "start_ns": <start>, "end_ns": <end>, "severity": "critical"}]}
+```
+
+Then 3-part summary:
+
+1. **Root cause** — regression magnitude + trigger:
+   > "`flash_bwd` accounts for +31% runtime after the change (+58 ms, 62% → 82% share).
+   > Classification: regression. Likely cause: sequence length increase."
+
+2. **Specific fix** — matched to `classification`:
+   - `regression` in `*gemm*` / `*flash*` → check dtype, shape alignment, matmul tile size
+   - `regression` in `nccl*` → bucket size, async overlap (Mode 2)
+   - `new` kernel → unnecessary op introduced; bisect the commit that added it
+   - NVTX-only regression → CPU pipeline stall (Mode 6)
+
+3. **Expected gain** (qualitative):
+   > "Reverting the sequence-length change should recover ~58 ms per step."
+
+**Always note** whether diff was global or iteration-scoped, and list any `warnings[]` items.

--- a/skills/analyze/references/M9_VARIANCE.md
+++ b/skills/analyze/references/M9_VARIANCE.md
@@ -1,0 +1,109 @@
+# Mode 9 — Variance (iteration spikes)
+
+Reference for `/nsys-ai` Mode 9. **Read `PRINCIPLES.md` first** — §4 guards, §5 evidence,
+§7 fail template, §10 checklist.
+
+---
+
+## 1. Precondition gate
+
+§4.1 row 8 / §4.3 row 3 — run `nsys-ai skill run iteration_timing <profile> --format json`.
+If result is `[]`:
+
+```
+Mode 9 requires a user choice.
+
+Why: no NVTX iteration markers and kernel-gap heuristic found no iterations.
+Fix: add a top-level NVTX range per step, e.g.:
+  with torch.cuda.nvtx.range("sample_0"): ...
+then re-profile.
+Alternative: Mode 5 Path B (kernel-name heuristics, no per-iteration attribution).
+
+Reply "B", re-profile, or "stop".
+```
+
+---
+
+## 2. Stages
+
+| # | Question | Condition / Default |
+|---|----------|--------------------|
+| 1 | Profile path | Required if not supplied |
+| 2 | Granularity: `iterations` / `ranks` / `kernels` | Optional; default `iterations` |
+| 3 | Metric: `max/min` / `p95/p50` / `p99/p50` | Optional; default `max/min` |
+
+Stage 2 `ranks` requires `nccl.collectives > 0` from manifest; if zero, offer `iterations`
+or `kernels` only.
+
+---
+
+## 3. Commands
+
+```bash
+# 1. Detect iterations and surface slow outliers
+nsys-ai skill run iteration_timing <profile> --format json
+
+# 2. Drill into a slow iteration (N from step 1 — skip index 0)
+nsys-ai skill run iteration_detail <profile> --format json -p iteration=<N>
+
+# 3. Top kernels in that iteration only
+nsys-ai skill run top_kernels <profile> --format json --iteration <N>
+
+# 4. Idle gaps in that iteration
+nsys-ai skill run gpu_idle_gaps <profile> --format json --iteration <N>
+
+# 5. Specific kernel instances in slow iteration
+nsys-ai skill run kernel_instances <profile> --format json --iteration <N> -p name=<hot>
+
+# 6. NCCL straggler check (only if nccl.collectives > 0)
+nsys-ai skill run nccl_anomaly <profile> --format json
+```
+
+---
+
+## 4. Signals
+
+From `iteration_timing` (per-row: `iteration`, `duration_ms`; skip index 0) and
+`iteration_detail` (fields: `duration_ms`, `vs_median`, `kernel_count`, `nccl_count`,
+`compute_ms`):
+
+| Pattern | Diagnosis | Action |
+|---------|-----------|--------|
+| Every Nth iteration slow (N = 4/8/16) | Gradient accumulation or eval step | Expected — confirm NVTX label; advise profiling eval separately |
+| First 2–3 iters slow, rest stable | JIT compilation / CUDA cache warmup | Expected — exclude iter 0 from benchmarks; profile from iter 2+ |
+| Random spikes, no period | DataLoader I/O latency variance | `pin_memory=True`; `num_workers ≥ 4`; `prefetch_factor=2` |
+| Slow iters have elevated `nccl_count` | NCCL retry or straggler rank | `NCCL_DEBUG=INFO`; check network link; Mode 2 |
+| `duration_ms` increases monotonically over run | GPU thermal throttle | `nvidia-smi -q -d CLOCK` → check `THERMAL` status; reduce power limit |
+| Alternating fast/slow pairs | Prefetch pipeline stall or double-buffer underrun | Increase prefetch depth; check `num_workers` |
+| `gpu_idle_gaps` large in slow iter, `compute_ms` unchanged | CPU starvation (DataLoader/GIL) | Mode 6 for idle breakdown |
+
+**Variance ratio**: `max_ms / median_ms > 1.5` → report as outlier. < 1.5 → within normal
+(no actionable spike; tell user and close).
+
+---
+
+## 5. Cross-mode exits
+
+| Mode | When to suggest |
+|------|----------------|
+| 2 (Comms) | Slow iters correlate with elevated `nccl_count` → straggler rank analysis |
+| 6 (Idle) | Slow iter has large `gpu_idle_gaps` with `compute_ms` unchanged → CPU cause |
+
+---
+
+## 6. Delivery
+
+Follow `PRINCIPLES.md §5` for evidence + timeline URL. Then 3-part summary:
+
+1. **Root cause** — outlier fraction + pattern:
+   > "3 of 12 iterations are ≥ 2× median (1420 ms vs 680 ms median). Pattern: random spikes.
+   > Top cause: DataLoader stall — `gpu_idle_gaps` spikes 740 ms in slow iters vs 12 ms normal."
+
+2. **Specific fix** — matched to pattern:
+   - DataLoader: `DataLoader(num_workers=4, pin_memory=True, prefetch_factor=2)`
+   - JIT: exclude iter 0 from benchmark; profile from iteration 2+
+   - Thermal: `nvidia-smi -pl <TDP_W>` to enforce power limit
+   - NCCL retry: `NCCL_DEBUG=INFO`; investigate straggler rank (Mode 2)
+
+3. **Expected gain** (qualitative):
+   > "Eliminating DataLoader stalls should reduce spiked iterations from 1420 ms to ~680 ms (2.1×)."

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -635,7 +635,8 @@ def _cmd_iters(args, _profile):
     from nsys_ai.overlap import detect_iterations, format_iterations
 
     with _profile.open(args.profile) as prof:
-        print(format_iterations(detect_iterations(prof, args.gpu, _parse_trim(args))))
+        device = args.gpu if args.gpu is not None else (prof.meta.devices[0] if prof.meta.devices else 0)
+        print(format_iterations(detect_iterations(prof, device, _parse_trim(args))))
 
 
 def _cmd_tree(args, _profile):

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -600,7 +600,7 @@ def _register_legacy_commands(sub):
     p.set_defaults(handler=_cmd_nccl)
 
     p = sub.add_parser("iters", help="Detect training iterations")
-    _add_gpu_trim(p)
+    _add_gpu_trim(p, gpu_required=False, trim_required=False)
     p.set_defaults(handler=_cmd_iters)
 
     p = sub.add_parser("tree", help="NVTX hierarchy as text")

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -524,7 +524,8 @@ class Profile:
         if trim:
             sql += " AND n.start >= ? AND n.[end] <= ?"
             params += list(trim)
-        sql += " GROUP BY text ORDER BY total_ns DESC"
+        sql += " GROUP BY COALESCE(n.text, s.value)" if self._nvtx_has_text_id else " GROUP BY text"
+        sql += " ORDER BY total_ns DESC"
         if limit is not None:
             sql += " LIMIT ?"
             params.append(int(limit))

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -467,7 +467,7 @@ class Profile:
         if trim:
             sql += " AND n.start >= ? AND n.[end] <= ?"
             params += list(trim)
-        sql += " GROUP BY text"
+        sql += " GROUP BY COALESCE(n.text, s.value)" if self._nvtx_has_text_id else " GROUP BY text"
         sql += " ORDER BY total_ns DESC"
         if limit is not None:
             sql += " LIMIT ?"

--- a/tests/test_duckdb_path.py
+++ b/tests/test_duckdb_path.py
@@ -247,3 +247,72 @@ class TestDuckDBCompatibilityFixes:
         # Should quietly return [] instead of raising duckdb.Error
         rows = skill.execute(bad_conn)
         assert rows == []
+
+    def _make_textid_db(self, nvtx_rows: list[tuple], string_rows: list[tuple]):
+        """Return a minimal DuckDB connection with textId-based NVTX schema."""
+        import duckdb
+
+        db = duckdb.connect()
+        db.execute("CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT)")
+        db.execute(
+            "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+            "(globalTid INT, deviceId INT, streamId INT, correlationId INT, "
+            "start INT, \"end\" INT, shortName INT, demangledName INT, "
+            "gridX INT, gridY INT, gridZ INT, blockX INT, blockY INT, blockZ INT)"
+        )
+        db.execute(
+            "CREATE TABLE NVTX_EVENTS "
+            "(globalTid INT, start INT, \"end\" INT, text TEXT, textId INT, eventType INT)"
+        )
+        db.execute("INSERT INTO StringIds VALUES (99, 'dummy_kernel')")
+        db.execute(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES "
+            "(0, 0, 7, 1, 0, 10000000, 99, 99, 1, 1, 1, 32, 1, 1)"
+        )
+        for row in string_rows:
+            db.execute("INSERT INTO StringIds VALUES (?, ?)", row)
+        for row in nvtx_rows:
+            db.execute("INSERT INTO NVTX_EVENTS VALUES (?, ?, ?, ?, ?, ?)", row)
+        return db
+
+    def test_aggregate_nvtx_ranges_text_id_schema(self):
+        """aggregate_nvtx_ranges must not raise DuckDB BinderException on textId schema.
+
+        Regression guard for the GROUP BY alias bug: grouping by `text` (alias) when
+        COALESCE(n.text, s.value) appears in SELECT caused DuckDB to reject the query.
+        """
+        from nsys_ai.profile import Profile
+
+        db = self._make_textid_db(
+            nvtx_rows=[
+                (0, 100, 500, None, 1, 59),   # forward, 400 ns
+                (0, 600, 900, None, 2, 59),   # backward, 300 ns
+            ],
+            string_rows=[(1, "forward"), (2, "backward")],
+        )
+
+        p = Profile._from_conn(db)
+        assert p._nvtx_has_text_id is True
+
+        rows = p.aggregate_nvtx_ranges()
+        texts = [r["text"] for r in rows]
+        assert "forward" in texts
+        assert "backward" in texts
+
+    def test_search_nvtx_names_text_id_schema(self):
+        """search_nvtx_names must not raise DuckDB BinderException on textId schema."""
+        from nsys_ai.profile import Profile
+
+        db = self._make_textid_db(
+            nvtx_rows=[
+                (0, 0, 1000, None, 1, 59),
+                (0, 1100, 2000, None, 2, 59),
+            ],
+            string_rows=[(1, "flash_fwd"), (2, "flash_bwd")],
+        )
+
+        p = Profile._from_conn(db)
+        rows = p.search_nvtx_names("flash")
+        texts = [r["text"] for r in rows]
+        assert "flash_fwd" in texts
+        assert "flash_bwd" in texts


### PR DESCRIPTION
  ## Summary                                                

  - **`M8_DIFF.md`** — new Mode 8 reference (rewrite of legacy `DIFF.md`): 3-stage diff                                                        
    workflow, all 6 JSON output keys documented, cross-mode exits (Mode 2/5/6), and
    delivery template with findings JSON + timeline URL. Zero occurrences of the 14                                                            
    obsolete agent-tool names from §12.7.                                                                                                      
  - **`M9_VARIANCE.md`** — new Mode 9 reference: iteration-spike precondition gate,                                                            
    3-stage questioning, 7 variance patterns (JIT warmup / DataLoader / thermal /                                                              
    NCCL straggler), and 3-part delivery template.                                                                                             
  - **`SKILL.md`** — menu rows 8 + 9 drop `(coming Stage C2)`; routing table updated                                                           
    to `Stage C2 (live)`; fallback stubs removed; all 9 priorities now route directly.                                                         
  - **`smoke_test.sh`** — Stage C2 block added (Mode 8: global diff, same-file identity                                                        
    check, `--gpu 0`, `--iteration 1`, NVTX search; Mode 9: `iteration_timing`,                                                                
    `iteration_detail`, `nccl_anomaly`); optional `[before.sqlite] [after.sqlite]`                                                             
    args allow a real before/after pair to be passed in.                                                                                       
  - **`profile.py` bugfix** — `aggregate_nvtx_ranges` crashed on DuckDB with                                                                   
    `BinderException: column "value" must appear in GROUP BY` when profiles use                                                                
    `textId`-based NVTX events. Fixed by grouping on `COALESCE(n.text, s.value)`                                                               
    instead of the bare alias `text` in the `_nvtx_has_text_id` path. Without this                                                             
    fix `nsys-ai diff` fails entirely on affected profiles.                                                                                    
                                                                                                                                               
  ## Test plan                                                                                                                                 
                                                                                                                                               
  - [ ] `grep -c '<14 obsolete tool names>' skills/analyze/references/M8_DIFF.md` → 0
  - [ ] `bash scripts/smoke_test.sh megatron_distca.sqlite mfu_training_latest.sqlite trace_before.sqlite trace_after.sqlite` → all checks     
  passed                                                                                                                                       
  - [ ] Keyword routing review: 2-path input → Mode 8; `spikes` keyword → Mode 9 precondition gate fires on no-NVTX profile                    
  - [ ] `nsys-ai diff <before> <after> --format json` on textId-NVTX profiles no longer crashes  