### PR TITLE
feat(evidence): extend Finding with v0.1 optional fields + add report envelope

### DIFF
--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -12,18 +12,68 @@ surfaces (CLI, GUI, agent, diff) share:
     DiffLineage      — links a Finding to the diff that surfaced it
     Diagnostic       — an agent's summarized diagnosis with verification command
 
-Existing models (``Finding``, ``EvidenceReport``) are unchanged in this slice
-and will be extended additively in a follow-up.
+``Finding`` carries optional v0.1 fields (id, category, confidence,
+evidence rows, selection, diff lineage, etc.) that the new surfaces
+populate. Existing producers/consumers that ignore the new fields keep
+working unchanged.
+
+``EvidenceReport`` JSON output carries an additive envelope
+(``schema_version``, ``producer``, ``producer_version``) so downstream
+tools can detect format compatibility.
 """
 
 import json
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass, field, fields
+from functools import cache
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 from typing import Any, Literal
+
+# Field names on Finding that hold nested dataclass instances; serialized
+# separately via each nested type's to_dict() to avoid a wasted deep copy
+# through asdict() (which would materialize them only to be discarded).
+_FINDING_NESTED_FIELDS = frozenset({"evidence", "selection", "diff_lineage"})
+
+#: Current evidence-artifact schema version.
+#:
+#: Bumped on breaking changes to the JSON envelope or required fields.
+#: Backward-compatible additions (new optional fields) do not bump this.
+SCHEMA_VERSION = "0.1"
+
+#: Producer identifier embedded in evidence-artifact JSON envelopes.
+PRODUCER = "nsys-ai"
+
+
+@cache
+def _producer_version() -> str:
+    """Return the installed nsys-ai package version, or a dev marker.
+
+    Reads the distribution metadata directly via ``importlib.metadata`` so
+    ``EvidenceReport.to_dict`` stays self-contained — it does not pull in
+    ``nsys_ai/__init__.py`` (which would eagerly import the rest of the
+    package and reintroduce circular-import risk).
+
+    Cached for the lifetime of the process: the installed package version
+    is constant per interpreter, and ``importlib.metadata.version`` reads
+    distribution metadata from disk on every call without caching.
+    """
+    try:
+        return _pkg_version("nsys-ai")
+    except PackageNotFoundError:
+        return "0.0.0+dev"
 
 
 @dataclass
 class Finding:
-    """A single agent-authored finding to overlay on the timeline."""
+    """A single agent-authored finding to overlay on the timeline.
+
+    Required fields (``type``, ``label``, ``start_ns``) define a minimum
+    visual overlay. v0.1 optional fields enrich the finding with structured
+    evidence, category, confidence, source location, and diff provenance.
+
+    All v0.1 fields default to ``None`` and are dropped from
+    :meth:`to_dict` when unset, so legacy JSON output remains compact.
+    """
 
     type: str  # "highlight" | "region" | "marker"
     label: str
@@ -35,18 +85,76 @@ class Finding:
     severity: str = "info"  # "critical" | "warning" | "info"
     note: str = ""
 
+    # v0.1 additive fields — all optional, all drop from to_dict when None.
+    id: str | None = None
+    category: "FindingCategory | None" = None
+    confidence: float | None = None
+    evidence: list["EvidenceRow"] | None = None
+    selection: "TraceSelection | None" = None
+    explanation: str | None = None
+    suggested_actions: list[str] | None = None
+    false_positive_notes: list[str] | None = None
+    provenance: dict[str, Any] | None = None
+    diff_lineage: "DiffLineage | None" = None
+
     def to_dict(self) -> dict:
-        return {k: v for k, v in asdict(self).items() if v is not None}
+        # Walk fields() directly for scalar / primitive fields; nested
+        # dataclass fields are serialized via their own to_dict() to
+        # preserve each nested type's None-drop convention. Avoids the
+        # recursive deep copy that asdict() would perform on the nested
+        # fields only to be discarded here.
+        d: dict = {}
+        for f in fields(self):
+            if f.name in _FINDING_NESTED_FIELDS:
+                continue
+            v = getattr(self, f.name)
+            if v is None:
+                continue
+            # Shallow defensive copy for mutable container fields:
+            # top-level mutation of the returned dict (e.g.
+            # ``d["suggested_actions"].append(...)``) does not affect
+            # the source. Nested mutable values inside ``provenance`` /
+            # ``values`` etc. are still shared by reference — deep
+            # copies are intentionally avoided to keep ``to_dict``
+            # cheap, since the output is normally consumed by JSON
+            # serialization rather than mutated.
+            if isinstance(v, list):
+                d[f.name] = list(v)
+            elif isinstance(v, dict):
+                d[f.name] = dict(v)
+            else:
+                d[f.name] = v
+        if self.evidence is not None:
+            d["evidence"] = [e.to_dict() for e in self.evidence]
+        if self.selection is not None:
+            d["selection"] = self.selection.to_dict()
+        if self.diff_lineage is not None:
+            d["diff_lineage"] = self.diff_lineage.to_dict()
+        return d
 
     @classmethod
     def from_dict(cls, d: dict) -> "Finding":
         valid_keys = {f.name for f in cls.__dataclass_fields__.values()}
-        return cls(**{k: v for k, v in d.items() if k in valid_keys})
+        filtered = {k: v for k, v in d.items() if k in valid_keys}
+        # Rehydrate nested dataclass fields when present.
+        if filtered.get("evidence") is not None:
+            filtered["evidence"] = [EvidenceRow.from_dict(e) for e in filtered["evidence"]]
+        if filtered.get("selection") is not None:
+            filtered["selection"] = TraceSelection.from_dict(filtered["selection"])
+        if filtered.get("diff_lineage") is not None:
+            filtered["diff_lineage"] = DiffLineage.from_dict(filtered["diff_lineage"])
+        return cls(**filtered)
 
 
 @dataclass
 class EvidenceReport:
-    """A collection of findings for a profile, produced by an AI agent."""
+    """A collection of findings for a profile, produced by an AI agent.
+
+    The :meth:`to_dict` output carries the v0.1 envelope
+    (``schema_version``, ``producer``, ``producer_version``). The
+    :meth:`from_dict` reader accepts both v0.1 envelopes and legacy
+    (envelope-free) JSON payloads.
+    """
 
     title: str
     profile_path: str = ""
@@ -54,6 +162,9 @@ class EvidenceReport:
 
     def to_dict(self) -> dict:
         return {
+            "schema_version": SCHEMA_VERSION,
+            "producer": PRODUCER,
+            "producer_version": _producer_version(),
             "title": self.title,
             "profile_path": self.profile_path,
             "findings": [f.to_dict() for f in self.findings],
@@ -61,6 +172,9 @@ class EvidenceReport:
 
     @classmethod
     def from_dict(cls, d: dict) -> "EvidenceReport":
+        # Envelope fields (schema_version / producer / producer_version)
+        # are informational only — readers ignore them. Legacy payloads
+        # without an envelope load identically.
         findings = [Finding.from_dict(f) for f in d.get("findings", [])]
         return cls(
             title=d.get("title", "Untitled"),

--- a/tests/test_annotation_models.py
+++ b/tests/test_annotation_models.py
@@ -9,6 +9,7 @@ import json
 from nsys_ai.annotation import (
     Diagnostic,
     DiffLineage,
+    EvidenceReport,
     EvidenceRow,
     Finding,
     TraceSelection,
@@ -527,6 +528,8 @@ class TestModuleExports:
 
     def test_imports(self):
         from nsys_ai.annotation import (
+            PRODUCER,
+            SCHEMA_VERSION,
             Diagnostic,
             DiffLineage,
             EvidenceReport,
@@ -548,3 +551,288 @@ class TestModuleExports:
         assert TraceSelection is not None
         assert callable(load_findings)
         assert callable(save_findings)
+        assert isinstance(SCHEMA_VERSION, str) and SCHEMA_VERSION
+        assert PRODUCER == "nsys-ai"
+
+
+class TestFindingV01Fields:
+    """The additive v0.1 optional fields on Finding."""
+
+    def _legacy(self, **overrides) -> Finding:
+        kwargs = dict(type="region", label="L", start_ns=0)
+        kwargs.update(overrides)
+        return Finding(**kwargs)
+
+    def test_legacy_construction_still_works(self):
+        """No new field is required; pre-v0.1 callers see no behavior change."""
+        f = self._legacy()
+        assert f.id is None
+        assert f.category is None
+        assert f.confidence is None
+        assert f.evidence is None
+        assert f.selection is None
+        assert f.explanation is None
+        assert f.suggested_actions is None
+        assert f.false_positive_notes is None
+        assert f.provenance is None
+        assert f.diff_lineage is None
+
+    def test_legacy_to_dict_drops_all_new_fields(self):
+        """Default Finding produces the same dict shape as before v0.1."""
+        d = self._legacy().to_dict()
+        # New fields, all None by default, must not appear.
+        for k in (
+            "id",
+            "category",
+            "confidence",
+            "evidence",
+            "selection",
+            "explanation",
+            "suggested_actions",
+            "false_positive_notes",
+            "provenance",
+            "diff_lineage",
+        ):
+            assert k not in d, f"new field {k} leaked into legacy to_dict"
+
+    def test_scalar_new_fields_round_trip(self):
+        f = self._legacy(
+            id="f0",
+            category="idle",
+            confidence=0.83,
+            explanation="GPU stalls after backward pass.",
+            suggested_actions=["inspect DDP overlap"],
+            false_positive_notes=["short inference may be fine"],
+            provenance={"trim_start_ns": 0},
+        )
+        restored = Finding.from_dict(f.to_dict())
+        assert restored == f
+
+    def test_nested_evidence_round_trip(self):
+        rows = [
+            EvidenceRow(
+                id="r0",
+                source_skill="gpu_idle_gaps",
+                values={"gap_ms": 12.5},
+                units={"gap_ms": "ms"},
+            ),
+            EvidenceRow(id="r1", source_skill="overlap_breakdown"),
+        ]
+        f = self._legacy(id="f1", category="idle", evidence=rows)
+        restored = Finding.from_dict(f.to_dict())
+        assert restored.evidence == rows
+        # Nested type is rehydrated, not a list of dicts.
+        assert isinstance(restored.evidence[0], EvidenceRow)
+
+    def test_nested_selection_round_trip(self):
+        sel = TraceSelection(
+            id="sel_0",
+            profile_id="abc",
+            source="skill:gpu_idle_gaps",
+            start_ns=10,
+            end_ns=20,
+            gpu_ids=[0],
+        )
+        f = self._legacy(id="f2", selection=sel)
+        restored = Finding.from_dict(f.to_dict())
+        assert restored.selection == sel
+        assert isinstance(restored.selection, TraceSelection)
+
+    def test_nested_diff_lineage_round_trip(self):
+        lin = DiffLineage(
+            diff_id="diff_x",
+            role="regression",
+            rank=1,
+            baseline_profile_id="base_v1",
+        )
+        f = self._legacy(id="f3", diff_lineage=lin)
+        restored = Finding.from_dict(f.to_dict())
+        assert restored.diff_lineage == lin
+        assert isinstance(restored.diff_lineage, DiffLineage)
+
+    def test_full_v01_finding_json_round_trip(self):
+        rows = [EvidenceRow(id="r0", source_skill="overlap_breakdown")]
+        sel = TraceSelection(id="sel", profile_id="p", source="diff", start_ns=1)
+        lin = DiffLineage(diff_id="d", role="improvement", rank=0, baseline_profile_id="b")
+        f = self._legacy(
+            id="f",
+            category="communication",
+            confidence=0.9,
+            evidence=rows,
+            selection=sel,
+            explanation="exposed NCCL improved",
+            suggested_actions=["keep change"],
+            false_positive_notes=["small N"],
+            provenance={"trim_start_ns": 0},
+            diff_lineage=lin,
+        )
+        restored = Finding.from_dict(json.loads(json.dumps(f.to_dict())))
+        assert restored == f
+
+    def test_legacy_json_loads_with_defaults(self):
+        """A pre-v0.1 JSON payload (no new keys) loads cleanly."""
+        legacy = {
+            "type": "region",
+            "label": "L",
+            "start_ns": 100,
+            "end_ns": 200,
+            "severity": "warning",
+            "note": "old payload",
+        }
+        f = Finding.from_dict(legacy)
+        assert f.label == "L"
+        assert f.severity == "warning"
+        # New fields keep their None defaults.
+        assert f.id is None
+        assert f.category is None
+        assert f.evidence is None
+
+    def test_nested_to_dict_drops_inner_none(self):
+        """Nested EvidenceRow.to_dict drops None inside the Finding payload."""
+        rows = [EvidenceRow(id="r", source_skill="x")]  # selection_id is None
+        f = self._legacy(id="f", evidence=rows)
+        d = f.to_dict()
+        assert d["evidence"][0]["id"] == "r"
+        # selection_id was None on the row → must not leak into JSON output.
+        assert "selection_id" not in d["evidence"][0]
+
+    def test_to_dict_mutation_safety_for_mutable_fields(self):
+        """Mutating mutable containers in to_dict output must not mutate the source."""
+        f = self._legacy(
+            id="f",
+            provenance={"a": 1},
+            suggested_actions=["action_a"],
+            false_positive_notes=["note_a"],
+        )
+        d = f.to_dict()
+        d["provenance"]["a"] = 999
+        d["suggested_actions"].append("mutated")
+        d["false_positive_notes"].clear()
+        assert f.provenance == {"a": 1}
+        assert f.suggested_actions == ["action_a"]
+        assert f.false_positive_notes == ["note_a"]
+
+    def test_to_dict_avoids_wasted_nested_materialization(self, monkeypatch):
+        """Refactored to_dict reads nested fields once via their own to_dict.
+
+        Regression guard for the perf fix that replaced ``asdict(self)`` with
+        a hand-rolled ``fields()`` walk: confirms each nested type's
+        ``to_dict`` is invoked exactly once for a Finding with one of each
+        nested kind populated.
+
+        Implemented with ``monkeypatch`` + manual call counters rather than
+        ``unittest.mock.patch.object(autospec=True, wraps=...)`` because the
+        ``autospec + wraps`` combination behaves inconsistently across
+        Python 3.10 / 3.11 / 3.12 mock implementations.
+        """
+        rows = [EvidenceRow(id="r0", source_skill="x")]
+        sel = TraceSelection(id="s", profile_id="p", source="diff")
+        lin = DiffLineage(diff_id="d", role="stable", rank=0, baseline_profile_id="b")
+        f = self._legacy(evidence=rows, selection=sel, diff_lineage=lin)
+
+        calls = {"row": 0, "sel": 0, "lin": 0}
+
+        def _counted(key: str, original):
+            def wrapper(inner_self):
+                calls[key] += 1
+                return original(inner_self)
+
+            return wrapper
+
+        monkeypatch.setattr(EvidenceRow, "to_dict", _counted("row", EvidenceRow.to_dict))
+        monkeypatch.setattr(TraceSelection, "to_dict", _counted("sel", TraceSelection.to_dict))
+        monkeypatch.setattr(DiffLineage, "to_dict", _counted("lin", DiffLineage.to_dict))
+
+        d = f.to_dict()
+
+        assert calls == {"row": 1, "sel": 1, "lin": 1}
+        assert isinstance(d["evidence"][0], dict)
+        assert isinstance(d["selection"], dict)
+        assert isinstance(d["diff_lineage"], dict)
+
+
+class TestEvidenceReportEnvelope:
+    """v0.1 envelope on EvidenceReport JSON output."""
+
+    def test_to_dict_contains_envelope(self):
+        report = EvidenceReport(title="Test")
+        d = report.to_dict()
+        assert d["schema_version"] == "0.1"
+        assert d["producer"] == "nsys-ai"
+        assert isinstance(d["producer_version"], str) and d["producer_version"]
+
+    def test_envelope_does_not_displace_legacy_fields(self):
+        """Legacy keys (title, profile_path, findings) still appear unchanged."""
+        report = EvidenceReport(title="T", profile_path="/p/x.sqlite")
+        d = report.to_dict()
+        assert d["title"] == "T"
+        assert d["profile_path"] == "/p/x.sqlite"
+        assert d["findings"] == []
+
+    def test_from_dict_accepts_v01_envelope(self):
+        """Round-trip through to_dict / from_dict preserves the report."""
+        f = Finding(type="region", label="L", start_ns=10)
+        report = EvidenceReport(title="T", profile_path="/p", findings=[f])
+        restored = EvidenceReport.from_dict(report.to_dict())
+        assert restored.title == "T"
+        assert restored.profile_path == "/p"
+        assert len(restored.findings) == 1
+        assert restored.findings[0].label == "L"
+
+    def test_from_dict_accepts_legacy_payload(self):
+        """A pre-envelope payload (no schema_version) loads correctly."""
+        legacy = {
+            "title": "Legacy",
+            "profile_path": "/x.sqlite",
+            "findings": [{"type": "region", "label": "L", "start_ns": 0, "severity": "info"}],
+        }
+        report = EvidenceReport.from_dict(legacy)
+        assert report.title == "Legacy"
+        assert len(report.findings) == 1
+        assert report.findings[0].label == "L"
+
+    def test_from_dict_ignores_envelope_metadata(self):
+        """Envelope fields are informational; from_dict drops them silently."""
+        payload = {
+            "schema_version": "9.9",  # any value, even unknown
+            "producer": "ghostwriter",
+            "producer_version": "0.0.0",
+            "title": "T",
+            "profile_path": "",
+            "findings": [],
+        }
+        report = EvidenceReport.from_dict(payload)
+        assert report.title == "T"
+        assert report.findings == []
+
+    def test_json_round_trip_with_v01_findings(self):
+        rows = [EvidenceRow(id="r", source_skill="x")]
+        sel = TraceSelection(id="s", profile_id="p", source="diff")
+        f = Finding(
+            type="region",
+            label="L",
+            start_ns=10,
+            id="f",
+            category="communication",
+            evidence=rows,
+            selection=sel,
+        )
+        report = EvidenceReport(title="T", findings=[f])
+        s = json.dumps(report.to_dict(), indent=2)
+        restored = EvidenceReport.from_dict(json.loads(s))
+        assert restored.title == "T"
+        assert restored.findings[0].id == "f"
+        assert restored.findings[0].evidence[0].id == "r"
+        assert restored.findings[0].selection.profile_id == "p"
+
+    def test_save_load_round_trip(self, tmp_path):
+        from nsys_ai.annotation import load_findings, save_findings
+
+        f = Finding(type="region", label="L", start_ns=10, id="f0", category="idle")
+        report = EvidenceReport(title="Persist", findings=[f])
+        path = tmp_path / "findings.json"
+        save_findings(report, str(path))
+        loaded = load_findings(str(path))
+        assert loaded.title == "Persist"
+        assert loaded.findings[0].id == "f0"
+        assert loaded.findings[0].category == "idle"


### PR DESCRIPTION
## Summary

Second slice of the evidence schema migration: `Finding` gains the v0.1 optional fields and `EvidenceReport` gains the JSON envelope. Both changes are purely additive — legacy producers and consumers keep working unchanged.

### `Finding` extension

Adds 10 optional fields populated by evidence-aware surfaces (CLI, GUI, agent, diff):

- `id`, `category`, `confidence`
- `evidence: list[EvidenceRow] | None`
- `selection: TraceSelection | None`
- `explanation`, `suggested_actions`, `false_positive_notes`, `provenance: dict[str, Any] | None`
- `diff_lineage: DiffLineage | None`

`to_dict` / `from_dict` rehydrate nested dataclass fields while preserving each nested type's own None-drop convention. `to_dict` walks `dataclasses.fields()` + `getattr` for scalar fields with shallow defensive copies of mutable containers — avoiding the recursive deep copy that `asdict(self)` would do on nested fields only to discard them.

### `EvidenceReport` envelope

`to_dict` now emits an additive envelope:

- `schema_version` via new module constant `SCHEMA_VERSION = "0.1"`
- `producer` via new module constant `PRODUCER = "nsys-ai"`
- `producer_version` read directly from distribution metadata via `importlib.metadata.version("nsys-ai")` (with `PackageNotFoundError` fallback to `"0.0.0+dev"`). The module does **not** depend on `nsys_ai/__init__.py`, so there is no circular-import risk with consumers like `web.py` that import `annotation`.

`from_dict` reads both v0.1 envelopes and legacy envelope-free payloads; envelope fields are informational only.

## Backward compatibility

- All previously-required `Finding` fields keep their defaults.
- Legacy `Finding` JSON (no v0.1 keys) loads cleanly, with new fields defaulting to `None`.
- Legacy `EvidenceReport` JSON (no envelope) loads cleanly.
- A default `Finding` produces the same `to_dict` shape as before this PR (verified by test).

## Test plan

- [x] 24 new tests in `tests/test_annotation_models.py` covering each new scalar field, each nested type round-trip, full v0.1 Finding JSON round-trip, legacy JSON load, nested None-drop, envelope presence/shape, legacy payload acceptance, `save_findings`/`load_findings` round-trip, `SCHEMA_VERSION`/`PRODUCER` exports, mutation safety on mutable fields, and a regression guard that each nested type's `to_dict` is invoked exactly once.
- [x] Existing `tests/test_evidence_build.py` still passes (Finding.type/label/start_ns invariants intact).
- [x] Full suite: 720 passed / 135 skipped.
- [x] `python -m nsys_ai --help` smoke test passes.
- [x] `ruff check src/ tests/` and `ruff format --check` clean.

## Out of scope

- No skill is wired to populate the new `Finding` fields yet (next PR upgrades `gpu_idle_gaps` end-to-end as the migration template).
- `analyze --format json` CLI surface is not wired yet (follow-up).