### PR TITLE
chore: bump version to 0.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
   "plugins": [
     {
       "name": "nsys-ai",
-      "description": "GPU profile analysis for NVIDIA Nsight Systems. Triage bottlenecks, diagnose NCCL, compute MFU, compare regressions, and drill into SASS instructions. Requires the nsys-ai CLI (>= 0.2.1): pip install nsys-ai.",
+      "description": "GPU profile analysis for NVIDIA Nsight Systems. Triage bottlenecks, diagnose NCCL, compute MFU, compare regressions, and drill into SASS instructions. Requires the nsys-ai CLI (>= 0.2.2): pip install nsys-ai.",
       "category": "development",
       "source": {
         "source": "url",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nsys-ai",
-  "version": "0.2.1",
-  "description": "GPU profile analysis for NVIDIA Nsight Systems. Triage bottlenecks, diagnose NCCL, compute MFU, compare regressions, and drill into SASS instructions. Requires the nsys-ai CLI (>= 0.2.1): pip install nsys-ai.",
+  "version": "0.2.2",
+  "description": "GPU profile analysis for NVIDIA Nsight Systems. Triage bottlenecks, diagnose NCCL, compute MFU, compare regressions, and drill into SASS instructions. Requires the nsys-ai CLI (>= 0.2.2): pip install nsys-ai.",
   "author": {
     "name": "GindaChen",
     "url": "https://github.com/GindaChen"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nsys-ai"
-version = "0.2.1"
+version = "0.2.2"
 description = "AI-powered analysis for NVIDIA Nsight Systems profiles — web viewer, timeline, kernel navigator, NVTX hierarchy"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
## Summary
                                                                                                                                               
  - Bump `pyproject.toml` and `.claude-plugin/plugin.json` version to 0.2.2.                                                                   
  - Raise the CLI requirement listed in `plugin.json` and `marketplace.json`                                                                   
    to `>= 0.2.2` so users who update the plugin 