### PR TITLE
feat(skills): add host_sync_parent_ranges + enforce code-pointer delivery

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -423,6 +423,13 @@ run_capture "sync_cost_analysis" "$SYNC_OUT" \
   nsys-ai skill run sync_cost_analysis "$PROFILE" --format json
 check_regex "  sync_cost_analysis: sync_density_pct" "$SYNC_OUT" '"sync_density_pct"'
 
+HOST_SYNC_OUT="$(mktemp)"
+run_capture_json "host_sync_parent_ranges" "$HOST_SYNC_OUT" \
+  nsys-ai skill run host_sync_parent_ranges "$NVTX_PROFILE" --format json
+check_field_conditional \
+  "  host_sync_parent_ranges: parent_range" "$HOST_SYNC_OUT" '"parent_range"' \
+  "no NVTX or no matching sync events"
+
 run "kernel_launch_overhead" nsys-ai skill run kernel_launch_overhead "$PROFILE" --format json
 
 run_capture "cpu_gpu_pipeline" "$CPU_GPU_OUT" \

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -134,6 +134,11 @@ first `iteration_timing` call — use the manifest values directly and jump to S
 5. No `SELECT *` — always name specific columns.
 6. Skip iteration 0 in Mode 3 MFU and Mode 8 diff — JIT warmup inflates it.
 7. Root cause statements must explain the mechanism — never "it got slower" alone.
+8. Host-sync diagnoses (`.item()`, `_local_scalar_dense`, `cudaStreamSynchronize`) require
+   PRINCIPLES.md §5.7 — NVTX parent range + repo grep → concrete `path/file.py:line` in Fix.
+9. "Per-step" cost claims require frequency verification (event count ≥ `iteration_count`);
+   one-shot events must be reframed as one-time overhead, not extrapolated.
+10. Code fixes must render as a before/after code block — no pure-prose "convert to …".
 
 **Universal evidence step** (PRINCIPLES.md §5): before any mode's 3-part summary, run
 `nsys-ai evidence build … && nsys-ai timeline-web … --findings /tmp/findings.json`, then

--- a/skills/analyze/references/M3_COMPUTE.md
+++ b/skills/analyze/references/M3_COMPUTE.md
@@ -63,6 +63,7 @@ and model architecture table.
 | `arithmetic_intensity.classification` starts with `"Compute-bound"` with low MFU | Above ridge but inefficient | occupancy issue; check register pressure / block size |
 | `kernel_launch_pattern.sync_stalls` > 0 on a stream | CPU dispatch bottleneck | use CUDA graphs; batch launches |
 | `top_kernels[0]` is custom / Triton AND > 60% | SASS-level investigation warranted | suggest Mode 7 |
+| manifest `sync.sync_density_pct > 40` OR `nvtx.top_regions[0].name` contains `item` / `_local_scalar_dense` / `cudaStreamSynchronize` | Workload is sync-bound, not compute-bound | **exit to Mode 6** before finishing Mode 3 — compute tuning won't recover sync stalls. Render `Cross-mode exit: sync-bound, hand off to Mode 6` and follow PRINCIPLES.md §5.7 for code correlation |
 
 ---
 
@@ -87,12 +88,19 @@ Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summar
    > accounts for 68% of GPU time. Tensor core utilization is 91% — compute is the bottleneck,
    > not memory."
 
-2. **Specific fix** — matching the finding:
-   - FP32 fallback: `model = model.to(torch.bfloat16)` or `torch.set_float32_matmul_precision('high')`
-   - Low MFU, memory-bound: increase batch size; fuse attention via `scaled_dot_product_attention`
+2. **Specific fix** — matching the finding. When the fix is a code change (dtype cast,
+   `sdpa` swap, shape padding, etc.), `grep` the user's repo for the relevant call and
+   cite at least one `path/file.py:line` candidate — or state "repo not accessible" if
+   the plugin cannot read the CWD. Do not emit a fix that names only a function class
+   ("your matmul call"): name the file.
+   - FP32 fallback: `model = model.to(torch.bfloat16)` or `torch.set_float32_matmul_precision('high')` — grep `torch.set_default_dtype|\.to\(torch\.float32\)`
+   - Low MFU, memory-bound: increase batch size; fuse attention via `scaled_dot_product_attention` — grep `F\.scaled_dot_product_attention|nn\.MultiheadAttention|custom attention impl`
    - Custom kernel: profiling alone can't fix — suggest Mode 7 for SASS-level diagnosis
    - Small matmul shapes: pad sequence length / batch to GEMM-friendly multiples (128, 256)
 
 3. **Expected gain** — MFU % if computed; `speedup_estimator` if NVTX present; omit otherwise.
+   If the hotspot is a host-sync (e.g. `aten::item` appears in `nvtx.top_regions` with
+   a large share), exit to Mode 6 rather than quantifying compute gain — Mode 3 cannot
+   fix a sync-bound workload. See PRINCIPLES.md §3 rule 9 on frequency verification.
 
 See `ROOT_CAUSE.md §1` for the cross-mode cause→fix matrix.

--- a/skills/analyze/references/M6_IDLE.md
+++ b/skills/analyze/references/M6_IDLE.md
@@ -32,10 +32,10 @@ Skip Stage 2 if keyword already implies sub-focus (e.g. "dataloader" → `cpu-pi
 | Sub-focus | Skills (in order) |
 |-----------|-------------------|
 | `gaps` | `gpu_idle_gaps -p min_gap_ns=1000000` → `stream_concurrency` |
-| `sync` | `sync_cost_analysis` |
+| `sync` | `sync_cost_analysis` → `host_sync_parent_ranges` (if `manifest.nvtx.has_nvtx`) |
 | `launch` | `kernel_launch_overhead` |
 | `cpu-pipeline` | `cpu_gpu_pipeline` → `thread_utilization` |
-| `all` (default) | `gpu_idle_gaps` → `stream_concurrency` → `sync_cost_analysis` → `kernel_launch_overhead` → `cpu_gpu_pipeline` → `thread_utilization` → `module_loading` → `gc_impact` (if `starvation_events > 0`) → `pipeline_bubble_metrics` (if `nccl.collectives > 0`) |
+| `all` (default) | `gpu_idle_gaps` → `stream_concurrency` → `sync_cost_analysis` → `host_sync_parent_ranges` (if `manifest.nvtx.has_nvtx` and `sync_cost_analysis.sync_density_pct > 20`) → `kernel_launch_overhead` → `cpu_gpu_pipeline` → `thread_utilization` → `module_loading` → `gc_impact` (if `starvation_events > 0`) → `pipeline_bubble_metrics` (if `nccl.collectives > 0`) |
 
 Device propagation: `gpu_idle_gaps` accepts `-p device=N`. `stream_concurrency`,
 `sync_cost_analysis`, `kernel_launch_overhead`, `cpu_gpu_pipeline` do not accept device.
@@ -61,6 +61,12 @@ See PRINCIPLES.md §6.
 and `attribution.top_apis[].name`. Look for `DataLoader` / `cudaMemcpyAsync` /
 `cudaStreamSynchronize` in those fields.
 
+**Host-sync workflow** (when `sync_cost_analysis` or NVTX top regions surface `.item()` /
+`_local_scalar_dense` / `cudaStreamSynchronize`): follow PRINCIPLES.md §5.7 (NVTX ancestor
+SQL + repo grep → `path/file.py:line` in Fix); divide the event count by
+`iteration_timing.iterations` before quantifying gain (§3 rule 9 — `count < iterations`
+is one-time overhead, not per-step).
+
 ---
 
 ## 5. Cross-mode exits
@@ -81,11 +87,23 @@ Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summar
    > "GPU is idle 23% of profile time. `gpu_idle_gaps` attributes 78% of gaps to
    > DataLoader workers — the CPU cannot prefetch fast enough to keep the GPU busy."
 
-2. **Specific fix** — matching the stall class:
-   - DataLoader starvation: `DataLoader(..., num_workers=8, pin_memory=True, prefetch_factor=4, persistent_workers=True)`
-   - `.item()` sync loop: remove from inner loop; accumulate as tensor, call once outside
-   - Launch overhead: batch small kernel launches; use CUDA graphs for repeated patterns
-   - GC stall: reduce allocation churn; reuse tensors/buffers; avoid frequent allocate/free cycles; `gc.disable()` only with explicit memory-safety caveat
-   - PP bubble: `num_micro_batches = pipeline_stages * 2` (1F1B schedule)
+2. **Specific fix** — must include a before/after code block per PRINCIPLES.md §3 rule 10.
+   Host-sync fixes additionally cite `path/file.py:line` from §5.7. Example:
 
-3. **Expected gain** — from `speedup_estimator` if NVTX present; omit otherwise.
+   ```python
+   # training_pipeline.py:342 — before (per-step GPU sync)
+   wandb.log({"loss": loss.item()})
+   # after (accumulate on-device, flush every N steps)
+   self._loss_buf.append(loss.detach())
+   if step % self.log_interval == 0:
+       wandb.log({"loss": torch.stack(self._loss_buf).mean().item()})
+       self._loss_buf.clear()
+   ```
+
+   Other stall classes: DataLoader → `num_workers`/`pin_memory`/`prefetch_factor`/`persistent_workers`;
+   launch overhead → CUDA graphs / batched launches; GC stall → reuse tensors;
+   PP bubble → `num_micro_batches = pipeline_stages * 2` (1F1B).
+
+3. **Expected gain** — `speedup_estimator` if NVTX present; for host-sync fixes, scale by
+   the §4 frequency check and bound by `sync_cost_analysis.sync_density_pct` drop (not
+   total step-time drop — other sync sources may remain).

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -42,6 +42,23 @@ You are a **CUDA ML Systems Performance Expert** invoked via the `/nsys-ai` slas
    Always state: what changed, evidence field+value, what to do.
 7. **End your message before waiting for user input.** Ask → end message → wait. Do not
    proceed without the answer.
+8. **Host-sync diagnoses require call-site localization.** When the root cause names a
+   host-GPU sync — `aten::item`, `aten::_local_scalar_dense`, `cudaStreamSynchronize`,
+   `.item()`, `.cpu()`, `.tolist()`, `.numpy()` — follow §5.7 before writing the Fix:
+   (a) query the parent NVTX range, and (b) `Grep` the user's repo for the exact call
+   sites. The Fix section must name `path/file.py:line` candidates, not phrases like
+   "typical culprits are …". If the repo is not accessible, say so explicitly.
+9. **Per-step cost claims require frequency verification.** Before writing "X ms per step"
+   or extrapolating to MFU/step-time gain, check the event's call count against
+   `iteration_timing.iterations` (or `iteration_count` in the manifest). A single long
+   call is a one-shot — report it as "one-time overhead", not per-step. A Fix that
+   assumes per-step elimination must be backed by `count ≥ iterations`.
+10. **Code fixes require a before/after block — no pure prose.** Whenever the Fix names
+    a code change (dtype cast, sync removal, kernel swap, config tuple, API replacement),
+    render it as a fenced code block showing both the current pattern and the target
+    pattern. Phrases like "convert to … instead of …" or "use … pattern" are not
+    acceptable Fix content on their own — show the code. Non-code fixes (e.g. "re-profile
+    with `--capture-range`") are exempt.
 
 ---
 
@@ -177,6 +194,49 @@ nsys-ai timeline-web <after> --findings /tmp/findings.json
 Rationale: there is no "before timeline" in a diff delivery; the user's attention goes
 to the regressed after-state. Annotating the before profile would be misleading.
 
+### §5.7 Code correlation for host-sync diagnoses
+
+Triggered by §3 rule 8 (root cause names a host-GPU sync event). Run both steps before
+the 3-part summary:
+
+**Step 1 — parent NVTX range** (identifies which training phase owns the sync).
+Only run if manifest `nvtx.has_nvtx` is true; otherwise skip this step.
+
+Call the dedicated builtin skill (JSON output, runs on the DuckDB parquet-cache path
+for fast self-joins on large NVTX tables):
+
+```bash
+nsys-ai skill run host_sync_parent_ranges <profile> --format json
+# Optional: override the default sync pattern set
+nsys-ai skill run host_sync_parent_ranges <profile> --format json \
+  -p patterns="aten::item,_local_scalar_dense,cudaStreamSynchronize"
+```
+
+Output is a list of `{parent_range, n_syncs, sync_ns, sync_ms, top_child_label}`
+ranked by `sync_ns` desc. If the list is empty, proceed without a parent range — do
+not invent one. On a profile without NVTX_EVENTS the skill returns a single error
+row; treat it the same as "empty" and fall through to Step 2.
+
+**Step 2 — Grep the repo for call sites.** Scope to the directory implied by the parent
+range if known (e.g. parent `train_step/optimizer` → scope `training/`); otherwise grep
+from repo root:
+
+```
+grep -rn --include='*.py' -E '\.item\(\)|_local_scalar_dense\(|\.cpu\(\)\.numpy\(\)|\.tolist\(\)|torch\.cuda\.synchronize' <repo_root>
+```
+
+Cross-reference the hits with the parent range's likely source location. Rank candidates
+by (a) inside any loop that runs ≥ `iteration_count` times, (b) inside logging / wandb /
+tqdm wrappers, (c) inside loss / metric computation.
+
+Report the top 3 candidates inline in the Fix section as
+`path/file.py:<line>: <one-line code excerpt>`. If the repo is not accessible (plugin
+running without CWD file access), state: "repo not accessible; Fix points are generic —
+please grep locally."
+
+**Fail-soft**: if Step 1 errors (e.g. nvtx view absent) or Step 2 finds zero matches, do
+not block delivery — emit the 3-part summary with the weaker evidence and label it so.
+
 ---
 
 ## §6 Device Propagation Table
@@ -274,6 +334,13 @@ After any mode completes, verify:
 - [ ] Mode 8 diff skipped iteration 0
 - [ ] Root-cause statement includes: cause + evidence field+value + recommendation
 - [ ] File:line fix when local source code accessible
+- [ ] Fix section shows a before/after code block (not pure prose) whenever the fix is a
+      code change — dtype cast, sync removal, kernel swap, etc.
+- [ ] Host-sync root cause: §5.7 Step 1 (NVTX ancestor) ran if NVTX present, AND §5.7 Step 2
+      (repo grep) produced at least one `path/file.py:line` candidate — or explicit "repo not
+      accessible" note
+- [ ] "Per-step" cost claims: event count ≥ `iteration_count` verified (§3 rule 9);
+      one-shot events reframed as "one-time overhead"
 - [ ] No `SELECT *` used
 - [ ] Time values converted from ns (÷ 1e6 ms, ÷ 1e9 s)
 - [ ] §5 evidence step ran; `http://127.0.0.1:PORT` URL printed

--- a/skills/analyze/references/SKILLS_REF.md
+++ b/skills/analyze/references/SKILLS_REF.md
@@ -91,6 +91,7 @@ nsys-ai skill run <skill_name> <profile> --format json [-p key=value ...]
 | `module_loading` | JIT compilation + cuModuleLoad stalls |
 | `gc_impact` | cudaMalloc/cudaFree stalls + Python GC events |
 | `sync_cost_analysis` | CPU-side sync density + blocking cost (cudaStreamSynchronize, etc.) |
+| `host_sync_parent_ranges` | NVTX ancestor attribution for `aten::item` / `_local_scalar_dense` / `cudaStreamSynchronize` — which training phase owns the sync |
 | `pipeline_bubble_metrics` | True GPU idle % (interval merge, O(n log n)) |
 
 ---

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -203,8 +203,10 @@ _TABLE_PROJECTIONS: dict[str, str] = {
     "ENUM_CUPTI_SYNC_TYPE": "id, name",
 }
 
-_TC_ELIGIBLE_PATTERN = "'(gemm|conv|linear|attention|matmul)'"
-_TC_ACTIVE_PATTERN = "'(xmma|mma_sync|16816|1688|884|ampere_bf16|sm80_tensor_op)'"
+_TC_ELIGIBLE_PATTERN = "'(gemm|conv|linear|attention|matmul|flash)'"
+_TC_ACTIVE_PATTERN = (
+    "'(xmma|mma_sync|16816|1688|884|ampere_bf16|sm80_tensor_op|tensorop|flash)'"
+)
 
 
 # Mapping from cache view name (e.g. "kernels") to the actual SQLite table names that

--- a/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
+++ b/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
@@ -55,18 +55,28 @@ def _execute(conn, **kwargs):
         trim_where = "AND n.start >= ? AND n.[end] <= ?"
         trim_params = [int(trim_start), int(trim_end)]
 
-    # Bound the LIKE patterns — user-supplied input flows through `patterns` param.
+    # Bound the LIKE patterns — user-supplied input flows through `patterns`
+    # param. Lower-case both sides so matching is consistent across DuckDB
+    # (case-sensitive LIKE) and SQLite (case-insensitive LIKE by default).
     like_parts = []
     like_params: list[str] = []
     for p in patterns:
-        like_parts.append("child.label LIKE ?")
-        like_params.append(f"%{p}%")
+        like_parts.append("LOWER(label) LIKE ?")
+        like_params.append(f"%{p.lower()}%")
     like_clause = " OR ".join(like_parts)
 
     # Self-exclusion predicate: parent must cover child strictly (either a
     # different start or a different end). This keeps same-labeled but
     # distinct ancestors — e.g. nested `train_step` scopes — while still
     # preventing a range from matching itself.
+    #
+    # Event-type filter: 59 = PushPop range, 60 = StartEnd range; markers
+    # and counter/payload events are excluded so they don't inflate the
+    # ancestry join or misattribute sync time.
+    #
+    # Performance: we pre-filter sync children into their own CTE so the
+    # ancestry join runs over only the rows that match the sync patterns,
+    # instead of the full NVTX set.
     sql = f"""
         WITH resolved AS (
             SELECT {label_expr} AS label,
@@ -75,19 +85,26 @@ def _execute(conn, **kwargs):
                    n.[end]       AS end_ns
             FROM {nvtx_table} n
             {label_join}
-            WHERE n.[end] > n.start {trim_where}
+            WHERE n.[end] > n.start
+              AND n.eventType IN (59, 60)
+              {trim_where}
+        ),
+        sync_children AS (
+            SELECT label, tid, start, end_ns
+            FROM resolved
+            WHERE ({like_clause}) AND label IS NOT NULL
         ),
         matched AS (
             SELECT parent.label                 AS parent_range,
                    child.label                  AS child_label,
                    child.end_ns - child.start   AS sync_ns
-            FROM resolved child
+            FROM sync_children child
             JOIN resolved parent
               ON parent.tid = child.tid
              AND parent.start <= child.start
              AND parent.end_ns >= child.end_ns
              AND (parent.start != child.start OR parent.end_ns != child.end_ns)
-            WHERE ({like_clause}) AND parent.label IS NOT NULL
+            WHERE parent.label IS NOT NULL
         ),
         parent_totals AS (
             SELECT parent_range,

--- a/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
+++ b/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
@@ -1,0 +1,149 @@
+"""Host-sync parent-range attribution.
+
+For each NVTX range that contains host-GPU sync events
+(`aten::item`, `aten::_local_scalar_dense`, `cudaStreamSynchronize`, ...),
+report the total sync time and event count. Used by Mode 6 to localize
+*which* training phase owns the sync cost before correlating with source
+code via `grep` (PRINCIPLES.md §5.7 Step 1).
+"""
+
+from ...connection import DB_ERRORS, wrap_connection
+from ..base import Skill, SkillParam
+
+# Substring patterns matched via SQL `LIKE '%<pattern>%'`. Intentionally narrow:
+# host-GPU sync signatures only — not every NVTX event. Additions should be
+# justified by an observed bottleneck class, not speculative.
+DEFAULT_PATTERNS = "item,_local_scalar_dense,cudaStreamSynchronize"
+
+
+def _execute(conn, **kwargs):
+    limit = int(kwargs.get("limit", 5))
+    raw_patterns = str(kwargs.get("patterns") or DEFAULT_PATTERNS)
+    patterns = [p.strip() for p in raw_patterns.split(",") if p.strip()]
+    if not patterns:
+        patterns = [p.strip() for p in DEFAULT_PATTERNS.split(",")]
+
+    trim_start = kwargs.get("trim_start_ns")
+    trim_end = kwargs.get("trim_end_ns")
+
+    adapter = wrap_connection(conn)
+    tables = adapter.resolve_activity_tables()
+    nvtx_table = tables.get("nvtx", "NVTX_EVENTS")
+
+    has_textid = adapter.detect_nvtx_text_id()
+    if has_textid:
+        label_expr = "COALESCE(n.text, s.value)"
+        label_join = "LEFT JOIN StringIds s ON n.textId = s.id"
+    else:
+        label_expr = "n.text"
+        label_join = ""
+
+    trim_where = ""
+    trim_params: list[int] = []
+    if trim_start is not None and trim_end is not None:
+        trim_where = "AND n.start >= ? AND n.[end] <= ?"
+        trim_params = [int(trim_start), int(trim_end)]
+
+    # Bound the LIKE patterns — user-supplied input flows through `patterns` param.
+    like_parts = []
+    like_params: list[str] = []
+    for p in patterns:
+        like_parts.append("child.label LIKE ?")
+        like_params.append(f"%{p}%")
+    like_clause = " OR ".join(like_parts)
+
+    sql = f"""
+        WITH resolved AS (
+            SELECT {label_expr} AS label,
+                   n.globalTid   AS tid,
+                   n.start       AS start,
+                   n.[end]       AS end_ns
+            FROM {nvtx_table} n
+            {label_join}
+            WHERE n.[end] > n.start {trim_where}
+        )
+        SELECT parent.label                  AS parent_range,
+               COUNT(*)                      AS n_syncs,
+               SUM(child.end_ns - child.start) AS sync_ns,
+               MIN(child.label)              AS top_child_label
+        FROM resolved child
+        JOIN resolved parent
+          ON parent.tid = child.tid
+         AND parent.start <= child.start
+         AND parent.end_ns >= child.end_ns
+         AND parent.label != child.label
+        WHERE ({like_clause}) AND parent.label IS NOT NULL
+        GROUP BY parent.label
+        ORDER BY sync_ns DESC
+        LIMIT {int(limit)}
+    """
+
+    try:
+        cur = adapter.execute(sql, trim_params + like_params)
+        rows = cur.fetchall()
+    except DB_ERRORS as exc:
+        return [
+            {
+                "error": (
+                    f"host_sync_parent_ranges query failed: {exc}. "
+                    "NVTX_EVENTS may be absent, or the profile schema is unexpected."
+                ),
+            }
+        ]
+
+    cols = ["parent_range", "n_syncs", "sync_ns", "top_child_label"]
+    out = []
+    for r in rows:
+        d = dict(zip(cols, r))
+        d["sync_ns"] = int(d["sync_ns"] or 0)
+        d["sync_ms"] = round(d["sync_ns"] / 1e6, 3)
+        out.append(d)
+    return out
+
+
+def _format(rows):
+    if not rows:
+        return "(No host-sync events found under any NVTX range)"
+    if "error" in rows[0]:
+        return f"Error: {rows[0]['error']}"
+
+    lines = [
+        "── Host-Sync Parent NVTX Ranges ──",
+        f"{'Parent Range':<50s}  {'n':>6s}  {'Sync (ms)':>10s}  {'Top Child':<28s}",
+        "─" * 102,
+    ]
+    for r in rows:
+        parent = (r.get("parent_range") or "(unnamed)")[:48]
+        child = (r.get("top_child_label") or "(unknown)")[:28]
+        lines.append(
+            f"{parent:<50s}  {r['n_syncs']:>6d}  {r['sync_ms']:>10.3f}  {child:<28s}"
+        )
+    return "\n".join(lines)
+
+
+SKILL = Skill(
+    name="host_sync_parent_ranges",
+    title="Host-Sync Parent NVTX Ranges",
+    description=(
+        "For each NVTX range that contains host-GPU sync events "
+        "(`aten::item`, `_local_scalar_dense`, `cudaStreamSynchronize`, …), "
+        "report total sync time and count. Localizes which training phase owns "
+        "the sync cost so the plugin can grep the user's repo for the exact "
+        "call site (PRINCIPLES.md §5.7 Step 1)."
+    ),
+    category="nvtx",
+    execute_fn=_execute,
+    format_fn=_format,
+    params=[
+        SkillParam("limit", "Max parent ranges to return", "int", False, 5),
+        SkillParam(
+            "patterns",
+            "Comma-separated substrings matched via LIKE "
+            "(default: 'item,_local_scalar_dense,cudaStreamSynchronize')",
+            "str",
+            False,
+            DEFAULT_PATTERNS,
+        ),
+    ],
+    tags=["nvtx", "sync", "host-sync", "attribution", "mode-6"],
+)

--- a/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
+++ b/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
@@ -15,9 +15,20 @@ from ..base import Skill, SkillParam
 # justified by an observed bottleneck class, not speculative.
 DEFAULT_PATTERNS = "item,_local_scalar_dense,cudaStreamSynchronize"
 
+# Cap on `limit` — guards the O(n²) ancestry self-join on pathological input.
+_MAX_LIMIT = 1000
+
 
 def _execute(conn, **kwargs):
-    limit = int(kwargs.get("limit", 5))
+    try:
+        limit = int(kwargs.get("limit", 5))
+    except (TypeError, ValueError):
+        return [{"error": "`limit` must be a positive integer"}]
+    if limit < 1:
+        return [{"error": f"`limit` must be >= 1 (got {limit})"}]
+    if limit > _MAX_LIMIT:
+        limit = _MAX_LIMIT
+
     raw_patterns = str(kwargs.get("patterns") or DEFAULT_PATTERNS)
     patterns = [p.strip() for p in raw_patterns.split(",") if p.strip()]
     if not patterns:
@@ -52,6 +63,10 @@ def _execute(conn, **kwargs):
         like_params.append(f"%{p}%")
     like_clause = " OR ".join(like_parts)
 
+    # Self-exclusion predicate: parent must cover child strictly (either a
+    # different start or a different end). This keeps same-labeled but
+    # distinct ancestors — e.g. nested `train_step` scopes — while still
+    # preventing a range from matching itself.
     sql = f"""
         WITH resolved AS (
             SELECT {label_expr} AS label,
@@ -61,20 +76,52 @@ def _execute(conn, **kwargs):
             FROM {nvtx_table} n
             {label_join}
             WHERE n.[end] > n.start {trim_where}
+        ),
+        matched AS (
+            SELECT parent.label                 AS parent_range,
+                   child.label                  AS child_label,
+                   child.end_ns - child.start   AS sync_ns
+            FROM resolved child
+            JOIN resolved parent
+              ON parent.tid = child.tid
+             AND parent.start <= child.start
+             AND parent.end_ns >= child.end_ns
+             AND (parent.start != child.start OR parent.end_ns != child.end_ns)
+            WHERE ({like_clause}) AND parent.label IS NOT NULL
+        ),
+        parent_totals AS (
+            SELECT parent_range,
+                   COUNT(*)     AS n_syncs,
+                   SUM(sync_ns) AS sync_ns
+            FROM matched
+            GROUP BY parent_range
+        ),
+        child_totals AS (
+            SELECT parent_range,
+                   child_label,
+                   COUNT(*)     AS child_n_syncs,
+                   SUM(sync_ns) AS child_sync_ns
+            FROM matched
+            GROUP BY parent_range, child_label
+        ),
+        ranked_children AS (
+            SELECT parent_range,
+                   child_label,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY parent_range
+                       ORDER BY child_sync_ns DESC, child_n_syncs DESC, child_label ASC
+                   ) AS rn
+            FROM child_totals
         )
-        SELECT parent.label                  AS parent_range,
-               COUNT(*)                      AS n_syncs,
-               SUM(child.end_ns - child.start) AS sync_ns,
-               MIN(child.label)              AS top_child_label
-        FROM resolved child
-        JOIN resolved parent
-          ON parent.tid = child.tid
-         AND parent.start <= child.start
-         AND parent.end_ns >= child.end_ns
-         AND parent.label != child.label
-        WHERE ({like_clause}) AND parent.label IS NOT NULL
-        GROUP BY parent.label
-        ORDER BY sync_ns DESC
+        SELECT pt.parent_range,
+               pt.n_syncs,
+               pt.sync_ns,
+               rc.child_label AS top_child_label
+        FROM parent_totals pt
+        LEFT JOIN ranked_children rc
+          ON rc.parent_range = pt.parent_range
+         AND rc.rn = 1
+        ORDER BY pt.sync_ns DESC
         LIMIT {int(limit)}
     """
 

--- a/tests/test_host_sync_parent_ranges.py
+++ b/tests/test_host_sync_parent_ranges.py
@@ -265,6 +265,65 @@ class TestHostSyncParentRanges:
         # No error row; just runs normally (empty since no syncs).
         assert out == []
 
+    def test_case_insensitive_pattern_matching(self):
+        # User supplies uppercase/mixed-case pattern; should still match
+        # lowercase labels in the profile (and vice versa). DuckDB's LIKE is
+        # case-sensitive by default, so this test guards the engine parity.
+        conn = _build_conn(
+            [
+                ("train_step",   0, 10_000_000),
+                ("aten::ITEM_UPPERCASE", 1_000_000, 1_500_000),
+            ]
+        )
+        out = skill_mod._execute(conn, patterns="item")  # lowercase pattern
+        assert len(out) == 1
+        assert out[0]["parent_range"] == "train_step"
+        # And vice versa — uppercase pattern matches lowercase label.
+        conn2 = _build_conn(
+            [
+                ("train_step",  0, 10_000_000),
+                ("aten::item",  1_000_000, 1_500_000),
+            ]
+        )
+        out2 = skill_mod._execute(conn2, patterns="ITEM")
+        assert len(out2) == 1
+        assert out2[0]["parent_range"] == "train_step"
+
+    def test_non_range_event_types_excluded(self):
+        # Marker-type NVTX events (eventType not in (59, 60)) must not be
+        # treated as ranges — they have zero duration semantics and would
+        # pollute the ancestry join.
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(
+            """
+            CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+            CREATE TABLE NVTX_EVENTS (
+                globalTid INTEGER DEFAULT 0,
+                start     INTEGER NOT NULL,
+                end       INTEGER NOT NULL,
+                text      TEXT,
+                textId    INTEGER,
+                eventType INTEGER DEFAULT 59
+            );
+            """
+        )
+        # A marker (eventType=75, some non-range code) containing an item
+        # call — must be skipped, leaving `train_step` (eventType=59) as
+        # the sole parent.
+        conn.executescript(
+            """
+            INSERT INTO NVTX_EVENTS (globalTid, start, end, text, eventType) VALUES
+                (1,        0, 10000000, 'train_step',         59),
+                (1,        0, 10000000, 'fake_marker_range',  75),
+                (1, 1000000,  1500000,  'aten::item',         59);
+            """
+        )
+        conn.commit()
+        out = skill_mod._execute(conn)
+        parents = {r["parent_range"] for r in out}
+        assert "train_step" in parents
+        assert "fake_marker_range" not in parents
+
     def test_registered_in_builtin_registry(self):
         from nsys_ai.skills import registry
 

--- a/tests/test_host_sync_parent_ranges.py
+++ b/tests/test_host_sync_parent_ranges.py
@@ -205,6 +205,66 @@ class TestHostSyncParentRanges:
     def test_format_error(self):
         assert skill_mod._format([{"error": "boom"}]) == "Error: boom"
 
+    def test_top_child_label_picks_max_sync_time_not_alphabetic(self):
+        # Parent contains two sync children:
+        #   aten::item                 — 100 µs single call
+        #   cudaStreamSynchronize_foo  — 1 ms single call (10x larger)
+        # Alphabetic MIN would pick `aten::item` (wrong); correct answer is
+        # `cudaStreamSynchronize_foo` (larger aggregated sync_ns).
+        conn = _build_conn(
+            [
+                ("train_step",               0,  10_000_000),
+                ("aten::item",       1_000_000,   1_100_000),
+                ("cudaStreamSynchronize_foo", 2_000_000, 3_000_000),
+            ]
+        )
+        out = skill_mod._execute(conn)
+        assert len(out) == 1
+        assert out[0]["parent_range"] == "train_step"
+        assert out[0]["top_child_label"] == "cudaStreamSynchronize_foo"
+
+    def test_same_labeled_nested_ranges_still_attributed(self):
+        # Nested same-label ranges — outer `train_step` contains inner
+        # `train_step` (iteration inside iteration), and the inner range
+        # contains the real sync. Outer should get credit; the previous
+        # `parent.label != child.label` filter would have dropped this.
+        conn = _build_conn(
+            [
+                ("train_step",     0,  10_000_000),  # outer
+                ("train_step", 2_000_000,   8_000_000),  # inner — same label
+                ("aten::item", 4_000_000,   4_500_000),
+            ]
+        )
+        out = skill_mod._execute(conn)
+        # Inner `train_step` and outer `train_step` share a parent_range in
+        # the GROUP BY, so we get ONE row labeled `train_step` with 2 syncs
+        # (outer contains aten::item AND outer contains inner train_step…
+        # but inner train_step doesn't match the sync pattern, so it isn't
+        # counted as a child — still 1 sync attributed but the outer range
+        # is no longer filtered out).
+        assert len(out) == 1
+        assert out[0]["parent_range"] == "train_step"
+        assert out[0]["top_child_label"] == "aten::item"
+
+    def test_invalid_limit_returns_error(self):
+        conn = _build_conn([("train_step", 0, 10_000_000)])
+        # Zero
+        out = skill_mod._execute(conn, limit=0)
+        assert len(out) == 1 and "error" in out[0]
+        # Negative
+        out = skill_mod._execute(conn, limit=-5)
+        assert len(out) == 1 and "error" in out[0]
+        # Non-numeric
+        out = skill_mod._execute(conn, limit="abc")
+        assert len(out) == 1 and "error" in out[0]
+
+    def test_limit_capped_at_max(self):
+        # Above _MAX_LIMIT should silently clamp, not error.
+        conn = _build_conn([("train_step", 0, 10_000_000)])
+        out = skill_mod._execute(conn, limit=10_000)
+        # No error row; just runs normally (empty since no syncs).
+        assert out == []
+
     def test_registered_in_builtin_registry(self):
         from nsys_ai.skills import registry
 

--- a/tests/test_host_sync_parent_ranges.py
+++ b/tests/test_host_sync_parent_ranges.py
@@ -1,0 +1,214 @@
+"""Tests for the host_sync_parent_ranges builtin skill."""
+
+import sqlite3
+
+import pytest
+
+from nsys_ai.skills.builtins import host_sync_parent_ranges as skill_mod
+
+
+def _build_conn(rows: list[tuple], *, default_tid: int = 1) -> sqlite3.Connection:
+    """Build a minimal sqlite3 connection with NVTX_EVENTS seeded.
+
+    ``rows`` accepts either 3-tuples ``(label, start, end_ns)`` or 4-tuples
+    ``(label, start, end_ns, globalTid)``. 3-tuples fall back to
+    ``default_tid`` so parent/child ancestry joins cleanly.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+        CREATE TABLE NVTX_EVENTS (
+            globalTid INTEGER DEFAULT 0,
+            start     INTEGER NOT NULL,
+            end       INTEGER NOT NULL,
+            text      TEXT,
+            textId    INTEGER,
+            eventType INTEGER DEFAULT 59
+        );
+        """
+    )
+    for row in rows:
+        if len(row) == 3:
+            label, start, end_ns = row
+            tid = default_tid
+        else:
+            label, start, end_ns, tid = row
+        conn.execute(
+            "INSERT INTO NVTX_EVENTS (globalTid, start, end, text) VALUES (?, ?, ?, ?)",
+            (tid, start, end_ns, label),
+        )
+    conn.commit()
+    return conn
+
+
+class TestHostSyncParentRanges:
+    def test_ranks_parents_by_sync_ns(self):
+        # Two disjoint training phases; each contains exactly one sync child.
+        # Durations chosen to round cleanly at 3 decimals in ms.
+        conn = _build_conn(
+            [
+                # forward_pass contains aten::item — 300 µs = 0.3 ms
+                ("forward_pass", 0, 10_000_000),
+                ("aten::item", 1_000_000, 1_300_000),
+                # optimizer contains aten::_local_scalar_dense — 500 µs = 0.5 ms
+                ("optimizer", 20_000_000, 30_000_000),
+                ("aten::_local_scalar_dense", 25_000_000, 25_500_000),
+                # unrelated wallclock-only range — contains no sync events
+                ("misc", 40_000_000, 50_000_000),
+            ]
+        )
+        out = skill_mod._execute(conn)
+        parents = {r["parent_range"] for r in out}
+        assert {"forward_pass", "optimizer"} <= parents
+        assert "misc" not in parents
+        # Ordering: optimizer (500 µs) > forward_pass (300 µs)
+        assert out[0]["parent_range"] == "optimizer"
+        assert out[0]["sync_ns"] == 500_000
+        assert out[0]["sync_ms"] == pytest.approx(0.5)
+        assert out[1]["parent_range"] == "forward_pass"
+        assert out[1]["sync_ns"] == 300_000
+        assert out[1]["sync_ms"] == pytest.approx(0.3)
+
+    def test_nested_parents_both_attributed(self):
+        # When parents nest, each enclosing range gets independent credit.
+        # Mirrors the real-world case where `aten::item` (outer pytorch wrapper)
+        # contains `aten::_local_scalar_dense` (inner sync).
+        conn = _build_conn(
+            [
+                ("train_step", 0, 10_000),  # outermost
+                ("aten::item", 100, 600),   # parent-of-child AND is itself a child
+                ("aten::_local_scalar_dense", 200, 500),  # inner child
+            ]
+        )
+        out = skill_mod._execute(conn)
+        parents = {r["parent_range"] for r in out}
+        # Both train_step (contains item + _local_scalar_dense) AND aten::item
+        # (contains _local_scalar_dense) should appear as parents.
+        assert "train_step" in parents
+        assert "aten::item" in parents
+
+    def test_matches_via_textid_indirection(self):
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(
+            """
+            CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+            CREATE TABLE NVTX_EVENTS (
+                globalTid INTEGER DEFAULT 0,
+                start     INTEGER NOT NULL,
+                end       INTEGER NOT NULL,
+                text      TEXT,
+                textId    INTEGER,
+                eventType INTEGER DEFAULT 59
+            );
+            """
+        )
+        # Labels live in StringIds; NVTX_EVENTS.text is NULL — exercises the COALESCE path.
+        conn.executescript(
+            """
+            INSERT INTO StringIds VALUES (1, 'train_step'), (2, 'aten::item');
+            INSERT INTO NVTX_EVENTS (start, end, text, textId) VALUES
+                (0, 10000, NULL, 1),
+                (200, 600, NULL, 2);
+            """
+        )
+        conn.commit()
+        out = skill_mod._execute(conn)
+        assert out and "error" not in out[0]
+        assert out[0]["parent_range"] == "train_step"
+        assert out[0]["n_syncs"] == 1
+        assert out[0]["sync_ns"] == 400
+
+    def test_empty_when_no_sync_events(self):
+        conn = _build_conn(
+            [
+                ("train_step", 0, 10_000),
+                ("forward_pass", 100, 500),
+            ]
+        )
+        assert skill_mod._execute(conn) == []
+
+    def test_custom_patterns_override_default(self):
+        conn = _build_conn(
+            [
+                ("train_step", 0, 10_000),
+                ("my_custom_sync_marker", 100, 600),
+            ]
+        )
+        # Default patterns should not match this label.
+        assert skill_mod._execute(conn) == []
+        # But a user-supplied pattern should.
+        out = skill_mod._execute(conn, patterns="custom_sync")
+        assert len(out) == 1
+        assert out[0]["parent_range"] == "train_step"
+        assert out[0]["n_syncs"] == 1
+
+    def test_cross_thread_parents_excluded(self):
+        # DataLoader NVTX range (tid=99) wraps the same wall-clock window as
+        # the main-thread sync, but is NOT on the same thread — must not be
+        # attributed as a parent of the main-thread sync.
+        conn = _build_conn(
+            [
+                ("dataloader_fetch",   0, 10_000_000,  99),
+                ("train_step",         0, 10_000_000,   1),
+                ("aten::item", 1_000_000,  1_500_000,   1),
+            ]
+        )
+        out = skill_mod._execute(conn)
+        parents = {r["parent_range"] for r in out}
+        assert "train_step" in parents
+        assert "dataloader_fetch" not in parents, (
+            "cross-thread NVTX range must not be matched as parent"
+        )
+
+    def test_missing_nvtx_table_returns_error_row(self):
+        conn = sqlite3.connect(":memory:")
+        # Intentionally no NVTX_EVENTS table.
+        out = skill_mod._execute(conn)
+        assert len(out) == 1
+        assert "error" in out[0]
+        assert "NVTX" in out[0]["error"]
+
+    def test_limit_caps_results(self):
+        # 6 distinct parents, each with one matching child — ask for 2.
+        rows = []
+        for i in range(6):
+            base = i * 1_000_000
+            rows.append((f"train_step_{i}", base, base + 100_000))
+            # child sync duration grows with i so ordering is deterministic
+            rows.append(("aten::item", base + 100, base + 100 + (i + 1) * 100))
+        conn = _build_conn(rows)
+        out = skill_mod._execute(conn, limit=2)
+        assert len(out) == 2
+        # Largest sync_ns first → parent of i=5 (600ns), then i=4 (500ns)
+        assert out[0]["parent_range"] == "train_step_5"
+        assert out[1]["parent_range"] == "train_step_4"
+
+    def test_format_renders_table(self):
+        rows = [
+            {
+                "parent_range": "train_step",
+                "n_syncs": 3,
+                "sync_ns": 500_000,
+                "top_child_label": "aten::item",
+                "sync_ms": 0.5,
+            }
+        ]
+        out = skill_mod._format(rows)
+        assert "train_step" in out
+        assert "aten::item" in out
+        assert "0.500" in out
+
+    def test_format_empty(self):
+        assert "No host-sync events" in skill_mod._format([])
+
+    def test_format_error(self):
+        assert skill_mod._format([{"error": "boom"}]) == "Error: boom"
+
+    def test_registered_in_builtin_registry(self):
+        from nsys_ai.skills import registry
+
+        s = registry.get_skill("host_sync_parent_ranges")
+        assert s is not None
+        assert s.name == "host_sync_parent_ranges"
+        assert {p.name for p in s.params} == {"limit", "patterns"}

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -129,3 +129,67 @@ class TestBuildAndOpen:
         assert db is not None
         db.close()
         assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is True
+
+
+class TestTensorCorePatterns:
+    """Regression coverage for the TC eligibility / active regex patterns.
+
+    The patterns are interpolated into DuckDB `regexp_matches()`; these cases
+    guard against drift that would cause Flash Attention / CUTLASS tensor-op
+    kernels to be silently mis-classified as FP32 fallback.
+    """
+
+    @staticmethod
+    def _strip(pattern: str) -> str:
+        # Stored as SQL-quoted literal, e.g. "'(gemm|...)'" — strip the outer quotes
+        # so Python's re module sees a plain pattern.
+        return pattern.strip("'")
+
+    def test_eligible_pattern_covers_flash_attention(self):
+        import re
+
+        elig = self._strip(parquet_cache._TC_ELIGIBLE_PATTERN)
+        for name in [
+            "flash_fwd_splitkv_kernel",
+            "flash_bwd_dq_dk_dv_loop_seqk_parallel",
+            "ampere_bf16_s1688gemm_bf16_128x128x32",
+            "cutlass_80_tensorop_bf16_s16816gemm_something",
+            "sm80_xmma_gemm_bf16",
+        ]:
+            assert re.search(elig, name.lower()), f"{name!r} should be TC-eligible"
+
+    def test_active_pattern_covers_cutlass_and_flash(self):
+        import re
+
+        active = self._strip(parquet_cache._TC_ACTIVE_PATTERN)
+        for name in [
+            "flash_fwd_splitkv_kernel",
+            "flash_bwd_dq_dk_dv_loop_seqk_parallel",
+            "cutlass_80_tensorop_bf16_s16816gemm_something",
+            "ampere_bf16_s1688gemm_bf16_128x128x32",
+            "some_kernel_with_16816_in_name",
+        ]:
+            assert re.search(active, name.lower()), f"{name!r} should be TC-active"
+
+    def test_non_tc_kernels_not_matched(self):
+        import re
+
+        elig = self._strip(parquet_cache._TC_ELIGIBLE_PATTERN)
+        active = self._strip(parquet_cache._TC_ACTIVE_PATTERN)
+        for name in [
+            "vectorized_elementwise_kernel",
+            "reduce_kernel",
+            "memset_kernel",
+        ]:
+            assert not re.search(elig, name.lower()), f"{name!r} should NOT be eligible"
+            assert not re.search(active, name.lower()), f"{name!r} should NOT be active"
+
+    def test_fp32_sgemm_is_eligible_but_not_tc_active(self):
+        """Classic FP32 sgemm: TC-eligible (it's a gemm) but not TC-active."""
+        import re
+
+        elig = self._strip(parquet_cache._TC_ELIGIBLE_PATTERN)
+        active = self._strip(parquet_cache._TC_ACTIVE_PATTERN)
+        name = "ampere_sgemm_128x128_nn"
+        assert re.search(elig, name.lower())
+        assert not re.search(active, name.lower())

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -18,6 +18,7 @@ def test_list_skills():
         "gc_impact",
         "gpu_idle_gaps",
         "h2d_distribution",
+        "host_sync_parent_ranges",
         "iteration_detail",
         "iteration_timing",
         "kernel_instances",


### PR DESCRIPTION
  ## Summary

  - **New builtin skill `host_sync_parent_ranges`** — walks `NVTX_EVENTS` to                                                                   
    attribute each host-GPU sync event (`aten::item`, `_local_scalar_dense`,
    `cudaStreamSynchronize`) to its enclosing NVTX range, ranked by sync time.                                                                 
    Same-thread ancestry only (filters out DataLoader-thread NVTX wrappers                                                                     
    that share wall-clock time with main-thread syncs). Runs on DuckDB                                                                         
    parquet cache by default; sqlite3 fallback uses the existing                                                                               
    `_nsysai_nvtx_range` compound index.                                                                                                       
  - **`/nsys-ai` plugin: stronger delivery rules.** Adds PRINCIPLES.md §3                                                                      
    rules 8/9/10 and §5.7 to require, when a mode blames a host-sync: a parent                                                                 
    NVTX lookup (now via the new skill), a repo grep for the exact call                                                                        
    site, a frequency check (one-shot vs per-step), and a before/after code                                                                    
    block in the Fix section. Mirrors the gaps found when `/nsys-ai` was run                                                                   
    against a real fastvideo training profile and surfaced a sync-bound                                                                        
    workload without pointing at `training_pipeline.py:line` or verifying                                                                      
    that the 3.11s `aten::item` was a per-step cost.                                                                                           
  - **Fix: Flash Attention / CUTLASS tensor-op detection.** Adds `flash` to                                                                    
    `_TC_ELIGIBLE_PATTERN` and `flash` + `tensorop` to `_TC_ACTIVE_PATTERN`                                                                    
    in `parquet_cache.py`. Previously `flash_fwd` / `flash_bwd_*` /                                                                            
    `cutlass_*_tensorop_*` kernels were silently classified as                                                                                 
    `tc_eligible=false`, making Mode 3 report Flash-Attention-heavy                                                                            
    workloads as FP32 fallback when they are in fact Tensor-Core-backed.                                                                       
  - **Mode 6 (`M6_IDLE.md`) wires the new skill** into the `sync` and `all`                                                                    
    sub-focus chains, gated on `manifest.nvtx.has_nvtx`.                                                                                       
  - **Smoke test** picks up the new skill via `run_capture_json` +                                                                             
    `check_field_conditional`; green on both `mock.sqlite` (no NVTX → SKIP)                                                                    
    and a real profile with 2M NVTX rows.                                                                                                      
                                                                                                                                               
  ## Why                                                                                                                                       
                                                                                                                                               
  Running `/nsys-ai` against a real fastvideo training profile surfaced
  three recurring weaknesses in the Mode 3/6 output:                                                                                           
                                                                                                                                               
  1. The fix was prose ("hunt `.item()` in `training_pipeline.py`") instead                                                                    
     of `file.py:line` candidates — despite the plugin running inside Claude                                                                   
     Code with Grep available.                                                                                                                 
  2. A "3.11s per step" claim was extrapolated from an event whose call                                                                        
     count had never been checked against `iteration_count`. That single                                                                       
     sync turned out to be a one-shot, not per-step.                                                                                           
  3. Flash-Attention kernels were flagged as TC-ineligible, producing a                                                                        
     misleading "FP32 fallback" signal on what were in fact fully                                                                              
     tensor-core-saturated workloads.                                                                                                          
                                                                                                                                               
  The new rules close (1) and (2); the pattern fix closes (3). The new                                                                         
  skill replaces what would otherwise have been a raw `sqlite3` shell                                                                          
  invocation in the PRINCIPLES document — giving the plugin a first-class,                                                                     
  caller-friendly way to ask "which NVTX range owns this sync?".                                                                               
                                                                                                                                               
  ## Test plan                                                                                                                                 
                                                            
  - [x] `pytest tests/` — 622 passed, 135 skipped, 0 failed
  - [x] New `tests/test_host_sync_parent_ranges.py` — 12 cases covering                                                                        
        ranking, nested parents, textId indirection, empty result, missing                                                                     
        table, custom patterns, cross-thread filter, limit, formatter                                                                          
  - [x] New `TestTensorCorePatterns` in `tests/test_parquet_cache.py` —                                                                        
        4 cases (flash / cutlass tensor-op / FP32 sgemm / non-TC)                                                                              
  - [x] `test_skills.py::test_list_skills` updated to 34 skills                                                                                
  - [x] `scripts/smoke_test.sh tests/fixtures/mock.sqlite` — all checks                                                                        
        pass, `host_sync_parent_ranges` SKIPs gracefully on no-NVTX input                                                                      
  - [x] `scripts/smoke_test.sh mock.sqlite <real_nvtx_profile.sqlite>` —                                                                       
        `host_sync_parent_ranges: parent_range` OK                                                                                             
  - [x] End-to-end CLI: `nsys-ai skill run host_sync_parent_ranges                                                                             
        mfu_training_latest.sqlite --format json` returns 5 ranked parent                                                                      
        ranges; top result reproduces the 3.11s `aten::item` hotspot                                                                           
        identified in the original manual analysis       