### PR TITLE
fix(plugin): use HTTPS url source so install works without SSH keys 

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,8 +12,8 @@
       "description": "GPU profile analysis for NVIDIA Nsight Systems. Triage bottlenecks, diagnose NCCL, compute MFU, compare regressions, and drill into SASS instructions. Requires the nsys-ai CLI (>= 0.2.1): pip install nsys-ai.",
       "category": "development",
       "source": {
-        "source": "github",
-        "repo": "GindaChen/nsys-ai"
+        "source": "url",
+        "url": "https://github.com/GindaChen/nsys-ai.git"
       },
       "homepage": "https://github.com/GindaChen/nsys-ai"
     }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,10 @@
       "name": "nsys-ai",
       "description": "GPU profile analysis for NVIDIA Nsight Systems. Triage bottlenecks, diagnose NCCL, compute MFU, compare regressions, and drill into SASS instructions. Requires the nsys-ai CLI (>= 0.2.1): pip install nsys-ai.",
       "category": "development",
-      "source": ".",
+      "source": {
+        "source": "github",
+        "repo": "GindaChen/nsys-ai"
+      },
       "homepage": "https://github.com/GindaChen/nsys-ai"
     }
   ]

--- a/docs/claude-plugin-quickstart.md
+++ b/docs/claude-plugin-quickstart.md
@@ -8,11 +8,22 @@ pip install "nsys-ai[agent]"
 
 ## 2. Add the plugin to Claude Code
 
-```bash
-# Option A — marketplace (once published)
-claude plugin install GindaChen/nsys-ai
+**Option A — marketplace (recommended).** In Claude Code, run:
 
-# Option B — local dev (session-scoped, run from cloned repo)
+```
+/plugin marketplace add GindaChen/nsys-ai
+/plugin install nsys-ai@GindaChen
+```
+
+The first command registers this repo as a marketplace (reads
+`.claude-plugin/marketplace.json`). The second installs the `nsys-ai` plugin
+from it. Both commands are typed into the Claude Code prompt, not a shell.
+
+To pick up marketplace changes later: `/plugin marketplace update GindaChen`.
+
+**Option B — local dev (session-scoped).**
+
+```bash
 git clone https://github.com/GindaChen/nsys-ai
 claude --plugin-dir ./nsys-ai
 ```

--- a/docs/claude-plugin.md
+++ b/docs/claude-plugin.md
@@ -6,15 +6,28 @@ a specific code fix, and a quantified expected gain — in 3 turns or fewer.
 
 ## Install
 
+**Step 1 — install the `nsys-ai` CLI** (required, used by the plugin):
+
 ```bash
-# 1. Install the nsys-ai CLI (required)
 pip install "nsys-ai[agent]"
+```
 
-# 2. Add the plugin to Claude Code
-#    Option A — marketplace (once published)
-claude plugin install GindaChen/nsys-ai
+**Step 2 — add the plugin to Claude Code.**
 
-#    Option B — local dev (session-scoped)
+Option A — marketplace (recommended). In the Claude Code prompt:
+
+```
+/plugin marketplace add GindaChen/nsys-ai
+/plugin install nsys-ai@GindaChen
+```
+
+`/plugin marketplace add` reads `.claude-plugin/marketplace.json` from this
+repo; `/plugin install` fetches the plugin over HTTPS. To refresh later:
+`/plugin marketplace update GindaChen`.
+
+Option B — local dev (session-scoped):
+
+```bash
 git clone https://github.com/GindaChen/nsys-ai
 claude --plugin-dir ./nsys-ai
 ```


### PR DESCRIPTION
  ## Summary                                                

  - Switch `marketplace.json` plugin source from `github` to `url` with an HTTPS                                                                     
    clone URL. The `github` source type resolves to `git@github.com:…`, which
    fails with `Permission denied (publickey)` for any user who hasn't set up a                                                                      
    GitHub SSH key — making `/plugin install nsys-ai@GindaChen` unusable for a                                                                       
    large fraction of first-time users.                                                                                                              
  - Rewrite the install sections of `docs/claude-plugin-quickstart.md` and                                                                           
    `docs/claude-plugin.md` to use the current two-step flow                                                                                         
    (`/plugin marketplace add GindaChen/nsys-ai` → `/plugin install nsys-ai@GindaChen`),                                                             
    replacing the stale `claude plugin install …` command. Clarify that these                                                                        
    are typed into the Claude Code prompt, not a shell, and document                                                                                 
    `/plugin marketplace update GindaChen` for refreshing.                                                                                           
                                                                                                                                                     
  ## Why                                                                                                                                             
                                                                                                                                                     
  A user hit `Failed to clone repository: git@github.com: Permission denied                                                                          
  (publickey)` when running `/plugin install nsys-ai@GindaChen`. The
  [marketplace schema](https://code.claude.com/docs/en/plugin-marketplaces#plugin-sources)                                                           
  documents `url` as the source type that accepts an explicit HTTPS URL, so                                                                          
  switching fixes it for everyone without requiring per-user SSH setup.   