### PR TITLE
fix(cache): serialize parquet cache builds with flock

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -81,7 +81,12 @@ def _build_lock(cache_dir: Path) -> Iterator[None]:
         return
     cache_dir.parent.mkdir(parents=True, exist_ok=True)
     lock_path = cache_dir.parent / f"{cache_dir.name}.build.lock"
-    fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT, 0o644)
+    # ``flock`` does not require a writable fd, so open the lock
+    # ``O_RDONLY``: a second user without write permission on a lock
+    # file created by the first user (default ``0o644``) can still
+    # acquire and release it. ``O_CLOEXEC`` prevents the fd leaking
+    # into any subprocess we spawn during the build.
+    fd = os.open(lock_path, os.O_RDONLY | os.O_CREAT | os.O_CLOEXEC, 0o644)
     try:
         _fcntl.flock(fd, _fcntl.LOCK_EX)  # blocks until acquired
         yield

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -184,12 +184,23 @@ def build_cache(sqlite_path: str) -> Path:
     caller waits out the first, it returns the freshly-built cache
     without re-running the ETL.
 
+    The lock is *only* acquired when a build is actually needed; an
+    initial ``is_cache_valid`` fast-path return avoids opening the lock
+    file at all when the cache is already good. This matters for
+    read-only profile directories (NFS / read-only mounts) where the
+    cache is readable but the lock file cannot be created.
+
     Returns the cache directory path.
     """
     import shutil
     import tempfile
 
     cache_dir = _cache_dir_for(sqlite_path)
+    # Fast path: cache already valid — no lock file creation needed.
+    # Lets read-only profile directories work as long as the cache was
+    # built earlier (e.g. by a previous writable session).
+    if is_cache_valid(sqlite_path):
+        return cache_dir
     with _build_lock(cache_dir):
         # Double-checked locking: another process may have built the
         # cache while we were waiting on the lock. Skip redundant ETL.

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -35,18 +35,59 @@ Environment (large profiles / DuckDB tuning):
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
 import re
 import sys
 import time
+from collections.abc import Iterator
 from hashlib import sha256
 from pathlib import Path
 
 import duckdb
 
+# fcntl is POSIX-only. On Windows we degrade to no-locking — concurrent
+# builders may then race redundantly, but ``build_cache``'s tmp_dir +
+# atomic rename still keeps the cache consistent.
+try:
+    import fcntl as _fcntl
+except ImportError:
+    _fcntl = None  # type: ignore[assignment]
+
 log = logging.getLogger(__name__)
+
+
+@contextlib.contextmanager
+def _build_lock(cache_dir: Path) -> Iterator[None]:
+    """Serialize cache builds for one profile across threads and processes.
+
+    Used by :func:`build_cache` to guarantee that two concurrent callers
+    against the same profile (e.g. ``nsys-ai`` running in two terminals)
+    do *not* both run the full ETL — the second waits on the lock, then
+    re-checks :func:`is_cache_valid` inside the critical section and
+    returns immediately when the first has already published the cache.
+
+    The lock file lives at ``<cache_dir>.build.lock`` next to the cache.
+    ``fcntl.flock`` is associated with the file descriptor, so the lock
+    is released automatically when the fd closes (including on process
+    crash).
+    """
+    if _fcntl is None:
+        # Windows: no flock. Two builders may run redundantly, but the
+        # tmp_dir + atomic rename below still keeps the cache consistent.
+        yield
+        return
+    cache_dir.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = cache_dir.parent / f"{cache_dir.name}.build.lock"
+    fd = os.open(lock_path, os.O_WRONLY | os.O_CREAT, 0o644)
+    try:
+        _fcntl.flock(fd, _fcntl.LOCK_EX)  # blocks until acquired
+        yield
+    finally:
+        # flock is held on the fd — closing releases it.
+        os.close(fd)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
 _CACHE_VERSION = 12  # bumped: sync.parquet now includes deviceId for per-rank sync attribution
@@ -137,52 +178,64 @@ def build_cache(sqlite_path: str) -> Path:
     ZSTD compression, and generates ``nvtx_kernel_map.parquet`` using the
     Python Tier 2 sort-merge logic.
 
+    Concurrency: serialized by :func:`_build_lock` across threads and
+    processes operating on the same profile, with a double-checked
+    :func:`is_cache_valid` inside the critical section — when a second
+    caller waits out the first, it returns the freshly-built cache
+    without re-running the ETL.
+
     Returns the cache directory path.
     """
     import shutil
     import tempfile
 
     cache_dir = _cache_dir_for(sqlite_path)
-    # Build into a temp dir first, then atomically rename to avoid race
-    # conditions when multiple threads/processes open the same profile.
-    tmp_dir = Path(
-        tempfile.mkdtemp(
-            prefix=".parquet_build_",
-            dir=cache_dir.parent,
+    with _build_lock(cache_dir):
+        # Double-checked locking: another process may have built the
+        # cache while we were waiting on the lock. Skip redundant ETL.
+        if is_cache_valid(sqlite_path):
+            return cache_dir
+
+        # Build into a temp dir first, then atomically rename to avoid race
+        # conditions when multiple threads/processes open the same profile.
+        tmp_dir = Path(
+            tempfile.mkdtemp(
+                prefix=".parquet_build_",
+                dir=cache_dir.parent,
+            )
         )
-    )
-    try:
-        _build_cache_into(sqlite_path, tmp_dir)
-    except BaseException:
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-        raise
+        try:
+            _build_cache_into(sqlite_path, tmp_dir)
+        except BaseException:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            raise
 
-    # Atomic swap: rename old cache aside, rename new into place, then clean up.
-    # This avoids a window where the cache directory is missing for concurrent readers.
-    # Use PID in the old-dir name so concurrent builders don't collide.
-    old_dir = cache_dir.parent / f"{cache_dir.name}.old.{os.getpid()}"
-    if old_dir.exists():
-        shutil.rmtree(old_dir, ignore_errors=True)
+        # Atomic swap: rename old cache aside, rename new into place, then clean up.
+        # This avoids a window where the cache directory is missing for concurrent readers.
+        # Use PID in the old-dir name so concurrent builders don't collide.
+        old_dir = cache_dir.parent / f"{cache_dir.name}.old.{os.getpid()}"
+        if old_dir.exists():
+            shutil.rmtree(old_dir, ignore_errors=True)
 
-    try:
-        if cache_dir.exists():
-            cache_dir.rename(old_dir)
-        tmp_dir.rename(cache_dir)
-    except (FileExistsError, OSError):
-        # Another process won the race and created cache_dir first.
-        # Discard our redundant build.
-        shutil.rmtree(tmp_dir, ignore_errors=True)
-        # Restore old_dir if cache_dir does not exist (failed for other transient reasons)
-        if old_dir.exists() and not cache_dir.exists():
-            try:
-                old_dir.rename(cache_dir)
-            except OSError:
-                pass
+        try:
+            if cache_dir.exists():
+                cache_dir.rename(old_dir)
+            tmp_dir.rename(cache_dir)
+        except (FileExistsError, OSError):
+            # Belt-and-braces: the build lock already prevents this race
+            # for cooperating callers, but the tmp_dir + rename dance
+            # is preserved for older readers that bypass the lock.
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+            if old_dir.exists() and not cache_dir.exists():
+                try:
+                    old_dir.rename(cache_dir)
+                except OSError:
+                    pass
 
-    # Clean up the old cache (now renamed aside) if we have a robust valid cache.
-    if old_dir.exists() and cache_dir.exists():
-        shutil.rmtree(old_dir, ignore_errors=True)
-    return cache_dir
+        # Clean up the old cache (now renamed aside) if we have a robust valid cache.
+        if old_dir.exists() and cache_dir.exists():
+            shutil.rmtree(old_dir, ignore_errors=True)
+        return cache_dir
 
 
 def _safe_path(p: Path) -> str:

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -204,6 +204,13 @@ class TestConcurrentBuild:
         for t in threads:
             t.join(timeout=30)
 
+        # If any thread is still alive the lock has deadlocked.
+        # Surface that immediately rather than letting a zombie thread
+        # leak into later tests where it could rebuild the cache and
+        # confuse unrelated assertions.
+        stuck = [t.name for t in threads if t.is_alive()]
+        assert not stuck, f"threads did not finish within 30s: {stuck}"
+
         assert errors == [], f"runners raised: {errors!r}"
         assert len(caches) == num_threads, (
             f"all {num_threads} runners must complete; got {len(caches)}"

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+from pathlib import Path
 
 from nsys_ai import parquet_cache
 
@@ -128,6 +129,79 @@ class TestBuildAndOpen:
         db = parquet_cache.open_cached_db(minimal_nsys_db_path)
         assert db is not None
         db.close()
+        assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is True
+
+
+class TestConcurrentBuild:
+    """Regression: two terminals opening the same profile concurrently
+    must NOT both run the full ETL.
+
+    Before the build-lock landed, ``is_cache_valid()`` returned False
+    for every concurrent caller until the first finished its atomic
+    rename, so every caller ran its own ``_build_cache_into``. On a
+    296MB profile that meant ~10s of wasted ETL per duplicate runner.
+    """
+
+    def test_concurrent_threads_only_build_once(self, minimal_nsys_db_path, monkeypatch):
+        import threading
+        import time
+
+        # Start clean — make sure no prior test left a valid cache for
+        # this fixture (the cache lives next to the .sqlite file).
+        parquet_cache.invalidate_cache(minimal_nsys_db_path)
+        assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is False
+
+        num_threads = 4
+        # Barrier so every runner enters ``build_cache`` essentially
+        # simultaneously — without this, on lightly-loaded systems the
+        # first thread can finish before the others even start, hiding
+        # any locking bug.
+        barrier = threading.Barrier(num_threads)
+        call_count = 0
+        count_lock = threading.Lock()
+        original_build_into = parquet_cache._build_cache_into
+
+        def counting_build_into(sqlite_path: str, tmp_dir: Path) -> None:
+            nonlocal call_count
+            with count_lock:
+                call_count += 1
+            # Hold the lock long enough that all other threads are
+            # guaranteed to be queued on flock before this one releases.
+            # ETL on the minimal fixture is ~50ms; 0.5s sleep gives a
+            # ~10× safety margin.
+            time.sleep(0.5)
+            original_build_into(sqlite_path, tmp_dir)
+
+        monkeypatch.setattr(parquet_cache, "_build_cache_into", counting_build_into)
+
+        results: list[Path | BaseException] = []
+        results_lock = threading.Lock()
+
+        def runner() -> None:
+            try:
+                barrier.wait(timeout=10)
+                cache = parquet_cache.build_cache(str(minimal_nsys_db_path))
+            except BaseException as e:  # pragma: no cover - defensive
+                with results_lock:
+                    results.append(e)
+                return
+            with results_lock:
+                results.append(cache)
+
+        threads = [threading.Thread(target=runner) for _ in range(num_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert len(results) == num_threads, "all threads must complete"
+        assert call_count == 1, (
+            f"_build_cache_into should run exactly once for {num_threads} "
+            f"concurrent callers; got {call_count}"
+        )
+        # Every caller returns the same cache directory.
+        cache_dirs = {r for r in results if isinstance(r, Path)}
+        assert len(cache_dirs) == 1, f"all callers must agree on cache_dir; got {cache_dirs}"
         assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is True
 
 

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -4,6 +4,8 @@ import json
 import os
 from pathlib import Path
 
+import pytest
+
 from nsys_ai import parquet_cache
 
 
@@ -142,6 +144,11 @@ class TestConcurrentBuild:
     296MB profile that meant ~10s of wasted ETL per duplicate runner.
     """
 
+    @pytest.mark.skipif(
+        parquet_cache._fcntl is None,
+        reason="build-lock degrades to no-op without POSIX fcntl; this assertion "
+        "only holds on platforms where the lock is real.",
+    )
     def test_concurrent_threads_only_build_once(self, minimal_nsys_db_path, monkeypatch):
         import threading
         import time
@@ -174,7 +181,10 @@ class TestConcurrentBuild:
 
         monkeypatch.setattr(parquet_cache, "_build_cache_into", counting_build_into)
 
-        results: list[Path | BaseException] = []
+        # Track caches and exceptions separately so a barrier timeout
+        # or any other error can't masquerade as "all paths succeeded".
+        caches: list[Path] = []
+        errors: list[BaseException] = []
         results_lock = threading.Lock()
 
         def runner() -> None:
@@ -183,10 +193,10 @@ class TestConcurrentBuild:
                 cache = parquet_cache.build_cache(str(minimal_nsys_db_path))
             except BaseException as e:  # pragma: no cover - defensive
                 with results_lock:
-                    results.append(e)
+                    errors.append(e)
                 return
             with results_lock:
-                results.append(cache)
+                caches.append(cache)
 
         threads = [threading.Thread(target=runner) for _ in range(num_threads)]
         for t in threads:
@@ -194,14 +204,16 @@ class TestConcurrentBuild:
         for t in threads:
             t.join(timeout=30)
 
-        assert len(results) == num_threads, "all threads must complete"
+        assert errors == [], f"runners raised: {errors!r}"
+        assert len(caches) == num_threads, (
+            f"all {num_threads} runners must complete; got {len(caches)}"
+        )
         assert call_count == 1, (
             f"_build_cache_into should run exactly once for {num_threads} "
             f"concurrent callers; got {call_count}"
         )
         # Every caller returns the same cache directory.
-        cache_dirs = {r for r in results if isinstance(r, Path)}
-        assert len(cache_dirs) == 1, f"all callers must agree on cache_dir; got {cache_dirs}"
+        assert len(set(caches)) == 1, f"all callers must agree on cache_dir; got {set(caches)}"
         assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is True
 
 


### PR DESCRIPTION
## Summary

Opening the same profile from two terminals concurrently used to run the full Parquet ETL twice. The existing tmp_dir + atomic rename only ensured the *final* on-disk cache was consistent — every concurrent caller still did the ~10s ETL work (much more on large profiles) because ``is_cache_valid()`` returned False for everyone until the first ``rename(tmp_dir, cache_dir)`` landed.

## What changed

- New ``_build_lock(cache_dir)`` context manager — POSIX ``fcntl.flock`` on a ``<cache_dir>.build.lock`` file next to the cache, blocks until acquired, releases automatically when the fd closes (including on process crash).
- ``build_cache`` now wraps its body in ``_build_lock`` *and* double-checks ``is_cache_valid`` inside the critical section. A second caller waits out the first, then sees the freshly-published cache and returns immediately without running ETL.
- Windows degrades to no-locking (no ``fcntl``); the existing tmp_dir + atomic rename still keeps the cache consistent there, just with the original redundant-work cost.
- The tmp_dir + rename dance is preserved as belt-and-braces for non-cooperating readers (e.g. a process from an older version that bypasses the lock).

## Why ``_build_lock`` lives inside ``build_cache`` (not in callers)

All ``open_cached_db`` / ``Profile`` / agent-backend paths funnel through ``build_cache`` when ETL is needed. Putting the lock at the funnel rather than at every caller means we cover all entry points (CLI, ``nsys-ai chat``, ``ai/backend/profile_db_tool.py``, ``cli/handlers.py``) with one change.

## Test plan

- [x] New ``TestConcurrentBuild::test_concurrent_threads_only_build_once`` — 4 threads enter ``build_cache`` simultaneously via ``threading.Barrier``; the patched ``_build_cache_into`` is asserted to run exactly once. Without the lock the same test counts 4 calls.
- [x] Stress: 10 isolated runs + 5 full-suite runs = 15/15 passed (the test was flaky in an earlier draft that relied only on a short sleep; barrier + 0.5s lock-hold removed the flake).
- [x] Existing parquet_cache tests (build / open / invalidate / rebuild-on-stale) all still pass — the only behavioural change is the idempotent re-check at the top of ``build_cache``.
- [x] ``ruff`` clean.