### PR TITLE
chore(github): add pull-request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,32 @@
+<!--
+Thanks for sending a PR! Keep this template tight — empty sections are fine.
+Delete any section that does not apply, but please at least keep Summary and Test plan.
+-->
+
+## Summary
+
+<!-- 1–3 bullets: what this PR changes and why. -->
+
+## Changes
+
+<!-- Group by area / file. Bullets only — no narrative. -->
+
+## Backward compatibility
+
+<!-- Yes / No. If "no", state the breaking change and the migration path explicitly. -->
+
+## Test plan
+
+- [ ] Tests added or updated for the new behavior
+- [ ] `python -m nsys_ai --help` — CLI loads without error
+- [ ] `pytest tests/ -v --tb=short` passes locally
+- [ ] `ruff check src/ tests/` clean
+- [ ] Manually exercised the changed CLI / GUI path (if applicable)
+
+## Out of scope
+
+<!-- What this PR deliberately does NOT do. List follow-up PRs / issues. -->
+
+## Linked issues
+
+<!-- Closes #N, Refs #N. Remove this section if none. -->


### PR DESCRIPTION
## Summary

- Test-plan checkboxes mirror the CI lint + test steps so contributors can self-verify before requesting review.

## Changes

- `.github/PULL_REQUEST_TEMPLATE.md` — new file. Sections: Summary / Changes / Backward compatibility / Test plan / Out of scope / Linked issues. Every section is optional except Summary and Test plan.

## Backward compatibility

Yes — purely additive. Existing PRs in flight are unaffected; the template only populates the body of *new* PRs opened after merge.

## Test plan

- [x] File renders correctly when previewed on GitHub's PR-create page (HTML comments suppressed, checkboxes interactive)
- [x] No CI / runtime impact (docs-only change)

## Out of scope

- Issue templates (`.github/ISSUE_TEMPLATE/`) — separate follow-up if/when needed.
- Multi-template directory layout (`.github/PULL_REQUEST_TEMPLATE/*.md`) — current single-file template covers all PR types.