### PR TITLE
feat(diff): emit v0.1 JSON envelope + verdict + category attribution

### DIFF
--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -232,6 +232,7 @@ def collect_sanity_warnings(
     """Return (warnings, comparability_confidence in [0,1])."""
     warnings: list[str] = []
     c_schema = 1.0
+    c_gpu = 1.0
     c_workload = 1.0
     c_kernel_overlap = 1.0
 
@@ -246,7 +247,7 @@ def collect_sanity_warnings(
         c_schema = 0.0
     if before.gpu is not None and after.gpu is not None and before.gpu != after.gpu:
         warnings.append("Different GPU IDs selected between before/after (unexpected).")
-        c_schema = 0.0
+        c_gpu = 0.0
 
     if before.kernel_rows and after.kernel_rows:
         lo = min(before.kernel_rows, after.kernel_rows)
@@ -271,7 +272,7 @@ def collect_sanity_warnings(
     if before.overlap.get("error") or after.overlap.get("error"):
         warnings.append("Overlap analysis unavailable (missing kernels or schema).")
 
-    confidence = max(0.0, min(1.0, c_schema * c_workload * c_kernel_overlap))
+    confidence = max(0.0, min(1.0, c_schema * c_gpu * c_workload * c_kernel_overlap))
     return warnings, round(confidence, 3)
 
 
@@ -283,6 +284,11 @@ def compute_category_attribution(
     before: ProfileSummary, after: ProfileSummary
 ) -> list[CategoryDelta]:
     # HTA convention: overlap_ms counts as compute; nccl_only_ms is exposed_comm.
+    # If either side's overlap analysis failed, attribution is unavailable —
+    # returning [] is honest "no signal", while all-zero buckets would look
+    # like a real "compute=0, comm=0, idle=0" measurement.
+    if before.overlap.get("error") or after.overlap.get("error"):
+        return []
     buckets: list[tuple[str, float, float]] = [
         (
             "compute",

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -112,7 +112,7 @@ class ProfileDiffSummary:
     verdict: str = "neutral"
     comparability_confidence: float = 1.0
     category_attribution: list[CategoryDelta] = field(default_factory=list)
-    step_time_delta_ms: float = 0.0
+    step_time_delta_ms: float | None = None
     step_time_delta_pct: float | None = None
     diff_id: str = ""
 
@@ -235,6 +235,7 @@ def collect_sanity_warnings(
     c_gpu = 1.0
     c_workload = 1.0
     c_kernel_overlap = 1.0
+    c_overlap = 1.0
 
     if (
         before.schema_version
@@ -271,8 +272,9 @@ def collect_sanity_warnings(
 
     if before.overlap.get("error") or after.overlap.get("error"):
         warnings.append("Overlap analysis unavailable (missing kernels or schema).")
+        c_overlap = 0.0
 
-    confidence = max(0.0, min(1.0, c_schema * c_gpu * c_workload * c_kernel_overlap))
+    confidence = max(0.0, min(1.0, c_schema * c_gpu * c_workload * c_kernel_overlap * c_overlap))
     return warnings, round(confidence, 3)
 
 
@@ -471,12 +473,14 @@ def diff_profiles(
                 pass
 
     category_attribution = compute_category_attribution(before, after)
-    step_time_before_ms = sum(c.before_ms for c in category_attribution)
-    delta = sum(c.after_ms for c in category_attribution) - step_time_before_ms
-    step_time_delta_ms = round(delta, 3)
-    step_time_delta_pct = (
-        round(delta / step_time_before_ms * 100.0, 2) if step_time_before_ms > 0 else None
-    )
+    step_time_delta_ms: float | None = None
+    step_time_delta_pct: float | None = None
+    if category_attribution:
+        step_time_before_ms = sum(c.before_ms for c in category_attribution)
+        delta = sum(c.after_ms for c in category_attribution) - step_time_before_ms
+        step_time_delta_ms = round(delta, 3)
+        if step_time_before_ms > 0:
+            step_time_delta_pct = round(delta / step_time_before_ms * 100.0, 2)
     verdict = compute_verdict(step_time_delta_pct, comparability_confidence)
     diff_id = _make_diff_id(
         before.profile_id,

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -7,13 +7,20 @@ as terminal/markdown/json output and later reused by a web compare UI.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
+from .fingerprint import get_profile_id
 from .overlap import overlap_analysis
 from .profile import Profile
 
 _log = logging.getLogger(__name__)
+
+STEP_TIME_REGRESSION_PCT = 5.0
+MIN_COMPARABILITY_CONFIDENCE = 0.5
+DIFF_ID_VERSION = "diff1"
 
 
 @dataclass(frozen=True)
@@ -46,6 +53,16 @@ class ProfileSummary:
     kernels: list[KernelAgg]
     nvtx: list[NvtxAgg]
     overlap: dict
+    profile_id: str = ""
+
+
+@dataclass(frozen=True)
+class CategoryDelta:
+    category: str  # "compute" | "communication" | "idle" | "launch_overhead"
+    before_ms: float
+    after_ms: float
+    delta_ms: float
+    delta_pct: float | None
 
 
 @dataclass(frozen=True)
@@ -92,6 +109,12 @@ class ProfileDiffSummary:
     overlap_delta: dict
     top_regressions: list[KernelDiff]
     top_improvements: list[KernelDiff]
+    verdict: str = "neutral"
+    comparability_confidence: float = 1.0
+    category_attribution: list[CategoryDelta] = field(default_factory=list)
+    step_time_delta_ms: float = 0.0
+    step_time_delta_pct: float | None = None
+    diff_id: str = ""
 
 
 def _safe_int(x) -> int:
@@ -188,6 +211,8 @@ def build_profile_summary(
         for k in ("compute_only_ms", "nccl_only_ms", "overlap_ms", "idle_ms", "total_ms"):
             overlap[k] = round(overlap[k], 2)
 
+    pid = get_profile_id(prof.conn, fallback_path=prof.path)
+
     return ProfileSummary(
         path=prof.path,
         gpu=gpu,
@@ -197,11 +222,19 @@ def build_profile_summary(
         kernels=kernels,
         nvtx=nvtx,
         overlap=overlap,
+        profile_id=pid,
     )
 
 
-def collect_sanity_warnings(before: ProfileSummary, after: ProfileSummary) -> list[str]:
+def collect_sanity_warnings(
+    before: ProfileSummary, after: ProfileSummary
+) -> tuple[list[str], float]:
+    """Return (warnings, comparability_confidence in [0,1])."""
     warnings: list[str] = []
+    c_schema = 1.0
+    c_workload = 1.0
+    c_kernel_overlap = 1.0
+
     if (
         before.schema_version
         and after.schema_version
@@ -210,33 +243,92 @@ def collect_sanity_warnings(before: ProfileSummary, after: ProfileSummary) -> li
         warnings.append(
             f"Nsight schema/version differs: before='{before.schema_version}' after='{after.schema_version}'."
         )
+        c_schema = 0.0
     if before.gpu is not None and after.gpu is not None and before.gpu != after.gpu:
         warnings.append("Different GPU IDs selected between before/after (unexpected).")
+        c_schema = 0.0
+
     if before.kernel_rows and after.kernel_rows:
-        # Very rough signal for "not comparable"
-        ratio = max(before.kernel_rows, after.kernel_rows) / max(
-            1, min(before.kernel_rows, after.kernel_rows)
-        )
-        if ratio >= 3.0:
+        lo = min(before.kernel_rows, after.kernel_rows)
+        hi = max(before.kernel_rows, after.kernel_rows)
+        c_workload = lo / hi
+        # Keep the legacy warning threshold so user-visible text doesn't change.
+        if hi / lo >= 3.0:
             warnings.append(
                 f"Kernel row counts differ a lot (before={before.kernel_rows}, after={after.kernel_rows}); compare may be dominated by workload differences."
             )
 
     b_keys = {k.key for k in before.kernels}
     a_keys = {k.key for k in after.kernels}
-    if b_keys and a_keys:
+    if b_keys and a_keys and len(b_keys) > 5 and len(a_keys) > 5:
         shared = b_keys.intersection(a_keys)
-        # If both profiles have a meaningful amount of kernels but share fewer than 5% of their names
-        if len(b_keys) > 5 and len(a_keys) > 5:
-            overlap_pct = len(shared) / min(len(b_keys), len(a_keys))
-            if overlap_pct < 0.05:
-                warnings.append(
-                    f"Profiles share almost no common kernels ({len(shared)} shared out of {len(b_keys)} and {len(a_keys)}). Are you comparing unrelated traces?"
-                )
+        c_kernel_overlap = len(shared) / min(len(b_keys), len(a_keys))
+        if c_kernel_overlap < 0.05:
+            warnings.append(
+                f"Profiles share almost no common kernels ({len(shared)} shared out of {len(b_keys)} and {len(a_keys)}). Are you comparing unrelated traces?"
+            )
 
     if before.overlap.get("error") or after.overlap.get("error"):
         warnings.append("Overlap analysis unavailable (missing kernels or schema).")
-    return warnings
+
+    confidence = max(0.0, min(1.0, c_schema * c_workload * c_kernel_overlap))
+    return warnings, round(confidence, 3)
+
+
+def _ms(overlap: dict, key: str) -> float:
+    return float(overlap.get(key) or 0.0)
+
+
+def compute_category_attribution(
+    before: ProfileSummary, after: ProfileSummary
+) -> list[CategoryDelta]:
+    # HTA convention: overlap_ms counts as compute; nccl_only_ms is exposed_comm.
+    buckets: list[tuple[str, float, float]] = [
+        (
+            "compute",
+            _ms(before.overlap, "compute_only_ms") + _ms(before.overlap, "overlap_ms"),
+            _ms(after.overlap, "compute_only_ms") + _ms(after.overlap, "overlap_ms"),
+        ),
+        (
+            "communication",
+            _ms(before.overlap, "nccl_only_ms"),
+            _ms(after.overlap, "nccl_only_ms"),
+        ),
+        (
+            "idle",
+            _ms(before.overlap, "idle_ms"),
+            _ms(after.overlap, "idle_ms"),
+        ),
+    ]
+    return [
+        CategoryDelta(
+            category=name,
+            before_ms=round(b_ms, 3),
+            after_ms=round(a_ms, 3),
+            delta_ms=round(a_ms - b_ms, 3),
+            delta_pct=round((a_ms - b_ms) / b_ms * 100.0, 2) if b_ms > 0 else None,
+        )
+        for name, b_ms, a_ms in buckets
+    ]
+
+
+def compute_verdict(step_time_delta_pct: float | None, confidence: float) -> str:
+    if confidence < MIN_COMPARABILITY_CONFIDENCE or step_time_delta_pct is None:
+        return "inconclusive"
+    if step_time_delta_pct >= STEP_TIME_REGRESSION_PCT:
+        return "regression_likely"
+    if step_time_delta_pct <= -STEP_TIME_REGRESSION_PCT:
+        return "improvement_likely"
+    return "neutral"
+
+
+def _make_diff_id(before_pid: str, after_pid: str, params: dict) -> str:
+    payload = json.dumps(
+        {"before": before_pid, "after": after_pid, "params": params},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return f"{DIFF_ID_VERSION}:sha256:{hashlib.sha256(payload).hexdigest()}"
 
 
 def _classify_delta(delta_ns: int, before_ns: int, after_ns: int) -> str:
@@ -268,7 +360,7 @@ def diff_profiles(
     t_after = trim_after if trim_after is not None else trim
     before = build_profile_summary(before_prof, gpu, t_before, nvtx_limit=nvtx_limit)
     after = build_profile_summary(after_prof, gpu, t_after, nvtx_limit=nvtx_limit)
-    warnings = collect_sanity_warnings(before, after)
+    warnings, comparability_confidence = collect_sanity_warnings(before, after)
 
     before_by_key = {k.key: k for k in before.kernels}
     after_by_key = {k.key: k for k in after.kernels}
@@ -372,6 +464,27 @@ def diff_profiles(
             except (TypeError, ValueError):
                 pass
 
+    category_attribution = compute_category_attribution(before, after)
+    step_time_before_ms = sum(c.before_ms for c in category_attribution)
+    delta = sum(c.after_ms for c in category_attribution) - step_time_before_ms
+    step_time_delta_ms = round(delta, 3)
+    step_time_delta_pct = (
+        round(delta / step_time_before_ms * 100.0, 2) if step_time_before_ms > 0 else None
+    )
+    verdict = compute_verdict(step_time_delta_pct, comparability_confidence)
+    diff_id = _make_diff_id(
+        before.profile_id,
+        after.profile_id,
+        {
+            "gpu": gpu,
+            "trim_before": trim_before,
+            "trim_after": trim_after,
+            "limit": limit,
+            "sort": sort,
+            "nvtx_limit": nvtx_limit,
+        },
+    )
+
     return ProfileDiffSummary(
         before=before,
         after=after,
@@ -383,4 +496,10 @@ def diff_profiles(
         overlap_delta=overlap_delta,
         top_regressions=regressions[: max(0, int(limit))],
         top_improvements=improvements[: max(0, int(limit))],
+        verdict=verdict,
+        comparability_confidence=comparability_confidence,
+        category_attribution=category_attribution,
+        step_time_delta_ms=step_time_delta_ms,
+        step_time_delta_pct=step_time_delta_pct,
+        diff_id=diff_id,
     )

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -275,7 +275,10 @@ def collect_sanity_warnings(
         c_overlap = 0.0
 
     confidence = max(0.0, min(1.0, c_schema * c_gpu * c_workload * c_kernel_overlap * c_overlap))
-    return warnings, round(confidence, 3)
+    # Return unrounded — compute_verdict reads this and the 0.5 gate must
+    # not be crossed by rounding artifacts (e.g. 0.4996 -> 0.5).
+    # Quantization happens at the serialization boundary in to_diff_json.
+    return warnings, confidence
 
 
 def _ms(overlap: dict, key: str) -> float:

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -442,12 +442,16 @@ def to_diff_json(data: ProfileDiffSummary) -> str:
         "diff_id": data.diff_id,
         "verdict": data.verdict,
         "comparability_confidence": data.comparability_confidence,
-        "step_time": {
-            "before_ms": round(sum(c.before_ms for c in data.category_attribution), 3),
-            "after_ms": round(sum(c.after_ms for c in data.category_attribution), 3),
-            "delta_ms": data.step_time_delta_ms,
-            "delta_pct": data.step_time_delta_pct,
-        },
+        "step_time": (
+            {
+                "before_ms": round(sum(c.before_ms for c in data.category_attribution), 3),
+                "after_ms": round(sum(c.after_ms for c in data.category_attribution), 3),
+                "delta_ms": data.step_time_delta_ms,
+                "delta_pct": data.step_time_delta_pct,
+            }
+            if data.category_attribution
+            else None
+        ),
         "category_attribution": [
             {
                 "category": c.category,

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -441,7 +441,11 @@ def to_diff_json(data: ProfileDiffSummary) -> str:
         "producer_version": _producer_version(),
         "diff_id": data.diff_id,
         "verdict": data.verdict,
-        "comparability_confidence": round(data.comparability_confidence, 3),
+        # Truncate (not round) so the displayed value can never cross the
+        # 0.5 verdict gate in the wrong direction — e.g. unrounded 0.4996
+        # would round up to 0.500 and look like it should have passed the
+        # gate, contradicting the (correct) "inconclusive" verdict.
+        "comparability_confidence": int(data.comparability_confidence * 1000) / 1000,
         "step_time": (
             {
                 "before_ms": round(sum(c.before_ms for c in data.category_attribution), 3),

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -441,7 +441,7 @@ def to_diff_json(data: ProfileDiffSummary) -> str:
         "producer_version": _producer_version(),
         "diff_id": data.diff_id,
         "verdict": data.verdict,
-        "comparability_confidence": data.comparability_confidence,
+        "comparability_confidence": round(data.comparability_confidence, 3),
         "step_time": (
             {
                 "before_ms": round(sum(c.before_ms for c in data.category_attribution), 3),

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 
 from .ai.diff_narrative import DiffNarrative
+from .annotation import PRODUCER, SCHEMA_VERSION, _producer_version
 from .diff import ProfileDiffSummary
 
 
@@ -435,14 +436,38 @@ def format_diff_markdown_multi(
 def to_diff_json(data: ProfileDiffSummary) -> str:
     # Keep this relatively stable; tests can snapshot it.
     payload = {
+        "schema_version": SCHEMA_VERSION,
+        "producer": PRODUCER,
+        "producer_version": _producer_version(),
+        "diff_id": data.diff_id,
+        "verdict": data.verdict,
+        "comparability_confidence": data.comparability_confidence,
+        "step_time": {
+            "before_ms": round(sum(c.before_ms for c in data.category_attribution), 3),
+            "after_ms": round(sum(c.after_ms for c in data.category_attribution), 3),
+            "delta_ms": data.step_time_delta_ms,
+            "delta_pct": data.step_time_delta_pct,
+        },
+        "category_attribution": [
+            {
+                "category": c.category,
+                "before_ms": c.before_ms,
+                "after_ms": c.after_ms,
+                "delta_ms": c.delta_ms,
+                "delta_pct": c.delta_pct,
+            }
+            for c in data.category_attribution
+        ],
         "before": {
             "path": data.before.path,
+            "profile_id": data.before.profile_id,
             "gpu": data.before.gpu,
             "schema_version": data.before.schema_version,
             "total_gpu_ns": data.before.total_gpu_ns,
         },
         "after": {
             "path": data.after.path,
+            "profile_id": data.after.profile_id,
             "gpu": data.after.gpu,
             "schema_version": data.after.schema_version,
             "total_gpu_ns": data.after.total_gpu_ns,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -814,6 +814,67 @@ def test_v01_diff_json_envelope_and_verdict(tmp_path):
     assert seen == {"compute", "communication", "idle"}
 
 
+def test_v01_confidence_separates_schema_and_gpu_mismatch():
+    """c_schema and c_gpu are independent factors; mismatching gpu alone zeros confidence."""
+    from nsys_ai.diff import ProfileSummary, collect_sanity_warnings
+
+    # Same schema, different gpu id → c_gpu = 0 → confidence = 0,
+    # but the warning text mentions GPU (not schema).
+    a = ProfileSummary(
+        path="a",
+        gpu=0,
+        schema_version="2024.1.1",
+        total_gpu_ns=100,
+        kernel_rows=100,
+        kernels=[],
+        nvtx=[],
+        overlap={},
+    )
+    b = ProfileSummary(
+        path="b",
+        gpu=1,  # different GPU id, same schema
+        schema_version="2024.1.1",
+        total_gpu_ns=100,
+        kernel_rows=100,
+        kernels=[],
+        nvtx=[],
+        overlap={},
+    )
+    warnings, conf = collect_sanity_warnings(a, b)
+    assert conf == 0.0
+    assert any("GPU" in w for w in warnings)
+    assert not any("schema" in w.lower() for w in warnings)
+
+
+def test_v01_category_attribution_empty_on_overlap_error():
+    """When either side has overlap error, attribution is [] (no fake zeros)."""
+    from nsys_ai.diff import ProfileSummary, compute_category_attribution
+
+    good = ProfileSummary(
+        path="b",
+        gpu=0,
+        schema_version=None,
+        total_gpu_ns=0,
+        kernel_rows=0,
+        kernels=[],
+        nvtx=[],
+        overlap=_make_overlap_dict(100, 20, 10, 5),
+    )
+    bad = ProfileSummary(
+        path="a",
+        gpu=0,
+        schema_version=None,
+        total_gpu_ns=0,
+        kernel_rows=0,
+        kernels=[],
+        nvtx=[],
+        overlap={"error": "no kernels found"},
+    )
+    assert compute_category_attribution(good, bad) == []
+    assert compute_category_attribution(bad, good) == []
+    assert compute_category_attribution(bad, bad) == []
+
+
 def test_v01_diff_id_is_stable_across_runs(tmp_path):
     """Same inputs → same diff_id (content-derived; not random)."""
     from nsys_ai import profile as profile_mod

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -846,6 +846,62 @@ def test_v01_confidence_separates_schema_and_gpu_mismatch():
     assert not any("schema" in w.lower() for w in warnings)
 
 
+def test_v01_no_signal_propagates_through_pipeline():
+    """Overlap error → confidence drops, attribution empty, step_time fields None,
+    JSON omits step_time block. No fake-zero leakage."""
+    from nsys_ai.diff import ProfileDiffSummary, ProfileSummary, collect_sanity_warnings
+    from nsys_ai.diff_render import to_diff_json
+
+    good = ProfileSummary(
+        path="b",
+        gpu=0,
+        schema_version="2024.1.1",
+        total_gpu_ns=100,
+        kernel_rows=100,
+        kernels=[],
+        nvtx=[],
+        overlap=_make_overlap_dict(100, 20, 10, 5),
+    )
+    bad = ProfileSummary(
+        path="a",
+        gpu=0,
+        schema_version="2024.1.1",
+        total_gpu_ns=0,
+        kernel_rows=0,
+        kernels=[],
+        nvtx=[],
+        overlap={"error": "no kernels found"},
+    )
+
+    # confidence must reflect the unavailability (c_overlap = 0 -> product 0)
+    warnings, conf = collect_sanity_warnings(good, bad)
+    assert conf == 0.0
+    assert any("Overlap analysis unavailable" in w for w in warnings)
+
+    # Build a summary that mirrors what diff_profiles would emit on this path
+    # (empty attribution, both step_time fields None) and verify the JSON
+    # never leaks fake zeros.
+    summary = ProfileDiffSummary(
+        before=good,
+        after=bad,
+        warnings=warnings,
+        kernel_diffs=[],
+        nvtx_diffs=[],
+        overlap_before=good.overlap,
+        overlap_after=bad.overlap,
+        overlap_delta={},
+        top_regressions=[],
+        top_improvements=[],
+        verdict="inconclusive",
+        comparability_confidence=conf,
+    )
+    payload = json.loads(to_diff_json(summary))
+    assert payload["step_time"] is None
+    assert payload["category_attribution"] == []
+    assert payload["verdict"] == "inconclusive"
+    assert payload["comparability_confidence"] == 0.0
+
+
 def test_v01_category_attribution_empty_on_overlap_error():
     """When either side has overlap error, attribution is [] (no fake zeros)."""
     from nsys_ai.diff import ProfileSummary, compute_category_attribution

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -848,7 +848,7 @@ def test_v01_confidence_separates_schema_and_gpu_mismatch():
 
 def test_v01_no_signal_propagates_through_pipeline():
     """Overlap error → confidence drops, attribution empty, step_time fields None,
-    JSON omits step_time block. No fake-zero leakage."""
+    JSON step_time is null (key present, value null). No fake-zero leakage."""
     from nsys_ai.diff import ProfileDiffSummary, ProfileSummary, collect_sanity_warnings
     from nsys_ai.diff_render import to_diff_json
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -646,3 +646,188 @@ def test_diff_cli_json_structure_unchanged(tmp_path):
     assert "before" in payload and "after" in payload and "top_regressions" in payload
     assert "executive_summary" not in payload
     assert "ai_narrative" not in payload
+
+
+# ---------------------------------------------------------------------------
+# v0.1 diff schema: envelope, verdict, category attribution, confidence
+# ---------------------------------------------------------------------------
+
+
+def _make_overlap_dict(compute_only_ms, nccl_only_ms, overlap_ms, idle_ms):
+    """Helper to build a fake overlap dict matching overlap_analysis output."""
+    total = compute_only_ms + nccl_only_ms + overlap_ms + idle_ms
+    return {
+        "compute_only_ms": compute_only_ms,
+        "nccl_only_ms": nccl_only_ms,
+        "overlap_ms": overlap_ms,
+        "idle_ms": idle_ms,
+        "total_ms": total,
+        "overlap_pct": 0.0,
+        "compute_kernels": 1,
+        "nccl_kernels": 0,
+    }
+
+
+def test_v01_category_attribution_hta_convention():
+    """compute_category_attribution: overlap_ms counts as compute (HTA convention)."""
+    from nsys_ai.diff import ProfileSummary, compute_category_attribution
+
+    # before: compute_only=100, nccl_only=20, overlap=10, idle=5 → compute=110, comm=20, idle=5
+    before = ProfileSummary(
+        path="b",
+        gpu=0,
+        schema_version=None,
+        total_gpu_ns=0,
+        kernel_rows=0,
+        kernels=[],
+        nvtx=[],
+        overlap=_make_overlap_dict(100, 20, 10, 5),
+    )
+    # after: compute_only=120, nccl_only=25, overlap=15, idle=10 → compute=135, comm=25, idle=10
+    after = ProfileSummary(
+        path="a",
+        gpu=0,
+        schema_version=None,
+        total_gpu_ns=0,
+        kernel_rows=0,
+        kernels=[],
+        nvtx=[],
+        overlap=_make_overlap_dict(120, 25, 15, 10),
+    )
+    cats = {c.category: c for c in compute_category_attribution(before, after)}
+    assert cats["compute"].before_ms == 110.0  # 100 + 10 (overlap)
+    assert cats["compute"].after_ms == 135.0  # 120 + 15
+    assert cats["compute"].delta_ms == 25.0
+    assert cats["communication"].before_ms == 20.0  # exposed_comm = nccl_only
+    assert cats["communication"].after_ms == 25.0
+    assert cats["idle"].before_ms == 5.0
+    assert cats["idle"].after_ms == 10.0
+    # launch_overhead is intentionally absent in v0.1 (PR-B will add it).
+    assert "launch_overhead" not in cats
+
+
+def test_v01_compute_verdict_thresholds():
+    """compute_verdict applies ±5% threshold + confidence ≥ 0.5 gate."""
+    from nsys_ai.diff import compute_verdict
+
+    assert compute_verdict(None, 1.0) == "inconclusive"
+    assert compute_verdict(10.0, 0.3) == "inconclusive"  # low confidence
+    assert compute_verdict(4.9, 1.0) == "neutral"  # below +5%
+    assert compute_verdict(-4.9, 1.0) == "neutral"  # above -5%
+    assert compute_verdict(5.0, 1.0) == "regression_likely"
+    assert compute_verdict(20.0, 0.7) == "regression_likely"
+    assert compute_verdict(-5.0, 1.0) == "improvement_likely"
+    assert compute_verdict(-20.0, 0.7) == "improvement_likely"
+
+
+def test_v01_collect_sanity_warnings_returns_confidence():
+    """collect_sanity_warnings now returns (warnings, confidence)."""
+    from nsys_ai.diff import ProfileSummary, collect_sanity_warnings
+
+    matched = ProfileSummary(
+        path="x",
+        gpu=0,
+        schema_version="2024.1.1",
+        total_gpu_ns=100,
+        kernel_rows=100,
+        kernels=[],
+        nvtx=[],
+        overlap={},
+    )
+    warnings, conf = collect_sanity_warnings(matched, matched)
+    assert isinstance(warnings, list)
+    assert isinstance(conf, float)
+    assert 0.0 <= conf <= 1.0
+    assert conf == 1.0  # identical → perfect confidence
+    assert warnings == []
+
+    # Schema mismatch → C_schema = 0 → confidence = 0
+    other = ProfileSummary(
+        path="y",
+        gpu=0,
+        schema_version="2025.2.2",
+        total_gpu_ns=100,
+        kernel_rows=100,
+        kernels=[],
+        nvtx=[],
+        overlap={},
+    )
+    warnings, conf = collect_sanity_warnings(matched, other)
+    assert conf == 0.0
+    assert any("schema" in w.lower() for w in warnings)
+
+
+def test_v01_diff_json_envelope_and_verdict(tmp_path):
+    """diff JSON v0.1: envelope + verdict + category_attribution + profile_id."""
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 20, 0, 7, 1, 1, 2)])
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--gpu",
+            "0",
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    # Envelope
+    assert payload["schema_version"] == "0.1"
+    assert payload["producer"] == "nsys-ai"
+    assert "producer_version" in payload
+    assert payload["diff_id"].startswith("diff1:sha256:")
+    # diff_id has a 64-char hex digest after the prefix
+    assert len(payload["diff_id"]) == len("diff1:sha256:") + 64
+
+    # profile_id in each side, content-derived
+    assert payload["before"]["profile_id"].startswith("nsys1:")
+    assert payload["after"]["profile_id"].startswith("nsys1:")
+
+    # Verdict + confidence
+    assert payload["verdict"] in {
+        "neutral",
+        "regression_likely",
+        "improvement_likely",
+        "inconclusive",
+    }
+    assert 0.0 <= payload["comparability_confidence"] <= 1.0
+
+    # step_time block
+    assert "step_time" in payload
+    assert "delta_ms" in payload["step_time"]
+
+    # category_attribution is a list of category bucket entries
+    cats = payload["category_attribution"]
+    assert isinstance(cats, list)
+    seen = {c["category"] for c in cats}
+    assert seen == {"compute", "communication", "idle"}
+
+
+def test_v01_diff_id_is_stable_across_runs(tmp_path):
+    """Same inputs → same diff_id (content-derived; not random)."""
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 20, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        d1 = diff_profiles(b, a, gpu=0, limit=10)
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        d2 = diff_profiles(b, a, gpu=0, limit=10)
+
+    assert d1.diff_id == d2.diff_id
+    assert d1.diff_id.startswith("diff1:sha256:")

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -931,6 +931,26 @@ def test_v01_category_attribution_empty_on_overlap_error():
     assert compute_category_attribution(bad, bad) == []
 
 
+def test_v01_confidence_serialization_truncates_not_rounds():
+    """JSON-serialized confidence must never cross the 0.5 verdict gate
+    via rounding (e.g. 0.4996 must NOT show as 0.500)."""
+    from nsys_ai.diff import ProfileDiffSummary, ProfileSummary
+    from nsys_ai.diff_render import to_diff_json
+
+    bare = ProfileSummary(
+        path="", gpu=0, schema_version=None, total_gpu_ns=0,
+        kernel_rows=0, kernels=[], nvtx=[], overlap={},
+    )
+    summary = ProfileDiffSummary(
+        before=bare, after=bare, warnings=[], kernel_diffs=[], nvtx_diffs=[],
+        overlap_before={}, overlap_after={}, overlap_delta={},
+        top_regressions=[], top_improvements=[],
+        comparability_confidence=0.4996,
+    )
+    payload = json.loads(to_diff_json(summary))
+    assert payload["comparability_confidence"] == 0.499
+
+
 def test_v01_diff_id_is_stable_across_runs(tmp_path):
     """Same inputs → same diff_id (content-derived; not random)."""
     from nsys_ai import profile as profile_mod


### PR DESCRIPTION
## Summary

- Add top-level `verdict`, `comparability_confidence`, `step_time` summary, and `category_attribution` rollup to `nsys-ai diff --format json`, plus a v0.1 envelope (`schema_version`, `producer`, `producer_version`, `diff_id`) and `profile_id` on each side.
- `category_attribution` follows the HTA convention: `overlap_ms` counts as compute, `nccl_only_ms` is exposed comm.
- `verdict` fires `regression_likely` / `improvement_likely` at ±5% step-time delta when `comparability_confidence ≥ 0.5`; below the gate or with no step-time signal → `inconclusive`.

## Changes

- `src/nsys_ai/diff.py`
  - `ProfileSummary.profile_id` (content-derived via `fingerprint.get_profile_id`).
  - `CategoryDelta` dataclass + `compute_category_attribution(before, after)` — compute / communication / idle buckets (launch_overhead reserved). Returns `[]` when either side's `overlap_analysis` carries an `error` key.
  - `compute_verdict(delta_pct, confidence)` — ±5% threshold + `MIN_COMPARABILITY_CONFIDENCE = 0.5` gate.
  - `collect_sanity_warnings` returns `(warnings, comparability_confidence)` where `confidence = c_schema * c_gpu * c_workload * c_kernel_overlap * c_overlap`. Each factor maps to a separate compatibility check (Nsight schema, selected GPU id, kernel-row volume, kernel-name overlap, overlap-analysis availability). Returned unrounded so the 0.5 verdict gate is not crossed by rounding artifacts; quantized at the JSON serialization boundary.
  - `_make_diff_id` → `diff1:sha256:<hex>` over both `profile_id`s + diff params.
  - `ProfileDiffSummary` gains `verdict`, `comparability_confidence`, `category_attribution`, `step_time_delta_ms` (Optional, `None` when attribution is empty), `step_time_delta_pct`, `diff_id` (all additive with defaults).
- `src/nsys_ai/diff_render.py` — `to_diff_json` emits the v0.1 envelope, verdict, confidence (rounded at this boundary), `step_time` block (`null` when attribution is empty), `category_attribution` list, and `profile_id` on each side. Existing keys preserved.
- `tests/test_diff.py` — 8 new tests: HTA attribution, verdict thresholds, confidence formula, JSON envelope shape, `diff_id` stability, `c_gpu` vs `c_schema` separation, `category_attribution = []` on overlap error, full pipeline "no signal" propagation.

## Backward compatibility

Yes. All new fields are additive (dataclass defaults, new JSON keys); the 19 pre-existing diff tests pass unchanged, including `test_diff_cli_json_structure_unchanged`.

## Test plan

- [x] Tests added: 8 new v0.1 tests in `tests/test_diff.py`
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 859 passed, 135 skipped
- [x] `ruff check src/ tests/` clean
- [x] `bandit -r src/nsys_ai/diff.py src/nsys_ai/diff_render.py` — no issues
- [x] Manually exercised `nsys-ai diff --format json` on a minimal fixture

## Out of scope

Reserved for the next PR:

- Communication / idle / launch-overhead detail axes (top NCCL regressions, etc.).
- `launch_overhead` bucket populated from the `kernel_launch_overhead` skill.
- `TraceSelection` attached to top regressions/improvements.
- `DiffLineage` written onto top regression/improvement entries.

## Linked issues

None.