### PR TITLE
fix(skills): device-presence correctness (fingerprint.distributed fallback + overlap_breakdown enrichments)

### DIFF
--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -131,6 +131,20 @@ def get_fingerprint(conn: typing.Any) -> ProfileFingerprint:
         except DB_ERRORS:
             pass
 
+    # Fallback: NVTX_PAYLOAD_SCHEMAS doesn't always register collective schemas
+    # (observed on fastvideo Wan-T2V profiles, PyTorch 2.11). Multi-device
+    # kernel activity is a robust signal for single-node multi-rank training.
+    if not distributed and "CUPTI_ACTIVITY_KIND_KERNEL" in tables:
+        try:
+            cur = adapter.execute(
+                "SELECT COUNT(DISTINCT deviceId) FROM CUPTI_ACTIVITY_KIND_KERNEL"
+            )
+            row = cur.fetchone()
+            if row and row[0] is not None and int(row[0]) > 1:
+                distributed = True
+        except DB_ERRORS:
+            pass
+
     return ProfileFingerprint(
         framework=framework,
         distributed=distributed,

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -132,8 +132,9 @@ def get_fingerprint(conn: typing.Any) -> ProfileFingerprint:
             pass
 
     # Fallback: NVTX_PAYLOAD_SCHEMAS doesn't always register collective schemas
-    # (observed on fastvideo Wan-T2V profiles, PyTorch 2.11). Multi-device
-    # kernel activity is a robust signal for single-node multi-rank training.
+    # (observed on some PyTorch versions where NCCL skips the typed-payload
+    # path). Multi-device kernel activity is a robust signal for single-node
+    # multi-rank training.
     if not distributed and "CUPTI_ACTIVITY_KIND_KERNEL" in tables:
         try:
             cur = adapter.execute(

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -58,11 +58,10 @@ def _execute(conn, **kwargs):
             )
             if same_stream:
                 result["same_stream_diagnosis"] = [str(r["streamId"]) for r in same_stream]
-                # Surface the proportion so callers can distinguish "100 % of
-                # both kinds collide on one stream" (the worst case, as on the
-                # fastvideo profile) from "5 % cross-mix" (a near-clean
-                # multi-stream layout that just happens to have a few edge
-                # cases). Trigger above is unchanged; this is purely additive.
+                # Quantify the diagnosis: a near-clean multi-stream layout
+                # with a few stray cross-stream kernels reads identically
+                # to 100 % collision without these percentages. Trigger
+                # above is unchanged; the proportions are purely additive.
                 totals = prof._duckdb_query(
                     f"""
                     SELECT
@@ -92,10 +91,9 @@ def _execute(conn, **kwargs):
     except DB_ERRORS:
         _log.debug("Failed to enrich stream compute/nccl overlap", exc_info=True)
 
-    # Surface other GPUs that exist in the profile. The skill defaults to
-    # device=0 silently, so a multi-rank single-node profile (e.g. 4 GPUs)
-    # was previously invisible to the agent. With present_devices the agent
-    # knows to re-run with -p device=N for each rank if needed.
+    # Surface other GPUs that exist in the profile. Otherwise a multi-rank
+    # single-node profile is invisible to the agent (which only sees
+    # device=0 by default).
     try:
         kernel_tbl = prof.schema.kernel_table
         if kernel_tbl:
@@ -141,6 +139,30 @@ def _format(rows):
     if r.get("sync_ms"):
         lines.append(f"  ⚡ CPU Sync:     {r['sync_ms']:.1f}ms (global host-side blocking)")
     lines.append(f"  Kernels:       {r['compute_kernels']} compute + {r['nccl_kernels']} NCCL")
+
+    # Same-stream serialization warning — surfaced in textual output so it's
+    # visible without parsing JSON. Proportions added when available.
+    streams = r.get("same_stream_diagnosis")
+    if streams:
+        compute_pct = r.get("same_stream_compute_pct")
+        nccl_pct = r.get("same_stream_nccl_pct")
+        suffix = ""
+        if compute_pct is not None and nccl_pct is not None:
+            suffix = f" — {compute_pct}% of compute + {nccl_pct}% of NCCL"
+        lines.append(
+            f"  ⚠️ Same-stream:  stream(s) [{', '.join(streams)}] carry both"
+            f"{suffix} → overlap blocked"
+        )
+
+    # Multi-device hint — textual users miss the device list otherwise.
+    devs = r.get("present_devices") or []
+    if len(devs) > 1:
+        analyzed = r.get("device_id", 0)
+        others = [str(d) for d in devs if d != analyzed]
+        lines.append(
+            f"  Devices:       {analyzed} (analyzed); profile also has "
+            f"[{', '.join(others)}] — re-run with -p device=N for each"
+        )
     return "\n".join(lines)
 
 
@@ -169,10 +191,17 @@ def _to_findings(rows: list[dict]) -> list:
         )
         streams = r.get("same_stream_diagnosis")
         if streams:
+            compute_pct = r.get("same_stream_compute_pct")
+            nccl_pct = r.get("same_stream_nccl_pct")
             note += (
                 f" Streams [{', '.join(streams)}] run both NCCL and "
                 f"compute — overlap is impossible on same stream."
             )
+            if compute_pct is not None and nccl_pct is not None:
+                note += (
+                    f" ({compute_pct}% of compute and {nccl_pct}% of NCCL "
+                    f"share these streams.)"
+                )
 
         findings.append(
             Finding(

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -14,6 +14,12 @@ from ..base import Skill, SkillParam
 
 _log = logging.getLogger(__name__)
 
+# Case-insensitive NCCL kernel-name match against StringIds.value, reused
+# across three queries below. Keep the OR-of-LIKE form (rather than
+# `LOWER(...) LIKE`) so SQLite/DuckDB can still use a string-prefix index
+# if one exists on StringIds.value.
+_NCCL_LIKE = "(s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%')"
+
 
 def _execute(conn, **kwargs):
     from ...overlap import overlap_analysis
@@ -44,10 +50,8 @@ def _execute(conn, **kwargs):
             same_stream = prof._duckdb_query(
                 f"""
                 SELECT k.streamId,
-                    SUM(CASE WHEN s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%'
-                        THEN 1 ELSE 0 END) AS nccl_count,
-                    SUM(CASE WHEN NOT (s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%')
-                        THEN 1 ELSE 0 END) AS compute_count
+                    SUM(CASE WHEN {_NCCL_LIKE} THEN 1 ELSE 0 END) AS nccl_count,
+                    SUM(CASE WHEN NOT {_NCCL_LIKE} THEN 1 ELSE 0 END) AS compute_count
                 FROM {kernel_tbl} k
                 JOIN StringIds s ON k.shortName = s.id
                 WHERE k.deviceId = ? {trim_clause}
@@ -65,10 +69,8 @@ def _execute(conn, **kwargs):
                 totals = prof._duckdb_query(
                     f"""
                     SELECT
-                        SUM(CASE WHEN s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%'
-                            THEN 1 ELSE 0 END) AS nccl_total,
-                        SUM(CASE WHEN NOT (s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%')
-                            THEN 1 ELSE 0 END) AS compute_total
+                        SUM(CASE WHEN {_NCCL_LIKE} THEN 1 ELSE 0 END) AS nccl_total,
+                        SUM(CASE WHEN NOT {_NCCL_LIKE} THEN 1 ELSE 0 END) AS compute_total
                     FROM {kernel_tbl} k
                     JOIN StringIds s ON k.shortName = s.id
                     WHERE k.deviceId = ? {trim_clause}
@@ -93,7 +95,10 @@ def _execute(conn, **kwargs):
 
     # Surface other GPUs that exist in the profile. Otherwise a multi-rank
     # single-node profile is invisible to the agent (which only sees
-    # device=0 by default).
+    # device=0 by default). Intentionally profile-wide — NOT window-scoped —
+    # because "which devices exist" is a topology property, not a per-window
+    # one. A trim window that excludes a rank's activity should not hide
+    # that rank from the device list.
     try:
         kernel_tbl = prof.schema.kernel_table
         if kernel_tbl:
@@ -244,12 +249,18 @@ SKILL = Skill(
     description=(
         "Quantifies how much GPU compute overlaps with NCCL communication. "
         "Shows compute-only, NCCL-only, overlap, and idle time. "
-        "overlap_pct > 60% means NCCL is well-hidden behind compute."
+        "overlap_pct > 60% means NCCL is well-hidden behind compute. "
+        "Also detects same-stream serialization (compute and NCCL sharing a "
+        "single stream, which blocks overlap) and surfaces multi-GPU presence "
+        "via present_devices for profiles with more than one rank."
     ),
     category="communication",
     execute_fn=_execute,
     format_fn=_format,
     to_findings_fn=_to_findings,
     params=[SkillParam("device", "GPU device ID", "int", False, 0)],
-    tags=["overlap", "nccl", "compute", "communication", "distributed"],
+    tags=[
+        "overlap", "nccl", "compute", "communication", "distributed",
+        "multi-gpu", "same-stream", "stream-serialization",
+    ],
 )

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -58,8 +58,56 @@ def _execute(conn, **kwargs):
             )
             if same_stream:
                 result["same_stream_diagnosis"] = [str(r["streamId"]) for r in same_stream]
+                # Surface the proportion so callers can distinguish "100 % of
+                # both kinds collide on one stream" (the worst case, as on the
+                # fastvideo profile) from "5 % cross-mix" (a near-clean
+                # multi-stream layout that just happens to have a few edge
+                # cases). Trigger above is unchanged; this is purely additive.
+                totals = prof._duckdb_query(
+                    f"""
+                    SELECT
+                        SUM(CASE WHEN s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%'
+                            THEN 1 ELSE 0 END) AS nccl_total,
+                        SUM(CASE WHEN NOT (s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%')
+                            THEN 1 ELSE 0 END) AS compute_total
+                    FROM {kernel_tbl} k
+                    JOIN StringIds s ON k.shortName = s.id
+                    WHERE k.deviceId = ? {trim_clause}
+                    """,
+                    params,
+                )
+                if totals:
+                    nccl_total = totals[0]["nccl_total"] or 0
+                    compute_total = totals[0]["compute_total"] or 0
+                    nccl_same = sum((r["nccl_count"] or 0) for r in same_stream)
+                    compute_same = sum((r["compute_count"] or 0) for r in same_stream)
+                    if compute_total > 0:
+                        result["same_stream_compute_pct"] = round(
+                            100 * compute_same / compute_total, 1
+                        )
+                    if nccl_total > 0:
+                        result["same_stream_nccl_pct"] = round(
+                            100 * nccl_same / nccl_total, 1
+                        )
     except DB_ERRORS:
         _log.debug("Failed to enrich stream compute/nccl overlap", exc_info=True)
+
+    # Surface other GPUs that exist in the profile. The skill defaults to
+    # device=0 silently, so a multi-rank single-node profile (e.g. 4 GPUs)
+    # was previously invisible to the agent. With present_devices the agent
+    # knows to re-run with -p device=N for each rank if needed.
+    try:
+        kernel_tbl = prof.schema.kernel_table
+        if kernel_tbl:
+            devs = prof._duckdb_query(
+                f"SELECT DISTINCT deviceId FROM {kernel_tbl} ORDER BY deviceId"
+            )
+            if devs:
+                result["present_devices"] = [
+                    int(r["deviceId"]) for r in devs if r["deviceId"] is not None
+                ]
+    except DB_ERRORS:
+        _log.debug("Failed to enumerate present devices", exc_info=True)
 
     try:
         from ...skills.registry import get_skill

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -128,6 +128,60 @@ def test_distributed_single_device_stays_false():
     assert fp.distributed is False
 
 
+def test_distributed_empty_kernel_table_stays_false():
+    """Empty kernel table (no rows) must not flip distributed."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute("CREATE TABLE NsightSchemaMeta (version INTEGER)")
+    c.execute("CREATE TABLE StringIds (value TEXT)")
+    c.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+        "(correlationId INTEGER, deviceId INTEGER)"
+    )
+    conn.commit()
+
+    fp = get_fingerprint(conn)
+    assert fp.distributed is False
+
+
+def test_distributed_kernel_table_missing_device_column_does_not_crash():
+    """Very old schemas may lack the deviceId column. Fallback must
+    swallow the OperationalError and leave distributed unchanged."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute("CREATE TABLE NsightSchemaMeta (version INTEGER)")
+    c.execute("CREATE TABLE StringIds (value TEXT)")
+    c.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (correlationId INTEGER)"
+    )
+    c.execute("INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (1)")
+    conn.commit()
+
+    fp = get_fingerprint(conn)
+    # Doesn't crash; remains False because the fallback query errored out.
+    assert fp.distributed is False
+
+
+def test_distributed_payload_schema_takes_precedence_over_fallback():
+    """When NVTX_PAYLOAD_SCHEMAS already proves NCCL, the kernel-fallback
+    must not run (or at least not change the outcome)."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute("CREATE TABLE NsightSchemaMeta (version INTEGER)")
+    c.execute("CREATE TABLE StringIds (value TEXT)")
+    c.execute("CREATE TABLE NVTX_PAYLOAD_SCHEMAS (name TEXT)")
+    c.execute("INSERT INTO NVTX_PAYLOAD_SCHEMAS VALUES ('NCCL_thing')")
+    c.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+        "(correlationId INTEGER, deviceId INTEGER)"
+    )
+    c.execute("INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (1, 0)")
+    conn.commit()
+
+    fp = get_fingerprint(conn)
+    assert fp.distributed is True
+
+
 # ---------------------------------------------------------------------------
 # get_profile_id — content-derived stable identifier
 # ---------------------------------------------------------------------------

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -83,6 +83,51 @@ def test_legacy_fallback():
     assert fp.framework == "DeepSpeed"
 
 
+def test_distributed_kernel_device_fallback():
+    """Multi-device kernel activity should mark distributed=True even when
+    NVTX_PAYLOAD_SCHEMAS has no NCCL entry (observed on fastvideo profiles)."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute("CREATE TABLE NsightSchemaMeta (version INTEGER)")
+    c.execute("CREATE TABLE StringIds (value TEXT)")
+    c.execute("INSERT INTO StringIds VALUES ('forward')")
+    c.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+        "(correlationId INTEGER, deviceId INTEGER)"
+    )
+    for dev in (0, 1, 2, 3):
+        c.execute(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?, ?)", (dev, dev)
+        )
+    conn.commit()
+
+    fp = get_fingerprint(conn)
+    assert fp.distributed is True, (
+        "Expected fallback to detect 4 distinct deviceIds as distributed"
+    )
+
+
+def test_distributed_single_device_stays_false():
+    """A profile with kernels on only one device must remain distributed=False."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute("CREATE TABLE NsightSchemaMeta (version INTEGER)")
+    c.execute("CREATE TABLE StringIds (value TEXT)")
+    c.execute("INSERT INTO StringIds VALUES ('forward')")
+    c.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+        "(correlationId INTEGER, deviceId INTEGER)"
+    )
+    for i in range(5):
+        c.execute(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?, 0)", (i,)
+        )
+    conn.commit()
+
+    fp = get_fingerprint(conn)
+    assert fp.distributed is False
+
+
 # ---------------------------------------------------------------------------
 # get_profile_id — content-derived stable identifier
 # ---------------------------------------------------------------------------

--- a/tests/test_overlap_breakdown.py
+++ b/tests/test_overlap_breakdown.py
@@ -5,6 +5,11 @@ Covers the v0.2.4 additions:
 - `same_stream_compute_pct` / `same_stream_nccl_pct` quantify the
   proportion behind `same_stream_diagnosis`
 
+Note: several tests mutate the `minimal_nsys_conn` fixture (INSERT/UPDATE
+extra rows). This is safe today because conftest declares it function-scoped
+— each test gets a fresh in-memory connection. If anyone bumps the fixture
+to session scope, these mutations will leak between tests.
+
 The conftest's `minimal_nsys_conn` seed places 5 kernels on device 0:
 
     streamId=7  compute (cId=1,  shortName=1  → kernel_A)
@@ -70,7 +75,7 @@ def test_same_stream_proportions(minimal_nsys_conn):
     )
 
 
-def test_no_same_stream_no_proportions(minimal_nsys_conn):
+def test_clean_multi_stream_does_not_fire_diagnostic(minimal_nsys_conn):
     """Move the same-stream NCCL kernel to stream 8 so no stream has both
     compute and NCCL. The diagnostic must not fire and the proportions
     must not be emitted."""

--- a/tests/test_overlap_breakdown.py
+++ b/tests/test_overlap_breakdown.py
@@ -1,0 +1,118 @@
+"""Tests for overlap_breakdown skill enrichments.
+
+Covers the v0.2.4 additions:
+- `present_devices` field surfaces other GPUs in the profile
+- `same_stream_compute_pct` / `same_stream_nccl_pct` quantify the
+  proportion behind `same_stream_diagnosis`
+
+The conftest's `minimal_nsys_conn` seed places 5 kernels on device 0:
+
+    streamId=7  compute (cId=1,  shortName=1  → kernel_A)
+    streamId=7  compute (cId=2,  shortName=2  → kernel_B)
+    streamId=8  NCCL    (cId=10, shortName=10 → nccl_AllReduce_kernel)
+    streamId=7  NCCL    (cId=12, shortName=11 → nccl_ReduceScatter_kernel)
+    streamId=7  compute (cId=13, shortName=1  → kernel_A)
+
+So stream 7 has 3 compute + 1 NCCL (a same-stream candidate). Stream 8
+has 1 NCCL only (not same-stream). Across the device:
+    total compute = 3, total NCCL = 2
+    same-stream compute on stream 7 = 3 (100 %)
+    same-stream NCCL on stream 7 = 1 (50 %)
+"""
+
+import sqlite3
+
+from nsys_ai.skills.builtins.overlap_breakdown import SKILL
+
+
+def test_present_devices_single_device(minimal_nsys_conn):
+    rows = SKILL.execute_fn(minimal_nsys_conn)
+    assert rows, "overlap_breakdown returned no rows"
+    r = rows[0]
+    assert r.get("present_devices") == [0], (
+        f"Expected [0] for single-device fixture, got {r.get('present_devices')!r}"
+    )
+
+
+def test_present_devices_multi_device(minimal_nsys_conn):
+    """Add kernels on devices 1, 2, 3 and confirm all four are surfaced."""
+    c = minimal_nsys_conn.cursor()
+    # Append a compute kernel on each extra device. Same shortName as
+    # existing rows so the schema check holds.
+    for dev in (1, 2, 3):
+        c.execute(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES "
+            "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (100, dev, 17, 50 + dev, 10_000_000 + dev * 100, 11_000_000 + dev * 100,
+             1, 1, 32, 1, 1, 256, 1, 1),
+        )
+    minimal_nsys_conn.commit()
+
+    rows = SKILL.execute_fn(minimal_nsys_conn)
+    assert rows[0].get("present_devices") == [0, 1, 2, 3]
+
+
+def test_same_stream_proportions(minimal_nsys_conn):
+    """Stream 7 carries all 3 compute + 1 of 2 NCCL kernels →
+    same_stream_compute_pct = 100, same_stream_nccl_pct = 50."""
+    rows = SKILL.execute_fn(minimal_nsys_conn)
+    r = rows[0]
+    assert r.get("same_stream_diagnosis") == ["7"], (
+        f"Expected stream 7 flagged, got {r.get('same_stream_diagnosis')!r}"
+    )
+    assert r.get("same_stream_compute_pct") == 100.0, (
+        f"Expected 100.0 % of compute on stream 7, "
+        f"got {r.get('same_stream_compute_pct')!r}"
+    )
+    assert r.get("same_stream_nccl_pct") == 50.0, (
+        f"Expected 50.0 % of NCCL on stream 7, "
+        f"got {r.get('same_stream_nccl_pct')!r}"
+    )
+
+
+def test_no_same_stream_no_proportions(minimal_nsys_conn):
+    """Move the same-stream NCCL kernel to stream 8 so no stream has both
+    compute and NCCL. The diagnostic must not fire and the proportions
+    must not be emitted."""
+    c = minimal_nsys_conn.cursor()
+    # cId=12 is the NCCL kernel currently on stream 7. Move it.
+    c.execute(
+        "UPDATE CUPTI_ACTIVITY_KIND_KERNEL SET streamId = 8 "
+        "WHERE correlationId = 12"
+    )
+    minimal_nsys_conn.commit()
+
+    rows = SKILL.execute_fn(minimal_nsys_conn)
+    r = rows[0]
+    assert "same_stream_diagnosis" not in r, (
+        f"Diagnostic should not fire when no stream has both kinds "
+        f"(got {r.get('same_stream_diagnosis')!r})"
+    )
+    assert "same_stream_compute_pct" not in r
+    assert "same_stream_nccl_pct" not in r
+
+
+def test_present_devices_survives_empty_kernel_table():
+    """If the kernel table exists but is empty, present_devices should
+    either be empty or absent — not crash."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute("CREATE TABLE NsightSchemaMeta (version INTEGER)")
+    c.execute("CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT)")
+    c.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+        "(globalPid INTEGER, deviceId INTEGER, streamId INTEGER, "
+        " correlationId INTEGER, start INTEGER, \"end\" INTEGER, "
+        " shortName INTEGER, demangledName INTEGER, "
+        " gridX INTEGER, gridY INTEGER, gridZ INTEGER, "
+        " blockX INTEGER, blockY INTEGER, blockZ INTEGER)"
+    )
+    conn.commit()
+
+    rows = SKILL.execute_fn(conn)
+    # Either an error row (no kernel activity) or normal row with no
+    # present_devices key. Both are acceptable; the assertion is that
+    # we don't crash.
+    assert rows is not None
+    if rows and "error" not in rows[0]:
+        assert rows[0].get("present_devices", []) == []

--- a/tests/test_overlap_breakdown.py
+++ b/tests/test_overlap_breakdown.py
@@ -116,3 +116,90 @@ def test_present_devices_survives_empty_kernel_table():
     assert rows is not None
     if rows and "error" not in rows[0]:
         assert rows[0].get("present_devices", []) == []
+
+
+# ---------------------------------------------------------------------------
+# Textual rendering — _format must surface the new fields so users running
+# the skill without --format json see same-stream warnings and multi-device
+# hints inline.
+# ---------------------------------------------------------------------------
+
+
+def test_format_shows_same_stream_warning_with_pct(minimal_nsys_conn):
+    """_format must emit the ⚠️ Same-stream line with the proportion."""
+    rows = SKILL.execute_fn(minimal_nsys_conn)
+    text = SKILL.format_fn(rows)
+    assert "Same-stream" in text, f"missing warning line in:\n{text}"
+    assert "[7]" in text, "expected stream id 7 in warning"
+    assert "100" in text and "50" in text, (
+        f"expected compute_pct=100 and nccl_pct=50 in warning, got:\n{text}"
+    )
+
+
+def test_format_shows_multi_device_hint(minimal_nsys_conn):
+    """When >1 device exists, _format hints at other ranks."""
+    c = minimal_nsys_conn.cursor()
+    for dev in (1, 2, 3):
+        c.execute(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES "
+            "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (100, dev, 17, 50 + dev, 10_000_000 + dev * 100, 11_000_000 + dev * 100,
+             1, 1, 32, 1, 1, 256, 1, 1),
+        )
+    minimal_nsys_conn.commit()
+
+    text = SKILL.format_fn(SKILL.execute_fn(minimal_nsys_conn))
+    assert "Devices:" in text, f"missing devices line in:\n{text}"
+    assert "1, 2, 3" in text, f"expected other ranks listed; got:\n{text}"
+
+
+def test_format_no_multi_device_hint_single_device(minimal_nsys_conn):
+    """Single-device profile must not emit the multi-device hint."""
+    text = SKILL.format_fn(SKILL.execute_fn(minimal_nsys_conn))
+    assert "Devices:" not in text, f"unexpected multi-device hint:\n{text}"
+
+
+# ---------------------------------------------------------------------------
+# Findings — _to_findings should bake the proportions into the note so the
+# evidence layer downstream of analyze --format json gets the context.
+# ---------------------------------------------------------------------------
+
+
+def test_findings_note_includes_same_stream_pct(minimal_nsys_conn):
+    rows = SKILL.execute_fn(minimal_nsys_conn)
+    findings = SKILL.to_findings_fn(rows)
+    # Look for the low-overlap finding (always emitted in this fixture
+    # because overlap_pct is < 30 with same-stream serialization).
+    low_overlap = [f for f in findings if "Low Compute/NCCL Overlap" in f.label]
+    assert low_overlap, f"expected a low-overlap finding, got: {[f.label for f in findings]}"
+    note = low_overlap[0].note
+    # Proportion strings must appear so consumers can quantify the warning
+    # without re-querying the skill output.
+    assert "100" in note and "50" in note, (
+        f"expected 100% / 50% proportions in finding note, got:\n{note}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trim-aware path — passing -p trim_start_ns / trim_end_ns must still emit
+# the new fields and proportions, scoped to the trimmed window.
+# ---------------------------------------------------------------------------
+
+
+def test_trim_window_preserves_enrichments(minimal_nsys_conn):
+    """All five fixture kernels fall in [1000000, 9000000] ns; a trim
+    that includes only stream-7 same-stream rows (4_000_000..6_000_000)
+    catches just the NCCL-on-stream-7 (cId=12, 4.5..5.5 ms) — proportions
+    should still emit if both kinds exist in the window."""
+    rows = SKILL.execute_fn(
+        minimal_nsys_conn,
+        trim_start_ns=500_000,
+        trim_end_ns=9_500_000,  # wide enough to include all 5 kernels
+    )
+    r = rows[0]
+    # present_devices is profile-wide, not window-scoped → always [0].
+    assert r.get("present_devices") == [0]
+    # Same-stream diagnosis should still fire with the wide trim.
+    assert r.get("same_stream_diagnosis") == ["7"]
+    assert r.get("same_stream_compute_pct") == 100.0
+    assert r.get("same_stream_nccl_pct") == 50.0


### PR DESCRIPTION
## Summary

Three additive skill-correctness fixes surfaced while drilling a 4-GPU fastvideo profile (\`perf_compile.sqlite\`, 677 s wall, 10 M NVTX events). All three are documented in \`docs/roadmap.md\` §4 B "Skill fidelity gaps"

All changes are **field additions**; no existing field semantics or skill output shapes change.

### Fix 1 — \`fingerprint.distributed\` fallback
Add \`COUNT(DISTINCT deviceId) > 1\` from the kernel table as a fallback signal when \`NVTX_PAYLOAD_SCHEMAS\` doesn't register a collective schema. Previously reported \`distributed: False\` for a clearly multi-rank 4-GPU profile.

### Fix 2 — \`overlap_breakdown.present_devices\`
The skill silently defaults to \`device=0\`; multi-rank single-node profiles were invisible to the agent. Now emits \`present_devices: [0, 1, 2, 3]\` so callers know to re-run per-rank if needed.

### Fix 3 — \`overlap_breakdown.same_stream_{compute,nccl}_pct\`
The existing \`same_stream_diagnosis\` trigger (\`HAVING nccl_count > 0 AND compute_count > 0\`) fires on a single mixed kernel. Adding the proportion lets callers distinguish "100 % of each on one stream" (worst case, fastvideo) from "5 % cross-mix" (mostly clean).

## Verification

End-to-end on the fastvideo profile:

\`\`\`
fingerprint.distributed:   False → True
present_devices:           (missing) → [0, 1, 2, 3]
same_stream_diagnosis:     ["7"] (unchanged)
same_stream_compute_pct:   (missing) → 100.0
same_stream_nccl_pct:      (missing) → 100.0
\`\`\`

## Test plan

- [x] 18 existing fingerprint tests pass
- [x] 2 new fingerprint tests added (4-device fallback fires, 1-device stays False)
- [x] All 85 tests in fingerprint / overlap_analysis / profile_health_manifest / skill_manifest pass
- [x] \`ruff check\` clean on all touched files
- [x] End-to-end verified on real 1.8 GB / 10 M NVTX profile (\`perf_compile.sqlite\`)
