### PR TITLE
docs(skills): rewrite §9 perf budget for NVTX-heavy profiles

### DIFF
--- a/skills/analyze/references/M2_COMMS.md
+++ b/skills/analyze/references/M2_COMMS.md
@@ -85,7 +85,7 @@ After delivery, suggest a second mode only if a distinct critical finding exists
 
 ## 6. Delivery
 
-Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+Follow `PRINCIPLES.md §5` for evidence + timeline URL. Then 3-part summary:
 
 1. **Root cause** — NCCL class + quantified waste:
    > "NCCL AllReduce is serialized with compute (overlap = 18%, DDP default bucket 25 MB).

--- a/skills/analyze/references/M3_COMPUTE.md
+++ b/skills/analyze/references/M3_COMPUTE.md
@@ -81,7 +81,7 @@ Soft cap: avoid suggesting >2 modes in one delivery.
 
 ## 6. Delivery
 
-Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+Follow `PRINCIPLES.md §5` for evidence + timeline URL. Then 3-part summary:
 
 1. **Root cause** — hotspot identity + quantified share:
    > "Top kernel `ampere_bf16_s16816gemm_bf16_128x128x32_ldg8_f2f_stages_32x3_nn`

--- a/skills/analyze/references/M4_MEMORY.md
+++ b/skills/analyze/references/M4_MEMORY.md
@@ -80,7 +80,7 @@ After delivery, suggest a second mode only if a distinct critical finding exists
 
 ## 6. Delivery
 
-Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+Follow `PRINCIPLES.md §5` for evidence + timeline URL. Then 3-part summary:
 
 1. **Root cause** — transfer class + direction + quantified waste:
    > "H2D transfers account for 22% of profile time. `h2d_distribution` shows a `spread_out`

--- a/skills/analyze/references/M5_NVTX.md
+++ b/skills/analyze/references/M5_NVTX.md
@@ -123,7 +123,7 @@ After delivery, suggest a second mode only if a distinct critical finding exists
 
 ## 6. Delivery
 
-Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+Follow `PRINCIPLES.md §5` for evidence + timeline URL. Then 3-part summary:
 
 1. **Root cause** — layer name + quantified % + mechanism:
    > "The `TransformerLayer.12.attn_fwd` region accounts for 34% of GPU time. Top kernel is

--- a/skills/analyze/references/M5_NVTX.md
+++ b/skills/analyze/references/M5_NVTX.md
@@ -7,13 +7,18 @@ Reference for `/nsys-ai` Mode 5. **Read `PRINCIPLES.md` first** — §4 guards, 
 
 ## 1. Precondition gate
 
-Run a single-row probe first:
+Check the manifest first (cheap — pre-computed at cache build):
 
 ```bash
-nsys-ai skill run nvtx_layer_breakdown <profile> --format json --max-rows 1
+nsys-ai skill run profile_health_manifest <profile> --format json
+# precondition: .nvtx.has_nvtx == true
 ```
 
-If empty, render the §7 template:
+Do NOT use `nvtx_layer_breakdown --max-rows 1` as a probe — `--max-rows` bounds
+output rows only; the underlying range-IEJoin still scans the whole NVTX table
+(see PRINCIPLES.md §9).
+
+If `nvtx.has_nvtx` is false, render the §7 template:
 
 ```
 Mode 5 requires a user choice.

--- a/skills/analyze/references/M6_IDLE.md
+++ b/skills/analyze/references/M6_IDLE.md
@@ -83,7 +83,7 @@ After delivery, suggest a second mode only if a distinct critical finding exists
 
 ## 6. Delivery
 
-Follow `PRINCIPLES.md §5` for evidence build + timeline URL. Then 3-part summary:
+Follow `PRINCIPLES.md §5` for evidence + timeline URL. Then 3-part summary:
 
 1. **Root cause** — stall class + quantified waste:
    > "GPU is idle 23% of profile time. `gpu_idle_gaps` attributes 78% of gaps to

--- a/skills/analyze/references/M7_CUTRACER.md
+++ b/skills/analyze/references/M7_CUTRACER.md
@@ -1,7 +1,7 @@
 # Mode 7 — CUTracer (SASS analysis)
 
 Reference for `/nsys-ai` Mode 7. **Read `PRINCIPLES.md` first** — §4 guards, §7 fail
-template, §10 checklist. **Evidence exception**: Mode 7 skips `evidence build` — see
+template, §10 checklist. **Evidence exception**: Mode 7 skips the §5.1 evidence step — see
 PRINCIPLES.md §5.5.
 
 ---
@@ -124,7 +124,7 @@ If `bottleneck = "unknown"` due to missing `.so`:
 
 ## 6. Delivery
 
-**Evidence**: Mode 7 skips `evidence build`. Open an unannotated timeline for context:
+**Evidence**: Mode 7 skips the §5.1 evidence step. Open an unannotated timeline for context:
 ```bash
 nsys-ai timeline-web <profile>
 ```

--- a/skills/analyze/references/M8_DIFF.md
+++ b/skills/analyze/references/M8_DIFF.md
@@ -98,7 +98,7 @@ fields: `name`, `demangled`, `delta_ns`, `before_share`, `after_share`, `classif
 
 ## 6. Delivery
 
-**Evidence**: follow PRINCIPLES §5.6 (Mode 8 adaptation) — run `evidence build <after>`
+**Evidence**: follow PRINCIPLES §5.6 (Mode 8 adaptation) — run `analyze <after> --gpu <device_id> --format json`
 only, never the before profile. Craft a findings JSON with regression labels, then serve
 the after-profile timeline:
 

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -124,9 +124,13 @@ Every Mode 1–9 ends with this sequence between skill execution and the 3-part 
 ### §5.1 CLI sequence
 
 ```bash
-nsys-ai evidence build <profile> --format json -o /tmp/findings.json
+nsys-ai analyze <profile> --gpu <device_id> --format json -o /tmp/findings.json
 nsys-ai timeline-web <profile> --findings /tmp/findings.json
 ```
+
+`<device_id>` from manifest's `overlap.device_id` (typically `0`). The legacy
+`nsys-ai evidence build` still works and emits the same JSON shape but is
+deprecated — use `analyze --format json`.
 
 Then tell the user the exact URL emitted by `timeline-web` (look for `http://127.0.0.1:PORT` in its stdout):
 > "Timeline ready at http://127.0.0.1:PORT — open in browser to see findings overlay."
@@ -152,9 +156,9 @@ Then `nsys-ai timeline-web <profile> --findings <custom.json>`.
 
 ### §5.3 Fail-soft rule
 
-If `evidence build` fails (profile has no detectable pattern), emit `{"findings": []}`
-and still run `timeline-web`. User sees an unannotated timeline; delivery proceeds. **Never
-block delivery on evidence-step failure.**
+If `analyze --format json` fails (profile has no detectable pattern), emit
+`{"findings": []}` and still run `timeline-web`. User sees an unannotated timeline;
+delivery proceeds. **Never block delivery on evidence-step failure.**
 
 ### §5.4 Optional text report
 
@@ -171,8 +175,9 @@ supplies from manifest: `gpu` = first device in `overlap.available_devices` or 0
 
 ### §5.5 Mode 7 evidence exception
 
-Mode 7 (CUTracer) **skips `evidence build` entirely** — `cutracer analyze` output is the
-evidence layer. Open `timeline-web` without `--findings` for unannotated context only:
+Mode 7 (CUTracer) **skips the §5.1 evidence step entirely** — `cutracer analyze`
+output is the evidence layer. Open `timeline-web` without `--findings` for
+unannotated context only:
 
 ```bash
 nsys-ai timeline-web <profile>
@@ -181,10 +186,10 @@ nsys-ai timeline-web <profile>
 ### §5.6 Mode 8 evidence adaptation
 
 Mode 8 (Diff) has two profiles but only **one after-timeline** is served. Run
-`evidence build` on the **after profile only** — never on the before profile.
+the §5.1 evidence step on the **after profile only** — never on the before profile.
 
 ```bash
-nsys-ai evidence build <after> --format json -o /tmp/findings.json
+nsys-ai analyze <after> --gpu <device_id> --format json -o /tmp/findings.json
 ```
 
 Then annotate `findings.json` with regression labels pulled from
@@ -400,9 +405,13 @@ Heavy skills (range-IEJoin: kernels × avg NVTX depth):
 
 | Skill | Trim trigger |
 |---|---|
-| `nvtx_layer_breakdown` | `nvtx.iteration_count > 1` OR `profile_span_ms > 30_000` |
+| `nvtx_layer_breakdown` | `nvtx.iteration_count > 1` OR full span > 30 s* |
 | `nvtx_kernel_map` | same |
-| `gpu_idle_gaps` | `profile_span_ms > 30_000` |
+| `gpu_idle_gaps` | full span > 30 s* |
+
+\* When `data_quality.auto_trim.applied == true` the top-level `profile_span_ms`
+is the trimmed window; read the actual span from
+`data_quality.auto_trim.profile_full_span_ms`.
 
 **First-open cache trap.** The cache builder materializes
 `nvtx_kernel_map.parquet` via the same range-IEJoin, so on NVTX-heavy

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -379,31 +379,51 @@ Reply with <options>, or "stop" to abort.
 
 ## §9 Performance budget
 
-Skills scale on row counts, not file size. Read counts from the manifest:
+Skills scale on row counts, not file size. For multi-iteration profiles the
+whole run is rarely useful — analyze a single iteration. Read trigger fields
+from the manifest:
 
 ```bash
 nsys-ai skill run profile_health_manifest <profile> --format json
-# fields used: kernel_count, nvtx.has_nvtx, nvtx.iteration_count
+# fields: nvtx.has_nvtx, nvtx.iteration_count, profile_span_ms
 ```
 
-Heavy skills and trim triggers:
+Trim modes on `nsys-ai skill run` (preference order):
 
-| Skill | Cost bound | Trim when |
-|---|---|---|
-| `nvtx_layer_breakdown` | kernels × avg nvtx depth (range-IEJoin) | `kernel_count` > 500_000 |
-| `nvtx_kernel_map` | same | same |
-| `gpu_idle_gaps` | kernels, sort | `kernel_count` > 500_000 |
+| Form | When |
+|---|---|
+| `--iteration N` | NVTX iteration markers present (cleanest) |
+| `--trim START_S END_S` | manual window, seconds |
+| `-p trim_start_ns=… -p trim_end_ns=…` | when ns precision matters |
 
-Trim to one representative iteration:
+Heavy skills (range-IEJoin: kernels × avg NVTX depth):
+
+| Skill | Trim trigger |
+|---|---|
+| `nvtx_layer_breakdown` | `nvtx.iteration_count > 1` OR `profile_span_ms > 30_000` |
+| `nvtx_kernel_map` | same |
+| `gpu_idle_gaps` | `profile_span_ms > 30_000` |
+
+**First-open cache trap.** The cache builder materializes
+`nvtx_kernel_map.parquet` via the same range-IEJoin, so on NVTX-heavy
+profiles even a cheap skill (`iteration_timing`, `profile_health_manifest`)
+blocks on it the first time — observed > 10 min on a 10 M NVTX × 1 M
+kernel profile. Once `<profile>.nsys-cache/nvtx_kernel_map.parquet`
+exists, subsequent skill runs are sub-second.
+
+Recipe with iteration markers (`nvtx.has_nvtx == true`):
+
+```bash
+nsys-ai skill run nvtx_layer_breakdown <profile> --iteration 5 --format json
+```
+
+Recipe without:
 
 1. `iteration_timing` → pick a median-duration iteration N (skip iter 0 — JIT)
-2. `iteration_detail -p iteration=N` → read `start_ns`, `end_ns`
-3. Heavy skill with `-p trim_start_ns=<start> -p trim_end_ns=<end>`
+2. `iteration_detail -p iteration=N` → read `gpu_start_ns`, `gpu_end_ns`
+3. Heavy skill with `-p trim_start_ns=<gpu_start_ns> -p trim_end_ns=<gpu_end_ns>`
 
 `--max-rows N` bounds output rows only, not query work. To bound work, trim.
-
-First-open cache build: ZSTD Parquet under `<profile>.nsys-cache/`; subsequent
-opens sub-second. Falls back to direct SQLite automatically.
 
 ---
 

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -128,7 +128,9 @@ nsys-ai analyze <profile> --gpu <device_id> --format json -o /tmp/findings.json
 nsys-ai timeline-web <profile> --findings /tmp/findings.json
 ```
 
-`<device_id>` from manifest's `overlap.device_id` (typically `0`). The legacy
+`<device_id>` is `0` for single-GPU runs. For multi-GPU profiles, run
+`overlap_breakdown` first and pick `available_devices[0]` from its output
+(the manifest's `overlap` subobject does not expose a device id). The legacy
 `nsys-ai evidence build` still works and emits the same JSON shape but is
 deprecated — use `analyze --format json`.
 
@@ -390,7 +392,9 @@ from the manifest:
 
 ```bash
 nsys-ai skill run profile_health_manifest <profile> --format json
-# fields: nvtx.has_nvtx, nvtx.iteration_count, profile_span_ms
+# fields: nvtx.has_nvtx, nvtx.iteration_count
+# full span: data_quality.auto_trim.profile_full_span_ms when auto-trimmed,
+#            else top-level profile_span_ms
 ```
 
 Trim modes on `nsys-ai skill run` (preference order):
@@ -418,7 +422,9 @@ is the trimmed window; read the actual span from
 profiles even a cheap skill (`iteration_timing`, `profile_health_manifest`)
 blocks on it the first time — observed > 10 min on a 10 M NVTX × 1 M
 kernel profile. Once `<profile>.nsys-cache/nvtx_kernel_map.parquet`
-exists, subsequent skill runs are sub-second.
+exists, subsequent skill runs range from sub-second (`top_kernels`,
+`memory_transfers`, `h2d_distribution`) to 20–30 s for the heavier ones
+(`iteration_detail`, `host_sync_parent_ranges`, `nvtx_layer_breakdown`).
 
 Recipe with iteration markers (`nvtx.has_nvtx == true`):
 

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -90,6 +90,7 @@ use the §7 template but offer an alternative path (not a hard block).
 | 6 | Mode 7 on host without GPU AND user declined Modal | `cutracer/runner.py` subprocess fails | Pre-check `nvidia-smi`; §4.3 row 2 first |
 | 7 | Mode 8 paths resolve to same inode | Not validated in `diff.py` | Plugin `os.stat().st_ino` compare; stop before `nsys-ai diff` |
 | 8 | Mode 9 empty `iteration_timing` | Skill returns `[]` only after NVTX matching and kernel-gap heuristic fallback both fail, or required runtime tables are unavailable | Offer Mode 5 Path B (see §4.3 row 3) |
+| 9 | `.sqlite` header invalid (partial `nsys export`) | First 16 bytes ≠ `"SQLite format 3"`; `profile.py` mtime check is fooled because the partial file is newer than the `.nsys-rep` | Pre-check magic header; if invalid and `.nsys-rep` exists, re-export silently (§4.2 row 1 flow) |
 
 ### §4.2 Auto-handled — plugin must NOT ask the user
 
@@ -376,15 +377,33 @@ Reply with <options>, or "stop" to abort.
 
 ---
 
-## §9 Performance Notes
+## §9 Performance budget
 
-- **DuckDB + Parquet default.** First open exports SQLite → `<profile>.nsys-cache/`
-  ZSTD Parquet. Subsequent opens sub-second. Falls back to direct SQLite automatically.
-- **Large profiles** (>100 MB): narrow the window via `--trim START_S END_S` on `skill run`.
-  Best practice: profile 1–2 representative iterations, not the entire run.
-- **Costliest skills** on big files: `nvtx_kernel_map`, `nvtx_layer_breakdown`,
-  `gpu_idle_gaps`. Trim before running.
-- **Auto-indexing**: one-time ~30 s cost for 250 MB profiles; speeds up subsequent queries.
+Skills scale on row counts, not file size. Read counts from the manifest:
+
+```bash
+nsys-ai skill run profile_health_manifest <profile> --format json
+# fields used: kernel_count, nvtx.has_nvtx, nvtx.iteration_count
+```
+
+Heavy skills and trim triggers:
+
+| Skill | Cost bound | Trim when |
+|---|---|---|
+| `nvtx_layer_breakdown` | kernels × avg nvtx depth (range-IEJoin) | `kernel_count` > 500_000 |
+| `nvtx_kernel_map` | same | same |
+| `gpu_idle_gaps` | kernels, sort | `kernel_count` > 500_000 |
+
+Trim to one representative iteration:
+
+1. `iteration_timing` → pick a median-duration iteration N (skip iter 0 — JIT)
+2. `iteration_detail -p iteration=N` → read `start_ns`, `end_ns`
+3. Heavy skill with `-p trim_start_ns=<start> -p trim_end_ns=<end>`
+
+`--max-rows N` bounds output rows only, not query work. To bound work, trim.
+
+First-open cache build: ZSTD Parquet under `<profile>.nsys-cache/`; subsequent
+opens sub-second. Falls back to direct SQLite automatically.
 
 ---
 

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -129,8 +129,10 @@ nsys-ai timeline-web <profile> --findings /tmp/findings.json
 ```
 
 `<device_id>` is `0` for single-GPU runs. For multi-GPU profiles, run
-`overlap_breakdown` first and pick `available_devices[0]` from its output
-(the manifest's `overlap` subobject does not expose a device id). The legacy
+`overlap_breakdown` first; each row has a `device_id` field — pick the
+first row's value (the manifest's `overlap` subobject does not expose a
+device id, and `available_devices` only appears in the empty-device-0
+diagnostic dict at `overlap.py:249`, not in normal output). The legacy
 `nsys-ai evidence build` still works and emits the same JSON shape but is
 deprecated — use `analyze --format json`.
 
@@ -170,10 +172,13 @@ Only on explicit user request ("save this", "generate report", "markdown report"
 nsys-ai report <profile> --gpu <device_id> --trim <start_s> <end_s> -o report.md
 ```
 
-Both `--gpu` and `--trim` are required (verified `src/nsys_ai/cli/parsers.py:289`). Plugin
-supplies from manifest: `gpu` = first device in `overlap.available_devices` or 0; `trim`
-= smart-trim iteration range (if Mode 1 Stage 3 was taken) else
-`0 profile_span_ms/1000`. Slow on large profiles — confirm before running.
+Both `--gpu` and `--trim` are required (verified `src/nsys_ai/cli/parsers.py:289`).
+Plugin defaults: `gpu` = `0` for single-GPU, else the first row's `device_id` from
+`overlap_breakdown` output (see §5.1 caveat about `available_devices`); `trim` =
+smart-trim iteration range (if Mode 1 Stage 3 was taken) else
+`0 → profile_span_ms/1000` (read full span from
+`data_quality.auto_trim.profile_full_span_ms` when auto-trim has applied).
+Slow on large profiles — confirm before running.
 
 ### §5.5 Mode 7 evidence exception
 


### PR DESCRIPTION
## Summary

Three doc fixes triggered by hitting a 506 MB / 10.4M-NVTX / 1.08M-kernel profile where `nvtx_layer_breakdown` ran for 5+ min before I killed it, plus a corrupt-sqlite trap that wasted another debug round-trip.

- **`PRINCIPLES.md` §9** — replace 4-bullet "Performance Notes" with a cost-model table + trim recipe. Old wording cited the wrong metric (file size, not row counts), the wrong flag (`--trim START_S END_S` doesn't exist on `skill run` — the params are `-p trim_start_ns / -p trim_end_ns`), and missed the actual cost driver (`kernels × avg_nvtx_depth` on the range-IEJoin in `nvtx_layer_breakdown.py:178-192`). Also drops the "30 s indexing for 250 MB" line — that conflated cache build with query work, and the query is the unbounded part.
- **`PRINCIPLES.md` §4.1 row 9** — new guard for `.sqlite` files left behind by an interrupted `nsys export`. The header gets zeroed but the file is newer than the `.nsys-rep`, so the mtime check in `profile.py:729-737` trusts it and every skill fails with `"file is not a database"`. Pre-check the magic header instead.
- **`M5_NVTX.md` §1** — replace `nvtx_layer_breakdown --max-rows 1` probe with `profile_health_manifest .nvtx.has_nvtx`. `--max-rows` bounds output rows only; the underlying IEJoin still scans everything, so the "single-row probe" can run for minutes on big profiles.

No code changes — docs only. Source of truth is `skills/analyze/references/`; the plugin redistributes from there at install time.

## Test plan

- [x] Edited source files at `skills/analyze/references/{PRINCIPLES,M5_NVTX}.md`
- [x] Mirrored to local plugin cache and `diff`'d byte-identical
- [x] §9 renders cleanly under `## §10 Acceptance Checklist`
- [ ] Re-trigger `/nsys-ai` on a fresh session post-merge to confirm new §9 loads