### PR TITLE
feat(skills): interactive /nsys-ai wizard + sync analysis upgrades

### DIFF
--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -6,6 +6,7 @@ description: >
   mentions NCCL / distributed slowdown, asks for MFU / efficiency, wants to compare two
   runs, mentions CUTracer / SASS, asks about variance / spikes, or types /nsys-ai,
   /nsys-analyze, /gpu-profile, /profile-analysis.
+argument-hint: "[profile.sqlite | question]"
 ---
 
 # nsys-ai — GPU Profile Analysis Skill
@@ -33,33 +34,63 @@ If not installed: `pip install "nsys-ai[agent]"`.
 
 ---
 
-## Mode Menu
+## Mode Menu (interactive wizard)
 
-If 0 args AND no profile path in message, scan CWD (top 10 by mtime):
+Fires AT MOST once per session, and ONLY when the user has not already steered
+via keyword. Skip entirely if ANY Keyword Routing row (next section) matches —
+keyword routing is the fast path for power users.
+
+### Step 0 — scan CWD (always)
+
 ```bash
-(ls -t *.sqlite *.nsys-rep 2>/dev/null || true) | head -10
+(ls -lt *.sqlite *.nsys-rep 2>/dev/null || true) | head -10
 ```
-(The `|| true` keeps the pipeline exit code 0 when no files match, so the "If empty" branch
-below is always reachable — without it, `ls` exits non-zero on no matches and may be treated
-as a tool failure.) If empty: `"No profile found in CWD; give me a path to a .sqlite or .nsys-rep file."`
+(The `|| true` keeps exit code 0 when no files match, so every branch below is
+reachable — without it, `ls` exits non-zero on no matches and may be treated as
+a tool failure.) Classify:
 
-Otherwise, render the menu **once per session**:
+- `0 files` AND no path in message → reply `"No profile found in CWD; give me a
+  path to a .sqlite or .nsys-rep file."` Do NOT call `AskUserQuestion`.
+- `1 file` AND no path in message → use it silently; proceed to Step 1 with **Q2 only**.
+- `2+ files` OR user already supplied a path → proceed to Step 1.
 
-```
-What would you like to analyze?
+### Step 1 — single `AskUserQuestion` call (batch Q1+Q2, or Q2 only)
 
-  1. Auto triage      — not sure where to start                  [default]
-  2. Comms            — NCCL / overlap / multi-GPU
-  3. Compute          — top kernels / tensor core / MFU
-  4. Memory           — H2D / D2H / bandwidth
-  5. NVTX / code map  — which layer / step consumes time
-  6. Idle / sync      — GPU gaps, CPU stalls, launch overhead
-  7. CUTracer         — SASS-level (requires re-run)
-  8. Diff             — compare two profiles
-  9. Variance         — some iterations much slower than others
+**Q1 — Profile** (omit if profile already supplied OR only 1 file found)
+- `header`: `"Profile"`
+- `question`: `"Which profile should I analyze?"`
+- `options` (2–4, newest by mtime first): `label` = filename basename;
+  `description` = relative mtime (`"2h ago"`, `"yesterday"`, etc. — derive from `ls -lt`).
+- Auto `Other` lets the user type a path (do NOT add `Other` manually).
 
-Reply with a number, or ask a question directly — keywords auto-route.
-```
+**Q2 — Focus** (always)
+- `header`: `"Focus"`
+- `question`: `"What would you like to analyze?"`
+- `options` (exactly 4, Recommended first):
+  1. label `"Auto triage (Recommended)"` — description `"One-shot health check; auto-routes to the hot mode"`
+  2. label `"Compute"` — description `"Kernels, MFU, tensor-core usage"`
+  3. label `"Comms"` — description `"NCCL, overlap %, multi-GPU distributed"`
+  4. label `"Idle"` — description `"GPU gaps, CPU sync, DataLoader stalls"`
+- Auto `Other` lets user type a keyword (e.g. `memory`, `nvtx`, `variance`,
+  `diff`, `cutracer`) — re-run Keyword Routing on the free text.
+
+### Step 2 — dispatch
+
+| Q2 answer | Mode ref |
+|---|---|
+| `Auto triage (Recommended)` | `references/M1_AUTO.md` |
+| `Compute` | `references/M3_COMPUTE.md` |
+| `Comms` | `references/M2_COMMS.md` |
+| `Idle` | `references/M6_IDLE.md` |
+| `Other` (free text) | Re-run Keyword Routing on the text; no match → Mode 1 |
+
+Once dispatched, follow the Mode ref's six sections (Precondition / Stages / Skills
+/ Signals / Cross-mode exits / Delivery).
+
+### Session invariant
+
+Wizard fires at most once per session. After the first run (or any keyword-routed
+run), subsequent messages use Keyword Routing only — never re-fire `AskUserQuestion`.
 
 ---
 
@@ -139,6 +170,7 @@ first `iteration_timing` call — use the manifest values directly and jump to S
 9. "Per-step" cost claims require frequency verification (event count ≥ `iteration_count`);
    one-shot events must be reframed as one-time overhead, not extrapolated.
 10. Code fixes must render as a before/after code block — no pure-prose "convert to …".
+11. Inferred numeric values must be labeled `(inferred from …)` or `≈` — no silent derivations.
 
 **Universal evidence step** (PRINCIPLES.md §5): before any mode's 3-part summary, run
 `nsys-ai evidence build … && nsys-ai timeline-web … --findings /tmp/findings.json`, then

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -43,11 +43,12 @@ keyword routing is the fast path for power users.
 ### Step 0 — scan CWD (always)
 
 ```bash
-(ls -lt *.sqlite *.nsys-rep 2>/dev/null || true) | head -10
+(ls -1t *.sqlite *.nsys-rep 2>/dev/null || true) | head -10
 ```
-(The `|| true` keeps exit code 0 when no files match, so every branch below is
-reachable — without it, `ls` exits non-zero on no matches and may be treated as
-a tool failure.) Classify:
+(`-1t` = one filename per line, sorted by mtime newest-first — avoids the
+`total N` header `ls -lt` emits. The `|| true` keeps exit code 0 when no files
+match so every branch below is reachable — without it, `ls` exits non-zero on
+no matches and may be treated as a tool failure.) Classify:
 
 - `0 files` AND no path in message → reply `"No profile found in CWD; give me a
   path to a .sqlite or .nsys-rep file."` Do NOT call `AskUserQuestion`.
@@ -60,7 +61,9 @@ a tool failure.) Classify:
 - `header`: `"Profile"`
 - `question`: `"Which profile should I analyze?"`
 - `options` (2–4, newest by mtime first): `label` = filename basename;
-  `description` = relative mtime (`"2h ago"`, `"yesterday"`, etc. — derive from `ls -lt`).
+  `description` = relative mtime (`"2h ago"`, `"yesterday"`, etc. — compute via
+  `stat -c '%Y %n' *.sqlite *.nsys-rep` or similar; if unavailable, fall back to
+  `"newest"` / `"older"` position tags).
 - Auto `Other` lets the user type a path (do NOT add `Other` manually).
 
 **Q2 — Focus** (always)

--- a/skills/analyze/references/M6_IDLE.md
+++ b/skills/analyze/references/M6_IDLE.md
@@ -37,9 +37,10 @@ Skip Stage 2 if keyword already implies sub-focus (e.g. "dataloader" → `cpu-pi
 | `cpu-pipeline` | `cpu_gpu_pipeline` → `thread_utilization` |
 | `all` (default) | `gpu_idle_gaps` → `stream_concurrency` → `sync_cost_analysis` → `host_sync_parent_ranges` (if `manifest.nvtx.has_nvtx` and `sync_cost_analysis.sync_density_pct > 20`) → `kernel_launch_overhead` → `cpu_gpu_pipeline` → `thread_utilization` → `module_loading` → `gc_impact` (if `starvation_events > 0`) → `pipeline_bubble_metrics` (if `nccl.collectives > 0`) |
 
-Device propagation: `gpu_idle_gaps` accepts `-p device=N`. `stream_concurrency`,
-`sync_cost_analysis`, `kernel_launch_overhead`, `cpu_gpu_pipeline` do not accept device.
-See PRINCIPLES.md §6.
+Device propagation: `gpu_idle_gaps` and `sync_cost_analysis` accept `-p device=N`.
+`stream_concurrency`, `kernel_launch_overhead`, `cpu_gpu_pipeline` do not accept device.
+`sync_cost_analysis` additionally emits `sync_by_device` in its unfiltered default, so a
+single call answers both "total sync" and "which rank owns it". See PRINCIPLES.md §6.
 
 ---
 
@@ -49,6 +50,7 @@ See PRINCIPLES.md §6.
 |-------------------|-----------|--------|
 | manifest `idle.idle_pct > 15` OR `pipeline_bubble_metrics.bubble_pct > 15` | GPU starved | check DataLoader / CPU dispatch |
 | `sync_cost_analysis.sync_density_pct > 20` | Excessive CPU→GPU syncs | remove `.item()` / `.cpu()` in loop |
+| `sync_cost_analysis.sync_by_device` shows one device >> others (ratio > 2× OR another device has 0 sync) | Multi-rank asymmetry: one rank stragglers the collective; other ranks just wait on it | fix sync on the stragglering device first. Do NOT cross-exit to Mode 2 (Comms) — the NCCL idle is a symptom of host-blocking, not real comm imbalance |
 | `kernel_launch_overhead.overhead_us` concentrated in the top `kernel_name` | High CPU dispatch latency | async launch; reduce Python overhead |
 | any `cpu_gpu_pipeline` row has `starvation_events > 0` | CPU can't feed GPU fast enough | `num_workers`, `pin_memory`, `prefetch_factor` |
 | `thread_utilization` non-empty: one Python/DataLoader thread dominating CPU utilization | CPU thread saturation / imbalance | `persistent_workers=True`, tune/reduce workers |

--- a/skills/analyze/references/M6_IDLE.md
+++ b/skills/analyze/references/M6_IDLE.md
@@ -50,7 +50,7 @@ single call answers both "total sync" and "which rank owns it". See PRINCIPLES.m
 |-------------------|-----------|--------|
 | manifest `idle.idle_pct > 15` OR `pipeline_bubble_metrics.bubble_pct > 15` | GPU starved | check DataLoader / CPU dispatch |
 | `sync_cost_analysis.sync_density_pct > 20` | Excessive CPU→GPU syncs | remove `.item()` / `.cpu()` in loop |
-| `sync_cost_analysis.sync_by_device` shows one device >> others (ratio > 2× OR another device has 0 sync) | Multi-rank asymmetry: one rank stragglers the collective; other ranks just wait on it | fix sync on the stragglering device first. Do NOT cross-exit to Mode 2 (Comms) — the NCCL idle is a symptom of host-blocking, not real comm imbalance |
+| `sync_cost_analysis.sync_by_device` shows one device >> others (ratio > 2× OR another device has 0 sync) | Multi-rank asymmetry: one rank is the straggler in the collective; other ranks just wait on it | fix sync on the straggling device first. Do NOT cross-exit to Mode 2 (Comms) — the NCCL idle is a symptom of host-blocking, not real comm imbalance |
 | `kernel_launch_overhead.overhead_us` concentrated in the top `kernel_name` | High CPU dispatch latency | async launch; reduce Python overhead |
 | any `cpu_gpu_pipeline` row has `starvation_events > 0` | CPU can't feed GPU fast enough | `num_workers`, `pin_memory`, `prefetch_factor` |
 | `thread_utilization` non-empty: one Python/DataLoader thread dominating CPU utilization | CPU thread saturation / imbalance | `persistent_workers=True`, tune/reduce workers |

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -59,6 +59,16 @@ You are a **CUDA ML Systems Performance Expert** invoked via the `/nsys-ai` slas
     pattern. Phrases like "convert to … instead of …" or "use … pattern" are not
     acceptable Fix content on their own — show the code. Non-code fixes (e.g. "re-profile
     with `--capture-range`") are exempt.
+11. **Inferred values must be labeled.** Any quantity in the 3-part summary that was not
+    directly returned by a skill — computed via arithmetic on skill outputs, estimated
+    from sync density, counted from NVTX strings, derived from sync_total ÷ step_gap —
+    must be suffixed `(inferred from <source>)` or prefixed with `≈`. Do not present
+    inferred values as if they were skill-reported.
+    - ✅ `"sync_density_pct = 71.15%"` — direct from `sync_cost_analysis`
+    - ✅ `"≈2,566 .item() calls per step (inferred from n_syncs ÷ iteration_count)"`
+    - ✅ `"step floor ≈ 1.23s (inferred from 4.28s × (1 − 0.712))"`
+    - ❌ `"over 15 iters"` — inferred; must mark
+    - ❌ `"MFU should improve to ~30%"` — bare claim; bound it with the arithmetic
 
 ---
 
@@ -237,6 +247,58 @@ please grep locally."
 **Fail-soft**: if Step 1 errors (e.g. nvtx view absent) or Step 2 finds zero matches, do
 not block delivery — emit the 3-part summary with the weaker evidence and label it so.
 
+**Step 2b — Consumer localization (only when the Fix preserves a scalar as a tensor).**
+
+If the proposed Fix converts a value from `X.item()` to keep `X` as a tensor (e.g.
+`.detach()` accumulation, deferred flush), every consumer that currently reads `X` as a
+scalar breaks. Grep the repo for reads:
+
+```
+grep -rn --include='*.py' -E '\.<X>\b|\b<X>\b' <repo_root>
+```
+
+Classify each hit:
+
+1. **Format/log site** (`wandb.log(...)`, `print`, f-string, `.format(...)`) — add
+   `.item()` at the consumer, gated by log cadence (`if step % log_interval == 0`).
+2. **Tensor-arithmetic site** (`torch.stack([..., X, ...])`, arithmetic) — no change.
+3. **Scalar control flow** (`if X > t:`, `if X == 0:`) — rewrite as tensor comparison
+   or add an explicit single `.item()` at the branch, not inside the training loop.
+4. **Cross-rank aggregation** (`dist.all_reduce(X)`) — typically fine; note whether the
+   sync is implied by the collective.
+
+The Fix section must emit a **consumer change-set** (producer diff + every consumer
+touched), not just the producer diff.
+
+**Step 3 — Structural-vs-hotspot classification.**
+
+Compute `syncs_per_step = sum(host_sync_parent_ranges.n_syncs) ÷ max(iteration_count, 1)`
+where `iteration_count` comes from `profile_health_manifest.nvtx.iteration_count`. Mark
+the result `(inferred from …)` per §3 rule 11.
+
+- **Hotspot mode** (`syncs_per_step ≤ 3`): single primary fix is sufficient. Top parent
+  from Step 1 + the `path/file.py:line` from Step 2 close the gap.
+- **Structural mode** (`syncs_per_step > 3` OR top parent accounts for <50% of total
+  `n_syncs`): fixing only the top parent leaves most of the cost. Escalate Step 2:
+  - **Widen directory scope**: also include `*/losses/`, `*/schedulers/`, `*/metrics/`,
+    `*/callbacks/`, `*/logger*`, `*/progress*` beyond the parent's implied scope.
+  - **Widen pattern set**: add `\.tolist\(\)`, `\.cpu\(\)\.numpy\(\)`,
+    `\.to\(['\"]cpu['\"]\)`, `torch\.cuda\.synchronize`, `len\(<tensor>` (implicit
+    sync on some backends).
+  - **Rank candidates by frequency context**: (1) inside `for batch in` / `for step in`
+    — highest; (2) inside `step(...)` / `training_step(...)` / loss — high; (3) inside
+    log/metric wrappers not gated by `if step % log_interval` — medium; (4) inside init
+    / validation / setup — low.
+  - List **top 10** candidates, grouped by tier, not top 3.
+
+  In the Fix section, either (a) name and change all tier-1+tier-2 candidates, or (b)
+  explicitly state that after fixing the primary site the residual requires a re-profile
+  (one static grep cannot diagnose every `.item()` call in a >1000/step workload).
+
+- **`iteration_count` unavailable** (no NVTX step markers): skip Step 3 classification.
+  Say: "cannot classify structural vs hotspot without iteration count — re-profile with
+  `torch.cuda.nvtx.range('step_N')` step markers to enable this check".
+
 ---
 
 ## §6 Device Propagation Table
@@ -244,21 +306,24 @@ not block delivery — emit the 3-part summary with the weaker evidence and labe
 When Mode 1's §2.2 auto-retry picks device N, or when any mode filters per device, pass
 `-p device=N`. Not all 33 skills accept it. Verified against `src/nsys_ai/skills/builtins/`.
 
-### §6.1 Accepts `-p device=N` (13 skills)
+### §6.1 Accepts `-p device=N` (14 skills)
 
 `profile_health_manifest`, `overlap_breakdown`, `nccl_breakdown`,
 `nccl_communicator_analysis`, `kernel_overlap_matrix`, `memory_bandwidth`,
 `iteration_timing`, `iteration_detail`, `arithmetic_intensity`,
-`gpu_idle_gaps`, `kernel_instances`, `h2d_distribution`, `root_cause_matcher`.
+`gpu_idle_gaps`, `kernel_instances`, `h2d_distribution`, `root_cause_matcher`,
+`sync_cost_analysis`. The last one also emits `sync_by_device` in its
+default (unfiltered) output — use that for multi-rank asymmetry detection
+without a second skill call.
 
 ### §6.1a Accepts `-p device_id=N` (1 skill)
 
 `region_mfu` — uses `device_id` (not `device`) as the parameter name.
 
-### §6.2 Does NOT accept device — use `--iteration N` or `--trim` (9 skills)
+### §6.2 Does NOT accept device — use `--iteration N` or `--trim` (8 skills)
 
 `top_kernels`, `tensor_core_usage`, `kernel_launch_overhead`, `cpu_gpu_pipeline`,
-`sync_cost_analysis`, `nvtx_layer_breakdown`, `nvtx_kernel_map`,
+`nvtx_layer_breakdown`, `nvtx_kernel_map`,
 `memory_transfers`, `stream_concurrency`.
 
 ### §6.3 Not device-scoped (10 skills)
@@ -336,6 +401,12 @@ After any mode completes, verify:
 - [ ] File:line fix when local source code accessible
 - [ ] Fix section shows a before/after code block (not pure prose) whenever the fix is a
       code change — dtype cast, sync removal, kernel swap, etc.
+- [ ] Every numeric claim in the 3-part summary is either (a) a direct skill field or
+      (b) marked `(inferred from <source>)` / prefixed with `≈`. No silent derivations.
+- [ ] If the primary fix preserves a value as a tensor, §5.7 Step 2b ran and a consumer
+      change-set is included in the Fix.
+- [ ] `syncs_per_step` computed per §5.7 Step 3 (or the skip note emitted when
+      `iteration_count` is unavailable); structural-mode escalation applied if triggered.
 - [ ] Host-sync root cause: §5.7 Step 1 (NVTX ancestor) ran if NVTX present, AND §5.7 Step 2
       (repo grep) produced at least one `path/file.py:line` candidate — or explicit "repo not
       accessible" note

--- a/skills/analyze/references/SKILLS_REF.md
+++ b/skills/analyze/references/SKILLS_REF.md
@@ -90,7 +90,7 @@ nsys-ai skill run <skill_name> <profile> --format json [-p key=value ...]
 |-------|-------------|
 | `module_loading` | JIT compilation + cuModuleLoad stalls |
 | `gc_impact` | cudaMalloc/cudaFree stalls + Python GC events |
-| `sync_cost_analysis` | CPU-side sync density + blocking cost (cudaStreamSynchronize, etc.) |
+| `sync_cost_analysis` | CPU-side sync density + blocking cost (cudaStreamSynchronize, etc.). Accepts `-p device=N`; emits `sync_by_device` for multi-rank asymmetry |
 | `host_sync_parent_ranges` | NVTX ancestor attribution for `aten::item` / `_local_scalar_dense` / `cudaStreamSynchronize` — which training phase owns the sync |
 | `pipeline_bubble_metrics` | True GPU idle % (interval merge, O(n log n)) |
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -49,7 +49,7 @@ import duckdb
 log = logging.getLogger(__name__)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
-_CACHE_VERSION = 11  # bumped: nvtx_kernel_map uses path_id surrogate + nvtx_path_dict.parquet
+_CACHE_VERSION = 12  # bumped: sync.parquet now includes deviceId for per-rank sync attribution
 
 _SAFE_PARQUETDIR_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
@@ -197,9 +197,9 @@ _TABLE_PROJECTIONS: dict[str, str] = {
     "CUPTI_ACTIVITY_KIND_RUNTIME": 'start, "end", correlationId, globalTid, nameId',
     "CUPTI_ACTIVITY_KIND_RUNTIME_V2": 'start, "end", correlationId, globalTid, nameId',
     "CUPTI_ACTIVITY_KIND_RUNTIME_V3": 'start, "end", correlationId, globalTid, nameId',
-    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION": 'start, "end", globalPid, syncType',
-    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION_V2": 'start, "end", globalPid, syncType',
-    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION_V3": 'start, "end", globalPid, syncType',
+    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION": 'start, "end", deviceId, globalPid, syncType',
+    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION_V2": 'start, "end", deviceId, globalPid, syncType',
+    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION_V3": 'start, "end", deviceId, globalPid, syncType',
     "ENUM_CUPTI_SYNC_TYPE": "id, name",
 }
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -420,6 +420,15 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
             if actual:
                 _progress(f"{view_name}.parquet")
                 projection = _TABLE_PROJECTIONS.get(actual, "*")
+                # Legacy Nsight exports may lack `deviceId` on synchronization
+                # tables. Drop it from the projection rather than failing the
+                # cache build — sync_cost_analysis degrades to single-device mode.
+                if (
+                    projection != "*"
+                    and actual.startswith("CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
+                    and not _table_has_column(db, f"src.{actual}", "deviceId")
+                ):
+                    projection = projection.replace("deviceId, ", "")
                 if projection == "*":
                     db.execute(f"""
                         COPY src.{actual}

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -8,7 +8,7 @@ stalls from naturally overlapping communications.
 from collections import defaultdict
 
 from ...connection import DB_ERRORS, is_safe_identifier, wrap_connection
-from ..base import Skill, _compute_interval_union
+from ..base import Skill, SkillParam, _compute_interval_union
 
 
 def _resolve_table_name(conn, candidate: str) -> str:
@@ -36,13 +36,14 @@ _CACHE_MAX_SIZE = 8  # bounded to prevent unbounded growth / id() reuse
 
 
 def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
-    # Module-level cache keyed by (connection identity, trim window).
+    # Module-level cache keyed by (connection identity, trim window, device).
     # Avoids redundant re-execution when called by multiple consumer skills
     # (manifest, root_cause, overlap, bubble) within the same profile session.
     cache_key = (
         id(conn),
         kwargs.get("trim_start_ns"),
         kwargs.get("trim_end_ns"),
+        kwargs.get("device"),
     )
     cached = _sync_result_cache.get(cache_key)
     if cached is not None:
@@ -56,6 +57,21 @@ def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
     return result
 
 
+def _has_device_id(adapter, sync_table: str) -> bool:
+    """Probe whether the sync table has a `deviceId` column.
+
+    Nsight Systems' `CUPTI_ACTIVITY_KIND_SYNCHRONIZATION` schema exposes a
+    `deviceId INT NOT NULL` column (nsys exporter docs), but older profiles
+    or stripped mock fixtures may lack it. Falling back to a global-only
+    result when absent keeps backward compatibility.
+    """
+    try:
+        adapter.execute(f"SELECT deviceId FROM {sync_table} LIMIT 0")
+        return True
+    except DB_ERRORS:
+        return False
+
+
 def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
     adapter = wrap_connection(conn)
     sync_table = _resolve_table_name(conn, "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
@@ -67,6 +83,7 @@ def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
             {
                 "total_sync_wall_ms": 0.0,
                 "sync_by_type_ms": {},
+                "sync_by_device": None,
                 "profile_span_ms": 0.0,
                 "sync_density_pct": 0.0,
                 "error": f"Unsafe table name resolved: {sync_table!r} / {type_table!r}",
@@ -75,6 +92,12 @@ def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
 
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")
+    device_filter = kwargs.get("device")
+    if device_filter is not None:
+        try:
+            device_filter = int(device_filter)
+        except (TypeError, ValueError):
+            return [{"error": f"`device` must be an integer (got {device_filter!r})"}]
 
     if trim_start is None or trim_end is None:
         try:
@@ -88,25 +111,36 @@ def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
         except Exception:
             pass
 
-    conds = ["1=1"]
-    params = []
+    has_device = _has_device_id(adapter, sync_table)
+    if device_filter is not None and not has_device:
+        return [
+            {
+                "error": (
+                    f"`device={device_filter}` requested but the sync table has no "
+                    "deviceId column (legacy Nsight export)."
+                )
+            }
+        ]
 
-    # We must explicitly clamp within SQL or Python. We'll do it in Python,
-    # but we can filter eagerly in SQL to limit data loading overhead.
+    conds = ["1=1"]
+    params: list = []
     if trim_start is not None:
         conds.append("s.[end] >= ?")
         params.append(int(trim_start))
     if trim_end is not None:
         conds.append("s.start <= ?")
         params.append(int(trim_end))
-
+    if device_filter is not None:
+        conds.append("s.deviceId = ?")
+        params.append(device_filter)
     where_clause = " AND ".join(conds)
 
+    device_expr = "s.deviceId AS device" if has_device else "NULL AS device"
     query = f"""
     SELECT
         s.start,
         s.[end],
-        s.globalPid,
+        {device_expr},
         COALESCE(e.name, 'Unknown') AS sync_type_name
     FROM {sync_table} s
     LEFT JOIN {type_table} e ON s.syncType = e.id
@@ -122,35 +156,45 @@ def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
             {
                 "total_sync_wall_ms": 0.0,
                 "sync_by_type_ms": {},
+                "sync_by_device": None,
                 "profile_span_ms": 0.0,
                 "sync_density_pct": 0.0,
                 "error": "Synchronization tables not found in profile",
             }
         ]
 
-    # Filter and clamp intervals
-    global_intervals = []
-    type_intervals = defaultdict(list)
+    # Filter and clamp intervals; accumulate global + per-type + per-device buckets.
+    global_intervals: list[tuple[int, int]] = []
+    type_intervals: dict[str, list[tuple[int, int]]] = defaultdict(list)
+    device_intervals: dict[int, list[tuple[int, int]]] = defaultdict(list)
+    device_type_intervals: dict[int, dict[str, list[tuple[int, int]]]] = defaultdict(
+        lambda: defaultdict(list)
+    )
 
     for row in rows:
         s_start, s_end = int(row[0]), int(row[1])
+        dev = row[2]
         sync_type_name = str(row[3])
 
-        # Explicit clamping to trim window
         if trim_start is not None:
             s_start = max(s_start, int(trim_start))
         if trim_end is not None:
             s_end = min(s_end, int(trim_end))
 
-        if s_start < s_end:
-            global_intervals.append((s_start, s_end))
-            type_intervals[sync_type_name].append((s_start, s_end))
+        if s_start >= s_end:
+            continue
+        global_intervals.append((s_start, s_end))
+        type_intervals[sync_type_name].append((s_start, s_end))
+        if dev is not None:
+            dev_i = int(dev)
+            device_intervals[dev_i].append((s_start, s_end))
+            device_type_intervals[dev_i][sync_type_name].append((s_start, s_end))
 
     total_sync_wall_ns = _compute_interval_union(global_intervals)
-    sync_by_type_ms = {}
-    for t_name, intervals in type_intervals.items():
-        type_ns = _compute_interval_union(intervals)
-        sync_by_type_ms[t_name] = round(type_ns / 1e6, 3)
+    sync_by_type_ms = {
+        t: round(_compute_interval_union(ivs) / 1e6, 3)
+        for t, ivs in type_intervals.items()
+    }
 
     profile_span_ns = 0
     if trim_start is not None and trim_end is not None:
@@ -158,15 +202,38 @@ def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
 
     total_sync_wall_ms = total_sync_wall_ns / 1e6
     profile_span_ms = profile_span_ns / 1e6
+    sync_density_pct = (
+        (total_sync_wall_ms / profile_span_ms) * 100 if profile_span_ms > 0 else 0.0
+    )
 
-    sync_density_pct = 0.0
-    if profile_span_ms > 0:
-        sync_density_pct = (total_sync_wall_ms / profile_span_ms) * 100
+    # Per-device breakdown. Always emitted when deviceId is available so
+    # callers can detect multi-rank asymmetry without a second skill call.
+    if has_device:
+        sync_by_device = []
+        for dev_i in sorted(device_intervals.keys()):
+            dev_ns = _compute_interval_union(device_intervals[dev_i])
+            dev_ms = dev_ns / 1e6
+            dev_density = (dev_ms / profile_span_ms) * 100 if profile_span_ms > 0 else 0.0
+            dev_by_type = {
+                t: round(_compute_interval_union(ivs) / 1e6, 3)
+                for t, ivs in device_type_intervals[dev_i].items()
+            }
+            sync_by_device.append(
+                {
+                    "device": dev_i,
+                    "total_sync_wall_ms": round(dev_ms, 3),
+                    "sync_density_pct": round(dev_density, 2),
+                    "sync_by_type_ms": dev_by_type,
+                }
+            )
+    else:
+        sync_by_device = None
 
     return [
         {
             "total_sync_wall_ms": round(total_sync_wall_ms, 3),
             "sync_by_type_ms": sync_by_type_ms,
+            "sync_by_device": sync_by_device,
             "profile_span_ms": round(profile_span_ms, 3),
             "sync_density_pct": round(sync_density_pct, 2),
         }
@@ -195,15 +262,41 @@ def _format_sync_analysis(rows: list[dict]) -> str:
     else:
         lines.append("    (None)")
 
+    by_device = m.get("sync_by_device")
+    if by_device:
+        lines.append("\n  Breakdown by Device:")
+        for d in sorted(by_device, key=lambda x: -x["total_sync_wall_ms"]):
+            lines.append(
+                f"    - device {d['device']}:"
+                f" {d['total_sync_wall_ms']:8.1f}ms"
+                f" ({d['sync_density_pct']:.1f}% density)"
+            )
+
     return "\n".join(lines)
 
 
 SKILL = Skill(
     name="sync_cost_analysis",
     title="Sync Cost Analysis",
-    description="Measures total wall-clock time the host CPU was blocked by CUPTI synchronization calls (e.g. cudaDeviceSynchronize, cudaStreamSynchronize). Reports sync density as a percentage of the profile span.",
+    description=(
+        "Measures total wall-clock time the host CPU was blocked by CUPTI "
+        "synchronization calls (cudaDeviceSynchronize, cudaStreamSynchronize, "
+        "cudaEventSynchronize). Reports sync density as a percentage of the "
+        "profile span, with an optional per-device breakdown (`sync_by_device`) "
+        "for detecting multi-rank asymmetry in distributed training."
+    ),
     category="system",
     sql="",
     execute_fn=_execute_sync_analysis,
     format_fn=_format_sync_analysis,
+    params=[
+        SkillParam(
+            "device",
+            "Filter to a single GPU device id (e.g. 0). Omit for all-devices "
+            "aggregate (sync_by_device still included).",
+            "int",
+            False,
+            None,
+        ),
+    ],
 )

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -39,11 +39,20 @@ def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
     # Module-level cache keyed by (connection identity, trim window, device).
     # Avoids redundant re-execution when called by multiple consumer skills
     # (manifest, root_cause, overlap, bubble) within the same profile session.
+    # Normalize `device` before caching so `device=1` and `device='1'` — which
+    # _impl coerces to the same int — share the cache entry. Invalid values
+    # pass through unchanged so _impl still emits its own error.
+    raw_device = kwargs.get("device")
+    if raw_device is not None:
+        try:
+            raw_device = int(raw_device)
+        except (TypeError, ValueError):
+            pass
     cache_key = (
         id(conn),
         kwargs.get("trim_start_ns"),
         kwargs.get("trim_end_ns"),
-        kwargs.get("device"),
+        raw_device,
     )
     cached = _sync_result_cache.get(cache_key)
     if cached is not None:

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -111,6 +111,27 @@ def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
         except Exception:
             pass
 
+    # Probe table existence before column existence so a missing sync table
+    # reports the right error (rather than "no deviceId column") when the user
+    # supplied `-p device=N`.
+    try:
+        adapter.execute(f"SELECT 1 FROM {sync_table} LIMIT 0")
+        sync_table_exists = True
+    except DB_ERRORS:
+        sync_table_exists = False
+
+    if not sync_table_exists:
+        return [
+            {
+                "total_sync_wall_ms": 0.0,
+                "sync_by_type_ms": {},
+                "sync_by_device": None,
+                "profile_span_ms": 0.0,
+                "sync_density_pct": 0.0,
+                "error": "Synchronization tables not found in profile",
+            }
+        ]
+
     has_device = _has_device_id(adapter, sync_table)
     if device_filter is not None and not has_device:
         return [

--- a/tests/test_skill_manifest.py
+++ b/tests/test_skill_manifest.py
@@ -1,0 +1,221 @@
+"""Smoke tests for skills/analyze/SKILL.md (the /nsys-ai Claude Code plugin manifest).
+
+These tests pin the wizard structure so a future edit that breaks the AskUserQuestion
+contract (missing section, wrong mode ref, >4 options, header too long) fails in CI
+instead of silently shipping.
+
+Zero runtime deps — parses the YAML frontmatter with stdlib string splitting.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILL_DIR = REPO_ROOT / "skills" / "analyze"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+REFS_DIR = SKILL_DIR / "references"
+
+
+@pytest.fixture(scope="module")
+def skill_text() -> str:
+    assert SKILL_MD.exists(), f"SKILL.md missing at {SKILL_MD}"
+    return SKILL_MD.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def frontmatter(skill_text: str) -> dict[str, str]:
+    # Frontmatter is between the first two '---' lines.
+    parts = skill_text.split("---", 2)
+    assert len(parts) >= 3, "SKILL.md must start with YAML frontmatter delimited by ---"
+    raw = parts[1]
+    # Stdlib parse: treat every "key: value" line as a mapping entry. Good enough for
+    # our flat frontmatter; multi-line scalars collapse into one string.
+    fm: dict[str, str] = {}
+    current_key: str | None = None
+    for line in raw.splitlines():
+        if not line.strip():
+            continue
+        m = re.match(r"^([a-zA-Z_-]+):\s*(.*)$", line)
+        if m:
+            current_key = m.group(1)
+            fm[current_key] = m.group(2).strip().strip('"').strip("'")
+        elif current_key is not None:
+            # Continuation of a folded scalar — append a space-joined chunk.
+            fm[current_key] = (fm[current_key] + " " + line.strip()).strip()
+    return fm
+
+
+def _section(skill_text: str, header: str) -> str:
+    """Return the text between `## {header}` and the next `## ` (or end-of-file)."""
+    pattern = rf"^## {re.escape(header)}\s*$"
+    lines = skill_text.splitlines()
+    start = None
+    for i, line in enumerate(lines):
+        if re.match(pattern, line):
+            start = i
+            break
+    if start is None:
+        return ""
+    for j in range(start + 1, len(lines)):
+        if re.match(r"^## [^#]", lines[j]):
+            return "\n".join(lines[start:j])
+    return "\n".join(lines[start:])
+
+
+# ---------------------------------------------------------------------------
+# Frontmatter
+
+def test_frontmatter_has_required_fields(frontmatter: dict[str, str]) -> None:
+    assert frontmatter.get("name") == "nsys-ai", "name must be 'nsys-ai'"
+    assert frontmatter.get("description"), "description required"
+    # argument-hint added in the wizard change — regression guard.
+    assert "argument-hint" in frontmatter, (
+        "argument-hint frontmatter missing — autocomplete UX regresses"
+    )
+
+
+def test_argument_hint_mentions_both_paths(frontmatter: dict[str, str]) -> None:
+    hint = frontmatter.get("argument-hint", "")
+    assert "profile" in hint.lower(), f"argument-hint should mention profile: {hint!r}"
+    assert "question" in hint.lower(), f"argument-hint should mention question: {hint!r}"
+
+
+# ---------------------------------------------------------------------------
+# Mode Menu wizard section
+
+def test_mode_menu_wizard_section_exists(skill_text: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    assert body, "## Mode Menu (interactive wizard) section missing"
+    # Core markers.
+    assert "AskUserQuestion" in body, "wizard must call AskUserQuestion"
+    assert "Step 0" in body, "wizard needs Step 0 (CWD scan)"
+    assert "Step 1" in body, "wizard needs Step 1 (question batch)"
+    assert "Step 2" in body, "wizard needs Step 2 (dispatch)"
+
+
+def test_wizard_fires_once_per_session(skill_text: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    assert "once per session" in body.lower(), "session invariant rule missing"
+
+
+def test_wizard_defers_to_keyword_routing(skill_text: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    # Any keyword match must bypass the wizard — otherwise power users get interrupted.
+    assert re.search(r"keyword routing", body, flags=re.IGNORECASE), (
+        "wizard section must reference Keyword Routing bypass"
+    )
+
+
+def test_wizard_handles_zero_one_many_profiles(skill_text: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    # Three branches are the whole point of Step 0.
+    assert "0 files" in body, "Step 0 must handle the 0-profile case"
+    assert "1 file" in body, "Step 0 must handle the 1-profile case"
+    assert re.search(r"2\+ files", body), "Step 0 must handle the 2+-profile case"
+
+
+# ---------------------------------------------------------------------------
+# AskUserQuestion contract (per official docs: 2–4 options, header ≤12 chars)
+
+def test_q2_focus_has_exactly_four_options(skill_text: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    # Q2 spec block: look for the numbered list of labels.
+    # Pin the four expected labels directly.
+    expected_labels = [
+        "Auto triage (Recommended)",
+        "Compute",
+        "Comms",
+        "Idle",
+    ]
+    for label in expected_labels:
+        assert f'"{label}"' in body, f"Q2 option label missing: {label!r}"
+
+
+def test_q2_recommended_option_is_first(skill_text: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    # Find the numbered list under "**Q2 — Focus**".
+    q2_idx = body.find("Q2 — Focus")
+    assert q2_idx >= 0, "Q2 block not found"
+    q2_body = body[q2_idx:]
+    # The first numbered bullet (`1.`) should carry (Recommended).
+    first_bullet = re.search(r"^\s*1\.\s*.*$", q2_body, flags=re.MULTILINE)
+    assert first_bullet, "Q2 first option (1.) not found"
+    assert "(Recommended)" in first_bullet.group(0), (
+        f"Q2 first option must be the Recommended one: {first_bullet.group(0)!r}"
+    )
+
+
+def test_question_headers_within_chip_length(skill_text: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    # Extract every `header: "..."` value and check length ≤ 12.
+    for match in re.finditer(r'`header`:\s*`"([^"]+)"`', body):
+        header = match.group(1)
+        assert len(header) <= 12, (
+            f"AskUserQuestion header chip must be ≤12 chars: {header!r} ({len(header)} chars)"
+        )
+
+
+def test_no_manual_other_option(skill_text: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    # Docs say "Other" is auto-added; manually listing it violates the tool contract.
+    assert re.search(
+        r"(do NOT add `Other` manually|Auto `Other`|auto `Other`|auto-`Other`)",
+        body,
+    ), "wizard must document that 'Other' is auto-added (not listed manually)"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch table → mode refs
+
+DISPATCH_EXPECTED = {
+    "Auto triage (Recommended)": "M1_AUTO.md",
+    "Compute": "M3_COMPUTE.md",
+    "Comms": "M2_COMMS.md",
+    "Idle": "M6_IDLE.md",
+}
+
+
+@pytest.mark.parametrize("answer,ref_file", list(DISPATCH_EXPECTED.items()))
+def test_dispatch_table_row(skill_text: str, answer: str, ref_file: str) -> None:
+    body = _section(skill_text, "Mode Menu (interactive wizard)")
+    # Find the Step 2 dispatch table row for this answer → ref mapping.
+    row = re.search(
+        rf"`{re.escape(answer)}`.*{re.escape(ref_file)}",
+        body,
+    )
+    assert row, f"dispatch row missing: {answer!r} → {ref_file}"
+
+
+@pytest.mark.parametrize("ref_file", sorted(set(DISPATCH_EXPECTED.values())))
+def test_dispatched_mode_ref_exists(ref_file: str) -> None:
+    assert (REFS_DIR / ref_file).exists(), (
+        f"dispatch target {ref_file} does not exist under {REFS_DIR}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Keyword Routing — unchanged-ness guard
+
+def test_keyword_routing_table_intact(skill_text: str) -> None:
+    body = _section(skill_text, "Keyword Routing (priority order; first match wins)")
+    assert body, "Keyword Routing section missing"
+    # All nine priority rows (1–9) must still be there.
+    for priority in range(1, 10):
+        assert re.search(rf"^\|\s*{priority}\s*\|", body, flags=re.MULTILINE), (
+            f"Keyword Routing priority {priority} row missing"
+        )
+
+
+def test_keyword_routing_empty_fallback_preserved(skill_text: str) -> None:
+    """Priority 9 'OR empty' is the safety net for sessions where the wizard already ran.
+    Removing it would strand re-fire empty messages with no route."""
+    body = _section(skill_text, "Keyword Routing (priority order; first match wins)")
+    p9 = re.search(r"^\|\s*9\s*\|.*$", body, flags=re.MULTILINE)
+    assert p9, "priority 9 row not found"
+    assert "empty" in p9.group(0).lower(), (
+        f"priority 9 'OR empty' fallback missing: {p9.group(0)!r}"
+    )

--- a/tests/test_skill_manifest.py
+++ b/tests/test_skill_manifest.py
@@ -28,10 +28,18 @@ def skill_text() -> str:
 
 @pytest.fixture(scope="module")
 def frontmatter(skill_text: str) -> dict[str, str]:
-    # Frontmatter is between the first two '---' lines.
-    parts = skill_text.split("---", 2)
-    assert len(parts) >= 3, "SKILL.md must start with YAML frontmatter delimited by ---"
-    raw = parts[1]
+    # Frontmatter must START the document (not just appear somewhere) and be
+    # delimited by standalone `---` lines — otherwise a later horizontal rule
+    # would be misparsed as a closing delimiter.
+    stripped = skill_text.lstrip("﻿\r\n\t ")
+    assert stripped.startswith("---\n") or stripped.startswith("---\r\n"), (
+        "SKILL.md must start with YAML frontmatter delimited by ---"
+    )
+    delimiters = list(re.finditer(r"(?m)^---[ \t]*$", skill_text))
+    assert len(delimiters) >= 2, (
+        "SKILL.md must contain YAML frontmatter delimited by standalone --- lines"
+    )
+    raw = skill_text[delimiters[0].end():delimiters[1].start()]
     # Stdlib parse: treat every "key: value" line as a mapping entry. Good enough for
     # our flat frontmatter; multi-line scalars collapse into one string.
     fm: dict[str, str] = {}
@@ -123,16 +131,31 @@ def test_wizard_handles_zero_one_many_profiles(skill_text: str) -> None:
 
 def test_q2_focus_has_exactly_four_options(skill_text: str) -> None:
     body = _section(skill_text, "Mode Menu (interactive wizard)")
-    # Q2 spec block: look for the numbered list of labels.
-    # Pin the four expected labels directly.
     expected_labels = [
         "Auto triage (Recommended)",
         "Compute",
         "Comms",
         "Idle",
     ]
-    for label in expected_labels:
-        assert f'"{label}"' in body, f"Q2 option label missing: {label!r}"
+
+    # Extract only the Q2 block and parse its numbered options so a 5th option
+    # (or a renamed/missing one) fails the test — "exactly 4" must be enforced,
+    # not just "these 4 are present somewhere".
+    q2_match = re.search(
+        r"Q2 — Focus(?P<q2_body>.*?)(?:^\*\*Q\d+\s+—|^###|\Z)",
+        body,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert q2_match, "Q2 block not found"
+    q2_body = q2_match.group("q2_body")
+
+    q2_labels = re.findall(r'^\s*\d+\.\s*label\s*`"([^"]+)"`', q2_body, flags=re.MULTILINE)
+    assert len(q2_labels) == 4, (
+        f"Q2 must define exactly 4 options, found {len(q2_labels)}: {q2_labels!r}"
+    )
+    assert set(q2_labels) == set(expected_labels), (
+        f"Q2 options must match expected labels exactly; found {q2_labels!r}"
+    )
 
 
 def test_q2_recommended_option_is_first(skill_text: str) -> None:
@@ -166,6 +189,25 @@ def test_no_manual_other_option(skill_text: str) -> None:
         r"(do NOT add `Other` manually|Auto `Other`|auto `Other`|auto-`Other`)",
         body,
     ), "wizard must document that 'Other' is auto-added (not listed manually)"
+
+    # Enforce the actual contract: no enumerated AskUserQuestion option in the
+    # Q1/Q2 blocks may manually list "Other" as a label. Documentation alone
+    # is not enough — a regression that adds `5. label "Other" …` would slip
+    # past the assertion above.
+    question_blocks = re.findall(
+        r"(?ms)(\*\*Q[12]\s+—.*?)(?=\*\*Q[12]\s+—|^###|\Z)",
+        body,
+    )
+    assert question_blocks, "Q1/Q2 blocks not found in wizard section"
+
+    numbered_option_re = re.compile(r"^\s*\d+\.\s*.*$", flags=re.MULTILINE)
+    manual_other_re = re.compile(r'(?i)label\s*`"Other"`|^\s*\d+\.\s*`"Other"`')
+
+    for block_text in question_blocks:
+        for option_line in numbered_option_re.findall(block_text):
+            assert not manual_other_re.search(option_line), (
+                f'"Other" must not be manually listed as an AskUserQuestion option: {option_line!r}'
+            )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -86,3 +86,106 @@ def test_sync_analysis_trimming(sync_skill):
     assert m["total_sync_wall_ms"] == 100.0
     assert m["profile_span_ms"] == 200.0
     assert m["sync_density_pct"] == 50.0
+
+
+# ---------------------------------------------------------------------------
+# Per-device aggregation (CUPTI_ACTIVITY_KIND_SYNCHRONIZATION.deviceId)
+# ---------------------------------------------------------------------------
+
+
+def _seed_multi_device(conn):
+    """Seed a sync table with two devices of unequal sync load (rank-asymmetry case)."""
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_SYNCHRONIZATION "
+        "(start INTEGER, [end] INTEGER, deviceId INTEGER, globalPid INTEGER, syncType INTEGER)"
+    )
+    conn.execute("CREATE TABLE ENUM_CUPTI_SYNC_TYPE (id INTEGER, name TEXT)")
+    conn.execute(
+        "INSERT INTO ENUM_CUPTI_SYNC_TYPE VALUES (1, 'Event sync'), (3, 'Stream sync')"
+    )
+    # Device 0: 300ms stream sync + 100ms event sync = 400ms total (union)
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES "
+        "(100000000, 400000000, 0, 1, 3),"  # stream sync device 0: 300ms
+        "(500000000, 600000000, 0, 1, 1)"   # event sync device 0: 100ms
+    )
+    # Device 1: 50ms event sync only — rank asymmetry
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES "
+        "(100000000, 150000000, 1, 2, 1)"   # event sync device 1: 50ms
+    )
+
+
+def test_sync_analysis_per_device_breakdown(sync_skill):
+    conn = sqlite3.connect(":memory:")
+    _seed_multi_device(conn)
+
+    rows = sync_skill.execute(
+        conn, trim_start_ns=0, trim_end_ns=1_000_000_000
+    )
+    m = rows[0]
+    assert m["sync_by_device"] is not None, "sync_by_device must appear when deviceId present"
+    by_dev = {d["device"]: d for d in m["sync_by_device"]}
+    assert set(by_dev) == {0, 1}
+    assert by_dev[0]["total_sync_wall_ms"] == 400.0
+    assert by_dev[1]["total_sync_wall_ms"] == 50.0
+    # sync_by_type_ms per device
+    assert by_dev[0]["sync_by_type_ms"]["Stream sync"] == 300.0
+    assert by_dev[0]["sync_by_type_ms"]["Event sync"] == 100.0
+    assert by_dev[1]["sync_by_type_ms"]["Event sync"] == 50.0
+    # density should reflect 1000ms span
+    assert by_dev[0]["sync_density_pct"] == 40.0
+    assert by_dev[1]["sync_density_pct"] == 5.0
+
+
+def test_sync_analysis_device_filter(sync_skill):
+    conn = sqlite3.connect(":memory:")
+    _seed_multi_device(conn)
+
+    rows = sync_skill.execute(
+        conn, trim_start_ns=0, trim_end_ns=1_000_000_000, device=1
+    )
+    m = rows[0]
+    assert m["total_sync_wall_ms"] == 50.0
+    # sync_by_device still present but filtered to only device 1
+    by_dev = {d["device"]: d for d in m["sync_by_device"]}
+    assert set(by_dev) == {1}
+    assert by_dev[1]["total_sync_wall_ms"] == 50.0
+
+
+def test_sync_analysis_legacy_schema_without_deviceid(sync_skill):
+    """Old Nsight exports lack deviceId; skill must fall back, not crash."""
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_SYNCHRONIZATION "
+        "(start INTEGER, [end] INTEGER, globalPid INTEGER, syncType INTEGER)"
+    )
+    conn.execute("CREATE TABLE ENUM_CUPTI_SYNC_TYPE (id INTEGER, name TEXT)")
+    conn.execute("INSERT INTO ENUM_CUPTI_SYNC_TYPE VALUES (1, 'Event sync')")
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_SYNCHRONIZATION VALUES (0, 100000000, 1, 1)"
+    )
+    rows = sync_skill.execute(conn)
+    m = rows[0]
+    assert m["total_sync_wall_ms"] == 100.0
+    assert m["sync_by_device"] is None, "legacy schema: sync_by_device must be null"
+
+
+def test_sync_analysis_device_filter_on_legacy_schema_errors(sync_skill):
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_SYNCHRONIZATION "
+        "(start INTEGER, [end] INTEGER, globalPid INTEGER, syncType INTEGER)"
+    )
+    conn.execute("CREATE TABLE ENUM_CUPTI_SYNC_TYPE (id INTEGER, name TEXT)")
+    rows = sync_skill.execute(conn, device=0)
+    assert "error" in rows[0]
+    assert "deviceId" in rows[0]["error"]
+
+
+def test_sync_analysis_invalid_device_param(sync_skill):
+    conn = sqlite3.connect(":memory:")
+    _seed_multi_device(conn)
+    rows = sync_skill.execute(conn, device="not-a-number")
+    assert "error" in rows[0]
+    assert "device" in rows[0]["error"].lower()

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -191,6 +191,25 @@ def test_sync_analysis_invalid_device_param(sync_skill):
     assert "device" in rows[0]["error"].lower()
 
 
+def test_sync_analysis_cache_key_normalizes_device_type(sync_skill):
+    """Regression: `device=1` and `device='1'` must share a cache entry.
+    _impl coerces both to int, so if the wrapper keyed the cache on the raw
+    kwarg, the string call would miss and re-run the query — defeating the
+    cross-skill cache reuse."""
+    conn = sqlite3.connect(":memory:")
+    _seed_multi_device(conn)
+
+    sync_skill.execute(conn, device=1)
+    size_after_int = len(_sync_result_cache)
+    sync_skill.execute(conn, device="1")
+    size_after_str = len(_sync_result_cache)
+
+    assert size_after_str == size_after_int, (
+        "device=1 and device='1' must share the cache entry "
+        f"(size grew {size_after_int} → {size_after_str})"
+    )
+
+
 def test_sync_analysis_device_filter_on_missing_tables_reports_not_found(sync_skill):
     """Regression: if sync tables are absent entirely, supplying `device=N`
     must still report 'Synchronization tables not found', not 'no deviceId column'.

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -189,3 +189,14 @@ def test_sync_analysis_invalid_device_param(sync_skill):
     rows = sync_skill.execute(conn, device="not-a-number")
     assert "error" in rows[0]
     assert "device" in rows[0]["error"].lower()
+
+
+def test_sync_analysis_device_filter_on_missing_tables_reports_not_found(sync_skill):
+    """Regression: if sync tables are absent entirely, supplying `device=N`
+    must still report 'Synchronization tables not found', not 'no deviceId column'.
+    The latter message is misleading when the table itself is missing."""
+    conn = sqlite3.connect(":memory:")
+    rows = sync_skill.execute(conn, device=0)
+    assert "error" in rows[0]
+    assert "not found" in rows[0]["error"].lower()
+    assert "deviceid" not in rows[0]["error"].lower()


### PR DESCRIPTION
## Summary

  Two independent upgrades to the `/nsys-ai` Claude Code plugin, bundled because both touch the                                                      
  `skills/analyze/` surface:
                                                                                                                                                     
  1. **Interactive wizard entry point** — replaces the text-only Mode Menu with an `AskUserQuestion`-                                                
     driven wizard so first-time users get a clickable flow instead of "reply with a number".
  2. **Deeper sync analysis** — `sync_cost_analysis` now attributes syncs per device (multi-rank                                                     
     asymmetry detection) and new PRINCIPLES rules guide the skill to distinguish structural vs                                                      
     hotspot sync patterns and localize consumer-side code for host-sync fixes.                                                                      
                                                                                                                                                     
  ## What changed                                                                                                                                    
                                                                                                                                                     
  ### Interactive wizard (`SKILL.md`, `tests/test_skill_manifest.py`)                                                                                
  
  - `argument-hint` frontmatter added so `/` autocomplete shows `[profile.sqlite | question]`.                                                       
  - Rewrote `## Mode Menu` as a three-step wizard:          
    - **Step 0** — CWD scan with three branches (`0 files` / `1 file` / `2+ files or path given`).                                                   
    - **Step 1** — single `AskUserQuestion` call batching Q1 `Profile` (omitted if profile known)                                                    
      + Q2 `Focus` with exactly 4 options: `Auto triage (Recommended)` / `Compute` / `Comms` / `Idle`.                                               
    - **Step 2** — dispatch table mapping answers to `M1/M2/M3/M6` refs.                                                                             
  - Session invariant: wizard fires at most once per session; keyword routing handles everything                                                     
    after. Priority-9 `OR empty` fallback preserved for re-fired empty messages.                                                                     
  - Memory / NVTX / Variance / Diff / CUTracer reachable via the auto-added `Other` free-text                                                        
    option — keyword routing catches the typed word.                                                                                                 
  - New `tests/test_skill_manifest.py` (20 tests, zero new deps) pins:                                                                               
    - Frontmatter fields (incl. new `argument-hint`).                                                                                                
    - Wizard structure (Step 0/1/2, session invariant, keyword-routing bypass).                                                                      
    - `AskUserQuestion` contract: exactly 4 Q2 options, Recommended option first, header chips                                                       
      ≤ 12 chars, no manually-listed `Other`.                                                                                                        
    - Dispatch table rows + existence of every referenced `M*.md`.                                                                                   
    - Keyword Routing priority table integrity (all 9 rows, `OR empty` fallback preserved).                                                          
                                                                                                                                                     
  ### Per-device sync attribution (`sync_cost_analysis.py`, `parquet_cache.py`)                                                                      
                                                                                                                                                     
  - `sync_cost_analysis` skill now accepts `-p device=N` and emits `sync_by_device` in its
    default (unfiltered) output — one call answers both "total sync" and "which rank owns it".                                                       
  - `_CACHE_VERSION` bumped to 12; parquet projection for `CUPTI_ACTIVITY_KIND_SYNCHRONIZATION`                                                      
    now includes `deviceId`.                                                                                                                         
  - Legacy schema without `deviceId` gracefully returns `sync_by_device: None` and errors cleanly                                                    
    if a device filter is supplied.                                                                                                                  
  - Five new tests cover multi-device breakdown, filter behavior, and legacy-schema compatibility.                                                   
                                                                                                                                                     
  ### Structural sync + consumer localization rules (`PRINCIPLES.md`, `M6_IDLE.md`, `SKILLS_REF.md`)                                                 
                                                                                                                                                     
  - `PRINCIPLES.md` rule 11: inferred values must be labeled `(inferred from …)` or `≈`.                                                             
  - `§5.7 Step 2b` (consumer localization): when a Fix preserves a scalar as a tensor, grep the
    repo for consumers and emit a consumer change-set.                                                                                               
  - `§5.7 Step 3` (structural classification): compute `syncs_per_step = sum(n_syncs) ÷ iterations`.                                                 
    Hotspot (≤3/step) widens scope narrowly; Structural (>3/step or top <50%) widens scope                                                           
    aggressively (losses, schedulers, metrics, callbacks, loggers, progress bars) and widens grep                                                    
    patterns (`.tolist()`, `.cpu().numpy()`, `.to('cpu')`, `torch.cuda.synchronize`, `len(<tensor>)`).                                               
  - `M6_IDLE.md`: new signal row for `sync_by_device` asymmetry (ratio > 2× or another device                                                        
    has 0 sync) — do NOT cross-exit to Mode 2; the NCCL idle is a symptom.                                                                           
  - `SKILLS_REF.md`: sync_cost_analysis entry documents the new `-p device=N` + `sync_by_device`                                                     
    emission.                                                                                                                                        
                                                                                                                                                     
  ## Test plan                                                                                                                                       
                                                                                                                                                     
  - [x] `python3 -m pytest tests/ -q` — **653 passed, 135 skipped, 0 failed** (prior: 633; +20 new                                             
  - `_CACHE_VERSION` bumped to 12; parquet projection for `CUPTI_ACTIVITY_KIND_SYNCHRONIZATION`
    now includes `deviceId`.
  - Legacy schema without `deviceId` gracefully returns `sync_by_device: None` and errors cleanly
    if a device filter is supplied.
  - Five new tests cover multi-device breakdown, filter behavior, and legacy-schema compatibility.