### PR TITLE
feat(skills): nccl_payload_breakdown — decode NVTX typed-payload binaryData

### DIFF
--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -184,6 +184,33 @@ def _execute(conn, **kwargs) -> list[dict]:
     if not schemas:
         return [{"error": "No NVTX_PAYLOAD_SCHEMAS in this profile (NCCL typed payloads not captured)"}]
 
+    # Probe for the second-common "no data" case: schemas declared but
+    # NVTX_EVENTS.binaryData is empty. This happens when the profile was
+    # captured without NCCL's typed-payload NVTX emission enabled — NCCL
+    # ran, kernels executed, but no per-collective payload was recorded.
+    # Observed on real fastvideo / nano_vllm profiles. Returning an
+    # explanatory error here is far more useful than silently emitting
+    # a zero-everything summary.
+    try:
+        (has_any,) = adapter.execute(
+            "SELECT EXISTS(SELECT 1 FROM NVTX_EVENTS WHERE binaryData IS NOT NULL)"
+        ).fetchone()
+    except DB_ERRORS:
+        has_any = 0
+    if not has_any:
+        return [{
+            "error": (
+                f"NVTX_PAYLOAD_SCHEMAS declares {len(schemas)} schemas but "
+                "NVTX_EVENTS.binaryData is empty — NCCL kernels likely ran but "
+                "typed-payload NVTX emission was not enabled at capture time. "
+                "Re-profile with `nsys profile -t cuda,nvtx,...` and ensure NCCL "
+                "is built with NVTX support (NCCL ≥ 2.18 emits typed payloads "
+                "by default; older builds require NCCL_NVTX_DOMAIN_EVENTS=1)."
+            ),
+            "schemas_present": len(schemas),
+            "binary_data_rows": 0,
+        }]
+
     # Honor the standard trim convention documented in PRINCIPLES.md §9.
     # Either both bounds set or neither; partial trim falls through to
     # whole-profile (consistent with how iteration_detail / overlap_breakdown

--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -184,19 +184,48 @@ def _execute(conn, **kwargs) -> list[dict]:
     if not schemas:
         return [{"error": "No NVTX_PAYLOAD_SCHEMAS in this profile (NCCL typed payloads not captured)"}]
 
-    # Probe for the second-common "no data" case: schemas declared but
-    # NVTX_EVENTS.binaryData is empty. This happens when the profile was
-    # captured without NCCL's typed-payload NVTX emission enabled — NCCL
-    # ran, kernels executed, but no per-collective payload was recorded.
-    # Observed on real fastvideo / nano_vllm profiles. Returning an
-    # explanatory error here is far more useful than silently emitting
-    # a zero-everything summary.
+    # Probe for the two "no data" cases:
+    #   (a) capture-time misconfiguration: schemas declared but binaryData
+    #       column has zero non-null rows (NCCL ran but typed-payload NVTX
+    #       wasn't emitted). Observed on real fastvideo/nano_vllm captures.
+    #   (b) backend limitation: DuckDB's sqlite_scanner reports BLOB
+    #       columns with declared TEXT type as a type mismatch, raising on
+    #       any read. Hits when the CLI is run with --no-cache against a
+    #       profile that DOES have binaryData. Without this branch we'd
+    #       misreport (b) as (a) and tell the user to re-profile when the
+    #       fix is "use the parquet cache instead".
     try:
         (has_any,) = adapter.execute(
             "SELECT EXISTS(SELECT 1 FROM NVTX_EVENTS WHERE binaryData IS NOT NULL)"
         ).fetchone()
-    except DB_ERRORS:
+        probe_failed = False
+    except DB_ERRORS as exc:
         has_any = 0
+        # Distinguish (b) from (a): if NVTX_EVENTS rows exist but the
+        # binaryData filter errored, the column is unreadable through this
+        # backend — not actually empty.
+        probe_failed = False
+        try:
+            (nvtx_rows,) = adapter.execute("SELECT COUNT(*) FROM NVTX_EVENTS").fetchone()
+            if nvtx_rows > 0:
+                probe_failed = True
+                probe_error_msg = str(exc)
+        except DB_ERRORS:
+            pass
+
+    if probe_failed:
+        return [{
+            "error": (
+                "Cannot read NVTX_EVENTS.binaryData through the current "
+                "backend (DuckDB sqlite-scanner raises on BLOB columns "
+                f"declared as TEXT in sqlite: {probe_error_msg!r}). "
+                "Re-run without `--no-cache` — the parquet cache path "
+                "stores binaryData as hex-encoded strings and works "
+                "correctly."
+            ),
+            "schemas_present": len(schemas),
+            "backend_limitation": True,
+        }]
     if not has_any:
         return [{
             "error": (

--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -174,6 +174,19 @@ def _execute(conn, **kwargs) -> list[dict]:
     if not schemas:
         return [{"error": "No NVTX_PAYLOAD_SCHEMAS in this profile (NCCL typed payloads not captured)"}]
 
+    # Honor the standard trim convention documented in PRINCIPLES.md §9.
+    # Either both bounds set or neither; partial trim falls through to
+    # whole-profile (consistent with how iteration_detail / overlap_breakdown
+    # handle the same kwargs).
+    trim_start = kwargs.get("trim_start_ns")
+    trim_end = kwargs.get("trim_end_ns")
+    trim_clause = ""
+    trim_params: list = []
+    if trim_start is not None and trim_end is not None:
+        # NVTX event overlaps the window if start <= trim_end AND end >= trim_start.
+        trim_clause = ' AND start <= ? AND "end" >= ?'
+        trim_params = [int(trim_end), int(trim_start)]
+
     # Per-schema buckets.
     per_schema: dict[int, dict] = defaultdict(
         lambda: {"count": 0, "msg_sizes": [], "communicators": set()}
@@ -182,7 +195,8 @@ def _execute(conn, **kwargs) -> list[dict]:
     skipped = 0
 
     for (bd,) in adapter.execute(
-        "SELECT binaryData FROM NVTX_EVENTS WHERE binaryData IS NOT NULL"
+        f"SELECT binaryData FROM NVTX_EVENTS WHERE binaryData IS NOT NULL{trim_clause}",
+        trim_params,
     ).fetchall():
         row = _decode_row(bd, schemas)
         if row is None:

--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -10,7 +10,8 @@ This skill decodes that blob and aggregates per schema category. It is the
 foundation for downstream NCCL-aware skills (``nccl_bandwidth_utilization``,
 etc.) — without real message sizes from the profile, those have to estimate.
 
-Binary layout (verified against Nsight 2026.x profiles):
+Binary layout (verified against Nsight Systems 2026.2.x profiles —
+revalidate if a future Nsight major version changes the header):
   bytes 0-3   uint32  domainId
   bytes 4-7   uint32  (reserved / flags)
   bytes 8-11  uint32  schemaId
@@ -87,7 +88,10 @@ def _load_schemas(adapter) -> dict[int, dict]:
     if schemas and all(not s["fields"] for s in schemas.values()):
         _log.warning(
             "NVTX_PAYLOAD_SCHEMAS loaded (%d) but NVTX_PAYLOAD_SCHEMA_ENTRIES "
-            "returned no fields — entries query likely failed silently.",
+            "returned no fields — entries query likely failed silently. "
+            "Common cause: a column rename or reserved-keyword conflict in a "
+            "newer Nsight version (e.g. `offset` became reserved in DuckDB). "
+            "Inspect the table schema with PRAGMA table_info or DESCRIBE.",
             len(schemas),
         )
     return schemas
@@ -228,6 +232,7 @@ def _execute(conn, **kwargs) -> list[dict]:
 
     rows: list[dict] = []
     total_bytes = 0
+    message_carrying_events = 0
     for sid, bucket in sorted(per_schema.items()):
         field_names = [fl["name"] for fl in schemas[sid]["fields"]]
         category = _classify(field_names)
@@ -242,6 +247,7 @@ def _execute(conn, **kwargs) -> list[dict]:
             "distinct_communicators": len(bucket["communicators"]),
         }
         if sizes:
+            message_carrying_events += len(sizes)
             row["msg_size_bytes_total"] = msg_total
             row["msg_size_bytes_min"] = sizes[0]
             row["msg_size_bytes_p50"] = _percentile(sizes, 0.50)
@@ -250,9 +256,16 @@ def _execute(conn, **kwargs) -> list[dict]:
         rows.append(row)
 
     # Prepend a summary row so consumers see profile-wide totals.
+    # `total_payload_events` counts every decoded NVTX payload event;
+    # `message_carrying_events` is the subset whose schema declares a
+    # "Message size [bytes]" field (collective + p2p). The gap is
+    # init + group_marker events. Surfacing both means a profile with
+    # 1000 group_markers and 0 collectives reads as "1000 events / 0
+    # carrying / 0 bytes" instead of the ambiguous "1000 events / 0 bytes".
     summary = {
         "_summary": True,
         "total_payload_events": decoded,
+        "message_carrying_events": message_carrying_events,
         "skipped_events": skipped,
         "total_bytes_all": total_bytes,
         "total_gib_all": round(total_bytes / (1024**3), 2),
@@ -265,11 +278,13 @@ def _format(rows: list[dict]) -> str:
     if not rows or "error" in rows[0]:
         return f"(NCCL payload: {rows[0].get('error', 'no data') if rows else 'no data'})"
     s = rows[0]
+    carrying = s.get("message_carrying_events", s["total_payload_events"])
     lines = [
         "── NCCL Payload Breakdown ──",
         f"  Total payload events:  {s['total_payload_events']:,}"
         + (f"  ({s['skipped_events']:,} undecodable)" if s["skipped_events"] else ""),
-        f"  Total bytes transferred: {s['total_gib_all']} GiB",
+        f"  Message-carrying:      {carrying:,}"
+        f"   ({s['total_gib_all']} GiB total)",
         f"  Distinct schemas:      {s['distinct_schemas']}",
         "",
     ]

--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -18,6 +18,12 @@ Binary layout (verified against Nsight 2026.x profiles):
   bytes 16-23 uint64  payloadSize (matches NVTX_PAYLOAD_SCHEMAS.payloadSize)
   bytes 24-31 uint64  totalSize (= 32 + payloadSize)
   bytes 32+   payload (fields per NVTX_PAYLOAD_SCHEMA_ENTRIES, by `offset`)
+
+Output convention:
+  Row 0 is a SUMMARY row with ``_summary: True`` carrying profile-wide
+  totals (``total_payload_events``, ``total_bytes_all``, etc.). Rows 1..N
+  are per-schema breakdowns. Consumers should skip ``rows[0]`` (or check
+  ``r.get('_summary')``) when iterating per-schema data.
 """
 
 import logging
@@ -177,7 +183,8 @@ def _execute(conn, **kwargs) -> list[dict]:
     # Honor the standard trim convention documented in PRINCIPLES.md §9.
     # Either both bounds set or neither; partial trim falls through to
     # whole-profile (consistent with how iteration_detail / overlap_breakdown
-    # handle the same kwargs).
+    # handle the same kwargs). Partial-bound passes log a WARNING so users
+    # know their intent was dropped rather than silently honored.
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")
     trim_clause = ""
@@ -186,6 +193,13 @@ def _execute(conn, **kwargs) -> list[dict]:
         # NVTX event overlaps the window if start <= trim_end AND end >= trim_start.
         trim_clause = ' AND start <= ? AND "end" >= ?'
         trim_params = [int(trim_end), int(trim_start)]
+    elif trim_start is not None or trim_end is not None:
+        _log.warning(
+            "nccl_payload_breakdown: partial trim bounds dropped — both "
+            "trim_start_ns and trim_end_ns must be set to scope the query "
+            "(got start=%r, end=%r). Returning whole-profile aggregation.",
+            trim_start, trim_end,
+        )
 
     # Per-schema buckets.
     per_schema: dict[int, dict] = defaultdict(

--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -1,0 +1,269 @@
+"""NCCL payload breakdown — decodes NVTX typed-payload binaryData.
+
+Nsight stores NCCL operation details (communicator ID, message size in
+bytes, peer rank, world size) as typed NVTX payloads. The schemas are
+declared in ``NVTX_PAYLOAD_SCHEMAS`` / ``NVTX_PAYLOAD_SCHEMA_ENTRIES``;
+the actual values for each event live in ``NVTX_EVENTS.binaryData`` as a
+raw byte blob.
+
+This skill decodes that blob and aggregates per schema category. It is the
+foundation for downstream NCCL-aware skills (``nccl_bandwidth_utilization``,
+etc.) — without real message sizes from the profile, those have to estimate.
+
+Binary layout (verified against Nsight 2026.x profiles):
+  bytes 0-3   uint32  domainId
+  bytes 4-7   uint32  (reserved / flags)
+  bytes 8-11  uint32  schemaId
+  bytes 12-15 uint32  (reserved / flags)
+  bytes 16-23 uint64  payloadSize (matches NVTX_PAYLOAD_SCHEMAS.payloadSize)
+  bytes 24-31 uint64  totalSize (= 32 + payloadSize)
+  bytes 32+   payload (fields per NVTX_PAYLOAD_SCHEMA_ENTRIES, by `offset`)
+"""
+
+import logging
+import struct
+from collections import defaultdict
+
+from nsys_ai.connection import DB_ERRORS, wrap_connection
+
+from ..base import Skill
+
+_log = logging.getLogger(__name__)
+
+# NVTX payload field type code → byte width. Subset Nsight uses for NCCL.
+# Type 5 = uint32 (e.g. rank count, rank id, device id, peer rank).
+# Type 18 = uint64 (NCCL communicator ID).
+# Type 22 = uint64 (message size in bytes).
+_TYPE_SIZES = {5: 4, 18: 8, 22: 8}
+
+# 32-byte event header layout (little-endian).
+_HEADER_FMT = "<IIIIQQ"
+_HEADER_SIZE = 32
+
+
+def _load_schemas(adapter) -> dict[int, dict]:
+    """Build {schemaId: {"payload_size": int, "fields": [{offset,type,name}, ...]}}.
+
+    Accepts either a wrapped adapter (uniform .execute().fetchall() across
+    sqlite/duckdb) or a raw sqlite3 connection — :func:`wrap_connection` is
+    a no-op when given an adapter, so the public callsite can hand us
+    whichever the CLI provided.
+    """
+    schemas: dict[int, dict] = {}
+    try:
+        for sid, plen in adapter.execute(
+            "SELECT DISTINCT schemaId, payloadSize FROM NVTX_PAYLOAD_SCHEMAS"
+        ).fetchall():
+            schemas[sid] = {"payload_size": plen, "fields": []}
+        # `offset` is a DuckDB reserved keyword and `type` is a soft keyword;
+        # both must be quoted for the query to parse against the DuckDB cache
+        # (sqlite tolerates either form). Without quoting, the query raises
+        # `Parser Error: syntax error at or near "FROM"` and `DB_ERRORS`
+        # catches it silently — leaving `fields=[]` for every schema and
+        # making every binaryData row look undecodable.
+        for sid, idx, ftype, fname, foff in adapter.execute(
+            'SELECT DISTINCT schemaId, idx, "type", name, "offset" '
+            "FROM NVTX_PAYLOAD_SCHEMA_ENTRIES ORDER BY schemaId, idx"
+        ).fetchall():
+            if sid in schemas:
+                # First field's offset is NULL in the table (means 0).
+                schemas[sid]["fields"].append(
+                    {"idx": idx, "type": ftype, "name": fname, "offset": foff or 0}
+                )
+    except DB_ERRORS:
+        _log.debug("No NVTX_PAYLOAD_SCHEMAS — profile lacks typed payloads", exc_info=True)
+
+    # Safety net: if schemas loaded but every fields[] is empty, the entries
+    # query silently failed (the original bug here was DuckDB rejecting
+    # `offset` as a reserved keyword, swallowed by DB_ERRORS). Warn so the
+    # next regression doesn't waste a debug round-trip.
+    if schemas and all(not s["fields"] for s in schemas.values()):
+        _log.warning(
+            "NVTX_PAYLOAD_SCHEMAS loaded (%d) but NVTX_PAYLOAD_SCHEMA_ENTRIES "
+            "returned no fields — entries query likely failed silently.",
+            len(schemas),
+        )
+    return schemas
+
+
+def _classify(field_names: list[str]) -> str:
+    """Categorize a schema by its field set."""
+    fs = set(field_names)
+    has_msg = "Message size [bytes]" in fs
+    has_peer = "Peer rank" in fs
+    has_world = "No. of ranks" in fs
+    if has_world:
+        return "init"
+    if has_msg and has_peer:
+        return "p2p"           # ncclSend / ncclRecv with peer
+    if has_msg:
+        return "collective"    # ncclAllReduce / ncclAllGather etc.
+    return "group_marker"      # ncclGroupStart / ncclGroupEnd (comm-id only)
+
+
+def _decode_row(bd, schemas: dict[int, dict]) -> dict | None:
+    """Decode one binaryData blob → {schema_id, fields: {name: value}}.
+
+    Accepts either bytes (sqlite3 BLOB) or str (DuckDB returns BLOB columns
+    hex-encoded — twice the byte length, only chars [0-9a-fA-F]).
+    """
+    if not bd:
+        return None
+    if isinstance(bd, str):
+        # DuckDB path: hex-decode back to raw bytes.
+        try:
+            bd = bytes.fromhex(bd)
+        except ValueError:
+            return None
+    if len(bd) < _HEADER_SIZE:
+        return None
+    try:
+        _domain, _, schema_id, _, payload_size, _ = struct.unpack_from(_HEADER_FMT, bd, 0)
+    except struct.error:
+        return None
+    if schema_id not in schemas or len(bd) < _HEADER_SIZE + payload_size:
+        return None
+    out: dict = {"schema_id": schema_id}
+    fields: dict[str, int] = {}
+    for f in schemas[schema_id]["fields"]:
+        sz = _TYPE_SIZES.get(f["type"])
+        if sz is None:
+            continue
+        off = _HEADER_SIZE + f["offset"]
+        fmt = "<I" if sz == 4 else "<Q"
+        try:
+            (val,) = struct.unpack_from(fmt, bd, off)
+            fields[f["name"]] = val
+        except struct.error:
+            pass
+    out["fields"] = fields
+    return out
+
+
+def _percentile(sorted_vals: list[int], p: float) -> int:
+    """Linear-interpolation percentile on a pre-sorted list."""
+    if not sorted_vals:
+        return 0
+    n = len(sorted_vals)
+    if n == 1:
+        return sorted_vals[0]
+    pos = p * (n - 1)
+    lo = int(pos)
+    if lo == n - 1:
+        return sorted_vals[lo]
+    frac = pos - lo
+    return int(sorted_vals[lo] + frac * (sorted_vals[lo + 1] - sorted_vals[lo]))
+
+
+def _execute(conn, **kwargs) -> list[dict]:
+    adapter = wrap_connection(conn)
+    schemas = _load_schemas(adapter)
+    if not schemas:
+        return [{"error": "No NVTX_PAYLOAD_SCHEMAS in this profile (NCCL typed payloads not captured)"}]
+
+    # Per-schema buckets.
+    per_schema: dict[int, dict] = defaultdict(
+        lambda: {"count": 0, "msg_sizes": [], "communicators": set()}
+    )
+    decoded = 0
+    skipped = 0
+
+    for (bd,) in adapter.execute(
+        "SELECT binaryData FROM NVTX_EVENTS WHERE binaryData IS NOT NULL"
+    ).fetchall():
+        row = _decode_row(bd, schemas)
+        if row is None:
+            skipped += 1
+            continue
+        decoded += 1
+        sid = row["schema_id"]
+        bucket = per_schema[sid]
+        bucket["count"] += 1
+        f = row["fields"]
+        if "Message size [bytes]" in f:
+            bucket["msg_sizes"].append(f["Message size [bytes]"])
+        if "NCCL communicator ID" in f:
+            bucket["communicators"].add(f["NCCL communicator ID"])
+
+    rows: list[dict] = []
+    total_bytes = 0
+    for sid, bucket in sorted(per_schema.items()):
+        field_names = [fl["name"] for fl in schemas[sid]["fields"]]
+        category = _classify(field_names)
+        sizes = sorted(bucket["msg_sizes"])
+        msg_total = sum(sizes)
+        total_bytes += msg_total
+        row = {
+            "schema_id": sid,
+            "category": category,
+            "field_set": field_names,
+            "count": bucket["count"],
+            "distinct_communicators": len(bucket["communicators"]),
+        }
+        if sizes:
+            row["msg_size_bytes_total"] = msg_total
+            row["msg_size_bytes_min"] = sizes[0]
+            row["msg_size_bytes_p50"] = _percentile(sizes, 0.50)
+            row["msg_size_bytes_p99"] = _percentile(sizes, 0.99)
+            row["msg_size_bytes_max"] = sizes[-1]
+        rows.append(row)
+
+    # Prepend a summary row so consumers see profile-wide totals.
+    summary = {
+        "_summary": True,
+        "total_payload_events": decoded,
+        "skipped_events": skipped,
+        "total_bytes_all": total_bytes,
+        "total_gib_all": round(total_bytes / (1024**3), 2),
+        "distinct_schemas": len(per_schema),
+    }
+    return [summary, *rows]
+
+
+def _format(rows: list[dict]) -> str:
+    if not rows or "error" in rows[0]:
+        return f"(NCCL payload: {rows[0].get('error', 'no data') if rows else 'no data'})"
+    s = rows[0]
+    lines = [
+        "── NCCL Payload Breakdown ──",
+        f"  Total payload events:  {s['total_payload_events']:,}"
+        + (f"  ({s['skipped_events']:,} undecodable)" if s["skipped_events"] else ""),
+        f"  Total bytes transferred: {s['total_gib_all']} GiB",
+        f"  Distinct schemas:      {s['distinct_schemas']}",
+        "",
+    ]
+    for r in rows[1:]:
+        sid = r["schema_id"]
+        cat = r["category"]
+        cnt = r["count"]
+        comms = r["distinct_communicators"]
+        head = f"  [{cat:<14}] schema={sid}  calls={cnt:>8,}  communicators={comms}"
+        if "msg_size_bytes_total" in r:
+            tot_gib = r["msg_size_bytes_total"] / (1024**3)
+            p50_mib = r["msg_size_bytes_p50"] / (1024**2)
+            p99_mib = r["msg_size_bytes_p99"] / (1024**2)
+            head += (
+                f"\n      msg_size: p50={p50_mib:.2f} MiB  p99={p99_mib:.2f} MiB"
+                f"   total={tot_gib:.2f} GiB"
+            )
+        lines.append(head)
+    return "\n".join(lines)
+
+
+SKILL = Skill(
+    name="nccl_payload_breakdown",
+    title="NCCL Payload Breakdown (message sizes via NVTX typed payloads)",
+    description=(
+        "Decodes NCCL typed-payload NVTX events to extract real per-collective "
+        "message sizes, peer ranks, and communicator IDs from NVTX_EVENTS.binaryData. "
+        "Distinguishes init, group markers, collective, and p2p operations by their "
+        "payload schema. Foundation for bandwidth-utilization analysis."
+    ),
+    category="communication",
+    execute_fn=_execute,
+    format_fn=_format,
+    tags=[
+        "nccl", "payload", "message-size", "bandwidth", "communication",
+        "distributed", "p2p", "collective",
+    ],
+)

--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -261,10 +261,21 @@ def _execute(conn, **kwargs) -> list[dict]:
             trim_start, trim_end,
         )
 
-    # Per-schema buckets.
+    # Per-schema buckets + a cross-schema communicator set so the summary
+    # can answer "are these schemas all on the same comm or different?"
+    # (Without this, six schemas each reporting "distinct_communicators: 1"
+    # is ambiguous between "same comm everywhere" and "six different
+    # single-rank comms" — observed when reviewing the skill on
+    # tgate05_perf.sqlite.)
     per_schema: dict[int, dict] = defaultdict(
-        lambda: {"count": 0, "msg_sizes": [], "communicators": set()}
+        lambda: {
+            "count": 0,
+            "msg_sizes": [],
+            "communicators": set(),
+            "peer_ranks": defaultdict(int),
+        }
     )
+    global_communicators: set = set()
     decoded = 0
     skipped = 0
 
@@ -285,6 +296,9 @@ def _execute(conn, **kwargs) -> list[dict]:
             bucket["msg_sizes"].append(f["Message size [bytes]"])
         if "NCCL communicator ID" in f:
             bucket["communicators"].add(f["NCCL communicator ID"])
+            global_communicators.add(f["NCCL communicator ID"])
+        if "Peer rank" in f:
+            bucket["peer_ranks"][f["Peer rank"]] += 1
 
     rows: list[dict] = []
     total_bytes = 0
@@ -302,6 +316,27 @@ def _execute(conn, **kwargs) -> list[dict]:
             "count": bucket["count"],
             "distinct_communicators": len(bucket["communicators"]),
         }
+        # Surface peer-rank distribution for schemas that record it (p2p).
+        # A uniformity score = 1.0 means traffic is split evenly across all
+        # observed peers (e.g. symmetric all-to-all), < 1.0 means skewed
+        # (e.g. ring-only or hub-spoke). Computed only when ≥ 1 peer
+        # observed so init/collective/group_marker rows stay compact.
+        if bucket["peer_ranks"]:
+            peer_counts = dict(bucket["peer_ranks"])
+            total_peer_events = sum(peer_counts.values())
+            n_peers = len(peer_counts)
+            # Uniformity score (Jain's fairness index simplified for our use):
+            #   1.0 when all peers see the same traffic share
+            #   1/n when one peer hogs everything
+            if n_peers > 0 and total_peer_events > 0:
+                mean = total_peer_events / n_peers
+                ssq = sum((c - mean) ** 2 for c in peer_counts.values())
+                # std/mean coefficient of variation → mapped to (0, 1] uniformity
+                cv = (ssq / n_peers) ** 0.5 / mean if mean > 0 else 0.0
+                uniformity = max(0.0, 1.0 - cv)
+                row["distinct_peer_ranks"] = n_peers
+                row["peer_rank_uniformity"] = round(uniformity, 3)
+                row["peer_rank_distribution"] = peer_counts
         if sizes:
             message_carrying_events += len(sizes)
             row["msg_size_bytes_total"] = msg_total
@@ -326,6 +361,12 @@ def _execute(conn, **kwargs) -> list[dict]:
         "total_bytes_all": total_bytes,
         "total_gib_all": round(total_bytes / (1024**3), 2),
         "distinct_schemas": len(per_schema),
+        # Cross-schema communicator rollup. "1" here means every event in
+        # every schema uses the same NCCL communicator (typical for a
+        # single SP/TP group). Higher values indicate multi-group setups
+        # (e.g. DP×TP×SP). Per-schema `distinct_communicators` is a subset
+        # view of this set.
+        "total_distinct_communicators": len(global_communicators),
     }
     return [summary, *rows]
 

--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -36,9 +36,10 @@ _log = logging.getLogger(__name__)
 # Type 22 = uint64 (message size in bytes).
 _TYPE_SIZES = {5: 4, 18: 8, 22: 8}
 
-# 32-byte event header layout (little-endian).
+# Event header layout (little-endian), 32 bytes total. Derive the size from
+# the format so a future format change can't desync this constant.
 _HEADER_FMT = "<IIIIQQ"
-_HEADER_SIZE = 32
+_HEADER_SIZE = struct.calcsize(_HEADER_FMT)
 
 
 def _load_schemas(adapter) -> dict[int, dict]:
@@ -118,10 +119,17 @@ def _decode_row(bd, schemas: dict[int, dict]) -> dict | None:
     if len(bd) < _HEADER_SIZE:
         return None
     try:
-        _domain, _, schema_id, _, payload_size, _ = struct.unpack_from(_HEADER_FMT, bd, 0)
+        _domain, _, schema_id, _, _hdr_payload_size, _ = struct.unpack_from(_HEADER_FMT, bd, 0)
     except struct.error:
         return None
-    if schema_id not in schemas or len(bd) < _HEADER_SIZE + payload_size:
+    if schema_id not in schemas:
+        return None
+    # Trust the schema's declared payload size (authoritative) over the
+    # header's payload_size field. Belt-and-braces: if either says the
+    # buffer is too short, bail.
+    schema_payload_size = schemas[schema_id]["payload_size"] or 0
+    required = _HEADER_SIZE + max(schema_payload_size, _hdr_payload_size or 0)
+    if len(bd) < required:
         return None
     out: dict = {"schema_id": schema_id}
     fields: dict[str, int] = {}
@@ -130,6 +138,11 @@ def _decode_row(bd, schemas: dict[int, dict]) -> dict | None:
         if sz is None:
             continue
         off = _HEADER_SIZE + f["offset"]
+        # Guard against schema rows whose offsets exceed the declared
+        # payload size — without this, a malformed schema could send us
+        # reading past the buffer end.
+        if off + sz > _HEADER_SIZE + schema_payload_size:
+            continue
         fmt = "<I" if sz == 4 else "<Q"
         try:
             (val,) = struct.unpack_from(fmt, bd, off)

--- a/tests/test_nccl_payload_breakdown.py
+++ b/tests/test_nccl_payload_breakdown.py
@@ -574,3 +574,81 @@ def test_skill_counts_distinct_communicators():
     rows = SKILL.execute_fn(conn)
     data = {r["schema_id"]: r for r in rows[1:]}
     assert data[100]["distinct_communicators"] == 2
+
+
+def test_summary_total_distinct_communicators_is_cross_schema():
+    """`distinct_communicators` per row is a per-schema view; we also need a
+    cross-schema rollup so users can answer 'is this a single-comm or
+    multi-comm setup?'. On a fresh fixture both schemas share the same
+    comm so the cross-schema total is 1."""
+    conn = _build_db_with_nccl_payloads()
+    rows = SKILL.execute_fn(conn)
+    assert rows[0]["total_distinct_communicators"] == 1
+
+    # Now add a second-comm event on schema 200 (p2p). Per-schema counts
+    # update; cross-schema rollup should bump to 2.
+    c = conn.cursor()
+    payload = struct.pack("<QQI", 0xDEAD_FACE_F00D_C0DE, 4096, 1) + b"\x00\x00\x00\x00"
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (?, 59, ?)", (0, _pack_event(200, payload)))
+    conn.commit()
+
+    rows2 = SKILL.execute_fn(conn)
+    assert rows2[0]["total_distinct_communicators"] == 2, (
+        f"expected cross-schema 2 comm IDs; got {rows2[0]['total_distinct_communicators']}"
+    )
+
+
+def test_p2p_peer_rank_distribution_uniform():
+    """When all peer ranks see equal traffic share (the all-to-all common
+    case), `peer_rank_uniformity` should be 1.0."""
+    conn = _build_db_with_nccl_payloads()
+    # Add 4 more p2p events with distinct peer ranks 0,1,2,3 — uniform 50/50.
+    # Existing fixture already has peers [1, 2] one each. Add peers [0, 3]
+    # so all four ranks see exactly one event each (perfectly uniform).
+    c = conn.cursor()
+    comm = 0xCAFE_BABE_DEAD_BEEF
+    for peer in (0, 3):
+        payload = struct.pack("<QQI", comm, 8192, peer) + b"\x00\x00\x00\x00"
+        c.execute("INSERT INTO NVTX_EVENTS VALUES (?, 59, ?)", (0, _pack_event(200, payload)))
+    conn.commit()
+
+    rows = SKILL.execute_fn(conn)
+    p2p_row = next(r for r in rows[1:] if r["schema_id"] == 200)
+    assert p2p_row["distinct_peer_ranks"] == 4
+    assert p2p_row["peer_rank_uniformity"] == 1.0, (
+        f"4 peers × 1 event each → uniform; got {p2p_row['peer_rank_uniformity']}"
+    )
+    assert p2p_row["peer_rank_distribution"] == {0: 1, 1: 1, 2: 1, 3: 1}
+
+
+def test_p2p_peer_rank_distribution_skewed():
+    """A skewed distribution (one peer dominates) gets uniformity < 1.0.
+    Catches future regressions where the score computation might lock to
+    1.0 for any non-empty distribution."""
+    conn = _build_db_with_nccl_payloads()
+    c = conn.cursor()
+    comm = 0xCAFE_BABE_DEAD_BEEF
+    # Pile 8 more events all on peer rank 1 (existing fixture: 1 each on
+    # peer 1 and 2). After: peer 1 has 9, peer 2 has 1 — highly skewed.
+    for _ in range(8):
+        payload = struct.pack("<QQI", comm, 8192, 1) + b"\x00\x00\x00\x00"
+        c.execute("INSERT INTO NVTX_EVENTS VALUES (?, 59, ?)", (0, _pack_event(200, payload)))
+    conn.commit()
+
+    rows = SKILL.execute_fn(conn)
+    p2p_row = next(r for r in rows[1:] if r["schema_id"] == 200)
+    assert p2p_row["distinct_peer_ranks"] == 2
+    assert p2p_row["peer_rank_uniformity"] < 1.0, (
+        f"skewed distribution should not score 1.0; got {p2p_row['peer_rank_uniformity']}"
+    )
+
+
+def test_collective_schemas_have_no_peer_rank_fields():
+    """Non-p2p schemas (no Peer rank in field_set) must not emit
+    peer-rank fields. Locks in compactness for init/collective rows."""
+    conn = _build_db_with_nccl_payloads()
+    rows = SKILL.execute_fn(conn)
+    collective_row = next(r for r in rows[1:] if r["schema_id"] == 100)
+    assert "distinct_peer_ranks" not in collective_row
+    assert "peer_rank_uniformity" not in collective_row
+    assert "peer_rank_distribution" not in collective_row

--- a/tests/test_nccl_payload_breakdown.py
+++ b/tests/test_nccl_payload_breakdown.py
@@ -203,14 +203,22 @@ def test_skill_returns_error_when_no_payload_schemas():
 
 
 def test_skill_handles_empty_events_table():
-    """Schemas defined but no binaryData events → summary with zero counts."""
+    """Schemas defined but no binaryData events → explicit error message
+    explaining the likely capture-flag issue, not silent zeros. This is
+    the second-most-common "no data" case after `no schemas at all` and
+    was observed on real fastvideo / nano_vllm profiles where NCCL ran
+    but typed-payload NVTX emission wasn't enabled at capture time."""
     conn = _build_db_with_nccl_payloads()
     conn.execute("DELETE FROM NVTX_EVENTS")
     conn.commit()
     rows = SKILL.execute_fn(conn)
-    assert rows[0]["_summary"] is True
-    assert rows[0]["total_payload_events"] == 0
-    assert rows[0]["total_bytes_all"] == 0
+    assert "error" in rows[0]
+    # Error must call out the capture-flag root cause:
+    assert "typed-payload" in rows[0]["error"]
+    assert "capture" in rows[0]["error"].lower()
+    # Diagnostic fields to help the agent build a re-profile suggestion:
+    assert rows[0]["schemas_present"] == 2  # from the fixture
+    assert rows[0]["binary_data_rows"] == 0
 
 
 def test_format_produces_human_readable_output():

--- a/tests/test_nccl_payload_breakdown.py
+++ b/tests/test_nccl_payload_breakdown.py
@@ -402,11 +402,55 @@ def test_skill_trim_partial_bounds_falls_through_to_whole_profile():
     """Only one of trim_start_ns / trim_end_ns set → trim ignored
     (consistent with overlap_breakdown / iteration_detail behavior)."""
     conn = _build_db_with_nccl_payloads()
-    full = SKILL.execute_fn(conn)["total_payload_events"] if False else SKILL.execute_fn(conn)[0]["total_payload_events"]
+    full = SKILL.execute_fn(conn)[0]["total_payload_events"]
     # Pass only trim_start_ns → should NOT filter (whole profile returned).
     partial = SKILL.execute_fn(conn, trim_start_ns=999_999_999_999)[0]["total_payload_events"]
     assert partial == full, (
         f"Partial-bounds trim should fall through; got {partial} vs full {full}"
+    )
+
+
+def test_skill_warns_on_partial_trim_bounds(caplog):
+    """A user passing only one trim bound is almost certainly a mistake —
+    must log a WARNING so the silent fall-through doesn't mask the bug."""
+    import logging
+
+    conn = _build_db_with_nccl_payloads()
+    with caplog.at_level(logging.WARNING, logger="nsys_ai.skills.builtins.nccl_payload_breakdown"):
+        SKILL.execute_fn(conn, trim_start_ns=12345)
+    assert any(
+        "partial trim bounds dropped" in rec.message for rec in caplog.records
+    ), f"expected WARNING about partial trim; got: {[r.message for r in caplog.records]}"
+
+
+def test_format_handles_summary_only_no_data_rows():
+    """When the schemas exist but no events match (e.g. heavy trim), the
+    summary row is the only row. The formatter must not crash and must
+    produce a recognisable output."""
+    conn = _build_db_with_nccl_payloads()
+    # Trim window in the distant past — captures zero events.
+    rows = SKILL.execute_fn(conn, trim_start_ns=-1_000_000, trim_end_ns=-1)
+    assert rows[0]["_summary"] is True
+    assert rows[0]["total_payload_events"] == 0
+    # Format must not crash on summary-only output.
+    text = SKILL.format_fn(rows)
+    assert "NCCL Payload Breakdown" in text
+    assert "Total payload events:  0" in text
+
+
+def test_summary_totals_consistent_with_per_schema_totals():
+    """`_summary.total_bytes_all` MUST equal the sum of per-schema
+    `msg_size_bytes_total` — any drift indicates the aggregation logic
+    diverged between the summary path and the per-row path."""
+    conn = _build_db_with_nccl_payloads()
+    rows = SKILL.execute_fn(conn)
+    summary = rows[0]
+    per_schema_total = sum(
+        r.get("msg_size_bytes_total", 0) for r in rows[1:]
+    )
+    assert summary["total_bytes_all"] == per_schema_total, (
+        f"summary total {summary['total_bytes_all']} != "
+        f"sum of per-schema totals {per_schema_total}"
     )
 
 

--- a/tests/test_nccl_payload_breakdown.py
+++ b/tests/test_nccl_payload_breakdown.py
@@ -12,6 +12,8 @@ import sqlite3
 import struct
 
 from nsys_ai.skills.builtins.nccl_payload_breakdown import (
+    _HEADER_FMT,
+    _HEADER_SIZE,
     SKILL,
     _classify,
     _decode_row,
@@ -21,11 +23,15 @@ from nsys_ai.skills.builtins.nccl_payload_breakdown import (
 
 
 def _pack_event(schema_id: int, payload_bytes: bytes) -> bytes:
-    """Build a 32-byte header + payload, matching Nsight's binaryData format."""
+    """Build the header + payload using the production constants.
+
+    Importing `_HEADER_FMT` / `_HEADER_SIZE` directly (rather than hard-coding
+    "<IIIIQQ" / 32 here) means any future header-layout change in the skill
+    will be reflected by these test fixtures too — preventing the test suite
+    from drifting silently behind production.
+    """
     payload_size = len(payload_bytes)
-    header = struct.pack(
-        "<IIIIQQ", 1, 0, schema_id, 0, payload_size, 32 + payload_size
-    )
+    header = struct.pack(_HEADER_FMT, 1, 0, schema_id, 0, payload_size, _HEADER_SIZE + payload_size)
     return header + payload_bytes
 
 
@@ -267,6 +273,81 @@ def test_decode_row_skips_unknown_field_type():
     assert decoded["fields"]["NCCL communicator ID"] == 0xCAFE_BEEF
     # Unknown-type field skipped (not crashed, not present):
     assert "Future field (unknown)" not in decoded["fields"]
+
+
+def test_load_schemas_warns_on_silent_entries_failure(caplog):
+    """Regression guard for the DuckDB reserved-keyword landmine: when
+    NVTX_PAYLOAD_SCHEMAS loads but NVTX_PAYLOAD_SCHEMA_ENTRIES fails (or
+    returns no rows), _load_schemas must log a WARNING. Without this, a
+    silent SQL failure leaves every event undecodable and no signal in
+    the output explains why."""
+    import logging
+
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    # Schemas table populated, entries table empty.
+    c.execute(
+        "CREATE TABLE NVTX_PAYLOAD_SCHEMAS "
+        "(domainId INTEGER, schemaId INTEGER, name TEXT, type INTEGER, "
+        " flags INTEGER, numEntries INTEGER, payloadSize INTEGER, alignTo INTEGER)"
+    )
+    c.execute("INSERT INTO NVTX_PAYLOAD_SCHEMAS VALUES (1, 100, NULL, 1, NULL, 2, 16, NULL)")
+    c.execute(
+        "CREATE TABLE NVTX_PAYLOAD_SCHEMA_ENTRIES "
+        "(domainId INTEGER, schemaId INTEGER, idx INTEGER, flags INTEGER, "
+        " type INTEGER, name TEXT, description TEXT, arrayOrUnionDetail INTEGER, offset INTEGER)"
+    )
+    conn.commit()
+
+    with caplog.at_level(logging.WARNING, logger="nsys_ai.skills.builtins.nccl_payload_breakdown"):
+        schemas = _load_schemas(conn)
+
+    assert len(schemas) == 1
+    assert all(not s["fields"] for s in schemas.values())
+    assert any(
+        "returned no fields" in rec.message for rec in caplog.records
+    ), f"expected WARNING about empty fields[], got: {[r.message for r in caplog.records]}"
+
+
+def test_decode_row_rejects_buffer_too_short_for_schema():
+    """When a header advertises a tiny payload but the schema declares
+    fields at higher offsets, the decoder must not read past the buffer
+    end. Trust the schema's declared payload size as authoritative."""
+    schemas = {100: {"payload_size": 24, "fields": [
+        {"idx": 0, "type": 18, "name": "NCCL communicator ID", "offset": 0},
+        {"idx": 1, "type": 22, "name": "Message size [bytes]", "offset": 8},
+        {"idx": 2, "type": 5, "name": "Peer rank", "offset": 16},
+    ]}}
+    # Pack a 16-byte payload (less than schema's 24-byte requirement).
+    short_payload = struct.pack("<QQ", 0xDEAD_BEEF, 4096)
+    bd = _pack_event(100, short_payload)
+    # bd length is _HEADER_SIZE + 16 — schema needs _HEADER_SIZE + 24.
+    decoded = _decode_row(bd, schemas)
+    assert decoded is None, (
+        "Decoder must reject when buffer is shorter than schema's declared "
+        "payload size, even if the header agrees with the shorter length"
+    )
+
+
+def test_decode_row_skips_field_offsets_beyond_payload():
+    """If a schema has a single oversized field offset beyond payload_size,
+    that field is skipped — other fields still decode."""
+    schemas = {100: {"payload_size": 16, "fields": [
+        {"idx": 0, "type": 18, "name": "NCCL communicator ID", "offset": 0},
+        # Bogus: offset 100 exceeds payload_size=16
+        {"idx": 1, "type": 22, "name": "Out-of-range field", "offset": 100},
+    ]}}
+    payload = struct.pack("<QQ", 0xCAFE_BEEF, 9999)
+    decoded = _decode_row(_pack_event(100, payload), schemas)
+    assert decoded is not None
+    assert decoded["fields"]["NCCL communicator ID"] == 0xCAFE_BEEF
+    assert "Out-of-range field" not in decoded["fields"]
+
+
+def test_header_size_matches_format():
+    """_HEADER_SIZE is computed from _HEADER_FMT at import time. Verify
+    they stay consistent in case someone hand-edits one but not the other."""
+    assert _HEADER_SIZE == struct.calcsize(_HEADER_FMT)
 
 
 def test_skill_counts_distinct_communicators():

--- a/tests/test_nccl_payload_breakdown.py
+++ b/tests/test_nccl_payload_breakdown.py
@@ -438,6 +438,50 @@ def test_format_handles_summary_only_no_data_rows():
     assert "Total payload events:  0" in text
 
 
+def test_skill_output_is_json_serializable():
+    """The skill emits via CLI's `--format json` path. If anything leaks
+    into the output that json can't serialize (set, bytes, NaN, None
+    from a malformed schema), this catches it before end-to-end."""
+    import json
+
+    conn = _build_db_with_nccl_payloads()
+    rows = SKILL.execute_fn(conn)
+    # Must not raise.
+    serialized = json.dumps(rows)
+    # Round-trip equality on basic structure.
+    re_parsed = json.loads(serialized)
+    assert re_parsed[0]["_summary"] is True
+    assert len(re_parsed) == len(rows)
+
+
+def test_summary_message_carrying_events_excludes_marker_only_schemas():
+    """`message_carrying_events` must count ONLY events whose schema declares
+    a "Message size [bytes]" field — group_marker / init events don't
+    contribute. Validates the field's documented semantics."""
+    conn = _build_db_with_nccl_payloads()
+    # Add a group_marker event (schema 300 with only comm_id, no msg_size).
+    c = conn.cursor()
+    c.execute("INSERT INTO NVTX_PAYLOAD_SCHEMAS VALUES (1, 300, NULL, 1, NULL, 1, 8, NULL)")
+    c.execute(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES "
+        "(1, 300, 0, NULL, 18, 'NCCL communicator ID', NULL, NULL, NULL)"
+    )
+    # 2 group_marker events
+    for _ in range(2):
+        payload = struct.pack("<Q", 0xCAFE_BABE_DEAD_BEEF)
+        c.execute("INSERT INTO NVTX_EVENTS VALUES (?, 59, ?)", (0, _pack_event(300, payload)))
+    conn.commit()
+
+    rows = SKILL.execute_fn(conn)
+    s = rows[0]
+    # Fixture: 3 collective + 2 p2p = 5 message-carrying. Plus 2 group_marker = 7 total.
+    assert s["total_payload_events"] == 7
+    assert s["message_carrying_events"] == 5, (
+        f"group_marker events must NOT be counted; got "
+        f"message_carrying={s['message_carrying_events']}"
+    )
+
+
 def test_summary_totals_consistent_with_per_schema_totals():
     """`_summary.total_bytes_all` MUST equal the sum of per-schema
     `msg_size_bytes_total` — any drift indicates the aggregation logic

--- a/tests/test_nccl_payload_breakdown.py
+++ b/tests/test_nccl_payload_breakdown.py
@@ -350,6 +350,66 @@ def test_header_size_matches_format():
     assert _HEADER_SIZE == struct.calcsize(_HEADER_FMT)
 
 
+def test_skill_respects_trim_window():
+    """Passing trim_start_ns / trim_end_ns must scope aggregation to events
+    whose [start, end] overlaps the window. Required by PRINCIPLES.md §9
+    so agents trimming to one iteration get scoped NCCL payload data."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute(
+        "CREATE TABLE NVTX_PAYLOAD_SCHEMAS "
+        "(domainId INTEGER, schemaId INTEGER, name TEXT, type INTEGER, "
+        " flags INTEGER, numEntries INTEGER, payloadSize INTEGER, alignTo INTEGER)"
+    )
+    c.execute("INSERT INTO NVTX_PAYLOAD_SCHEMAS VALUES (1, 100, NULL, 1, NULL, 2, 16, NULL)")
+    c.execute(
+        "CREATE TABLE NVTX_PAYLOAD_SCHEMA_ENTRIES "
+        "(domainId INTEGER, schemaId INTEGER, idx INTEGER, flags INTEGER, "
+        " type INTEGER, name TEXT, description TEXT, arrayOrUnionDetail INTEGER, offset INTEGER)"
+    )
+    c.execute("INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES (1, 100, 0, NULL, 18, 'NCCL communicator ID', NULL, NULL, NULL)")
+    c.execute("INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES (1, 100, 1, NULL, 22, 'Message size [bytes]', NULL, NULL, 8)")
+    c.execute(
+        'CREATE TABLE NVTX_EVENTS (start INTEGER, "end" INTEGER, binaryData BLOB)'
+    )
+    # 3 events at three different time windows: 0-100, 1000-1100, 2000-2100.
+    for start, msg_size in ((0, 1024), (1000, 2048), (2000, 4096)):
+        payload = struct.pack("<QQ", 0xCAFE_BABE, msg_size)
+        c.execute(
+            "INSERT INTO NVTX_EVENTS VALUES (?, ?, ?)",
+            (start, start + 100, _pack_event(100, payload)),
+        )
+    conn.commit()
+
+    # Without trim: all 3 events
+    rows_all = SKILL.execute_fn(conn)
+    assert rows_all[0]["total_payload_events"] == 3
+
+    # Trim to [500, 1500] — only the middle event (1000-1100) overlaps
+    rows_mid = SKILL.execute_fn(conn, trim_start_ns=500, trim_end_ns=1500)
+    assert rows_mid[0]["total_payload_events"] == 1
+    # Confirm the middle message size (2048) is the only one captured
+    by_sid = {r["schema_id"]: r for r in rows_mid[1:]}
+    assert by_sid[100]["msg_size_bytes_total"] == 2048
+
+    # Trim to [50, 2050] — captures all three (each event 100ns wide, all
+    # within or overlapping this 2 µs window)
+    rows_wide = SKILL.execute_fn(conn, trim_start_ns=50, trim_end_ns=2050)
+    assert rows_wide[0]["total_payload_events"] == 3
+
+
+def test_skill_trim_partial_bounds_falls_through_to_whole_profile():
+    """Only one of trim_start_ns / trim_end_ns set → trim ignored
+    (consistent with overlap_breakdown / iteration_detail behavior)."""
+    conn = _build_db_with_nccl_payloads()
+    full = SKILL.execute_fn(conn)["total_payload_events"] if False else SKILL.execute_fn(conn)[0]["total_payload_events"]
+    # Pass only trim_start_ns → should NOT filter (whole profile returned).
+    partial = SKILL.execute_fn(conn, trim_start_ns=999_999_999_999)[0]["total_payload_events"]
+    assert partial == full, (
+        f"Partial-bounds trim should fall through; got {partial} vs full {full}"
+    )
+
+
 def test_skill_counts_distinct_communicators():
     """When two events share a communicator ID, distinct_communicators must
     not double-count. When they differ, it must reflect both."""

--- a/tests/test_nccl_payload_breakdown.py
+++ b/tests/test_nccl_payload_breakdown.py
@@ -202,6 +202,56 @@ def test_skill_returns_error_when_no_payload_schemas():
     assert "NVTX_PAYLOAD" in rows[0]["error"]
 
 
+def test_skill_distinguishes_blob_read_failure_from_empty_data():
+    """If the backend's BLOB scanner errors out (observed: DuckDB
+    sqlite-scanner on --no-cache mode raises a 'Mismatch Type Error' for
+    BLOB columns declared as TEXT in sqlite), the skill must NOT silently
+    report 'binaryData empty' — that would tell users to re-profile when
+    the real fix is to switch off --no-cache.
+
+    Mocks the adapter so the binaryData probe raises, but the table-row
+    count succeeds (i.e. table is reachable, just unreadable through this
+    backend)."""
+    from nsys_ai.connection import DB_ERRORS
+
+    # Pick a real DB_ERRORS class to raise. We use the first one in the
+    # tuple (typically sqlite3.Error) which IS in DB_ERRORS, so the
+    # skill's try/except matches.
+    db_error_cls = DB_ERRORS[0]
+
+    class _FlakyAdapter:
+        """Reports schemas + total rows fine, but errors on binaryData reads."""
+
+        def __init__(self, base_conn):
+            self._base = base_conn
+
+        def execute(self, sql, params=()):
+            if "binaryData IS NOT NULL" in sql:
+                raise db_error_cls(
+                    "Mismatch Type Error: column declared text, found blob"
+                )
+            return self._base.execute(sql, params)
+
+    conn = _build_db_with_nccl_payloads()
+    # Patch wrap_connection to return our flaky adapter.
+    from nsys_ai.skills.builtins import nccl_payload_breakdown as mod
+    orig = mod.wrap_connection
+    mod.wrap_connection = lambda c: _FlakyAdapter(c)
+    try:
+        rows = SKILL.execute_fn(conn)
+    finally:
+        mod.wrap_connection = orig
+
+    assert "error" in rows[0]
+    assert rows[0].get("backend_limitation") is True, (
+        f"Expected backend_limitation:True; got {rows[0]}"
+    )
+    # Error message must NOT recommend re-profiling (the real fix is
+    # switching backend, not re-capturing the profile).
+    assert "Re-profile" not in rows[0]["error"]
+    assert "--no-cache" in rows[0]["error"]
+
+
 def test_skill_handles_empty_events_table():
     """Schemas defined but no binaryData events → explicit error message
     explaining the likely capture-flag issue, not silent zeros. This is

--- a/tests/test_nccl_payload_breakdown.py
+++ b/tests/test_nccl_payload_breakdown.py
@@ -1,0 +1,289 @@
+"""Tests for nccl_payload_breakdown skill.
+
+Builds a minimal sqlite that mirrors Nsight's NVTX_PAYLOAD_SCHEMAS +
+NVTX_PAYLOAD_SCHEMA_ENTRIES + NVTX_EVENTS.binaryData layout, then asserts
+the decoder + aggregator produce the expected per-category breakdown.
+
+Binary layout encoded by `_pack_event` mirrors the format documented in the
+skill's module docstring (32-byte header + payload-bytes from schema).
+"""
+
+import sqlite3
+import struct
+
+from nsys_ai.skills.builtins.nccl_payload_breakdown import (
+    SKILL,
+    _classify,
+    _decode_row,
+    _load_schemas,
+    _percentile,
+)
+
+
+def _pack_event(schema_id: int, payload_bytes: bytes) -> bytes:
+    """Build a 32-byte header + payload, matching Nsight's binaryData format."""
+    payload_size = len(payload_bytes)
+    header = struct.pack(
+        "<IIIIQQ", 1, 0, schema_id, 0, payload_size, 32 + payload_size
+    )
+    return header + payload_bytes
+
+
+def _build_db_with_nccl_payloads():
+    """Create an in-memory sqlite with two schemas + a handful of decoded rows."""
+    conn = sqlite3.connect(":memory:")
+    c = conn.cursor()
+    c.execute(
+        "CREATE TABLE NVTX_PAYLOAD_SCHEMAS "
+        "(domainId INTEGER, schemaId INTEGER, name TEXT, type INTEGER, "
+        " flags INTEGER, numEntries INTEGER, payloadSize INTEGER, alignTo INTEGER)"
+    )
+    c.execute(
+        "CREATE TABLE NVTX_PAYLOAD_SCHEMA_ENTRIES "
+        "(domainId INTEGER, schemaId INTEGER, idx INTEGER, flags INTEGER, "
+        " type INTEGER, name TEXT, description TEXT, arrayOrUnionDetail INTEGER, offset INTEGER)"
+    )
+    c.execute(
+        "CREATE TABLE NVTX_EVENTS "
+        "(start INTEGER, eventType INTEGER, binaryData BLOB)"
+    )
+
+    # Schema A: simple collective (16 bytes payload — comm_id + msg_size)
+    c.execute(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMAS VALUES (1, 100, NULL, 1, NULL, 2, 16, NULL)"
+    )
+    c.execute(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES "
+        "(1, 100, 0, NULL, 18, 'NCCL communicator ID', NULL, NULL, NULL)"
+    )
+    c.execute(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES "
+        "(1, 100, 1, NULL, 22, 'Message size [bytes]', NULL, NULL, 8)"
+    )
+
+    # Schema B: p2p (24 bytes — comm_id + msg_size + peer_rank)
+    c.execute(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMAS VALUES (1, 200, NULL, 1, NULL, 3, 24, NULL)"
+    )
+    c.execute(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES "
+        "(1, 200, 0, NULL, 18, 'NCCL communicator ID', NULL, NULL, NULL)"
+    )
+    c.execute(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES "
+        "(1, 200, 1, NULL, 22, 'Message size [bytes]', NULL, NULL, 8)"
+    )
+    c.execute(
+        "INSERT INTO NVTX_PAYLOAD_SCHEMA_ENTRIES VALUES "
+        "(1, 200, 2, NULL, 5, 'Peer rank', NULL, NULL, 16)"
+    )
+
+    # Insert events:
+    #   - 3 collective events on schema 100 with msg_sizes [1024, 2048, 4096]
+    #   - 2 p2p events on schema 200 with msg_sizes [8192, 16384], peers [1, 2]
+    comm = 0xCAFE_BABE_DEAD_BEEF
+    for ms in (1024, 2048, 4096):
+        payload = struct.pack("<QQ", comm, ms)
+        c.execute(
+            "INSERT INTO NVTX_EVENTS VALUES (?, 59, ?)", (0, _pack_event(100, payload))
+        )
+    for ms, peer in ((8192, 1), (16384, 2)):
+        payload = struct.pack("<QQI", comm, ms, peer) + b"\x00\x00\x00\x00"
+        c.execute(
+            "INSERT INTO NVTX_EVENTS VALUES (?, 59, ?)", (0, _pack_event(200, payload))
+        )
+    conn.commit()
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Decoder unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_load_schemas_returns_field_layout():
+    conn = _build_db_with_nccl_payloads()
+    schemas = _load_schemas(conn)
+    assert set(schemas.keys()) == {100, 200}
+    assert schemas[100]["payload_size"] == 16
+    assert schemas[200]["payload_size"] == 24
+    # field offsets: first is NULL → coerced to 0
+    s100_fields = {f["name"]: f["offset"] for f in schemas[100]["fields"]}
+    assert s100_fields == {"NCCL communicator ID": 0, "Message size [bytes]": 8}
+
+
+def test_decode_row_extracts_fields():
+    schemas = {100: {"payload_size": 16, "fields": [
+        {"idx": 0, "type": 18, "name": "NCCL communicator ID", "offset": 0},
+        {"idx": 1, "type": 22, "name": "Message size [bytes]", "offset": 8},
+    ]}}
+    payload = struct.pack("<QQ", 0xDEAD_BEEF, 65536)
+    bd = _pack_event(100, payload)
+    decoded = _decode_row(bd, schemas)
+    assert decoded == {
+        "schema_id": 100,
+        "fields": {"NCCL communicator ID": 0xDEAD_BEEF, "Message size [bytes]": 65536},
+    }
+
+
+def test_decode_row_returns_none_on_truncated_blob():
+    assert _decode_row(b"", {}) is None
+    assert _decode_row(b"\x00" * 10, {}) is None  # shorter than 32-byte header
+
+
+def test_decode_row_returns_none_on_unknown_schema():
+    bd = _pack_event(99999, struct.pack("<QQ", 1, 1))
+    assert _decode_row(bd, {}) is None
+
+
+def test_classify_buckets():
+    assert _classify(["NCCL communicator ID"]) == "group_marker"
+    assert _classify(["NCCL communicator ID", "Message size [bytes]"]) == "collective"
+    assert _classify(["NCCL communicator ID", "Message size [bytes]", "Peer rank"]) == "p2p"
+    assert _classify(["NCCL communicator ID", "No. of ranks", "Rank", "CUDA device"]) == "init"
+
+
+def test_percentile_handles_edge_cases():
+    assert _percentile([], 0.5) == 0
+    assert _percentile([42], 0.5) == 42
+    # p50 of [10, 20, 30] = 20 (linear interp at index 1.0)
+    assert _percentile([10, 20, 30], 0.5) == 20
+    # p99 of [10, 20, 30] ≈ 29.6 → int → 29
+    assert _percentile([10, 20, 30], 0.99) == 29
+
+
+# ---------------------------------------------------------------------------
+# Skill execute + aggregate
+# ---------------------------------------------------------------------------
+
+
+def test_skill_aggregates_per_schema_correctly():
+    conn = _build_db_with_nccl_payloads()
+    rows = SKILL.execute_fn(conn)
+
+    # First row is the summary.
+    s = rows[0]
+    assert s["_summary"] is True
+    assert s["total_payload_events"] == 5  # 3 collective + 2 p2p
+    assert s["distinct_schemas"] == 2
+
+    # Per-schema rows.
+    data = {r["schema_id"]: r for r in rows[1:]}
+    assert 100 in data and 200 in data
+
+    coll = data[100]
+    assert coll["category"] == "collective"
+    assert coll["count"] == 3
+    assert coll["msg_size_bytes_total"] == 1024 + 2048 + 4096
+    assert coll["msg_size_bytes_min"] == 1024
+    assert coll["msg_size_bytes_max"] == 4096
+    assert coll["distinct_communicators"] == 1
+
+    p2p = data[200]
+    assert p2p["category"] == "p2p"
+    assert p2p["count"] == 2
+    assert p2p["msg_size_bytes_total"] == 8192 + 16384
+    assert "Peer rank" not in p2p["field_set"] or "Peer rank" in p2p["field_set"]
+    # The peer field is captured in field_set:
+    assert "Peer rank" in p2p["field_set"]
+
+
+def test_skill_returns_error_when_no_payload_schemas():
+    """If the profile has no NVTX_PAYLOAD_SCHEMAS table, return a clear error."""
+    conn = sqlite3.connect(":memory:")
+    rows = SKILL.execute_fn(conn)
+    assert "error" in rows[0]
+    assert "NVTX_PAYLOAD" in rows[0]["error"]
+
+
+def test_skill_handles_empty_events_table():
+    """Schemas defined but no binaryData events → summary with zero counts."""
+    conn = _build_db_with_nccl_payloads()
+    conn.execute("DELETE FROM NVTX_EVENTS")
+    conn.commit()
+    rows = SKILL.execute_fn(conn)
+    assert rows[0]["_summary"] is True
+    assert rows[0]["total_payload_events"] == 0
+    assert rows[0]["total_bytes_all"] == 0
+
+
+def test_format_produces_human_readable_output():
+    conn = _build_db_with_nccl_payloads()
+    text = SKILL.format_fn(SKILL.execute_fn(conn))
+    assert "NCCL Payload Breakdown" in text
+    assert "collective" in text
+    assert "p2p" in text
+    assert "MiB" in text  # message size formatted
+
+
+# ---------------------------------------------------------------------------
+# Regression / coverage gaps surfaced during real-profile end-to-end debugging
+# ---------------------------------------------------------------------------
+
+
+def test_decode_row_accepts_hex_string_blob():
+    """DuckDB returns BLOB columns as hex-encoded strings (e.g. '0100...').
+    Sqlite3 returns raw bytes. The decoder must handle both — this test
+    locks in the hex-string path so a future regression that re-breaks
+    DuckDB compatibility fails fast at unit-test time."""
+    schemas = {100: {"payload_size": 16, "fields": [
+        {"idx": 0, "type": 18, "name": "NCCL communicator ID", "offset": 0},
+        {"idx": 1, "type": 22, "name": "Message size [bytes]", "offset": 8},
+    ]}}
+    payload = struct.pack("<QQ", 0xCAFE_BEEF, 32768)
+    raw = _pack_event(100, payload)
+    hex_str = raw.hex()  # DuckDB-style representation
+    decoded = _decode_row(hex_str, schemas)
+    assert decoded is not None
+    assert decoded["schema_id"] == 100
+    assert decoded["fields"]["Message size [bytes]"] == 32768
+
+
+def test_decode_row_rejects_non_hex_string():
+    """A str blob that isn't valid hex (e.g. garbage) must return None,
+    not raise."""
+    assert _decode_row("not-actually-hex-zzz", {}) is None
+
+
+def test_percentile_boundary_p0_and_p1():
+    """Percentile at the endpoints should return min/max exactly."""
+    vals = [10, 20, 30, 40, 50]
+    assert _percentile(vals, 0.0) == 10
+    assert _percentile(vals, 1.0) == 50
+
+
+def test_decode_row_skips_unknown_field_type():
+    """If a schema declares a field with a type not in TYPE_SIZES (e.g. a
+    future Nsight emits type 99 = string), the decoder must skip that
+    field — never crash. The other fields with known types still decode."""
+    schemas = {100: {"payload_size": 16, "fields": [
+        {"idx": 0, "type": 18, "name": "NCCL communicator ID", "offset": 0},
+        {"idx": 1, "type": 99, "name": "Future field (unknown)", "offset": 8},
+    ]}}
+    payload = struct.pack("<QQ", 0xCAFE_BEEF, 12345)
+    decoded = _decode_row(_pack_event(100, payload), schemas)
+    assert decoded is not None
+    # Known field decoded:
+    assert decoded["fields"]["NCCL communicator ID"] == 0xCAFE_BEEF
+    # Unknown-type field skipped (not crashed, not present):
+    assert "Future field (unknown)" not in decoded["fields"]
+
+
+def test_skill_counts_distinct_communicators():
+    """When two events share a communicator ID, distinct_communicators must
+    not double-count. When they differ, it must reflect both."""
+    conn = _build_db_with_nccl_payloads()
+    # The fixture uses the same comm_id (0xCAFEBABEDEADBEEF) for all events.
+    rows = SKILL.execute_fn(conn)
+    data = {r["schema_id"]: r for r in rows[1:]}
+    assert data[100]["distinct_communicators"] == 1
+    assert data[200]["distinct_communicators"] == 1
+
+    # Add an event on schema 100 with a different communicator and re-check.
+    c = conn.cursor()
+    payload = struct.pack("<QQ", 0xFEED_FACE_BEEFCAFE, 8192)
+    c.execute("INSERT INTO NVTX_EVENTS VALUES (?, 59, ?)", (0, _pack_event(100, payload)))
+    conn.commit()
+    rows = SKILL.execute_fn(conn)
+    data = {r["schema_id"]: r for r in rows[1:]}
+    assert data[100]["distinct_communicators"] == 2

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -31,6 +31,7 @@ def test_list_skills():
         "nccl_anomaly",
         "nccl_breakdown",
         "nccl_communicator_analysis",
+        "nccl_payload_breakdown",
         "nvtx_kernel_map",
         "nvtx_layer_breakdown",
         "overlap_breakdown",


### PR DESCRIPTION
## Summary

New skill that decodes NCCL operation details from `NVTX_EVENTS.binaryData` using the schemas in `NVTX_PAYLOAD_SCHEMAS` / `NVTX_PAYLOAD_SCHEMA_ENTRIES`. Extracts **real per-collective message sizes, peer ranks, and communicator IDs** — the data has been in every NCCL-enabled profile all along, but no existing skill surfaces it.

This is the **foundation for downstream NCCL bandwidth-utilization analysis** — without measured message sizes, transfer-time-vs-payload reasoning has to be estimated rather than empirical. See \`docs/roadmap.md\` §4 B "Skill fidelity gaps" (audit 2026-05-14) for the larger plan.

## What's in the profile (verified on real 4× L40S fastvideo profile)

\`\`\`
Total payload events:    346,400
Total bytes transferred: 8,936 GiB
Distinct schemas:        6

[init        ] schema=16777218  calls=     4   communicators=1
[collective  ] schema=16777220  calls=   724   communicators=1
    msg_size: p50=52.73 MiB  p99=52.73 MiB   total=37.08 GiB
[p2p         ] schema=16777225  calls=172,832  communicators=1
    msg_size: p50=13.18 MiB  p99=39.55 MiB   total=4,449.46 GiB
[p2p         ] schema=16777226  calls=172,832  communicators=1
    msg_size: p50=13.18 MiB  p99=39.55 MiB   total=4,449.46 GiB
[init        ] schema=16777227  calls=     4   communicators=1
[group_marker] schema=16777230  calls=     4   communicators=1
\`\`\`

These are real numbers — first time an agent can see actual NCCL message sizes without hand-querying the SQLite.

## Binary layout (32B header + payload, little-endian, verified vs Nsight 2026.x)

\`\`\`
bytes 0-3    uint32  domainId
bytes 4-7    uint32  (reserved)
bytes 8-11   uint32  schemaId        ← look up in NVTX_PAYLOAD_SCHEMAS
bytes 12-15  uint32  (reserved)
bytes 16-23  uint64  payloadSize
bytes 24-31  uint64  totalSize
bytes 32+    payload (fields per NVTX_PAYLOAD_SCHEMA_ENTRIES by offset)
\`\`\`

## Non-obvious portability landmines (now commented in source)

1. **\`offset\` is a DuckDB reserved keyword.** The schema-entries query fails to parse without quoting. \`DB_ERRORS\` swallowed the parser error silently, leaving every schema with \`fields=[]\` and every binaryData row marked "undecodable". Added a WARNING-level log when schemas load but field arrays are empty, so any future similar regression surfaces immediately rather than ghost-skipping every row.

2. **DuckDB returns BLOB columns as hex-encoded strings** (\`'0100000a...'\`), sqlite3 returns raw bytes. \`_decode_row\` handles both via \`isinstance\` check + \`bytes.fromhex\` with \`ValueError\` trap.

## Output schema

Summary row (one per call) + N per-schema rows:

\`\`\`json
[
  {"_summary": true, "total_payload_events": N, "skipped_events": M,
   "total_bytes_all": B, "total_gib_all": G, "distinct_schemas": K},
  {"schema_id": ..., "category": "init|collective|p2p|group_marker",
   "field_set": [...], "count": ..., "distinct_communicators": ...,
   "msg_size_bytes_total/min/p50/p99/max": ...  (when msg-size field present)}
]
\`\`\`

## Test plan

- [x] 15 tests in \`tests/test_nccl_payload_breakdown.py\`
  - Decoder unit cases: bytes path, hex-string path (DuckDB), truncated blob, unknown schema, unknown field type
  - Schema loading: field offsets, NULL→0 first-field handling
  - Aggregation: per-schema counts, msg_size totals, distinct_communicators de-dup
  - Percentile boundaries: empty list, single element, p=0.0, p=1.0, p=0.99
  - Error paths: missing NVTX_PAYLOAD tables, empty events table
  - Format output: human-readable rendering
- [x] \`test_skills.py\` updated to add \`nccl_payload_breakdown\` to expected list
- [x] Full suite: **838 passed, 135 skipped**, ruff clean
- [x] End-to-end verified on real 1.8 GB / 346K-NCCL fastvideo profile

## Follow-ups (separate PRs)

- \`nccl_bandwidth_utilization\` — uses this skill's message sizes + observed transfer time to classify each collective as BW-bound vs latency-bound (gap #B in roadmap §4 B)
- Enrich \`nccl_breakdown\` / \`nccl_communicator_analysis\` outputs with payload data instead of pure timing