### PR TITLE
feat(evidence): add content-derived stable profile_id to envelope

### DIFF
--- a/docs/agent_skills/commands/evidence_schema.md
+++ b/docs/agent_skills/commands/evidence_schema.md
@@ -15,7 +15,6 @@ This minimal form is what existed before v0.1 and still loads identically today 
 cat > /tmp/findings.json << 'EOF'
 {
   "title": "Pipeline Parallelism Bubble Analysis",
-  "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "profile_path": "fastvideo.sqlite",
   "findings": [
     {

--- a/docs/agent_skills/commands/evidence_schema.md
+++ b/docs/agent_skills/commands/evidence_schema.md
@@ -15,6 +15,7 @@ This minimal form is what existed before v0.1 and still loads identically today 
 cat > /tmp/findings.json << 'EOF'
 {
   "title": "Pipeline Parallelism Bubble Analysis",
+  "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "profile_path": "fastvideo.sqlite",
   "findings": [
     {
@@ -108,6 +109,7 @@ Findings should encode **conclusions**, not raw data. The agent must reason abou
   "producer": "nsys-ai",
   "producer_version": "0.2.2",
   "title": "Human-readable title for the report",
+  "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "profile_path": "path/to/profile.sqlite",
   "findings": [ ... ]
 }
@@ -117,10 +119,11 @@ Findings should encode **conclusions**, not raw data. The agent must reason abou
 - `producer`: Always `"nsys-ai"` for reports emitted by this tool.
 - `producer_version`: Version of the `nsys-ai` package that wrote the report.
 - `title`: Displayed at the top of the evidence sidebar.
-- `profile_path`: Optional, for reference only.
+- `profile_id`: Content-derived stable identifier produced by `fingerprint.get_profile_id`. Format: `nsys1:sha256:<64-hex>` (or `nsys1:path:<64-hex>` fallback when the source carries no Nsight metadata, e.g. a parquetdir-only backend). Two surfaces looking at the same profile agree on this value without depending on the filesystem path. **Every `TraceSelection.profile_id` produced during the same build carries the same value** — readers can join across surfaces by equality.
+- `profile_path`: Filesystem path the producer opened. Reference only — not an identifier.
 - `findings`: Array of Finding objects (see above).
 
-Legacy payloads without the envelope keys (`schema_version` / `producer` / `producer_version`) load identically — readers ignore unknown / missing envelope fields.
+Legacy payloads without the envelope keys (`schema_version` / `producer` / `producer_version` / `profile_id`) load identically — readers ignore unknown / missing envelope fields, and `profile_id` defaults to `""` for pre-`profile_id` payloads.
 
 ---
 
@@ -168,7 +171,7 @@ A region of a profile. All location fields are optional — a selection may be t
 ```json
 {
   "id": "sel_idle_gap_gpu0_stream7_500",
-  "profile_id": "/path/to/profile.sqlite",
+  "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "source": "skill:gpu_idle_gaps",
   "start_ns": 500,
   "end_ns": 12500500,
@@ -180,7 +183,7 @@ A region of a profile. All location fields are optional — a selection may be t
 ```
 
 - `id`: Stable id for this selection.
-- `profile_id`: Opaque profile identifier — any string the producer picks, treated by readers as an equality key. Two surfaces looking at the same profile should agree on the value. Built-in skills today use the profile's filesystem path; future producers may use a content-hash fingerprint.
+- `profile_id`: Content-derived stable identifier — matches the enclosing `EvidenceReport.profile_id` and is sourced from `fingerprint.get_profile_id`. Format: `nsys1:sha256:<64-hex>` (or `nsys1:path:<64-hex>` fallback when no Nsight metadata is reachable). Treated by readers as an equality key — two surfaces looking at the same profile agree on the value without depending on the filesystem path.
 - `source`: Who produced the selection — `"skill:<name>"`, `"gui"`, `"user"`, or `"diff"`.
 - `start_ns` / `end_ns`: Time window (nanoseconds, absolute from profile epoch).
 - `gpu_ids` / `rank_ids` / `stream_ids`: Location lists. Empty list (`[]`) means "no GPUs/ranks/streams" — distinct from omission, which means "unspecified".
@@ -197,7 +200,7 @@ Set on findings that originated from a before/after diff comparison.
   "diff_id": "diff_20260512",
   "role": "regression",
   "rank": 1,
-  "baseline_profile_id": "/path/to/baseline.sqlite"
+  "baseline_profile_id": "nsys1:sha256:6b1f9a0e0b3e2c7a8b8d5f0e1b2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d"
 }
 ```
 
@@ -240,6 +243,7 @@ Same finding as the [Quick Example](#quick-example-minimal--legacy-fields-only) 
   "producer": "nsys-ai",
   "producer_version": "0.2.2",
   "title": "Pipeline Parallelism Bubble Analysis",
+  "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "profile_path": "fastvideo.sqlite",
   "findings": [
     {
@@ -263,7 +267,7 @@ Same finding as the [Quick Example](#quick-example-minimal--legacy-fields-only) 
       ],
       "selection": {
         "id": "sel_pp_bubble_iter142",
-        "profile_id": "fastvideo.sqlite",
+        "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
         "source": "skill:gpu_idle_gaps",
         "start_ns": 89000000000,
         "end_ns": 110000000000,

--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -157,9 +157,13 @@ class EvidenceReport:
     """
 
     title: str
-    profile_id: str = ""
+    # ``profile_id`` is keyword-only so adding it after the original
+    # ``title`` / ``profile_path`` fields does not shift the positional
+    # signature — pre-v0.1 callers using ``EvidenceReport("T", "/p")``
+    # still get ``profile_path="/p"``, not ``profile_id="/p"``.
     profile_path: str = ""
     findings: list[Finding] = field(default_factory=list)
+    profile_id: str = field(default="", kw_only=True)
 
     def to_dict(self) -> dict:
         return {

--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -154,6 +154,12 @@ class EvidenceReport:
     (``schema_version``, ``producer``, ``producer_version``). The
     :meth:`from_dict` reader accepts both v0.1 envelopes and legacy
     (envelope-free) JSON payloads.
+
+    .. note::
+       New envelope fields must be added as ``field(..., kw_only=True)``
+       (see ``profile_id`` below). Inserting a non-kw-only field before
+       the existing positional ones would silently shift the positional
+       signature and rebind old callers.
     """
 
     title: str
@@ -164,6 +170,16 @@ class EvidenceReport:
     profile_path: str = ""
     findings: list[Finding] = field(default_factory=list)
     profile_id: str = field(default="", kw_only=True)
+
+    def __post_init__(self) -> None:
+        # Callers occasionally hand in ``pathlib.Path`` even though the
+        # field is typed ``str``. Coerce now so ``to_dict()`` /
+        # ``save_findings`` downstream can JSON-dump without
+        # ``TypeError: Object of type PosixPath is not JSON serializable``.
+        if self.profile_path:
+            import os
+
+            self.profile_path = os.fspath(self.profile_path)
 
     def to_dict(self) -> dict:
         return {

--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -157,6 +157,7 @@ class EvidenceReport:
     """
 
     title: str
+    profile_id: str = ""
     profile_path: str = ""
     findings: list[Finding] = field(default_factory=list)
 
@@ -166,6 +167,7 @@ class EvidenceReport:
             "producer": PRODUCER,
             "producer_version": _producer_version(),
             "title": self.title,
+            "profile_id": self.profile_id,
             "profile_path": self.profile_path,
             "findings": [f.to_dict() for f in self.findings],
         }
@@ -173,11 +175,12 @@ class EvidenceReport:
     @classmethod
     def from_dict(cls, d: dict) -> "EvidenceReport":
         # Envelope fields (schema_version / producer / producer_version)
-        # are informational only — readers ignore them. Legacy payloads
-        # without an envelope load identically.
+        # are informational only — readers ignore them. Pre-profile_id
+        # payloads load with an empty profile_id (additive, not breaking).
         findings = [Finding.from_dict(f) for f in d.get("findings", [])]
         return cls(
             title=d.get("title", "Untitled"),
+            profile_id=d.get("profile_id", ""),
             profile_path=d.get("profile_path", ""),
             findings=findings,
         )

--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -7,6 +7,7 @@ to produce findings with exact nanosecond timestamps for timeline overlay.
 
 import inspect
 import logging
+import os
 from collections.abc import Callable
 
 from .annotation import EvidenceReport, Finding
@@ -85,7 +86,11 @@ class EvidenceBuilder:
         from .fingerprint import get_profile_id
         from .skills.registry import get_skill
 
-        profile_path = getattr(self.prof, "path", "")
+        # Coerce to str up-front: ``Profile.path`` is whatever the caller
+        # passed (often ``pathlib.Path`` in tests). Both ``get_profile_id``
+        # and downstream JSON serialisation need a real ``str``.
+        raw_path = getattr(self.prof, "path", None)
+        profile_path: str = os.fspath(raw_path) if raw_path is not None else ""
         # ``profile_id`` is a content-derived stable hash (see
         # ``fingerprint.get_profile_id``). It uses ``self.prof.conn``
         # because the META_DATA / TARGET_INFO tables it reads are *not*

--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -82,14 +82,23 @@ class EvidenceBuilder:
                   kernel_hotspots, overlap_ratio, memory_anomalies, h2d_spikes.
                   If None, run all analyzers.
         """
+        from .fingerprint import get_profile_id
         from .skills.registry import get_skill
+
+        profile_path = getattr(self.prof, "path", "")
+        # ``profile_id`` is a content-derived stable hash (see
+        # ``fingerprint.get_profile_id``). It uses ``self.prof.conn``
+        # because the META_DATA / TARGET_INFO tables it reads are *not*
+        # part of the parquet cache — only the original SQLite (or a
+        # direct-attach DuckDB view) carries them. Falls back to a
+        # path-derived id when those tables are unreachable
+        # (e.g. backend='parquetdir').
+        profile_id = get_profile_id(getattr(self.prof, "conn", None), fallback_path=profile_path)
 
         findings: list[Finding] = []
         # v0.1 context handed to upgraded skills' to_findings_fn for
         # constructing TraceSelection / EvidenceRow with provenance.
-        # profile_id is sourced from the profile's filesystem path until
-        # a stable content fingerprint is wired through.
-        context: dict = {"profile_id": str(getattr(self.prof, "path", ""))}
+        context: dict = {"profile_id": profile_id}
         for analyzer_name, (skill_name, params) in self._SKILL_PIPELINE.items():
             if only is not None and analyzer_name not in only:
                 continue
@@ -120,6 +129,7 @@ class EvidenceBuilder:
 
         return EvidenceReport(
             title="Auto-Analysis",
-            profile_path=getattr(self.prof, "path", ""),
+            profile_id=profile_id,
+            profile_path=profile_path,
             findings=findings,
         )

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -8,6 +8,7 @@ artefacts (envelope and ``TraceSelection``).
 """
 
 import hashlib
+import json
 import typing
 from dataclasses import dataclass, field
 
@@ -155,10 +156,18 @@ def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str
     ``journal_mode`` changes, and filesystem moves:
 
       - ``TARGET_INFO_SESSION_START_TIME.utcEpochNs``
-      - ``ANALYSIS_DETAILS`` ``duration / startTime / stopTime``
-      - ``TARGET_INFO_GPU`` rows (``id``, ``name``, hardware ``uuid``)
+      - ``ANALYSIS_DETAILS`` rows (``duration / startTime / stopTime``)
+      - ``TARGET_INFO_GPU`` rows (``id``, ``name``)
+      - ``TARGET_INFO_GPU.uuid`` values when the column exists
+        (newer Nsight); older exports keep ``uuid`` on
+        ``TARGET_INFO_CUDA_DEVICE`` and that contribution degrades to
+        empty rather than failing
       - distinct ``ANALYSIS_FILE.globalPid`` values
       - ``CUPTI_ACTIVITY_KIND_KERNEL`` row count
+
+    Each contribution is JSON-encoded as a ``(label, value)`` pair before
+    hashing, so values containing ``|`` / ``;`` / ``\\n`` can never collide
+    with neighbouring values via separator ambiguity.
 
     Format::
 
@@ -173,6 +182,19 @@ def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str
 
     ``fallback_path`` is hashed verbatim — pass an absolute path if you
     want it to compare equal across working-directory changes.
+
+    .. note::
+       When *both* ``conn`` is None / empty and ``fallback_path`` is
+       None, the function returns ``nsys1:sha256:<sha256 of empty>``.
+       That is a recognisable null-id sentinel: every such caller
+       collapses to the same value. Always pass ``fallback_path`` if
+       cross-call distinguishability matters.
+
+    .. note::
+       ``NULLS LAST`` requires SQLite ≥ 3.30 (2019-10-04) and is native
+       in DuckDB. Older SQLite raises ``OperationalError`` on the
+       ``ORDER BY ... NULLS LAST`` clause; the offending contribution
+       is caught and degraded to empty rather than crashing.
     """
     # None-safe shortcut: wrap_connection(None) returns a SQLiteAdapter
     # over None, whose .execute() raises AttributeError (not a DB error),
@@ -185,67 +207,81 @@ def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str
         return f"{PROFILE_ID_VERSION}:sha256:{empty}"
 
     adapter = wrap_connection(conn)
-    parts: list[tuple[str, str]] = []
 
-    def _one(sql: str) -> str:
+    def _scalar(sql: str) -> typing.Any:
+        """Return the single cell from a one-row/one-column query, or None."""
         try:
             row = adapter.execute(sql).fetchone()
-            return str(row[0]) if row and row[0] is not None else ""
+            return row[0] if row and row[0] is not None else None
         except DB_ERRORS:
-            return ""
+            return None
 
-    def _all(sql: str) -> str:
+    def _rows(sql: str) -> list[list[typing.Any]]:
+        """Return all rows as a list of lists (JSON-serialisable)."""
         try:
-            rows = adapter.execute(sql).fetchall()
-            return ";".join(str(r[0]) for r in rows if r and r[0] is not None)
+            return [list(r) for r in adapter.execute(sql).fetchall() if r]
         except DB_ERRORS:
-            return ""
+            return []
 
-    parts.append(
-        ("session_start_utc_ns", _one("SELECT utcEpochNs FROM TARGET_INFO_SESSION_START_TIME"))
-    )
-    parts.append(
+    # NULLS LAST: SQLite defaults to NULLS FIRST, DuckDB to NULLS LAST —
+    # pin it so two engine adapters on the same data hash identically.
+    parts: list[tuple[str, typing.Any]] = [
+        ("session_start_utc_ns", _scalar("SELECT utcEpochNs FROM TARGET_INFO_SESSION_START_TIME")),
+        # ANALYSIS_DETAILS is conventionally single-row, but serialise all
+        # rows in deterministic order so the contribution stays stable
+        # if a future profile carries more than one row.
         (
-            "trace_range",
-            # ANALYSIS_DETAILS is conventionally single-row, but pin the
-            # ordering anyway so a multi-row session is deterministic.
-            _one(
-                "SELECT duration || '|' || startTime || '|' || stopTime "
-                "FROM ANALYSIS_DETAILS ORDER BY startTime, stopTime LIMIT 1"
+            "analysis_details",
+            _rows(
+                "SELECT duration, startTime, stopTime FROM ANALYSIS_DETAILS "
+                "ORDER BY startTime, stopTime"
             ),
-        )
-    )
-    parts.append(
+        ),
+        # GPU id + name works on every Nsight schema we've seen.
         (
             "gpus",
-            # NULLS LAST: SQLite defaults to NULLS FIRST, DuckDB to
-            # NULLS LAST — pin it so two engine adapters on the same data
-            # hash identically.
-            _all(
-                "SELECT id || '|' || name || '|' || COALESCE(uuid, '') "
-                "FROM TARGET_INFO_GPU ORDER BY id NULLS LAST"
+            _rows("SELECT id, name FROM TARGET_INFO_GPU ORDER BY id NULLS LAST"),
+        ),
+        # uuid lives on TARGET_INFO_GPU in newer Nsight exports and on
+        # TARGET_INFO_CUDA_DEVICE in older ones (and in our minimal test
+        # fixture). Query each in its own contribution so a schema
+        # mismatch degrades only that part, not the whole id.
+        (
+            "gpu_uuids",
+            _rows("SELECT uuid FROM TARGET_INFO_GPU ORDER BY id NULLS LAST"),
+        ),
+        (
+            "cuda_device_uuids",
+            _rows(
+                "SELECT uuid FROM TARGET_INFO_CUDA_DEVICE "
+                "ORDER BY gpuId NULLS LAST, cudaId NULLS LAST"
             ),
-        )
-    )
-    parts.append(
+        ),
         (
             "pids",
-            _all(
+            _rows(
                 "SELECT DISTINCT globalPid FROM ANALYSIS_FILE "
                 "ORDER BY globalPid NULLS LAST"
             ),
-        )
-    )
-    parts.append(("kernel_count", _one("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_KERNEL")))
+        ),
+        ("kernel_count", _scalar("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_KERNEL")),
+    ]
 
-    canonical = "\n".join(f"{k}={v}" for k, v in parts)
+    # If every contribution is missing/empty the conn carries no Nsight
+    # metadata (e.g. parquetdir backend). Fall back to a clearly-labelled
+    # path-derived id rather than collapse every such profile to the
+    # same constant hash.
+    def _empty(v: typing.Any) -> bool:
+        return v is None or v == "" or v == [] or v == 0
 
-    # If every contribution is empty the conn carries no Nsight metadata
-    # (e.g. parquetdir backend). Fall back to a clearly-labelled
-    # path-derived id rather than collapse every such profile to the same
-    # constant hash.
-    if not any(v for _, v in parts) and fallback_path:
+    if all(_empty(v) for _, v in parts) and fallback_path:
         digest = hashlib.sha256(fallback_path.encode("utf-8")).hexdigest()
         return f"{PROFILE_ID_VERSION}:path:{digest}"
+
+    # JSON canonical: structured, unambiguous, no separator collisions.
+    # ``sort_keys=False`` because ``parts`` is already ordered; flipping
+    # the order would change the hash, which is intended (algorithm
+    # change → bump PROFILE_ID_VERSION).
+    canonical = json.dumps(parts, ensure_ascii=False, separators=(",", ":"))
     digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
     return f"{PROFILE_ID_VERSION}:sha256:{digest}"

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -9,6 +9,7 @@ artefacts (envelope and ``TraceSelection``).
 
 import hashlib
 import json
+import os
 import typing
 from dataclasses import dataclass, field
 
@@ -148,7 +149,9 @@ PROFILE_ID_VERSION = "nsys1"
 contributing columns or the canonical serialisation change."""
 
 
-def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str:
+def get_profile_id(
+    conn: typing.Any, *, fallback_path: str | os.PathLike[str] | None = None
+) -> str:
     """Return a stable content-derived id for a Nsight Systems profile.
 
     The hash spans only fields stamped at *profile-capture* time, so it
@@ -196,12 +199,18 @@ def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str
        ``ORDER BY ... NULLS LAST`` clause; the offending contribution
        is caught and degraded to empty rather than crashing.
     """
+    # Coerce ``fallback_path`` once: callers often pass ``pathlib.Path``
+    # (e.g. via ``Profile(Path(...))`` → ``Profile.path``). Both fallback
+    # branches below would otherwise crash with AttributeError on
+    # ``.encode("utf-8")``.
+    fallback_str = os.fspath(fallback_path) if fallback_path is not None else None
+
     # None-safe shortcut: wrap_connection(None) returns a SQLiteAdapter
     # over None, whose .execute() raises AttributeError (not a DB error),
     # so the loop's try/except wouldn't catch it. Skip the queries.
     if conn is None:
-        if fallback_path:
-            digest = hashlib.sha256(fallback_path.encode("utf-8")).hexdigest()
+        if fallback_str:
+            digest = hashlib.sha256(fallback_str.encode("utf-8")).hexdigest()
             return f"{PROFILE_ID_VERSION}:path:{digest}"
         empty = hashlib.sha256(b"").hexdigest()
         return f"{PROFILE_ID_VERSION}:sha256:{empty}"
@@ -274,8 +283,8 @@ def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str
     def _empty(v: typing.Any) -> bool:
         return v is None or v == "" or v == [] or v == 0
 
-    if all(_empty(v) for _, v in parts) and fallback_path:
-        digest = hashlib.sha256(fallback_path.encode("utf-8")).hexdigest()
+    if all(_empty(v) for _, v in parts) and fallback_str:
+        digest = hashlib.sha256(fallback_str.encode("utf-8")).hexdigest()
         return f"{PROFILE_ID_VERSION}:path:{digest}"
 
     # JSON canonical: structured, unambiguous, no separator collisions.

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -205,15 +205,21 @@ def get_profile_id(
     # ``.encode("utf-8")``.
     fallback_str = os.fspath(fallback_path) if fallback_path is not None else None
 
+    def _path_id(p: str) -> str:
+        digest = hashlib.sha256(p.encode("utf-8")).hexdigest()
+        return f"{PROFILE_ID_VERSION}:path:{digest}"
+
+    def _null_id() -> str:
+        """The shared null-id sentinel — same value whether ``conn`` is
+        None or merely empty, so consumers can detect "no usable
+        identity" with a single equality check."""
+        return f"{PROFILE_ID_VERSION}:sha256:{hashlib.sha256(b'').hexdigest()}"
+
     # None-safe shortcut: wrap_connection(None) returns a SQLiteAdapter
     # over None, whose .execute() raises AttributeError (not a DB error),
     # so the loop's try/except wouldn't catch it. Skip the queries.
     if conn is None:
-        if fallback_str:
-            digest = hashlib.sha256(fallback_str.encode("utf-8")).hexdigest()
-            return f"{PROFILE_ID_VERSION}:path:{digest}"
-        empty = hashlib.sha256(b"").hexdigest()
-        return f"{PROFILE_ID_VERSION}:sha256:{empty}"
+        return _path_id(fallback_str) if fallback_str else _null_id()
 
     adapter = wrap_connection(conn)
 
@@ -283,9 +289,11 @@ def get_profile_id(
     def _empty(v: typing.Any) -> bool:
         return v is None or v == "" or v == [] or v == 0
 
-    if all(_empty(v) for _, v in parts) and fallback_str:
-        digest = hashlib.sha256(fallback_str.encode("utf-8")).hexdigest()
-        return f"{PROFILE_ID_VERSION}:path:{digest}"
+    if all(_empty(v) for _, v in parts):
+        # Same shape as the ``conn is None`` branch above: path-fallback
+        # if available, else the null-id sentinel. This keeps the
+        # "no usable identity" check a single equality.
+        return _path_id(fallback_str) if fallback_str else _null_id()
 
     # JSON canonical: structured, unambiguous, no separator collisions.
     # ``sort_keys=False`` because ``parts`` is already ordered; flipping

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -240,6 +240,12 @@ def get_profile_id(
 
     # NULLS LAST: SQLite defaults to NULLS FIRST, DuckDB to NULLS LAST —
     # pin it so two engine adapters on the same data hash identically.
+    #
+    # Determinism rule for ``_rows`` queries: ``ORDER BY`` must cover the
+    # superset of every SELECTed column. Otherwise two rows that tie on
+    # the partial ORDER BY can have *different* selected values, and the
+    # relative order between them is engine-defined — VACUUM, schema
+    # rebuild, or a different adapter can flip them and change the hash.
     parts: list[tuple[str, typing.Any]] = [
         ("session_start_utc_ns", _scalar("SELECT utcEpochNs FROM TARGET_INFO_SESSION_START_TIME")),
         # ANALYSIS_DETAILS is conventionally single-row, but serialise all
@@ -249,13 +255,16 @@ def get_profile_id(
             "analysis_details",
             _rows(
                 "SELECT duration, startTime, stopTime FROM ANALYSIS_DETAILS "
-                "ORDER BY startTime, stopTime"
+                "ORDER BY startTime NULLS LAST, stopTime NULLS LAST, duration NULLS LAST"
             ),
         ),
         # GPU id + name works on every Nsight schema we've seen.
         (
             "gpus",
-            _rows("SELECT id, name FROM TARGET_INFO_GPU ORDER BY id NULLS LAST"),
+            _rows(
+                "SELECT id, name FROM TARGET_INFO_GPU "
+                "ORDER BY id NULLS LAST, name NULLS LAST"
+            ),
         ),
         # uuid lives on TARGET_INFO_GPU in newer Nsight exports and on
         # TARGET_INFO_CUDA_DEVICE in older ones (and in our minimal test
@@ -263,17 +272,26 @@ def get_profile_id(
         # mismatch degrades only that part, not the whole id.
         (
             "gpu_uuids",
-            _rows("SELECT uuid FROM TARGET_INFO_GPU ORDER BY id NULLS LAST"),
+            _rows(
+                "SELECT uuid FROM TARGET_INFO_GPU "
+                "ORDER BY id NULLS LAST, uuid NULLS LAST"
+            ),
         ),
+        # ``TARGET_INFO_CUDA_DEVICE`` commonly carries multiple rows per
+        # (gpuId, cudaId) — one per process — so ``pid`` and ``uuid`` are
+        # required tie-breakers to make the hash stable across engines.
         (
             "cuda_device_uuids",
             _rows(
                 "SELECT uuid FROM TARGET_INFO_CUDA_DEVICE "
-                "ORDER BY gpuId NULLS LAST, cudaId NULLS LAST"
+                "ORDER BY gpuId NULLS LAST, cudaId NULLS LAST, "
+                "pid NULLS LAST, uuid NULLS LAST"
             ),
         ),
         (
             "pids",
+            # DISTINCT guarantees no ties on the SELECTed column, so
+            # ORDER BY globalPid alone is total.
             _rows(
                 "SELECT DISTINCT globalPid FROM ANALYSIS_FILE "
                 "ORDER BY globalPid NULLS LAST"

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -170,7 +170,20 @@ def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str
     never materialised. Callers should pass ``self.prof.conn`` (the
     SQLite source where available); the function never reads
     ``self.prof.db`` semantics — it just runs SQL.
+
+    ``fallback_path`` is hashed verbatim — pass an absolute path if you
+    want it to compare equal across working-directory changes.
     """
+    # None-safe shortcut: wrap_connection(None) returns a SQLiteAdapter
+    # over None, whose .execute() raises AttributeError (not a DB error),
+    # so the loop's try/except wouldn't catch it. Skip the queries.
+    if conn is None:
+        if fallback_path:
+            digest = hashlib.sha256(fallback_path.encode("utf-8")).hexdigest()
+            return f"{PROFILE_ID_VERSION}:path:{digest}"
+        empty = hashlib.sha256(b"").hexdigest()
+        return f"{PROFILE_ID_VERSION}:sha256:{empty}"
+
     adapter = wrap_connection(conn)
     parts: list[tuple[str, str]] = []
 
@@ -194,22 +207,34 @@ def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str
     parts.append(
         (
             "trace_range",
+            # ANALYSIS_DETAILS is conventionally single-row, but pin the
+            # ordering anyway so a multi-row session is deterministic.
             _one(
-                "SELECT duration || '|' || startTime || '|' || stopTime FROM ANALYSIS_DETAILS"
+                "SELECT duration || '|' || startTime || '|' || stopTime "
+                "FROM ANALYSIS_DETAILS ORDER BY startTime, stopTime LIMIT 1"
             ),
         )
     )
     parts.append(
         (
             "gpus",
+            # NULLS LAST: SQLite defaults to NULLS FIRST, DuckDB to
+            # NULLS LAST — pin it so two engine adapters on the same data
+            # hash identically.
             _all(
                 "SELECT id || '|' || name || '|' || COALESCE(uuid, '') "
-                "FROM TARGET_INFO_GPU ORDER BY id"
+                "FROM TARGET_INFO_GPU ORDER BY id NULLS LAST"
             ),
         )
     )
     parts.append(
-        ("pids", _all("SELECT DISTINCT globalPid FROM ANALYSIS_FILE ORDER BY globalPid"))
+        (
+            "pids",
+            _all(
+                "SELECT DISTINCT globalPid FROM ANALYSIS_FILE "
+                "ORDER BY globalPid NULLS LAST"
+            ),
+        )
     )
     parts.append(("kernel_count", _one("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_KERNEL")))
 

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -2,8 +2,12 @@
 fingerprint.py — Detects the ML framework and network topology from Nsight SQLite traces.
 
 Extracts a ProfileFingerprint efficiently using O(1) string pool queries.
+Also exposes ``get_profile_id`` — a content-derived stable identifier
+for a profile, used as the canonical ``profile_id`` in evidence
+artefacts (envelope and ``TraceSelection``).
 """
 
+import hashlib
 import typing
 from dataclasses import dataclass, field
 
@@ -132,3 +136,91 @@ def get_fingerprint(conn: typing.Any) -> ProfileFingerprint:
         nic_summary=nic_summary,
         precision_notes=[],
     )
+
+
+# ---------------------------------------------------------------------------
+# profile_id — stable content-derived identifier
+# ---------------------------------------------------------------------------
+
+PROFILE_ID_VERSION = "nsys1"
+"""Algorithm tag for :func:`get_profile_id`. Bump (``nsys2``, …) if the
+contributing columns or the canonical serialisation change."""
+
+
+def get_profile_id(conn: typing.Any, *, fallback_path: str | None = None) -> str:
+    """Return a stable content-derived id for a Nsight Systems profile.
+
+    The hash spans only fields stamped at *profile-capture* time, so it
+    survives ``.nsys-rep`` → ``.sqlite`` re-export, ``VACUUM``,
+    ``journal_mode`` changes, and filesystem moves:
+
+      - ``TARGET_INFO_SESSION_START_TIME.utcEpochNs``
+      - ``ANALYSIS_DETAILS`` ``duration / startTime / stopTime``
+      - ``TARGET_INFO_GPU`` rows (``id``, ``name``, hardware ``uuid``)
+      - distinct ``ANALYSIS_FILE.globalPid`` values
+      - ``CUPTI_ACTIVITY_KIND_KERNEL`` row count
+
+    Format::
+
+        nsys1:sha256:<64-hex>   # preferred — content-derived
+        nsys1:path:<64-hex>     # fallback — when no Nsight metadata is reachable
+
+    The fallback fires for backends that expose only the parquet cache
+    (``backend='parquetdir'``) where META_DATA / TARGET_INFO tables were
+    never materialised. Callers should pass ``self.prof.conn`` (the
+    SQLite source where available); the function never reads
+    ``self.prof.db`` semantics — it just runs SQL.
+    """
+    adapter = wrap_connection(conn)
+    parts: list[tuple[str, str]] = []
+
+    def _one(sql: str) -> str:
+        try:
+            row = adapter.execute(sql).fetchone()
+            return str(row[0]) if row and row[0] is not None else ""
+        except DB_ERRORS:
+            return ""
+
+    def _all(sql: str) -> str:
+        try:
+            rows = adapter.execute(sql).fetchall()
+            return ";".join(str(r[0]) for r in rows if r and r[0] is not None)
+        except DB_ERRORS:
+            return ""
+
+    parts.append(
+        ("session_start_utc_ns", _one("SELECT utcEpochNs FROM TARGET_INFO_SESSION_START_TIME"))
+    )
+    parts.append(
+        (
+            "trace_range",
+            _one(
+                "SELECT duration || '|' || startTime || '|' || stopTime FROM ANALYSIS_DETAILS"
+            ),
+        )
+    )
+    parts.append(
+        (
+            "gpus",
+            _all(
+                "SELECT id || '|' || name || '|' || COALESCE(uuid, '') "
+                "FROM TARGET_INFO_GPU ORDER BY id"
+            ),
+        )
+    )
+    parts.append(
+        ("pids", _all("SELECT DISTINCT globalPid FROM ANALYSIS_FILE ORDER BY globalPid"))
+    )
+    parts.append(("kernel_count", _one("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_KERNEL")))
+
+    canonical = "\n".join(f"{k}={v}" for k, v in parts)
+
+    # If every contribution is empty the conn carries no Nsight metadata
+    # (e.g. parquetdir backend). Fall back to a clearly-labelled
+    # path-derived id rather than collapse every such profile to the same
+    # constant hash.
+    if not any(v for _, v in parts) and fallback_path:
+        digest = hashlib.sha256(fallback_path.encode("utf-8")).hexdigest()
+        return f"{PROFILE_ID_VERSION}:path:{digest}"
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f"{PROFILE_ID_VERSION}:sha256:{digest}"

--- a/tests/test_analyze_format_json.py
+++ b/tests/test_analyze_format_json.py
@@ -52,6 +52,9 @@ class TestAnalyzeFormatJson:
         assert isinstance(payload["producer_version"], str) and payload["producer_version"]
         assert "findings" in payload
         assert isinstance(payload["findings"], list)
+        # v0.1 content-derived profile id
+        assert isinstance(payload["profile_id"], str)
+        assert payload["profile_id"].startswith("nsys1:"), payload["profile_id"]
 
     def test_profile_path_present(self, minimal_nsys_db_path):
         """Envelope contains a profile_path string sourced from the opened Profile."""
@@ -68,13 +71,12 @@ class TestAnalyzeFormatJson:
         assert payload["profile_path"] == str(minimal_nsys_db_path)
 
     def test_envelope_and_selection_profile_id_agree(self, minimal_nsys_db_path):
-        """Single source of truth: envelope profile_path matches every
+        """Single source of truth: envelope profile_id matches every
         Finding.selection.profile_id inside the same payload.
 
-        Regression guard for the v0.1 identifier-consistency bug where
-        the CLI used to override envelope.profile_path independently of
-        the resolved Profile.path that EvidenceBuilder stamps onto
-        selection.profile_id.
+        ``profile_id`` is the content-derived hash (``nsys1:sha256:...``)
+        from ``fingerprint.get_profile_id`` — both the envelope and every
+        ``TraceSelection`` produced during the same build must carry it.
         """
         from nsys_ai import profile as profile_module
         from nsys_ai.cli.handlers import _cmd_analyze
@@ -83,14 +85,15 @@ class TestAnalyzeFormatJson:
         stdout, _ = _capture(_cmd_analyze, args, profile_module)
         payload = json.loads(stdout)
 
-        envelope_path = payload["profile_path"]
+        envelope_id = payload["profile_id"]
+        assert envelope_id.startswith("nsys1:"), envelope_id
         for f in payload["findings"]:
             sel = f.get("selection")
             if sel is None:
                 continue
-            assert sel["profile_id"] == envelope_path, (
+            assert sel["profile_id"] == envelope_id, (
                 f"Finding {f.get('id')} selection.profile_id={sel['profile_id']!r} "
-                f"disagrees with envelope profile_path={envelope_path!r}"
+                f"disagrees with envelope profile_id={envelope_id!r}"
             )
 
     def test_no_deprecation_warning_for_analyze(self, minimal_nsys_db_path):
@@ -115,10 +118,13 @@ class TestAnalyzeFormatJson:
         stdout, _ = _capture(_cmd_analyze, args, profile_module)
         payload = json.loads(stdout)
         idle = [f for f in payload["findings"] if f.get("category") == "idle"]
+        envelope_id = payload["profile_id"]
         for f in idle:
             assert f.get("id"), "Finding must have an id when v0.1-aware"
             assert "selection" in f, "Idle findings should have a selection"
-            assert f["selection"]["profile_id"] == str(minimal_nsys_db_path)
+            # Selection.profile_id is the same content-derived hash carried
+            # by the envelope — both sourced from EvidenceBuilder context.
+            assert f["selection"]["profile_id"] == envelope_id
             assert f["selection"]["source"] == "skill:gpu_idle_gaps"
 
     def test_writes_to_output_file_when_provided(self, minimal_nsys_db_path, tmp_path):

--- a/tests/test_annotation_models.py
+++ b/tests/test_annotation_models.py
@@ -790,6 +790,27 @@ class TestEvidenceReportEnvelope:
         restored = EvidenceReport.from_dict({"title": "T", "profile_path": "/p"})
         assert restored.profile_id == ""
 
+    def test_profile_id_is_keyword_only(self):
+        """Regression for Copilot review: ``profile_id`` was originally
+        inserted before ``profile_path`` in the dataclass fields, which
+        silently broke positional callers (``EvidenceReport("T", "/p")``
+        would have bound ``/p`` to ``profile_id`` instead of
+        ``profile_path``). Marking it ``kw_only=True`` preserves the
+        positional signature and forces explicit naming.
+        """
+        import pytest
+
+        # Positional binding of ``profile_id`` is forbidden:
+        with pytest.raises(TypeError):
+            EvidenceReport("T", "/p", [], "nsys1:sha256:abc")  # type: ignore[misc]
+
+        # Old positional usage (title, profile_path[, findings]) still
+        # binds to the same fields it always did.
+        report = EvidenceReport("T", "/some/profile.sqlite")
+        assert report.title == "T"
+        assert report.profile_path == "/some/profile.sqlite"
+        assert report.profile_id == ""  # default kept
+
     def test_from_dict_accepts_v01_envelope(self):
         """Round-trip through to_dict / from_dict preserves the report."""
         f = Finding(type="region", label="L", start_ns=10)

--- a/tests/test_annotation_models.py
+++ b/tests/test_annotation_models.py
@@ -790,6 +790,26 @@ class TestEvidenceReportEnvelope:
         restored = EvidenceReport.from_dict({"title": "T", "profile_path": "/p"})
         assert restored.profile_id == ""
 
+    def test_post_init_coerces_pathlib_profile_path(self):
+        """``EvidenceReport.profile_path`` is typed ``str``, but callers
+        sometimes hand in ``pathlib.Path``. ``__post_init__`` coerces so
+        downstream JSON serialization doesn't choke on PosixPath.
+        """
+        import json
+        from pathlib import Path
+
+        report = EvidenceReport(title="T", profile_path=Path("/x.sqlite"))
+        assert isinstance(report.profile_path, str)
+        assert report.profile_path == "/x.sqlite"
+        # to_dict + json.dumps must work end-to-end
+        json.dumps(report.to_dict())
+
+    def test_post_init_leaves_empty_profile_path_alone(self):
+        """Default empty ``profile_path`` must stay an empty string after
+        ``__post_init__`` — don't crash, don't replace with ``"."``."""
+        report = EvidenceReport(title="T")
+        assert report.profile_path == ""
+
     def test_profile_id_is_keyword_only(self):
         """Regression for Copilot review: ``profile_id`` was originally
         inserted before ``profile_path`` in the dataclass fields, which

--- a/tests/test_annotation_models.py
+++ b/tests/test_annotation_models.py
@@ -768,6 +768,27 @@ class TestEvidenceReportEnvelope:
         assert d["title"] == "T"
         assert d["profile_path"] == "/p/x.sqlite"
         assert d["findings"] == []
+        # ``profile_id`` is additive — always present (empty default when
+        # not supplied), so consumers can rely on the key existing.
+        assert "profile_id" in d
+        assert d["profile_id"] == ""
+
+    def test_envelope_carries_profile_id(self):
+        """When set, profile_id is serialized verbatim in the envelope."""
+        report = EvidenceReport(title="T", profile_id="nsys1:sha256:abc", profile_path="/p")
+        d = report.to_dict()
+        assert d["profile_id"] == "nsys1:sha256:abc"
+
+    def test_from_dict_preserves_profile_id(self):
+        restored = EvidenceReport.from_dict(
+            {"title": "T", "profile_id": "nsys1:sha256:deadbeef", "profile_path": "/p"}
+        )
+        assert restored.profile_id == "nsys1:sha256:deadbeef"
+
+    def test_from_dict_defaults_profile_id_when_missing(self):
+        """Pre-profile_id payloads (no key) load with profile_id=''."""
+        restored = EvidenceReport.from_dict({"title": "T", "profile_path": "/p"})
+        assert restored.profile_id == ""
 
     def test_from_dict_accepts_v01_envelope(self):
         """Round-trip through to_dict / from_dict preserves the report."""

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -197,6 +197,27 @@ def test_get_profile_id_none_conn_with_fallback():
     assert _PATH_RE.match(pid), pid
 
 
+def test_get_profile_id_accepts_pathlib_fallback():
+    """Regression for Copilot review: ``Profile.path`` is often a
+    ``pathlib.Path`` in tests. Both fallback branches must coerce it
+    via ``os.fspath`` before ``.encode("utf-8")`` — passing a Path
+    used to crash with ``AttributeError`` in the very scenario the
+    fallback is meant to handle."""
+    from pathlib import Path
+
+    # conn=None branch
+    pid_none = get_profile_id(None, fallback_path=Path("/some/profile.sqlite"))
+    assert _PATH_RE.match(pid_none), pid_none
+    # Equality with str-form to confirm the coercion is value-stable.
+    assert pid_none == get_profile_id(None, fallback_path="/some/profile.sqlite")
+
+    # Empty-conn → fallback branch (real conn, no Nsight tables)
+    empty_conn = sqlite3.connect(":memory:")
+    pid_empty = get_profile_id(empty_conn, fallback_path=Path("/some/profile.sqlite"))
+    assert _PATH_RE.match(pid_empty), pid_empty
+    assert pid_empty == get_profile_id(empty_conn, fallback_path="/some/profile.sqlite")
+
+
 def test_get_profile_id_none_conn_without_fallback_is_null_sentinel():
     """``conn=None`` and no fallback yields the recognisable empty-sha256
     sentinel — every such caller collapses to the same value, which is

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -173,10 +173,18 @@ def test_get_profile_id_missing_tables_falls_back_to_path():
     assert _PATH_RE.match(pid), pid
 
 
-def test_get_profile_id_missing_tables_without_fallback_is_constant_hash():
-    """Empty conn + no fallback → constant nsys1:sha256 (degraded but valid)."""
+def test_get_profile_id_missing_tables_without_fallback_is_null_sentinel():
+    """Empty conn + no fallback → the *same* null-id sentinel as
+    ``get_profile_id(None)``. Consumers should be able to detect
+    "no usable identity" with a single equality check regardless of
+    whether the caller passed ``None`` or a real-but-empty conn."""
     pid = get_profile_id(sqlite3.connect(":memory:"))
-    assert _SHA256_RE.match(pid), pid
+    assert pid == get_profile_id(None), (
+        "conn=empty and conn=None must produce the same null-id sentinel"
+    )
+    # And they must both be the well-known empty-string SHA-256.
+    empty_sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    assert pid == f"nsys1:sha256:{empty_sha}"
 
 
 def test_get_profile_id_partial_metadata_still_content_path():

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -189,3 +189,74 @@ def test_get_profile_id_partial_metadata_still_content_path():
     conn.commit()
     pid = get_profile_id(conn, fallback_path="/x.sqlite")
     assert _SHA256_RE.match(pid), pid
+
+
+def test_get_profile_id_none_conn_with_fallback():
+    """``conn=None`` short-circuits to the path-derived fallback."""
+    pid = get_profile_id(None, fallback_path="/some/profile.sqlite")
+    assert _PATH_RE.match(pid), pid
+
+
+def test_get_profile_id_none_conn_without_fallback_is_null_sentinel():
+    """``conn=None`` and no fallback yields the recognisable empty-sha256
+    sentinel — every such caller collapses to the same value, which is
+    intentional (it's a null-id marker, not a usable identifier)."""
+    pid = get_profile_id(None)
+    assert _SHA256_RE.match(pid), pid
+    # The well-known SHA-256 of the empty string. If this constant ever
+    # changes, hashlib has changed, not our algorithm.
+    empty_sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    assert pid == f"nsys1:sha256:{empty_sha}"
+
+
+def test_get_profile_id_no_separator_collision():
+    """Regression for Copilot review: previous canonical built strings by
+    concatenating values with ``|`` / ``;`` separators, so a GPU named
+    ``"A|B"`` could collide with two distinct fields ``("A", "B")`` etc.
+    JSON canonical eliminates this entirely."""
+    # Two profiles differing only in *where* the ``|`` lives.
+    a = _nsight_meta_db(gpus=[(0, "A|B", "uuid")])
+    b = _nsight_meta_db(gpus=[(0, "A", "B|uuid")])
+    assert get_profile_id(a) != get_profile_id(b)
+
+
+def test_get_profile_id_handles_missing_gpu_uuid_column():
+    """The repo's own minimal fixture stores ``uuid`` on
+    ``TARGET_INFO_CUDA_DEVICE``, not ``TARGET_INFO_GPU``. The ``gpu_uuids``
+    contribution must fail gracefully on such schemas without aborting
+    the whole id computation."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    # Older-style schema: TARGET_INFO_GPU has no uuid column.
+    c.execute(
+        "CREATE TABLE TARGET_INFO_GPU "
+        "(id INTEGER PRIMARY KEY, name TEXT, busLocation TEXT)"
+    )
+    c.execute("INSERT INTO TARGET_INFO_GPU VALUES (0, 'NVIDIA H100', '0000:91:00.0')")
+    # uuid lives here in this schema:
+    c.execute(
+        "CREATE TABLE TARGET_INFO_CUDA_DEVICE "
+        "(gpuId INTEGER, cudaId INTEGER, pid INTEGER, uuid TEXT)"
+    )
+    c.execute("INSERT INTO TARGET_INFO_CUDA_DEVICE VALUES (0, 0, 100, 'older-style-uuid')")
+    conn.commit()
+
+    pid = get_profile_id(conn, fallback_path="/x.sqlite")
+    assert _SHA256_RE.match(pid), pid
+    # Sanity: a profile with the *same* GPU id+name but a *different*
+    # cuda_device uuid must hash differently — the contribution must
+    # actually be reaching the canonical bytes.
+    other = sqlite3.connect(":memory:")
+    oc = other.cursor()
+    oc.execute(
+        "CREATE TABLE TARGET_INFO_GPU "
+        "(id INTEGER PRIMARY KEY, name TEXT, busLocation TEXT)"
+    )
+    oc.execute("INSERT INTO TARGET_INFO_GPU VALUES (0, 'NVIDIA H100', '0000:91:00.0')")
+    oc.execute(
+        "CREATE TABLE TARGET_INFO_CUDA_DEVICE "
+        "(gpuId INTEGER, cudaId INTEGER, pid INTEGER, uuid TEXT)"
+    )
+    oc.execute("INSERT INTO TARGET_INFO_CUDA_DEVICE VALUES (0, 0, 100, 'different-uuid')")
+    other.commit()
+    assert get_profile_id(other, fallback_path="/x.sqlite") != pid

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,8 +1,9 @@
 """Tests for framework fingerprinting logic."""
 
+import re
 import sqlite3
 
-from nsys_ai.fingerprint import get_fingerprint
+from nsys_ai.fingerprint import PROFILE_ID_VERSION, get_fingerprint, get_profile_id
 
 
 def build_mock_db(
@@ -80,3 +81,111 @@ def test_legacy_fallback():
 
     fp = get_fingerprint(conn)
     assert fp.framework == "DeepSpeed"
+
+
+# ---------------------------------------------------------------------------
+# get_profile_id — content-derived stable identifier
+# ---------------------------------------------------------------------------
+
+
+_SHA256_RE = re.compile(r"^nsys1:sha256:[0-9a-f]{64}$")
+_PATH_RE = re.compile(r"^nsys1:path:[0-9a-f]{64}$")
+
+
+def _nsight_meta_db(
+    *,
+    session_start_ns: int = 1_700_000_000_000_000_000,
+    duration_ns: int = 100_000_000,
+    gpus: list[tuple[int, str, str]] | None = None,
+    pids: list[int] | None = None,
+    kernel_count: int = 0,
+) -> sqlite3.Connection:
+    """Build an in-memory sqlite that looks enough like a Nsight export
+    for ``get_profile_id`` to read its META / TARGET_INFO tables.
+    """
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute("CREATE TABLE TARGET_INFO_SESSION_START_TIME (utcEpochNs INTEGER)")
+    c.execute("INSERT INTO TARGET_INFO_SESSION_START_TIME VALUES (?)", (session_start_ns,))
+    c.execute(
+        "CREATE TABLE ANALYSIS_DETAILS "
+        "(globalVid INTEGER, duration INTEGER, startTime INTEGER, stopTime INTEGER)"
+    )
+    c.execute(
+        "INSERT INTO ANALYSIS_DETAILS VALUES (1, ?, 0, ?)",
+        (duration_ns, duration_ns),
+    )
+    c.execute("CREATE TABLE TARGET_INFO_GPU (id INTEGER, name TEXT, uuid TEXT)")
+    for gid, name, uuid in gpus or []:
+        c.execute("INSERT INTO TARGET_INFO_GPU VALUES (?, ?, ?)", (gid, name, uuid))
+    c.execute("CREATE TABLE ANALYSIS_FILE (id INTEGER, filename TEXT, globalPid INTEGER)")
+    for i, pid in enumerate(pids or []):
+        c.execute("INSERT INTO ANALYSIS_FILE VALUES (?, '/tmp/x', ?)", (i, pid))
+    c.execute("CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (correlationId INTEGER)")
+    for i in range(kernel_count):
+        c.execute("INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?)", (i,))
+    conn.commit()
+    return conn
+
+
+def test_get_profile_id_format():
+    """Default-shaped result is ``nsys1:sha256:<64-hex>``."""
+    conn = _nsight_meta_db()
+    pid = get_profile_id(conn)
+    assert _SHA256_RE.match(pid), pid
+    assert pid.startswith(f"{PROFILE_ID_VERSION}:sha256:")
+
+
+def test_get_profile_id_deterministic():
+    """Two builds of the same META content yield the same id."""
+    a = _nsight_meta_db(
+        gpus=[(0, "NVIDIA H100", "abc-uuid-0")], pids=[1234, 5678], kernel_count=10
+    )
+    b = _nsight_meta_db(
+        gpus=[(0, "NVIDIA H100", "abc-uuid-0")], pids=[1234, 5678], kernel_count=10
+    )
+    assert get_profile_id(a) == get_profile_id(b)
+
+
+def test_get_profile_id_differs_on_content_change():
+    base = _nsight_meta_db(kernel_count=10)
+    # Different kernel count alone changes the id.
+    other = _nsight_meta_db(kernel_count=11)
+    assert get_profile_id(base) != get_profile_id(other)
+    # Different GPU set alone changes the id.
+    diff_gpu = _nsight_meta_db(gpus=[(0, "NVIDIA H100", "xyz")], kernel_count=10)
+    assert get_profile_id(base) != get_profile_id(diff_gpu)
+
+
+def test_get_profile_id_path_independent():
+    """``profile_id`` is content-derived; fallback_path does not influence
+    the content hash when META tables are present."""
+    conn = _nsight_meta_db(kernel_count=3)
+    assert get_profile_id(conn, fallback_path="/a/x.sqlite") == get_profile_id(
+        conn, fallback_path="/b/y.sqlite"
+    )
+
+
+def test_get_profile_id_missing_tables_falls_back_to_path():
+    """Empty conn (no Nsight tables) + fallback_path → nsys1:path:..."""
+    conn = sqlite3.connect(":memory:")
+    pid = get_profile_id(conn, fallback_path="/some/profile.sqlite")
+    assert _PATH_RE.match(pid), pid
+
+
+def test_get_profile_id_missing_tables_without_fallback_is_constant_hash():
+    """Empty conn + no fallback → constant nsys1:sha256 (degraded but valid)."""
+    pid = get_profile_id(sqlite3.connect(":memory:"))
+    assert _SHA256_RE.match(pid), pid
+
+
+def test_get_profile_id_partial_metadata_still_content_path():
+    """If *any* META contribution is non-empty we stay on the sha256 path,
+    even when fallback_path is supplied."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute("CREATE TABLE TARGET_INFO_SESSION_START_TIME (utcEpochNs INTEGER)")
+    c.execute("INSERT INTO TARGET_INFO_SESSION_START_TIME VALUES (999)")
+    conn.commit()
+    pid = get_profile_id(conn, fallback_path="/x.sqlite")
+    assert _SHA256_RE.match(pid), pid

--- a/tests/test_gpu_idle_gaps_findings.py
+++ b/tests/test_gpu_idle_gaps_findings.py
@@ -273,19 +273,22 @@ class TestEvidenceBuilderIntegration:
             builder = EvidenceBuilder(prof, device=0)
             report = builder.build(only=["idle_gaps"])
 
+        # The envelope must always be stamped with a content-derived id,
+        # regardless of whether the fixture happened to produce findings.
+        assert report.profile_id.startswith("nsys1:"), report.profile_id
+        assert report.profile_id != str(minimal_nsys_db_path), (
+            "profile_id must be a hash, not the filesystem path"
+        )
+
         # The envelope and every nested selection share one profile_id;
         # the minimal fixture may or may not produce idle-gap findings on
-        # any given run, so we only assert when at least one exists.
+        # any given run, so we only check the per-finding contract when
+        # at least one finding exists.
         idle = [f for f in report.findings if f.category == "idle"]
-        if idle:
-            assert report.profile_id.startswith("nsys1:"), report.profile_id
-            assert report.profile_id != str(minimal_nsys_db_path), (
-                "profile_id must be a hash, not the filesystem path"
-            )
-            for f in idle:
-                assert f.selection is not None
-                assert f.selection.profile_id == report.profile_id
-                assert f.selection.source == "skill:gpu_idle_gaps"
+        for f in idle:
+            assert f.selection is not None
+            assert f.selection.profile_id == report.profile_id
+            assert f.selection.source == "skill:gpu_idle_gaps"
 
     def test_builder_still_works_with_legacy_single_arg_skills(self, minimal_nsys_db_path):
         """Skills whose to_findings_fn is the legacy (rows) single-arg form

--- a/tests/test_gpu_idle_gaps_findings.py
+++ b/tests/test_gpu_idle_gaps_findings.py
@@ -264,7 +264,8 @@ class TestSerialization:
 class TestEvidenceBuilderIntegration:
     def test_builder_passes_profile_id_to_idle_gaps(self, minimal_nsys_db_path):
         """Real DB integration: TraceSelections produced under EvidenceBuilder
-        carry the profile path as profile_id (the current placeholder identity)."""
+        carry the content-derived ``profile_id`` (``nsys1:sha256:...``)
+        from ``fingerprint.get_profile_id``, *not* the filesystem path."""
         from nsys_ai.evidence_builder import EvidenceBuilder
         from nsys_ai.profile import Profile
 
@@ -272,15 +273,18 @@ class TestEvidenceBuilderIntegration:
             builder = EvidenceBuilder(prof, device=0)
             report = builder.build(only=["idle_gaps"])
 
-        # The minimal fixture may not produce idle-gap findings on every
-        # run; we only assert that *if* idle-gap findings exist they
-        # carry profile_id from the profile path.
+        # The envelope and every nested selection share one profile_id;
+        # the minimal fixture may or may not produce idle-gap findings on
+        # any given run, so we only assert when at least one exists.
         idle = [f for f in report.findings if f.category == "idle"]
         if idle:
-            expected = str(minimal_nsys_db_path)
+            assert report.profile_id.startswith("nsys1:"), report.profile_id
+            assert report.profile_id != str(minimal_nsys_db_path), (
+                "profile_id must be a hash, not the filesystem path"
+            )
             for f in idle:
                 assert f.selection is not None
-                assert f.selection.profile_id == expected
+                assert f.selection.profile_id == report.profile_id
                 assert f.selection.source == "skill:gpu_idle_gaps"
 
     def test_builder_still_works_with_legacy_single_arg_skills(self, minimal_nsys_db_path):

--- a/tests/test_gpu_idle_gaps_findings.py
+++ b/tests/test_gpu_idle_gaps_findings.py
@@ -303,3 +303,27 @@ class TestEvidenceBuilderIntegration:
             report = builder.build()
         assert report is not None
         assert isinstance(report.findings, list)
+
+    def test_builder_accepts_pathlib_profile_path(self, minimal_nsys_db_path):
+        """End-to-end regression: passing ``pathlib.Path`` to ``Profile``
+        must flow through ``EvidenceBuilder`` → ``EvidenceReport`` → JSON
+        without crashing on ``Path.encode`` or
+        ``Object of type PosixPath is not JSON serializable``.
+        """
+        import json
+        from pathlib import Path
+
+        from nsys_ai.evidence_builder import EvidenceBuilder
+        from nsys_ai.profile import Profile
+
+        with Profile(Path(minimal_nsys_db_path)) as prof:
+            builder = EvidenceBuilder(prof, device=0)
+            report = builder.build()
+
+        # builder coerces and ``EvidenceReport.__post_init__`` coerces
+        # again as a belt-and-braces guarantee.
+        assert isinstance(report.profile_path, str)
+        assert report.profile_id.startswith("nsys1:"), report.profile_id
+        # JSON-dumpable end-to-end (this is the failure mode if either
+        # coercion regresses).
+        json.dumps(report.to_dict())


### PR DESCRIPTION
## Summary

The v0.1 spec said `profile_id` should be a content fingerprint so two surfaces looking at the same `.sqlite` agree on identity without depending on the filesystem path. In practice the implementation stamped `str(prof.path)` everywhere — envelope, evidence context, and `selection.profile_id` — which collapses the moment a profile is moved or re-exported.

This PR makes `profile_id` actually stable.

## What changed

- **`fingerprint.get_profile_id(conn, *, fallback_path=None)`** — new helper that returns `nsys1:sha256:<64-hex>` computed from capture-time Nsight fields:
  - `TARGET_INFO_SESSION_START_TIME.utcEpochNs`
  - `ANALYSIS_DETAILS` (duration / start / stop)
  - `TARGET_INFO_GPU` rows (id, name, hardware uuid)
  - distinct `ANALYSIS_FILE.globalPid`
  - `CUPTI_ACTIVITY_KIND_KERNEL` row count
- These fields are stamped at profile-capture time, so the hash survives `.nsys-rep → .sqlite` re-export, `VACUUM`, and `journal_mode` changes.
- Each contribution is wrapped in try/except — missing tables degrade gracefully.
- Path fallback (`nsys1:path:<64-hex>`) fires when no Nsight metadata is reachable (e.g. `backend='parquetdir'`, where META / TARGET_INFO tables are not in the parquet cache).
- **`EvidenceReport`** gets an additive `profile_id` field; envelope JSON gains the same key. Legacy payloads still load (default `""`).
- **`EvidenceBuilder`** computes `profile_id` once via `self.prof.conn` (not `self.prof.db` — META tables aren't cached as parquet) and propagates it to both the envelope and `TraceSelection.profile_id` on every emitted finding.

## Why not full-file SHA-256?

Full-file SHA changes whenever the `.nsys-rep` is re-exported / `VACUUM`ed / `journal_mode`-switched even when the *trace content* is identical. The dbhash pattern (https://sqlite.org/dbhash.html) — hash a canonical projection of logical content — gives a stable id without that brittleness. We project just the capture-time tables (~50ms total query cost) rather than the whole sqlite.

## Compat checked against existing infra

- `self.prof.conn` is the right connection: sqlite source has META tables directly; direct-attach DuckDB aliases them too. Parquet cache and parquetdir backends don't carry META — those degrade to the `nsys1:path:` fallback.
- Parquet cache schema unchanged — no `_CACHE_VERSION` bump needed.

## Test plan

- [x] `test_fingerprint`: format / determinism / content-change sensitivity / path-independence / missing-table fallback
- [x] `test_annotation_models`: envelope carries `profile_id`; legacy payloads load with `profile_id=''`
- [x] `test_analyze_format_json`: envelope.`profile_id` matches every selection.`profile_id` (`nsys1:` prefix)
- [x] `test_gpu_idle_gaps_findings`: integration now asserts hash, not path
- [x] Smoke-tested on three real profiles (megatron / nano_vllm / fastvideo) — deterministic on repeat runs, distinct across profiles
- [x] Full pytest: 765 passed / 135 skipped / 0 failed
- [x] ruff clean on touched files

## Docs

- `docs/agent_skills/commands/evidence_schema.md` — documents the new envelope field and the identity contract
- `docs/roadmap.md` §A clarification is also done locally but `roadmap.md` is still untracked in the repo; it will land with the roadmap file's own first commit