### PR TITLE
perf(manifest): auto-trim long profiles to a representative window

### DIFF
--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -48,6 +48,18 @@ _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS = 120 * 10**9   # 120 s
 # block, (b) small enough that a 15 M-row NVTX IEJoin completes in seconds.
 _AUTO_TRIM_TARGET_WINDOW_NS = 20 * 10**9             # 20 s
 
+# Values that turn NSYS_AI_MANIFEST_AUTO_TRIM off. Matches the parsing
+# of NSYS_AI_DEFER_NVTX_KERNEL_MAP in parquet_cache.py so users get
+# the same on/off semantics across env vars in this repo.
+_AUTO_TRIM_FALSE_TOKENS = frozenset({"0", "false", "no", "off"})
+
+
+def _auto_trim_enabled() -> bool:
+    """Read NSYS_AI_MANIFEST_AUTO_TRIM with 0/false/no/off → disabled."""
+    import os
+
+    return os.environ.get("NSYS_AI_MANIFEST_AUTO_TRIM", "1").strip().lower() not in _AUTO_TRIM_FALSE_TOKENS
+
 
 def _auto_select_trim_window(prof) -> tuple[int, int] | None:
     """Pick a representative steady-state window for a long profile.
@@ -90,17 +102,18 @@ def _auto_select_trim_window(prof) -> tuple[int, int] | None:
     # works on both `nvtx_high` and full `nvtx` (DuckDB cache view) and
     # on raw `NVTX_EVENTS` (SQLite fallback); _duckdb_query translates
     # the [end] dialect when needed.
-    nvtx_table = "nvtx_high"
-    try:
-        prof._duckdb_query("SELECT 1 FROM nvtx_high LIMIT 1")
-    except (sqlite3.Error, duckdb.Error):
-        # Fall back to full nvtx; the explicit aten:: exclusion below
-        # keeps the query meaningful even without the high-level view.
-        nvtx_table = "nvtx"
+    #
+    # Probe candidates in preference order. The first one that can be
+    # opened wins — `nvtx_high` is fastest because aten::* is already
+    # filtered, but it only exists on _CACHE_VERSION ≥ 14 caches.
+    nvtx_table = "NVTX_EVENTS"  # final fallback; main query catches missing-table
+    for candidate in ("nvtx_high", "nvtx", "NVTX_EVENTS"):
         try:
-            prof._duckdb_query("SELECT 1 FROM nvtx LIMIT 1")
+            prof._duckdb_query(f"SELECT 1 FROM {candidate} LIMIT 1")
+            nvtx_table = candidate
+            break
         except (sqlite3.Error, duckdb.Error):
-            nvtx_table = "NVTX_EVENTS"
+            continue
 
     sql = f"""
         WITH ranged AS (
@@ -154,8 +167,6 @@ def _auto_select_trim_window(prof) -> tuple[int, int] | None:
 
 def _execute(conn, **kwargs):
     """Build a compact profile health manifest."""
-    import os
-
     from ...profile import Profile
 
     device = int(kwargs.get("device", 0))
@@ -176,7 +187,7 @@ def _execute(conn, **kwargs):
     # melts on the NVTX×kernel IEJoin (15M+ rows) and `iteration_timing`
     # full-table scans. Opt out with NSYS_AI_MANIFEST_AUTO_TRIM=0.
     auto_trim_meta: dict | None = None
-    if not explicit_trim and os.environ.get("NSYS_AI_MANIFEST_AUTO_TRIM", "1") != "0":
+    if not explicit_trim and _auto_trim_enabled():
         try:
             picked = _auto_select_trim_window(prof)
         except Exception as exc:  # noqa: BLE001 — best-effort, never block manifest

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -61,23 +61,108 @@ def _auto_trim_enabled() -> bool:
     return os.environ.get("NSYS_AI_MANIFEST_AUTO_TRIM", "1").strip().lower() not in _AUTO_TRIM_FALSE_TOKENS
 
 
+def _resolve_nvtx_table_for_auto_trim(prof) -> str | None:
+    """Find a NVTX-bearing table or view we can scan for iteration markers.
+
+    Preference order:
+      * ``nvtx_high`` view — DuckDB cache, aten::* already filtered.
+      * ``nvtx`` view — DuckDB cache, full NVTX with resolved text.
+      * Versioned canonical table — ``NVTX_EVENTS`` / ``NVTX_EVENTS_V2`` /
+        ``NVTX_EVENTS_V3`` (the actual nsys export schema for the version
+        we attached). Resolved via ``prof.schema.tables`` rather than
+        hardcoded so newer Nsight exports without an unversioned alias
+        still work.
+
+    Returns the chosen name or ``None`` when no NVTX source can be opened.
+    """
+    import sqlite3
+
+    import duckdb
+
+    # Cache-view candidates always have resolved text (no StringIds join
+    # needed by the caller). Probe each; pick the first that can be
+    # opened.
+    for candidate in ("nvtx_high", "nvtx"):
+        try:
+            prof._duckdb_query(f"SELECT 1 FROM {candidate} LIMIT 1")
+            return candidate
+        except (sqlite3.Error, duckdb.Error):
+            continue
+
+    # Raw-SQLite path: walk the actual schema for an NVTX-prefixed name.
+    try:
+        tables = set(prof.schema.tables)
+    except Exception:
+        tables = set()
+    if "NVTX_EVENTS" in tables:
+        return "NVTX_EVENTS"
+    for t in sorted(tables):
+        if t.startswith("NVTX_EVENTS"):
+            return t
+    return None
+
+
+def _build_auto_trim_nvtx_sql(prof, nvtx_table: str) -> str:
+    """SQL that picks the middle instance of the dominant NVTX iteration.
+
+    Cache views (``nvtx_high`` / ``nvtx``) already carry resolved text in
+    the ``text`` column — no StringIds join needed. The raw
+    ``NVTX_EVENTS`` family does need the join when the export stores
+    labels via ``textId`` (newer Nsight schemas with
+    ``sqlite_all_varchar=true`` attach), so we COALESCE the two and
+    LEFT JOIN ``StringIds`` only on that path.
+    """
+    is_cache_view = nvtx_table in ("nvtx_high", "nvtx")
+    if is_cache_view:
+        text_expr = "n.text"
+        text_join = ""
+    else:
+        text_expr = "COALESCE(n.text, s.value)"
+        text_join = "LEFT JOIN StringIds s ON n.textId = s.id"
+    return f"""
+        WITH ranged AS (
+            SELECT {text_expr} AS text, n.start, n.[end]
+            FROM {nvtx_table} n
+            {text_join}
+            WHERE {text_expr} IS NOT NULL
+              AND n.[end] > n.start
+              AND {text_expr} NOT LIKE 'aten::%'
+              AND {text_expr} NOT LIKE 'cudaLaunch%'
+              AND {text_expr} NOT LIKE 'cudaMemcpy%'
+        )
+        SELECT text, start, [end] FROM ranged
+        WHERE text = (
+            SELECT text FROM ranged
+            GROUP BY text
+            HAVING COUNT(*) >= 3
+            ORDER BY SUM([end] - start) DESC, text ASC
+            LIMIT 1
+        )
+        ORDER BY start
+    """
+
+
 def _auto_select_trim_window(prof) -> tuple[int, int] | None:
     """Pick a representative steady-state window for a long profile.
 
     Returns ``(start_ns, end_ns)`` to feed into sub-skills as
-    ``trim_start_ns`` / ``trim_end_ns``, or ``None`` when no trim is
-    needed (profile span below threshold) or no signal is available.
+    ``trim_start_ns`` / ``trim_end_ns``, or ``None`` when no trim should
+    be applied — either because the profile span is at/under the
+    threshold, or because the time_range itself is unusable (None,
+    inverted, missing meta).
 
     Strategy:
-      1. If profile span ≤ ``_AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS``,
+      1. If profile span ``≤ _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS``,
          return None — the full manifest will fit a normal turn budget.
-      2. Otherwise, find the top non-`aten::*` NVTX range name with
+      2. Otherwise, find the top non-``aten::*`` NVTX range name with
          ≥ 3 instances (iteration / stage marker) and pick the *middle*
          instance — skips index-0 JIT warmup. If the chosen instance is
          wider than ``_AUTO_TRIM_TARGET_WINDOW_NS``, trim further to the
          middle of that range.
       3. If no qualifying NVTX range exists, fall back to the middle
-         ``_AUTO_TRIM_TARGET_WINDOW_NS`` of the profile span.
+         ``_AUTO_TRIM_TARGET_WINDOW_NS`` of the profile span — better
+         to land near steady state than to scan head-of-trace JIT plus
+         tail teardown.
 
     Failures are absorbed — auto-trim is best-effort; the caller proceeds
     untrimmed when this returns None or raises.
@@ -94,52 +179,28 @@ def _auto_select_trim_window(prof) -> tuple[int, int] | None:
     if start_ns is None or end_ns is None or end_ns <= start_ns:
         return None
     span_ns = end_ns - start_ns
-    if span_ns < _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS:
+    # Use ≤ so the boundary matches the docstring contract — a span
+    # exactly equal to the threshold is short enough to not need trim.
+    if span_ns <= _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS:
         return None
 
-    # Query the highest-volume non-op-level NVTX range and order its
-    # instances by start so we can pick the middle one. The CTE form
-    # works on both `nvtx_high` and full `nvtx` (DuckDB cache view) and
-    # on raw `NVTX_EVENTS` (SQLite fallback); _duckdb_query translates
-    # the [end] dialect when needed.
-    #
     # Probe candidates in preference order. The first one that can be
     # opened wins — `nvtx_high` is fastest because aten::* is already
     # filtered, but it only exists on _CACHE_VERSION ≥ 14 caches.
-    nvtx_table = "NVTX_EVENTS"  # final fallback; main query catches missing-table
-    for candidate in ("nvtx_high", "nvtx", "NVTX_EVENTS"):
+    # `nvtx` is the resolved-text cache view. `NVTX_EVENTS` (and its
+    # versioned variants) is the raw SQLite table.
+    nvtx_table = _resolve_nvtx_table_for_auto_trim(prof)
+    if nvtx_table is None:
+        # No NVTX source at all → skip the SQL path and fall straight to
+        # the middle-of-span fallback below.
+        rows: list = []
+    else:
+        sql = _build_auto_trim_nvtx_sql(prof, nvtx_table)
         try:
-            prof._duckdb_query(f"SELECT 1 FROM {candidate} LIMIT 1")
-            nvtx_table = candidate
-            break
-        except (sqlite3.Error, duckdb.Error):
-            continue
-
-    sql = f"""
-        WITH ranged AS (
-            SELECT text, start, [end]
-            FROM {nvtx_table}
-            WHERE text IS NOT NULL
-              AND [end] > start
-              AND text NOT LIKE 'aten::%'
-              AND text NOT LIKE 'cudaLaunch%'
-              AND text NOT LIKE 'cudaMemcpy%'
-        )
-        SELECT text, start, [end] FROM ranged
-        WHERE text = (
-            SELECT text FROM ranged
-            GROUP BY text
-            HAVING COUNT(*) >= 3
-            ORDER BY SUM([end] - start) DESC, text ASC
-            LIMIT 1
-        )
-        ORDER BY start
-    """
-    try:
-        rows = prof._duckdb_query(sql)
-    except (sqlite3.Error, duckdb.Error) as exc:
-        _log.debug("auto-trim NVTX query failed: %s", exc)
-        rows = []
+            rows = prof._duckdb_query(sql)
+        except (sqlite3.Error, duckdb.Error) as exc:
+            _log.debug("auto-trim NVTX query failed: %s", exc)
+            rows = []
 
     if rows:
         # Skip the first instance (JIT warmup / one-time setup cost) and
@@ -172,12 +233,25 @@ def _execute(conn, **kwargs):
     device = int(kwargs.get("device", 0))
     overhead_ns = kwargs.get("overhead_ns", 0)
 
-    # Forward trim kwargs if present
+    # Forward trim kwargs if present. Treat trim as "explicit" only when
+    # BOTH endpoints are supplied — a partial trim is unusable downstream
+    # (sub-skills ignore it) and would otherwise silence auto-trim while
+    # leaving the manifest scanning the full profile.
     trim_kwargs = {}
     for k in ("trim_start_ns", "trim_end_ns"):
         if kwargs.get(k) is not None:
             trim_kwargs[k] = kwargs[k]
-    explicit_trim = bool(trim_kwargs)
+    explicit_trim = (
+        "trim_start_ns" in trim_kwargs and "trim_end_ns" in trim_kwargs
+    )
+    if trim_kwargs and not explicit_trim:
+        # Drop the partial trim so it can't be forwarded to sub-skills
+        # in a half-useless state; auto-trim (below) will replace it.
+        _log.debug(
+            "manifest: partial trim_kwargs %s discarded; will auto-trim if long",
+            list(trim_kwargs),
+        )
+        trim_kwargs = {}
 
     # ── 1. Profile metadata ──────────────────────────────────────
     prof = Profile._from_conn(conn)

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -38,8 +38,121 @@ def _safe_skill_run(skill_name: str, conn, **kwargs):
         return []
 
 
+# Threshold past which a no-trim manifest is auto-narrowed to a
+# representative window. Below this, the full scan is fast enough that
+# sub-skills (nvtx_layer_breakdown IEJoin, root_cause_matcher, …) won't
+# blow past their soft budgets even on a multi-GPU export.
+_AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS = 120 * 10**9   # 120 s
+# Target width of the auto-selected window. Picked to be (a) large enough
+# to capture at least a few steady-state iterations of any DiT / transformer
+# block, (b) small enough that a 15 M-row NVTX IEJoin completes in seconds.
+_AUTO_TRIM_TARGET_WINDOW_NS = 20 * 10**9             # 20 s
+
+
+def _auto_select_trim_window(prof, conn) -> tuple[int, int] | None:
+    """Pick a representative steady-state window for a long profile.
+
+    Returns ``(start_ns, end_ns)`` to feed into sub-skills as
+    ``trim_start_ns`` / ``trim_end_ns``, or ``None`` when no trim is
+    needed (profile span below threshold) or no signal is available.
+
+    Strategy:
+      1. If profile span ≤ ``_AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS``,
+         return None — the full manifest will fit a normal turn budget.
+      2. Otherwise, find the top non-`aten::*` NVTX range name with
+         ≥ 3 instances (iteration / stage marker) and pick the *middle*
+         instance — skips index-0 JIT warmup. If the chosen instance is
+         wider than ``_AUTO_TRIM_TARGET_WINDOW_NS``, trim further to the
+         middle of that range.
+      3. If no qualifying NVTX range exists, fall back to the middle
+         ``_AUTO_TRIM_TARGET_WINDOW_NS`` of the profile span.
+
+    Failures are absorbed — auto-trim is best-effort; the caller proceeds
+    untrimmed when this returns None or raises.
+    """
+    import sqlite3
+
+    import duckdb
+
+    try:
+        start_ns, end_ns = prof.meta.time_range
+    except Exception:
+        return None
+    span_ns = (end_ns or 0) - (start_ns or 0)
+    if span_ns < _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS:
+        return None
+
+    # Query the highest-volume non-op-level NVTX range and order its
+    # instances by start so we can pick the middle one. The CTE form
+    # works on both `nvtx_high` and full `nvtx` (DuckDB cache view) and
+    # on raw `NVTX_EVENTS` (SQLite fallback); _duckdb_query translates
+    # the [end] dialect when needed.
+    nvtx_table = "nvtx_high"
+    try:
+        prof._duckdb_query("SELECT 1 FROM nvtx_high LIMIT 1")
+    except (sqlite3.Error, duckdb.Error):
+        # Fall back to full nvtx; the explicit aten:: exclusion below
+        # keeps the query meaningful even without the high-level view.
+        nvtx_table = "nvtx"
+        try:
+            prof._duckdb_query("SELECT 1 FROM nvtx LIMIT 1")
+        except (sqlite3.Error, duckdb.Error):
+            nvtx_table = "NVTX_EVENTS"
+
+    sql = f"""
+        WITH ranged AS (
+            SELECT text, start, [end]
+            FROM {nvtx_table}
+            WHERE text IS NOT NULL
+              AND [end] > start
+              AND text NOT LIKE 'aten::%'
+              AND text NOT LIKE 'cudaLaunch%'
+              AND text NOT LIKE 'cudaMemcpy%'
+        )
+        SELECT text, start, [end] FROM ranged
+        WHERE text = (
+            SELECT text FROM ranged
+            GROUP BY text
+            HAVING COUNT(*) >= 3
+            ORDER BY SUM([end] - start) DESC, text ASC
+            LIMIT 1
+        )
+        ORDER BY start
+    """
+    try:
+        rows = prof._duckdb_query(sql)
+    except (sqlite3.Error, duckdb.Error) as exc:
+        _log.debug("auto-trim NVTX query failed: %s", exc)
+        rows = []
+
+    if rows:
+        # Skip the first instance (JIT warmup / one-time setup cost) and
+        # pick the middle of what remains so we land in steady state.
+        idx = max(1, len(rows) // 2)
+        if idx >= len(rows):
+            idx = len(rows) - 1
+        chosen = rows[idx]
+        c_start = int(chosen["start"])
+        c_end = int(chosen["end"])
+        # Trim very wide stage ranges down to a 20 s slice in their middle
+        # so sub-skills still get steady-state behaviour but don't grind.
+        if c_end - c_start > _AUTO_TRIM_TARGET_WINDOW_NS:
+            mid = (c_start + c_end) // 2
+            half = _AUTO_TRIM_TARGET_WINDOW_NS // 2
+            return (mid - half, mid + half)
+        return (c_start, c_end)
+
+    # No usable NVTX iteration marker — take the middle 20 s of the
+    # profile so we at least avoid head-of-trace JIT and tail teardown.
+    mid = (start_ns + end_ns) // 2
+    half = _AUTO_TRIM_TARGET_WINDOW_NS // 2
+    return (mid - half, mid + half)
+
+
 def _execute(conn, **kwargs):
     """Build a compact profile health manifest."""
+    import os
+
     from ...profile import Profile
 
     device = int(kwargs.get("device", 0))
@@ -50,9 +163,37 @@ def _execute(conn, **kwargs):
     for k in ("trim_start_ns", "trim_end_ns"):
         if kwargs.get(k) is not None:
             trim_kwargs[k] = kwargs[k]
+    explicit_trim = bool(trim_kwargs)
 
     # ── 1. Profile metadata ──────────────────────────────────────
     prof = Profile._from_conn(conn)
+
+    # ── 1a. Auto-trim for very long profiles ────────────────────
+    # Without this guard, manifest on a multi-GB / 10-minute profile
+    # melts on the NVTX×kernel IEJoin (15M+ rows) and `iteration_timing`
+    # full-table scans. Opt out with NSYS_AI_MANIFEST_AUTO_TRIM=0.
+    auto_trim_meta: dict | None = None
+    if not explicit_trim and os.environ.get("NSYS_AI_MANIFEST_AUTO_TRIM", "1") != "0":
+        try:
+            picked = _auto_select_trim_window(prof, conn)
+        except Exception as exc:  # noqa: BLE001 — best-effort, never block manifest
+            _log.debug("manifest auto-trim selection failed: %s", exc, exc_info=True)
+            picked = None
+        if picked is not None:
+            t0, t1 = picked
+            trim_kwargs = {"trim_start_ns": int(t0), "trim_end_ns": int(t1)}
+            auto_trim_meta = {
+                "applied": True,
+                "trim_start_ns": int(t0),
+                "trim_end_ns": int(t1),
+                "window_ms": round((t1 - t0) / 1e6, 1),
+            }
+            _log.info(
+                "manifest auto-trimmed to %.2fs–%.2fs (%.1fs window) on long profile",
+                t0 / 1e9,
+                t1 / 1e9,
+                (t1 - t0) / 1e9,
+            )
     # Prefer the GPU name for the requested device, if available.
     gpu_name = "unknown"
     gpu_info = getattr(prof.meta, "gpu_info", None)
@@ -92,6 +233,8 @@ def _execute(conn, **kwargs):
         "overhead_pct": overhead_pct,
         "overhead_pct_raw": overhead_pct_raw,
     }
+    if auto_trim_meta is not None:
+        data_quality["auto_trim"] = auto_trim_meta
 
     # ── 2. Top kernels (compact: top 5 only) ─────────────────────
     trim_tuple = None

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -49,7 +49,7 @@ _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS = 120 * 10**9   # 120 s
 _AUTO_TRIM_TARGET_WINDOW_NS = 20 * 10**9             # 20 s
 
 
-def _auto_select_trim_window(prof, conn) -> tuple[int, int] | None:
+def _auto_select_trim_window(prof) -> tuple[int, int] | None:
     """Pick a representative steady-state window for a long profile.
 
     Returns ``(start_ns, end_ns)`` to feed into sub-skills as
@@ -78,7 +78,10 @@ def _auto_select_trim_window(prof, conn) -> tuple[int, int] | None:
         start_ns, end_ns = prof.meta.time_range
     except Exception:
         return None
-    span_ns = (end_ns or 0) - (start_ns or 0)
+    # Profiles missing or with a degenerate time_range can't be trimmed.
+    if start_ns is None or end_ns is None or end_ns <= start_ns:
+        return None
+    span_ns = end_ns - start_ns
     if span_ns < _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS:
         return None
 
@@ -175,18 +178,24 @@ def _execute(conn, **kwargs):
     auto_trim_meta: dict | None = None
     if not explicit_trim and os.environ.get("NSYS_AI_MANIFEST_AUTO_TRIM", "1") != "0":
         try:
-            picked = _auto_select_trim_window(prof, conn)
+            picked = _auto_select_trim_window(prof)
         except Exception as exc:  # noqa: BLE001 — best-effort, never block manifest
             _log.debug("manifest auto-trim selection failed: %s", exc, exc_info=True)
             picked = None
         if picked is not None:
             t0, t1 = picked
             trim_kwargs = {"trim_start_ns": int(t0), "trim_end_ns": int(t1)}
+            # Preserve the original profile span — the standard
+            # `profile_span_ms` below will reflect the trim window, so a
+            # caller who wants to know "this is a 10-minute profile"
+            # would otherwise see 20 s. The pre-trim span lives here.
+            full_start, full_end = prof.meta.time_range
             auto_trim_meta = {
                 "applied": True,
                 "trim_start_ns": int(t0),
                 "trim_end_ns": int(t1),
                 "window_ms": round((t1 - t0) / 1e6, 1),
+                "profile_full_span_ms": round((full_end - full_start) / 1e6, 1),
             }
             _log.info(
                 "manifest auto-trimmed to %.2fs–%.2fs (%.1fs window) on long profile",

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -224,9 +224,14 @@ class TestManifestAutoTrim:
         rows = manifest_skill.execute(minimal_nsys_conn, device=0)
         assert "auto_trim" not in rows[0]["data_quality"]
 
-    def test_env_var_disables_auto_trim(self, monkeypatch, minimal_nsys_conn, manifest_skill):
-        """NSYS_AI_MANIFEST_AUTO_TRIM=0 opts out even on long profiles."""
-        monkeypatch.setenv("NSYS_AI_MANIFEST_AUTO_TRIM", "0")
+    @pytest.mark.parametrize("token", ["0", "false", "False", "no", "OFF", " 0 "])
+    def test_env_var_disables_auto_trim(
+        self, token, monkeypatch, minimal_nsys_conn, manifest_skill
+    ):
+        """NSYS_AI_MANIFEST_AUTO_TRIM accepts the same off-tokens as the rest
+        of the repo (0 / false / no / off, case-insensitive, trim-tolerant).
+        """
+        monkeypatch.setenv("NSYS_AI_MANIFEST_AUTO_TRIM", token)
         # Also lower the threshold so the fixture profile would normally
         # qualify for auto-trim — proves the env var is what stopped it.
         monkeypatch.setattr(
@@ -235,6 +240,21 @@ class TestManifestAutoTrim:
         )
         rows = manifest_skill.execute(minimal_nsys_conn, device=0)
         assert "auto_trim" not in rows[0]["data_quality"]
+
+    @pytest.mark.parametrize("token", ["1", "true", "yes", "on", ""])
+    def test_env_var_truthy_keeps_auto_trim_enabled(
+        self, token, monkeypatch, minimal_nsys_conn, manifest_skill
+    ):
+        """Any value that is NOT in the off-token set leaves auto-trim on."""
+        monkeypatch.setenv("NSYS_AI_MANIFEST_AUTO_TRIM", token)
+        monkeypatch.setattr(
+            "nsys_ai.skills.builtins.profile_health_manifest._AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS",
+            0,
+        )
+        rows = manifest_skill.execute(minimal_nsys_conn, device=0)
+        # auto_trim will be applied (threshold=0) — proves the env var
+        # didn't switch it off.
+        assert rows[0]["data_quality"].get("auto_trim", {}).get("applied") is True
 
 
 class TestManifestFormat:

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -256,6 +256,74 @@ class TestManifestAutoTrim:
         # didn't switch it off.
         assert rows[0]["data_quality"].get("auto_trim", {}).get("applied") is True
 
+    def test_auto_trim_applied_block_present_in_manifest(
+        self, monkeypatch, minimal_nsys_conn, manifest_skill
+    ):
+        """Positive coverage: when the selector returns a window, the
+        manifest emits a complete `data_quality.auto_trim` block.
+
+        Stubs the selector so the test doesn't depend on the fixture
+        actually having NVTX iteration markers — focuses on the
+        `_execute()` plumbing.
+        """
+        fake_t0, fake_t1 = 1_000_000, 5_000_000  # 1 ms – 5 ms within fixture
+        monkeypatch.setattr(
+            "nsys_ai.skills.builtins.profile_health_manifest._auto_select_trim_window",
+            lambda _prof: (fake_t0, fake_t1),
+        )
+        rows = manifest_skill.execute(minimal_nsys_conn, device=0)
+        dq = rows[0]["data_quality"]
+        assert "auto_trim" in dq, "expected auto_trim block when selector returns a window"
+        at = dq["auto_trim"]
+        assert at["applied"] is True
+        assert at["trim_start_ns"] == fake_t0
+        assert at["trim_end_ns"] == fake_t1
+        assert at["window_ms"] == round((fake_t1 - fake_t0) / 1e6, 1)
+        # profile_full_span_ms must show the ORIGINAL profile length,
+        # not the trim window — that's the whole point of carrying it.
+        assert at["profile_full_span_ms"] >= at["window_ms"]
+        # And the top-level profile_span_ms should reflect the window.
+        assert rows[0]["profile_span_ms"] == at["window_ms"]
+
+    def test_partial_trim_does_not_block_auto_trim(
+        self, monkeypatch, minimal_nsys_conn, manifest_skill
+    ):
+        """Only one trim endpoint supplied → treat as no explicit trim.
+
+        Otherwise long profiles would silently scan in full because the
+        partial trim flag-set toggles `explicit_trim` to True but the
+        sub-skills' filters need BOTH endpoints to fire.
+        """
+        monkeypatch.setattr(
+            "nsys_ai.skills.builtins.profile_health_manifest._AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS",
+            0,
+        )
+        # Only start, no end — partial trim
+        rows = manifest_skill.execute(
+            minimal_nsys_conn,
+            device=0,
+            trim_start_ns=500_000,
+        )
+        # Auto-trim should kick in because explicit_trim was False
+        # (partial trim got discarded).
+        assert rows[0]["data_quality"].get("auto_trim", {}).get("applied") is True
+
+    def test_span_exactly_at_threshold_returns_none(self):
+        """Boundary contract: span == threshold → no trim.
+
+        Matches the docstring (≤ threshold returns None) and protects
+        against the off-by-one between < / ≤ that PR review caught.
+        """
+        from nsys_ai.skills.builtins.profile_health_manifest import (
+            _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS,
+        )
+
+        prof = self._make_profile_stub(span_ns=_AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS)
+        assert _auto_select_trim_window(prof) is None
+        # And one ns over the threshold should trip the auto-trim path.
+        prof = self._make_profile_stub(span_ns=_AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS + 1)
+        assert _auto_select_trim_window(prof) is not None
+
 
 class TestManifestFormat:
     def test_format_includes_header(self, minimal_nsys_conn, manifest_skill):

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -199,7 +199,9 @@ class TestManifestAutoTrim:
         prof = SimpleNamespace(meta=SimpleNamespace())
         assert _auto_select_trim_window(prof) is None
 
-    def test_explicit_trim_disables_auto_trim_on_long_profile(self, monkeypatch):
+    def test_explicit_trim_disables_auto_trim_on_long_profile(
+        self, monkeypatch, minimal_nsys_conn, manifest_skill
+    ):
         """Even when span is over threshold, explicit trim_start_ns /
         trim_end_ns from the caller must not be replaced by auto-trim."""
         # Lower the threshold so the minimal fixture profile counts as
@@ -209,21 +211,12 @@ class TestManifestAutoTrim:
             "nsys_ai.skills.builtins.profile_health_manifest._AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS",
             0,
         )
-        skill = get_skill("profile_health_manifest")
-        # Build a tiny in-memory profile so we have a real Profile + conn.
-        import sqlite3
-
-        conn = sqlite3.connect(":memory:")
-        try:
-            from tests.conftest import _NSYS_SCHEMA_SQL, _NSYS_SEED_SQL
-
-            conn.executescript(_NSYS_SCHEMA_SQL)
-            conn.executescript(_NSYS_SEED_SQL)
-            rows = skill.execute(
-                conn, device=0, trim_start_ns=0, trim_end_ns=10_000_000
-            )
-        finally:
-            conn.close()
+        rows = manifest_skill.execute(
+            minimal_nsys_conn,
+            device=0,
+            trim_start_ns=0,
+            trim_end_ns=10_000_000,
+        )
         assert "auto_trim" not in rows[0]["data_quality"]
 
     def test_short_profile_no_auto_trim_in_manifest(self, minimal_nsys_conn, manifest_skill):

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -88,6 +88,138 @@ class TestManifestExecute:
         assert isinstance(dq["overhead_pct"], (int, float))
 
 
+class TestManifestAutoTrim:
+    """Auto-trim picks a representative window on long profiles so the
+    manifest doesn't grind through 10-minute / 2 GB exports.
+
+    Boundary: profiles shorter than _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS
+    pass through untouched; longer profiles get the middle steady-state
+    instance of the top non-aten:: NVTX range, or the middle 20 s as a
+    fallback when no NVTX iteration markers are present.
+    """
+
+    def _make_profile_stub(self, span_ns: int, nvtx_rows: list[tuple]):
+        """Lightweight Profile + connection pair sufficient for auto-trim."""
+        from types import SimpleNamespace
+
+        # The auto-trim selector only reaches for `prof.meta.time_range`
+        # and `prof._duckdb_query`. Stubbing both decouples the test from
+        # the rest of the Profile machinery.
+        captured_queries: list[str] = []
+
+        def fake_query(sql, params=None):
+            captured_queries.append(sql)
+            sl = sql.lower()
+            # Probe queries — let the selector think nvtx exists.
+            if "from nvtx_high" in sl and "limit 1" in sl and "where" not in sl.split("from nvtx_high")[1].split("limit")[0]:
+                return [{"1": 1}]
+            # The real CTE query — return the NVTX rows seeded by the test
+            # if they match the expected schema (text, start, end).
+            if "from ranged" in sl:
+                # nvtx_rows is the post-filter set (no aten::*).
+                return [{"text": r[0], "start": r[1], "end": r[2]} for r in nvtx_rows]
+            return []
+
+        prof = SimpleNamespace(
+            meta=SimpleNamespace(time_range=(0, span_ns)),
+            _duckdb_query=fake_query,
+        )
+        return prof, captured_queries
+
+    def test_short_profile_returns_none(self):
+        """Profile span below threshold → no auto-trim."""
+        from nsys_ai.skills.builtins.profile_health_manifest import (
+            _auto_select_trim_window,
+        )
+
+        prof, _ = self._make_profile_stub(span_ns=30 * 10**9, nvtx_rows=[])
+        assert _auto_select_trim_window(prof, conn=None) is None
+
+    def test_long_profile_picks_middle_nvtx_instance(self):
+        """3 stage instances → middle one (skip JIT warmup at idx 0)."""
+        from nsys_ai.skills.builtins.profile_health_manifest import (
+            _auto_select_trim_window,
+        )
+
+        # Three short ranges (each < 20 s) so the selector returns them
+        # verbatim rather than slicing to a 20 s sub-window.
+        nvtx_rows = [
+            # (text, start_ns, end_ns)
+            ("stage::DenoisingStage", 100_000_000_000, 110_000_000_000),
+            ("stage::DenoisingStage", 200_000_000_000, 210_000_000_000),
+            ("stage::DenoisingStage", 300_000_000_000, 310_000_000_000),
+        ]
+        prof, _ = self._make_profile_stub(span_ns=500 * 10**9, nvtx_rows=nvtx_rows)
+        picked = _auto_select_trim_window(prof, conn=None)
+        assert picked is not None
+        # Index 1 (the middle of 3, skipping idx 0)
+        assert picked == (200_000_000_000, 210_000_000_000)
+
+    def test_long_profile_trims_wide_range_to_middle_20s(self):
+        """Range wider than 20 s gets narrowed to its middle 20 s."""
+        from nsys_ai.skills.builtins.profile_health_manifest import (
+            _AUTO_TRIM_TARGET_WINDOW_NS,
+            _auto_select_trim_window,
+        )
+
+        # One 200 s range × 3 instances; middle instance spans
+        # 400 s → 600 s. Auto-trim should return middle ± 10 s = 490-510 s.
+        nvtx_rows = [
+            ("stage::DenoisingStage", 100_000_000_000, 300_000_000_000),
+            ("stage::DenoisingStage", 400_000_000_000, 600_000_000_000),
+            ("stage::DenoisingStage", 700_000_000_000, 900_000_000_000),
+        ]
+        prof, _ = self._make_profile_stub(span_ns=1000 * 10**9, nvtx_rows=nvtx_rows)
+        picked = _auto_select_trim_window(prof, conn=None)
+        assert picked is not None
+        lo, hi = picked
+        assert hi - lo == _AUTO_TRIM_TARGET_WINDOW_NS
+        # Centered on the middle of (400e9, 600e9) = 500e9
+        assert lo == 500_000_000_000 - _AUTO_TRIM_TARGET_WINDOW_NS // 2
+        assert hi == 500_000_000_000 + _AUTO_TRIM_TARGET_WINDOW_NS // 2
+
+    def test_long_profile_no_nvtx_falls_back_to_middle(self):
+        """No qualifying NVTX iteration markers → middle 20 s of span."""
+        from nsys_ai.skills.builtins.profile_health_manifest import (
+            _AUTO_TRIM_TARGET_WINDOW_NS,
+            _auto_select_trim_window,
+        )
+
+        prof, _ = self._make_profile_stub(span_ns=400 * 10**9, nvtx_rows=[])
+        picked = _auto_select_trim_window(prof, conn=None)
+        assert picked is not None
+        lo, hi = picked
+        assert hi - lo == _AUTO_TRIM_TARGET_WINDOW_NS
+        # Span midpoint is 200 s; window is [190 s, 210 s]
+        assert lo == 200 * 10**9 - _AUTO_TRIM_TARGET_WINDOW_NS // 2
+        assert hi == 200 * 10**9 + _AUTO_TRIM_TARGET_WINDOW_NS // 2
+
+    def test_explicit_trim_disables_auto_trim(self, minimal_nsys_conn, manifest_skill):
+        """When the caller passes trim_start_ns / trim_end_ns, the manifest
+        must honour it and not inject an auto-trim window."""
+        rows = manifest_skill.execute(
+            minimal_nsys_conn,
+            device=0,
+            trim_start_ns=0,
+            trim_end_ns=10_000_000,
+        )
+        dq = rows[0]["data_quality"]
+        assert "auto_trim" not in dq
+
+    def test_short_profile_no_auto_trim_in_manifest(self, minimal_nsys_conn, manifest_skill):
+        """Fixture profile spans ~24 ms — well below threshold; no auto-trim."""
+        rows = manifest_skill.execute(minimal_nsys_conn, device=0)
+        dq = rows[0]["data_quality"]
+        assert "auto_trim" not in dq
+
+    def test_env_var_disables_auto_trim(self, monkeypatch, minimal_nsys_conn, manifest_skill):
+        """NSYS_AI_MANIFEST_AUTO_TRIM=0 opts out even on long profiles."""
+        monkeypatch.setenv("NSYS_AI_MANIFEST_AUTO_TRIM", "0")
+        rows = manifest_skill.execute(minimal_nsys_conn, device=0)
+        dq = rows[0]["data_quality"]
+        assert "auto_trim" not in dq
+
+
 class TestManifestFormat:
     def test_format_includes_header(self, minimal_nsys_conn, manifest_skill):
         rows = manifest_skill.execute(minimal_nsys_conn, device=0)

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -5,6 +5,10 @@ Uses the minimal_nsys_conn and duckdb_conn fixtures from conftest.py.
 
 import pytest
 
+from nsys_ai.skills.builtins.profile_health_manifest import (
+    _AUTO_TRIM_TARGET_WINDOW_NS,
+    _auto_select_trim_window,
+)
 from nsys_ai.skills.registry import get_skill
 
 # ── Fixtures ──────────────────────────────────────────────────────
@@ -98,49 +102,41 @@ class TestManifestAutoTrim:
     fallback when no NVTX iteration markers are present.
     """
 
-    def _make_profile_stub(self, span_ns: int, nvtx_rows: list[tuple]):
-        """Lightweight Profile + connection pair sufficient for auto-trim."""
+    @staticmethod
+    def _make_profile_stub(span_ns: int, nvtx_rows: list[tuple] | None = None):
+        """Lightweight Profile stub sufficient for `_auto_select_trim_window`.
+
+        ``nvtx_rows`` is the post-filter set (i.e. these rows survive the
+        CTE's ``NOT LIKE 'aten::%'`` exclusion). ``None`` means "no NVTX
+        iteration markers" — the selector should hit the middle-of-span
+        fallback path.
+        """
         from types import SimpleNamespace
 
-        # The auto-trim selector only reaches for `prof.meta.time_range`
-        # and `prof._duckdb_query`. Stubbing both decouples the test from
-        # the rest of the Profile machinery.
-        captured_queries: list[str] = []
+        rows = list(nvtx_rows or [])
 
         def fake_query(sql, params=None):
-            captured_queries.append(sql)
-            sl = sql.lower()
-            # Probe queries — let the selector think nvtx exists.
-            if "from nvtx_high" in sl and "limit 1" in sl and "where" not in sl.split("from nvtx_high")[1].split("limit")[0]:
+            normalized = " ".join(sql.split()).lower()
+            # Probe queries — bare `SELECT 1 FROM <view> LIMIT 1` — say "yes".
+            if normalized.startswith("select 1 from") and normalized.endswith("limit 1"):
                 return [{"1": 1}]
-            # The real CTE query — return the NVTX rows seeded by the test
-            # if they match the expected schema (text, start, end).
-            if "from ranged" in sl:
-                # nvtx_rows is the post-filter set (no aten::*).
-                return [{"text": r[0], "start": r[1], "end": r[2]} for r in nvtx_rows]
+            # The CTE query is the only other shape this function emits.
+            if "with ranged" in normalized and rows:
+                return [{"text": r[0], "start": r[1], "end": r[2]} for r in rows]
             return []
 
-        prof = SimpleNamespace(
+        return SimpleNamespace(
             meta=SimpleNamespace(time_range=(0, span_ns)),
             _duckdb_query=fake_query,
         )
-        return prof, captured_queries
 
     def test_short_profile_returns_none(self):
         """Profile span below threshold → no auto-trim."""
-        from nsys_ai.skills.builtins.profile_health_manifest import (
-            _auto_select_trim_window,
-        )
-
-        prof, _ = self._make_profile_stub(span_ns=30 * 10**9, nvtx_rows=[])
-        assert _auto_select_trim_window(prof, conn=None) is None
+        prof = self._make_profile_stub(span_ns=30 * 10**9)
+        assert _auto_select_trim_window(prof) is None
 
     def test_long_profile_picks_middle_nvtx_instance(self):
         """3 stage instances → middle one (skip JIT warmup at idx 0)."""
-        from nsys_ai.skills.builtins.profile_health_manifest import (
-            _auto_select_trim_window,
-        )
-
         # Three short ranges (each < 20 s) so the selector returns them
         # verbatim rather than slicing to a 20 s sub-window.
         nvtx_rows = [
@@ -149,19 +145,13 @@ class TestManifestAutoTrim:
             ("stage::DenoisingStage", 200_000_000_000, 210_000_000_000),
             ("stage::DenoisingStage", 300_000_000_000, 310_000_000_000),
         ]
-        prof, _ = self._make_profile_stub(span_ns=500 * 10**9, nvtx_rows=nvtx_rows)
-        picked = _auto_select_trim_window(prof, conn=None)
-        assert picked is not None
+        prof = self._make_profile_stub(span_ns=500 * 10**9, nvtx_rows=nvtx_rows)
+        picked = _auto_select_trim_window(prof)
         # Index 1 (the middle of 3, skipping idx 0)
         assert picked == (200_000_000_000, 210_000_000_000)
 
     def test_long_profile_trims_wide_range_to_middle_20s(self):
         """Range wider than 20 s gets narrowed to its middle 20 s."""
-        from nsys_ai.skills.builtins.profile_health_manifest import (
-            _AUTO_TRIM_TARGET_WINDOW_NS,
-            _auto_select_trim_window,
-        )
-
         # One 200 s range × 3 instances; middle instance spans
         # 400 s → 600 s. Auto-trim should return middle ± 10 s = 490-510 s.
         nvtx_rows = [
@@ -169,8 +159,8 @@ class TestManifestAutoTrim:
             ("stage::DenoisingStage", 400_000_000_000, 600_000_000_000),
             ("stage::DenoisingStage", 700_000_000_000, 900_000_000_000),
         ]
-        prof, _ = self._make_profile_stub(span_ns=1000 * 10**9, nvtx_rows=nvtx_rows)
-        picked = _auto_select_trim_window(prof, conn=None)
+        prof = self._make_profile_stub(span_ns=1000 * 10**9, nvtx_rows=nvtx_rows)
+        picked = _auto_select_trim_window(prof)
         assert picked is not None
         lo, hi = picked
         assert hi - lo == _AUTO_TRIM_TARGET_WINDOW_NS
@@ -180,13 +170,8 @@ class TestManifestAutoTrim:
 
     def test_long_profile_no_nvtx_falls_back_to_middle(self):
         """No qualifying NVTX iteration markers → middle 20 s of span."""
-        from nsys_ai.skills.builtins.profile_health_manifest import (
-            _AUTO_TRIM_TARGET_WINDOW_NS,
-            _auto_select_trim_window,
-        )
-
-        prof, _ = self._make_profile_stub(span_ns=400 * 10**9, nvtx_rows=[])
-        picked = _auto_select_trim_window(prof, conn=None)
+        prof = self._make_profile_stub(span_ns=400 * 10**9)
+        picked = _auto_select_trim_window(prof)
         assert picked is not None
         lo, hi = picked
         assert hi - lo == _AUTO_TRIM_TARGET_WINDOW_NS
@@ -194,30 +179,69 @@ class TestManifestAutoTrim:
         assert lo == 200 * 10**9 - _AUTO_TRIM_TARGET_WINDOW_NS // 2
         assert hi == 200 * 10**9 + _AUTO_TRIM_TARGET_WINDOW_NS // 2
 
-    def test_explicit_trim_disables_auto_trim(self, minimal_nsys_conn, manifest_skill):
-        """When the caller passes trim_start_ns / trim_end_ns, the manifest
-        must honour it and not inject an auto-trim window."""
-        rows = manifest_skill.execute(
-            minimal_nsys_conn,
-            device=0,
-            trim_start_ns=0,
-            trim_end_ns=10_000_000,
+    def test_degenerate_time_range_returns_none(self):
+        """None / inverted / zero-width time_range → no auto-trim."""
+        from types import SimpleNamespace
+
+        # Missing endpoint
+        prof = SimpleNamespace(
+            meta=SimpleNamespace(time_range=(None, None)),
+            _duckdb_query=lambda *a, **k: [],
         )
-        dq = rows[0]["data_quality"]
-        assert "auto_trim" not in dq
+        assert _auto_select_trim_window(prof) is None
+        # Inverted endpoints
+        prof = SimpleNamespace(
+            meta=SimpleNamespace(time_range=(200, 100)),
+            _duckdb_query=lambda *a, **k: [],
+        )
+        assert _auto_select_trim_window(prof) is None
+        # meta missing entirely
+        prof = SimpleNamespace(meta=SimpleNamespace())
+        assert _auto_select_trim_window(prof) is None
+
+    def test_explicit_trim_disables_auto_trim_on_long_profile(self, monkeypatch):
+        """Even when span is over threshold, explicit trim_start_ns /
+        trim_end_ns from the caller must not be replaced by auto-trim."""
+        # Lower the threshold so the minimal fixture profile counts as
+        # "long" without us needing a real 2 GB sqlite. The point is to
+        # exercise the explicit-trim guard, not the threshold itself.
+        monkeypatch.setattr(
+            "nsys_ai.skills.builtins.profile_health_manifest._AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS",
+            0,
+        )
+        skill = get_skill("profile_health_manifest")
+        # Build a tiny in-memory profile so we have a real Profile + conn.
+        import sqlite3
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            from tests.conftest import _NSYS_SCHEMA_SQL, _NSYS_SEED_SQL
+
+            conn.executescript(_NSYS_SCHEMA_SQL)
+            conn.executescript(_NSYS_SEED_SQL)
+            rows = skill.execute(
+                conn, device=0, trim_start_ns=0, trim_end_ns=10_000_000
+            )
+        finally:
+            conn.close()
+        assert "auto_trim" not in rows[0]["data_quality"]
 
     def test_short_profile_no_auto_trim_in_manifest(self, minimal_nsys_conn, manifest_skill):
         """Fixture profile spans ~24 ms — well below threshold; no auto-trim."""
         rows = manifest_skill.execute(minimal_nsys_conn, device=0)
-        dq = rows[0]["data_quality"]
-        assert "auto_trim" not in dq
+        assert "auto_trim" not in rows[0]["data_quality"]
 
     def test_env_var_disables_auto_trim(self, monkeypatch, minimal_nsys_conn, manifest_skill):
         """NSYS_AI_MANIFEST_AUTO_TRIM=0 opts out even on long profiles."""
         monkeypatch.setenv("NSYS_AI_MANIFEST_AUTO_TRIM", "0")
+        # Also lower the threshold so the fixture profile would normally
+        # qualify for auto-trim — proves the env var is what stopped it.
+        monkeypatch.setattr(
+            "nsys_ai.skills.builtins.profile_health_manifest._AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS",
+            0,
+        )
         rows = manifest_skill.execute(minimal_nsys_conn, device=0)
-        dq = rows[0]["data_quality"]
-        assert "auto_trim" not in dq
+        assert "auto_trim" not in rows[0]["data_quality"]
 
 
 class TestManifestFormat:


### PR DESCRIPTION
## Summary

- `profile_health_manifest` without `--trim` previously hung on multi-GB profiles (>12 min on a 2.2 GB FastVideo trace, had to be killed). Sub-skills like `nvtx_layer_breakdown` and `iteration_timing` scaled with the full profile span.
- Auto-detect a representative steady-state window (top non-`aten::*` NVTX range, middle instance, narrowed to 20 s) when profile span > 120 s and no explicit `--trim` is provided.
- The picked window is exposed via `manifest.data_quality.auto_trim` so callers can tell what was analyzed; opt out with `NSYS_AI_MANIFEST_AUTO_TRIM=0`.

## Changes

**`src/nsys_ai/skills/builtins/profile_health_manifest.py`**
- New helper `_auto_select_trim_window(prof, conn)` — stateless, pure function over `prof.meta.time_range` + `prof._duckdb_query`. Probes `nvtx_high` view first (PR #123), falls back to `nvtx` then raw `NVTX_EVENTS`. Uses `[end]` dialect so it works on both DuckDB and SQLite paths.
- Selection rules:
  1. Span ≤ 120 s → return None (no trim).
  2. Top non-`aten::*` NVTX range with ≥ 3 instances → pick middle instance (skip index 0 = JIT warmup).
  3. If picked instance is wider than 20 s → narrow to middle 20 s.
  4. No qualifying NVTX → middle 20 s of profile span.
- `_execute()` calls the helper when no explicit trim is supplied; injects the result into `trim_kwargs` and records `auto_trim_meta` for the manifest output.
- New env var `NSYS_AI_MANIFEST_AUTO_TRIM=0` disables the behaviour.
- Best-effort: any exception in the selector is swallowed and the manifest proceeds untrimmed.

**`tests/test_profile_health_manifest.py`**
- New `TestManifestAutoTrim` (7 cases):
  - `test_short_profile_returns_none` — sub-threshold span → no trim.
  - `test_long_profile_picks_middle_nvtx_instance` — 3 stage instances → middle one.
  - `test_long_profile_trims_wide_range_to_middle_20s` — 200 s range → centered 20 s.
  - `test_long_profile_no_nvtx_falls_back_to_middle` — no NVTX → middle 20 s of span.
  - `test_explicit_trim_disables_auto_trim` — caller's trim wins.
  - `test_short_profile_no_auto_trim_in_manifest` — sub-threshold real fixture profile.
  - `test_env_var_disables_auto_trim` — opt-out via env.

## Measured impact

Profile: `/home/rich-wsl/fastvideo/profile_results/perf.sqlite` — 2.2 GB, 15.9 M NVTX events, 4 GPUs, **no `--trim`**.

| Metric | Before | After | Δ |
| --- | --- | --- | --- |
| `profile_health_manifest` wall | killed at 12 min+ | **7.45 s** | ≫ 100× |
| Auto-picked window | — | 456.6 s – 476.6 s (Gen 2 `DenoisingStage` middle) | — |
| `suspected_bottleneck` quality | n/a | "High CPU Synchronization Blocking (89.7%)" — same diagnosis as manual `--trim 400 420` | — |

## Backward compatibility

Yes.
- Explicit `--trim` always wins; the auto-trim path only fires when none is supplied.
- Sub-threshold profiles (< 120 s) get the identical untrimmed manifest as before.
- Env var `NSYS_AI_MANIFEST_AUTO_TRIM=0` gives a hard opt-out for the unlikely case a caller wants the full-span scan back.
- No public CLI / output schema change beyond adding the optional `data_quality.auto_trim` block.

## Test plan

- [x] Tests added (7 new cases in `TestManifestAutoTrim`)
- [x] `python -m nsys_ai --help` — CLI loads
- [x] `pytest tests/ -v --tb=short` — **785 passed, 135 skipped, 0 failed** (was 778)
- [x] `ruff check src/ tests/` clean
- [x] `bandit -r src/ -c pyproject.toml` clean
- [x] Manually re-ran `nsys-ai skill run profile_health_manifest <2GB profile> --format json` (no `--trim`) — 7.45 s, auto-trim block present with sensible window

## Out of scope

- `iteration_timing` per-skill optimization (~4 s of the 7.77 s trimmed manifest) — its slow point is `prof.kernel_map(device)` building a 550K-entry Python dict, separate from NVTX cost. Will land separately.
- Hive-partition by `deviceId` and predicate-pushdown summary tables — listed in the original optimization plan as Phases 2 / 3, neither blocks this UX fix.

## Linked issues

Refs #123 (uses the `nvtx_high` view it introduced).