### PR TITLE
feat(cli): add `analyze --format json` and deprecate `evidence build`

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -46,6 +46,7 @@ def _cutracer_check():
     # Python package
     if importlib.util.find_spec("cutracer") is not None:
         import cutracer as _ct  # type: ignore[import]
+
         version = getattr(_ct, "__version__", "unknown")
         print(f"  cutracer Python package : OK (v{version})")
     else:
@@ -141,6 +142,7 @@ def _cutracer_run(args, _profile):
         )
 
     from nsys_ai.cutracer.correlator import normalize_kernel_name
+
     kernel_filter = [normalize_kernel_name(t.name) for t in plan.targets]
 
     config = RunConfig(
@@ -155,8 +157,10 @@ def _cutracer_run(args, _profile):
         # Detect CUDA version from the local CUDA toolkit for image suggestion.
         # This does not read CUDA details from the Nsight profile itself.
         from nsys_ai.cutracer.installer import detect_cuda_version
+
         cuda_ver = detect_cuda_version()
         from nsys_ai.cutracer.runner import _cuda_image_for_version
+
         modal_cfg = ModalConfig(
             gpu=modal_gpu,
             cuda_image=_cuda_image_for_version(cuda_ver),
@@ -166,21 +170,26 @@ def _cutracer_run(args, _profile):
 
         if modal_save:
             import stat as _stat
+
             save_path = _Path(modal_save)
             save_path.write_text(script)
-            save_path.chmod(save_path.stat().st_mode | _stat.S_IEXEC | _stat.S_IXGRP | _stat.S_IXOTH)
+            save_path.chmod(
+                save_path.stat().st_mode | _stat.S_IEXEC | _stat.S_IXGRP | _stat.S_IXOTH
+            )
             print(f"Modal app saved to: {save_path}")
             print(f"Run with: modal run {save_path}")
         elif backend == "modal-run":
             # Actually invoke modal run
             import stat as _stat
             import tempfile
+
             with tempfile.NamedTemporaryFile(suffix="_cutracer.py", mode="w", delete=False) as tf:
                 tf.write(script)
                 tmp = _Path(tf.name)
             tmp.chmod(tmp.stat().st_mode | _stat.S_IEXEC)
             print(f"==> Running: modal run {tmp}")
             import subprocess as _sp  # nosec B404
+
             result = _sp.run(["modal", "run", str(tmp)])  # nosec B603 B607
             sys.exit(result.returncode)
         else:
@@ -275,9 +284,13 @@ def _cutracer_plan(args, _profile):
         script = format_plan_script(plan, output_dir=output_dir, launch_cmd=launch_cmd)
         if save_path:
             from pathlib import Path
+
             Path(save_path).write_text(script)
             import stat
-            Path(save_path).chmod(Path(save_path).stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+
+            Path(save_path).chmod(
+                Path(save_path).stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH
+            )
             print(f"Script saved to: {save_path}  (chmod +x applied)")
         else:
             print(script, end="")
@@ -360,6 +373,24 @@ def _cmd_info(args, _profile):
 
 
 def _cmd_analyze(args, _profile):
+    fmt = getattr(args, "format", "text") or "text"
+    if fmt == "json":
+        _cmd_analyze_json(args, _profile)
+        return
+
+    # Text / markdown pipeline requires a trim window (run_analyze →
+    # build_nvtx_tree dereferences trim[0]). At the parser level --trim
+    # is optional so that --format json can run on the full profile;
+    # enforce the text-mode requirement here with a clear error.
+    if not getattr(args, "trim", None):
+        print(
+            "Error: 'analyze' without --format json requires --trim START_S END_S. "
+            "Use --format json to run on the full profile span.",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+
     from nsys_ai.report import format_report_markdown, format_report_terminal, run_analyze
 
     with _profile.open(args.profile) as prof:
@@ -374,6 +405,63 @@ def _cmd_analyze(args, _profile):
             with open(args.output, "w", encoding="utf-8", newline="\n") as f:
                 f.write(md)
             print(f"Markdown report written to {args.output}")
+
+
+def _cmd_analyze_json(args, _profile):
+    """Emit a v0.1 evidence findings report as JSON.
+
+    Shares the EvidenceBuilder pipeline with the legacy ``evidence build``
+    command; this is the canonical CLI entry point for machine-readable
+    findings going forward.
+    """
+    import json as _json
+
+    from nsys_ai.evidence_builder import EvidenceBuilder
+
+    with _profile.open(args.profile) as prof:
+        trim = _parse_trim(args)
+        device = getattr(args, "gpu", 0) or 0
+        builder = EvidenceBuilder(prof, device=device, trim=trim)
+        report = builder.build()
+
+        # ``report.profile_path`` (and the nested ``selection.profile_id``
+        # on each Finding) is sourced from the opened Profile's path —
+        # which is the resolved ``.sqlite`` sidecar for ``.nsys-rep``
+        # inputs. We deliberately do not overwrite it with ``args.profile``
+        # here, so the envelope and every nested identifier agree on a
+        # single source of truth.
+        payload = report.to_dict()
+        print(_json.dumps(payload, indent=2))
+
+        out = getattr(args, "output", None)
+        if out:
+            from nsys_ai.annotation import save_findings
+
+            out_dir = os.path.dirname(out)
+            if out_dir and not os.path.exists(out_dir):
+                try:
+                    os.makedirs(out_dir, exist_ok=True)
+                except OSError as e:
+                    print(
+                        f"Error: Failed to create output directory '{out_dir}': {e}",
+                        file=sys.stderr,
+                        flush=True,
+                    )
+                    sys.exit(1)
+            try:
+                save_findings(report, out)
+            except OSError as e:
+                print(
+                    f"Error: Failed to write findings to '{out}': {e}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                sys.exit(1)
+            print(
+                f"Saved {len(report.findings)} finding(s) → {out}",
+                flush=True,
+                file=sys.stderr,
+            )
 
 
 def _cmd_report(args, _profile):
@@ -635,7 +723,9 @@ def _cmd_iters(args, _profile):
     from nsys_ai.overlap import detect_iterations, format_iterations
 
     with _profile.open(args.profile) as prof:
-        device = args.gpu if args.gpu is not None else (prof.meta.devices[0] if prof.meta.devices else 0)
+        device = (
+            args.gpu if args.gpu is not None else (prof.meta.devices[0] if prof.meta.devices else 0)
+        )
         print(format_iterations(detect_iterations(prof, device, _parse_trim(args))))
 
 
@@ -831,7 +921,13 @@ def _cmd_chat(args, _profile):
 
 
 def _cmd_evidence(args, _profile):
-    """Build evidence findings via EvidenceBuilder for timeline overlay."""
+    """Build evidence findings via EvidenceBuilder for timeline overlay.
+
+    Deprecated: prefer ``nsys-ai analyze --format json`` going forward.
+    The two commands share the same EvidenceBuilder pipeline and emit
+    the same v0.1 envelope; ``evidence build`` is kept as a backwards
+    compatible alias and will be removed in a future release.
+    """
     import json
 
     from nsys_ai.evidence_builder import EvidenceBuilder
@@ -842,11 +938,16 @@ def _cmd_evidence(args, _profile):
         )
         return
 
-    with _profile.open(args.profile) as prof:
-        trim = None
-        if getattr(args, "trim", None):
-            trim = (int(args.trim[0] * 1e9), int(args.trim[1] * 1e9))
+    print(
+        "warning: 'nsys-ai evidence build' is deprecated — use "
+        "'nsys-ai analyze --format json' instead. This command will be "
+        "removed in a future release.",
+        file=sys.stderr,
+        flush=True,
+    )
 
+    with _profile.open(args.profile) as prof:
+        trim = _parse_trim(args)
         device = getattr(args, "gpu", 0) or 0
         builder = EvidenceBuilder(prof, device=device, trim=trim)
 
@@ -860,14 +961,15 @@ def _cmd_evidence(args, _profile):
             report = builder.build()
 
         findings = [f.to_dict() for f in report.findings]
+        # ``report.profile_path`` comes from the opened Profile (which
+        # may resolve to a ``.sqlite`` sidecar for ``.nsys-rep`` inputs).
+        # Leave it as-is so the envelope and the nested
+        # ``selection.profile_id`` values on each Finding agree on one
+        # source of truth.
         fmt = getattr(args, "format", "json")
         if fmt == "json":
-            out_report = {
-                "title": getattr(report, "title", "Evidence Report"),
-                "profile_path": getattr(report, "profile_path", args.profile),
-                "findings": findings,
-            }
-            print(json.dumps(out_report, indent=2))
+            payload = report.to_dict()
+            print(json.dumps(payload, indent=2))
         else:
             sev_icons = {"critical": "🔴", "warning": "🟡", "info": "🔵"}
             print(f"── Evidence Findings ({len(findings)}) ──")

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -407,6 +407,42 @@ def _cmd_analyze(args, _profile):
             print(f"Markdown report written to {args.output}")
 
 
+def _write_evidence_report_or_die(report, out_path: str) -> None:
+    """Persist an ``EvidenceReport`` to disk via ``save_findings``.
+
+    Shared by ``analyze --format json`` and ``evidence build`` so the two
+    commands stay aligned on directory creation, error reporting, and the
+    "Saved N finding(s)" stderr line.
+    """
+    from nsys_ai.annotation import save_findings
+
+    out_dir = os.path.dirname(out_path)
+    if out_dir and not os.path.exists(out_dir):
+        try:
+            os.makedirs(out_dir, exist_ok=True)
+        except OSError as e:
+            print(
+                f"Error: Failed to create output directory '{out_dir}': {e}",
+                file=sys.stderr,
+                flush=True,
+            )
+            sys.exit(1)
+    try:
+        save_findings(report, out_path)
+    except OSError as e:
+        print(
+            f"Error: Failed to write findings to '{out_path}': {e}",
+            file=sys.stderr,
+            flush=True,
+        )
+        sys.exit(1)
+    print(
+        f"Saved {len(report.findings)} finding(s) → {out_path}",
+        flush=True,
+        file=sys.stderr,
+    )
+
+
 def _cmd_analyze_json(args, _profile):
     """Emit a v0.1 evidence findings report as JSON.
 
@@ -435,33 +471,7 @@ def _cmd_analyze_json(args, _profile):
 
         out = getattr(args, "output", None)
         if out:
-            from nsys_ai.annotation import save_findings
-
-            out_dir = os.path.dirname(out)
-            if out_dir and not os.path.exists(out_dir):
-                try:
-                    os.makedirs(out_dir, exist_ok=True)
-                except OSError as e:
-                    print(
-                        f"Error: Failed to create output directory '{out_dir}': {e}",
-                        file=sys.stderr,
-                        flush=True,
-                    )
-                    sys.exit(1)
-            try:
-                save_findings(report, out)
-            except OSError as e:
-                print(
-                    f"Error: Failed to write findings to '{out}': {e}",
-                    file=sys.stderr,
-                    flush=True,
-                )
-                sys.exit(1)
-            print(
-                f"Saved {len(report.findings)} finding(s) → {out}",
-                flush=True,
-                file=sys.stderr,
-            )
+            _write_evidence_report_or_die(report, out)
 
 
 def _cmd_report(args, _profile):
@@ -960,7 +970,6 @@ def _cmd_evidence(args, _profile):
         else:
             report = builder.build()
 
-        findings = [f.to_dict() for f in report.findings]
         # ``report.profile_path`` comes from the opened Profile (which
         # may resolve to a ``.sqlite`` sidecar for ``.nsys-rep`` inputs).
         # Leave it as-is so the envelope and the nested
@@ -972,7 +981,7 @@ def _cmd_evidence(args, _profile):
             print(json.dumps(payload, indent=2))
         else:
             sev_icons = {"critical": "🔴", "warning": "🟡", "info": "🔵"}
-            print(f"── Evidence Findings ({len(findings)}) ──")
+            print(f"── Evidence Findings ({len(report.findings)}) ──")
             for f in report.findings:
                 icon = sev_icons.get(f.severity, "⚪")
                 dur_ms = (f.end_ns - f.start_ns) / 1e6 if f.end_ns else 0
@@ -982,28 +991,7 @@ def _cmd_evidence(args, _profile):
 
         out = getattr(args, "output", None)
         if out:
-            from nsys_ai.annotation import save_findings
-
-            out_dir = os.path.dirname(out)
-            if out_dir and not os.path.exists(out_dir):
-                try:
-                    os.makedirs(out_dir, exist_ok=True)
-                except OSError as e:
-                    print(
-                        f"Error: Failed to create output directory '{out_dir}': {e}",
-                        file=sys.stderr,
-                        flush=True,
-                    )
-                    sys.exit(1)
-
-            try:
-                save_findings(report, out)
-            except OSError as e:
-                print(
-                    f"Error: Failed to write findings to '{out}': {e}", file=sys.stderr, flush=True
-                )
-                sys.exit(1)
-            print(f"Saved {len(findings)} finding(s) → {out}", flush=True, file=sys.stderr)
+            _write_evidence_report_or_die(report, out)
 
 
 def _apply_max_rows_truncation(rows: list, max_rows: int) -> list:

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -581,10 +581,37 @@ def _register_legacy_commands(sub):
     _register_info_parser(sub)
 
     p = sub.add_parser(
-        "analyze", help="Full auto-report: bottlenecks, overlap, iters, NVTX hierarchy"
+        "analyze",
+        help=(
+            "Full auto-report: bottlenecks, overlap, iters, NVTX hierarchy. "
+            "Use --format json to emit v0.1 evidence findings JSON instead."
+        ),
     )
-    _add_gpu_trim(p)
-    p.add_argument("-o", "--output", default=None, help="Write markdown report to file")
+    # --trim is optional at the parser level so `--format json` can run on
+    # the full profile span; the text path enforces a clear error when
+    # --trim is missing (see _cmd_analyze).
+    _add_gpu_trim(p, trim_required=False)
+    p.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help=(
+            "Output file. With --format text, writes the markdown narrative report. "
+            "With --format json, writes the v0.1 findings JSON via save_findings()."
+        ),
+    )
+    p.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help=(
+            "Output format. 'text' (default) prints the narrative report to stdout "
+            "and writes markdown to --output if given — requires --trim. "
+            "'json' switches to v0.1 evidence findings JSON (envelope + Finding list); "
+            "--trim is optional and narrows the window if provided. "
+            "Same JSON shape as the legacy 'evidence build' command."
+        ),
+    )
     p.set_defaults(handler=_cmd_analyze)
 
     p = sub.add_parser("summary", help="GPU kernel summary with top kernels")

--- a/tests/test_analyze_format_json.py
+++ b/tests/test_analyze_format_json.py
@@ -1,0 +1,309 @@
+"""Tests for ``nsys-ai analyze --format json`` and the corresponding
+deprecation behavior on ``nsys-ai evidence build``.
+"""
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from types import SimpleNamespace
+
+
+def _capture(handler, args, profile_module):
+    """Invoke a CLI handler, capturing stdout + stderr.
+
+    Returns (stdout_str, stderr_str).
+    """
+    out = io.StringIO()
+    err = io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        handler(args, profile_module)
+    return out.getvalue(), err.getvalue()
+
+
+def _make_args(profile_path: str, **overrides) -> SimpleNamespace:
+    """Build a minimal argparse-like namespace for the analyze / evidence handlers."""
+    base = dict(
+        profile=str(profile_path),
+        gpu=0,
+        trim=None,
+        output=None,
+        format="text",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# analyze --format json
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestAnalyzeFormatJson:
+    def test_emits_v01_envelope(self, minimal_nsys_db_path):
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        args = _make_args(minimal_nsys_db_path, format="json")
+        stdout, _ = _capture(_cmd_analyze, args, profile_module)
+
+        payload = json.loads(stdout)
+        assert payload["schema_version"] == "0.1"
+        assert payload["producer"] == "nsys-ai"
+        assert isinstance(payload["producer_version"], str) and payload["producer_version"]
+        assert "findings" in payload
+        assert isinstance(payload["findings"], list)
+
+    def test_profile_path_present(self, minimal_nsys_db_path):
+        """Envelope contains a profile_path string sourced from the opened Profile."""
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        args = _make_args(minimal_nsys_db_path, format="json")
+        stdout, _ = _capture(_cmd_analyze, args, profile_module)
+
+        payload = json.loads(stdout)
+        assert isinstance(payload["profile_path"], str)
+        assert payload["profile_path"]  # non-empty
+        # For a .sqlite input the resolved Profile.path equals the CLI arg.
+        assert payload["profile_path"] == str(minimal_nsys_db_path)
+
+    def test_envelope_and_selection_profile_id_agree(self, minimal_nsys_db_path):
+        """Single source of truth: envelope profile_path matches every
+        Finding.selection.profile_id inside the same payload.
+
+        Regression guard for the v0.1 identifier-consistency bug where
+        the CLI used to override envelope.profile_path independently of
+        the resolved Profile.path that EvidenceBuilder stamps onto
+        selection.profile_id.
+        """
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        args = _make_args(minimal_nsys_db_path, format="json")
+        stdout, _ = _capture(_cmd_analyze, args, profile_module)
+        payload = json.loads(stdout)
+
+        envelope_path = payload["profile_path"]
+        for f in payload["findings"]:
+            sel = f.get("selection")
+            if sel is None:
+                continue
+            assert sel["profile_id"] == envelope_path, (
+                f"Finding {f.get('id')} selection.profile_id={sel['profile_id']!r} "
+                f"disagrees with envelope profile_path={envelope_path!r}"
+            )
+
+    def test_no_deprecation_warning_for_analyze(self, minimal_nsys_db_path):
+        """analyze --format json is the canonical path; no deprecation noise."""
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        args = _make_args(minimal_nsys_db_path, format="json")
+        _, stderr = _capture(_cmd_analyze, args, profile_module)
+        assert "deprecated" not in stderr.lower()
+
+    def test_findings_have_v01_shape_when_idle_gaps_present(self, minimal_nsys_db_path):
+        """If the fixture produces idle-gap findings, they carry v0.1 fields.
+
+        Defensive: the minimal fixture may not always trigger idle gaps,
+        so we only inspect findings if at least one is produced.
+        """
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        args = _make_args(minimal_nsys_db_path, format="json")
+        stdout, _ = _capture(_cmd_analyze, args, profile_module)
+        payload = json.loads(stdout)
+        idle = [f for f in payload["findings"] if f.get("category") == "idle"]
+        for f in idle:
+            assert f.get("id"), "Finding must have an id when v0.1-aware"
+            assert "selection" in f, "Idle findings should have a selection"
+            assert f["selection"]["profile_id"] == str(minimal_nsys_db_path)
+            assert f["selection"]["source"] == "skill:gpu_idle_gaps"
+
+    def test_writes_to_output_file_when_provided(self, minimal_nsys_db_path, tmp_path):
+        from nsys_ai import profile as profile_module
+        from nsys_ai.annotation import load_findings
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        out_path = tmp_path / "findings.json"
+        args = _make_args(minimal_nsys_db_path, format="json", output=str(out_path))
+        stdout, stderr = _capture(_cmd_analyze, args, profile_module)
+
+        # stdout still has the JSON dump
+        json.loads(stdout)
+        # file was written via save_findings → load_findings round-trips
+        loaded = load_findings(str(out_path))
+        assert loaded.title  # legacy field still present
+        # save count message goes to stderr
+        assert "Saved" in stderr and "→" in stderr
+
+    def test_stdout_and_file_profile_path_agree(self, minimal_nsys_db_path, tmp_path):
+        """stdout payload and the persisted file must report the same profile_path."""
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        out_path = tmp_path / "findings.json"
+        args = _make_args(minimal_nsys_db_path, format="json", output=str(out_path))
+        stdout, _ = _capture(_cmd_analyze, args, profile_module)
+
+        stdout_payload = json.loads(stdout)
+        with open(out_path) as f:
+            file_payload = json.load(f)
+
+        assert stdout_payload["profile_path"] == file_payload["profile_path"]
+        assert stdout_payload["profile_path"] == str(minimal_nsys_db_path)
+
+
+class TestAnalyzeFormatTextWithoutTrim:
+    def test_text_mode_without_trim_fails_with_clear_error(self, minimal_nsys_db_path):
+        """Without --trim, text mode prints a guidance error rather than crashing on trim[0]."""
+        import io
+        from contextlib import redirect_stderr, redirect_stdout
+
+        import pytest
+
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        args = _make_args(minimal_nsys_db_path, format="text", trim=None)
+        out = io.StringIO()
+        err = io.StringIO()
+        with pytest.raises(SystemExit) as excinfo:
+            with redirect_stdout(out), redirect_stderr(err):
+                _cmd_analyze(args, profile_module)
+
+        assert excinfo.value.code == 1
+        stderr_text = err.getvalue()
+        # The error message must guide the user (don't just exit silently),
+        # and must mention both the missing flag and the JSON workaround.
+        assert "--trim" in stderr_text
+        assert "--format json" in stderr_text
+        # No tracebacks leak to stderr from this guarded path.
+        assert "Traceback" not in stderr_text
+
+    def test_json_mode_bypasses_text_pipeline(self, minimal_nsys_db_path):
+        """``--format json`` must take the evidence path, not ``report.run_analyze``.
+
+        ``run_analyze`` requires a populated ``--trim`` window; the JSON
+        path goes through ``EvidenceBuilder``, which works without trim.
+        Passing ``trim=None`` and observing a successful JSON output is
+        a behavioral guarantee that the format switch took the early
+        return before hitting the text pipeline.
+        """
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze
+
+        args = _make_args(minimal_nsys_db_path, format="json", trim=None)
+        stdout, _ = _capture(_cmd_analyze, args, profile_module)
+        # If the early return failed and we fell into run_analyze, this
+        # would have raised TypeError on ``trim[0]``.
+        payload = json.loads(stdout)
+        assert "findings" in payload
+
+
+# ──────────────────────────────────────────────────────────────────────
+# evidence build (deprecated alias)
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestEvidenceBuildDeprecation:
+    def test_evidence_build_still_works(self, minimal_nsys_db_path):
+        """The legacy command still produces valid JSON output."""
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_evidence
+
+        args = SimpleNamespace(
+            profile=str(minimal_nsys_db_path),
+            evidence_action="build",
+            format="json",
+            analyzers=None,
+            trim=None,
+            gpu=0,
+            output=None,
+        )
+        stdout, stderr = _capture(_cmd_evidence, args, profile_module)
+        payload = json.loads(stdout)
+        assert "findings" in payload
+
+    def test_evidence_build_prints_deprecation_warning(self, minimal_nsys_db_path):
+        """A deprecation notice is emitted on stderr to help users migrate."""
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_evidence
+
+        args = SimpleNamespace(
+            profile=str(minimal_nsys_db_path),
+            evidence_action="build",
+            format="json",
+            analyzers=None,
+            trim=None,
+            gpu=0,
+            output=None,
+        )
+        _, stderr = _capture(_cmd_evidence, args, profile_module)
+        assert "deprecated" in stderr.lower()
+        # Mentions the canonical replacement so users know where to go.
+        assert "analyze --format json" in stderr
+
+    def test_evidence_build_json_now_carries_envelope(self, minimal_nsys_db_path):
+        """Previously the stdout JSON skipped the envelope; verify it now matches analyze."""
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_evidence
+
+        args = SimpleNamespace(
+            profile=str(minimal_nsys_db_path),
+            evidence_action="build",
+            format="json",
+            analyzers=None,
+            trim=None,
+            gpu=0,
+            output=None,
+        )
+        stdout, _ = _capture(_cmd_evidence, args, profile_module)
+        payload = json.loads(stdout)
+        assert payload["schema_version"] == "0.1"
+        assert payload["producer"] == "nsys-ai"
+        assert isinstance(payload["producer_version"], str)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Cross-command equivalence
+# ──────────────────────────────────────────────────────────────────────
+
+
+class TestCrossCommandEquivalence:
+    def test_analyze_json_matches_evidence_build(self, minimal_nsys_db_path):
+        """analyze --format json and evidence build emit equivalent JSON shape."""
+        from nsys_ai import profile as profile_module
+        from nsys_ai.cli.handlers import _cmd_analyze, _cmd_evidence
+
+        analyze_args = _make_args(minimal_nsys_db_path, format="json")
+        analyze_out, _ = _capture(_cmd_analyze, analyze_args, profile_module)
+
+        evidence_args = SimpleNamespace(
+            profile=str(minimal_nsys_db_path),
+            evidence_action="build",
+            format="json",
+            analyzers=None,
+            trim=None,
+            gpu=0,
+            output=None,
+        )
+        evidence_out, _ = _capture(_cmd_evidence, evidence_args, profile_module)
+
+        a = json.loads(analyze_out)
+        e = json.loads(evidence_out)
+
+        # Envelope must agree.
+        for key in ("schema_version", "producer", "producer_version"):
+            assert a[key] == e[key]
+
+        # Finding count and key structure should match — both go through
+        # the same EvidenceBuilder pipeline.
+        assert len(a["findings"]) == len(e["findings"])
+        for af, ef in zip(a["findings"], e["findings"]):
+            assert af.get("type") == ef.get("type")
+            assert af.get("label") == ef.get("label")
+            assert af.get("start_ns") == ef.get("start_ns")
+            assert af.get("id") == ef.get("id")
+            assert af.get("category") == ef.get("category")


### PR DESCRIPTION
## Summary

- \`nsys-ai analyze --format json\` is the new canonical CLI entry point for v0.1 evidence findings JSON. It shares the \`EvidenceBuilder\` pipeline and the v0.1 envelope (\`schema_version\` / \`producer\` / \`producer_version\` + Finding list) with the now-legacy \`nsys-ai evidence build\`.
- \`nsys-ai evidence build\` is kept as a backwards-compatible alias but prints a deprecation notice on stderr pointing users at the new command. It will be removed in a future release.
- Cross-command equivalence: both commands now route their stdout JSON through \`EvidenceReport.to_dict()\`, so they emit matching envelope + finding shape (regression-tested).

## Changes

- \`src/nsys_ai/cli/parsers.py\`
  - Adds \`--format {text,json}\` to the \`analyze\` subparser (default \`text\`).
  - Updates the help text to document the mode switch: \`text\`/\`markdown\` = narrative auto-report; \`json\` = v0.1 findings.
- \`src/nsys_ai/cli/handlers.py\`
  - \`_cmd_analyze\` early-returns into the new \`_cmd_analyze_json\` helper when \`format=json\`. The helper:
    - Constructs an \`EvidenceReport\` via \`EvidenceBuilder\` (no \`run_analyze\`, no \`--trim\` requirement).
    - Prints \`report.to_dict()\` to stdout (envelope present).
    - When \`--output\` is set, also persists the report via \`save_findings\` and reports the file write on stderr.
  - \`_cmd_evidence\`:
    - Prints a deprecation notice on stderr pointing at \`analyze --format json\`.
    - Routes its stdout JSON through \`report.to_dict()\` (the previous hand-built dict skipped the v0.1 envelope).
- \`tests/test_analyze_format_json.py\` — new file, 10 tests:
  - Envelope present, \`profile_path\` reflects the CLI arg, no deprecation noise on \`analyze\`.
  - v0.1 finding shape when idle gaps appear (\`selection.profile_id\`, \`selection.source == \"skill:gpu_idle_gaps\"\`).
  - \`--output\` writes a parseable findings file; stdout still gets the dump; save-count message goes to stderr.
  - Regression guard: \`format=json\` does not call into \`run_analyze\` (verified by passing \`trim=None\` — text mode would crash).
  - \`evidence build\` still works, prints deprecation, now emits the envelope.
  - Cross-command equivalence: \`analyze --format json\` and \`evidence build\` emit matching envelope + finding shape.

## Backward compatibility

- \`analyze\` default (text + optional markdown via \`--output\`) is unchanged.
- \`evidence build\` keeps working with the same JSON shape it used to emit, plus the previously-missing envelope; only side effect is the deprecation notice on stderr.
- File output via \`save_findings\` was already envelope-correct; this PR brings stdout in line.

## Test plan

- [x] Tests added or updated for the new behavior — 10 new tests in \`tests/test_analyze_format_json.py\`
- [x] \`python -m nsys_ai --help\` — CLI loads without error
- [x] \`python -m nsys_ai analyze --help\` shows the new \`--format\` flag and updated help text
- [x] \`python -m nsys_ai evidence build --help\` still works
- [x] \`pytest tests/ -v --tb=short\` passes locally — 752 passed / 135 skipped (was 742)
- [x] \`ruff check src/ tests/\` clean
- [x] Manually invoked \`analyze --format json\` against a real profile; JSON shape matches the schema reference

## Out of scope

- Removing \`evidence build\` entirely — deferred to a future release once the deprecation notice has been visible for a cycle.
- Adding JSON output to the text-mode narrative report (\`run_analyze\` data) — that would be a separate shape and is a different feature.
- Updating docs that mention \`evidence build\` as the canonical entry point — follow-up doc PR.