### PR TITLE
feat(skills): nccl_compile_context_breakdown + temporal-containment docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `nccl_compile_context_breakdown` skill — classifies NCCL kernels by their
+  **leaf** NVTX label into eager / inductor_captured / temporal_only buckets.
+  Decides whether a collective perf fix lives in user code (stream wrap,
+  `async_op=True`) or in `torch._inductor.config` (functional collectives,
+  `reorder_for_compute_comm_overlap`).
+- `nsys-ai diff --format json` emits a v0.1 envelope (`schema_version`,
+  `producer`, `producer_version`, `diff_id`) plus top-level `verdict`,
+  `comparability_confidence`, step-time `category_attribution` (HTA
+  convention: `overlap_ms` counts as compute, `nccl_only_ms` is exposed
+  comm), and content-derived `profile_id` on each side (PR #130).
+- `nccl_payload_breakdown` skill — decodes NVTX typed-payload `binaryData`
+  to extract real NCCL message sizes, peer ranks, and communicator IDs
+  (PR #128).
+
+### Changed
+
+- `nvtx_kernel_map` docstring now documents temporal-containment semantics:
+  `nvtx_text` is the **leaf** NVTX label (innermost open scope at kernel
+  launch), and `nvtx_path` containment is temporal, not lexical.
+  Classifying by ancestor-path substring (e.g. `LIKE '%Torch-Compiled%'`)
+  can pick up kernels whose enclosing scope merely happened to still be
+  open — not kernels that the enclosing tool actually traced.
+
+### Fixed
+
+- `fingerprint.distributed` falls back to `COUNT(DISTINCT deviceId) > 1`
+  so multi-GPU single-node profiles report `distributed=True`;
+  `overlap_breakdown` surfaces `present_devices` and warns when the caller
+  did not pass `-p device=N` on a multi-device profile (PR #127).
+- Parquet cache builds are `flock`-serialized to prevent concurrent crashes
+  when two `nsys-ai` invocations target the same cache directory (PR #122).
+
+### Performance
+
+- `overlap_analysis` SQL sweep-line — 3.2× speedup on the analysis call
+  (PR #125).
+- NVTX layer breakdown 43s → 1.4s via `nvtx_high` parquet + `ORDER BY`
+  (PR #123).
+- `profile_health_manifest` auto-trims long profiles to a representative
+  window (PR #124).
+
+### Docs
+
+- Evidence schema reference brought up to v0.1: new optional fields,
+  envelope keys, supporting types, enriched example (PR #119).
+- `docs/agent_skills/.../perf_budget.md` §9 rewritten for NVTX-heavy
+  profiles (PR #126).
+
+## [0.2.3] — 2026-05-12 and earlier
+
+See `git log v0.2.3` for changes prior to the introduction of this
+changelog.
+
+[Unreleased]: https://github.com/GindaChen/nsys-ai/compare/v0.2.3...HEAD
+[0.2.3]: https://github.com/GindaChen/nsys-ai/releases/tag/v0.2.3

--- a/src/nsys_ai/nvtx_attribution.py
+++ b/src/nsys_ai/nvtx_attribution.py
@@ -203,6 +203,7 @@ def attribute_kernels_to_nvtx(
     sqlite_path: str | None = None,
     trim: tuple[int, int] | None = None,
     limit: int | None = None,
+    kernel_name_substring: str | None = None,
 ) -> list[dict]:
     """Attribute GPU kernels to their enclosing NVTX ranges.
 
@@ -212,6 +213,12 @@ def attribute_kernels_to_nvtx(
     Returns list of dicts with keys:
       nvtx_text, nvtx_depth, nvtx_path,
       kernel_name, k_start, k_end, k_dur_ns
+
+    ``kernel_name_substring`` (advisory): when set, the DuckDB-cache fast
+    path pushes ``kernel_name ILIKE '%<substring>%'`` into the SQL so
+    unrelated kernels are never materialized into Python. Other backends
+    ignore this parameter — callers asking for filtered output must still
+    filter the returned list themselves as defense-in-depth.
     """
 
     # DuckDB: try reading from precomputed nvtx_kernel_map first.
@@ -237,19 +244,22 @@ def attribute_kernels_to_nvtx(
                 uses_path_id = cached_nvtx_map_uses_path_id(adapter.raw_conn)
 
                 if uses_path_id:
-                    trim_sql_m = ""
-                    if trim:
-                        trim_sql_m = "WHERE m.k_start >= ? AND m.k_end <= ?"
+                    where_m = "WHERE m.k_start >= ? AND m.k_end <= ?" if trim else ""
+                    extra_params: list = []
+                    if kernel_name_substring:
+                        connector = " AND" if where_m else "WHERE"
+                        where_m = f"{where_m}{connector} m.kernel_name ILIKE ?"
+                        extra_params.append(f"%{kernel_name_substring}%")
                     cur = adapter.execute(
                         f"""
                         SELECT m.nvtx_text, m.nvtx_depth, d.nvtx_path, m.kernel_name,
                                m.k_start, m.k_end, m.k_dur_ns
                         FROM nvtx_kernel_map m
                         JOIN nvtx_path_dict d ON m.path_id = d.path_id
-                        {trim_sql_m}
+                        {where_m}
                         ORDER BY m.k_start{limit_sql}
                         """,
-                        params,
+                        params + extra_params,
                     )
                 else:
                     cur = adapter.execute(

--- a/src/nsys_ai/nvtx_attribution.py
+++ b/src/nsys_ai/nvtx_attribution.py
@@ -262,9 +262,15 @@ def attribute_kernels_to_nvtx(
                         params + extra_params,
                     )
                 else:
+                    where_legacy = trim_sql
+                    extra_legacy: list = []
+                    if kernel_name_substring:
+                        connector = " AND" if where_legacy else "WHERE"
+                        where_legacy = f"{where_legacy}{connector} kernel_name ILIKE ?"
+                        extra_legacy.append(f"%{kernel_name_substring}%")
                     cur = adapter.execute(
-                        f"SELECT * FROM nvtx_kernel_map {trim_sql} ORDER BY k_start{limit_sql}",
-                        params,
+                        f"SELECT * FROM nvtx_kernel_map {where_legacy} ORDER BY k_start{limit_sql}",
+                        params + extra_legacy,
                     )
                 cols = [d[0] for d in cur.description]
                 return [dict(zip(cols, row)) for row in cur.fetchall()]

--- a/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
@@ -1,0 +1,156 @@
+"""Classify NCCL kernels by their leaf NVTX label (call mode).
+
+Answers a single question: of the NCCL kernels in this profile, what
+fraction were called eagerly (user code reaching c10d / NCCL directly),
+captured inside an inductor-compiled graph, or running under some
+unrelated NVTX scope?
+
+The fix recommendation depends on the dominant bucket:
+
+  - eager-dominant         → caller-side fix: wrap collectives with
+                              ``async_op=True`` or move them to a
+                              dedicated stream
+  - inductor-dominant      → ``torch._inductor.config`` knobs:
+                              functional collectives,
+                              ``reorder_for_compute_comm_overlap``
+  - temporal_only-dominant → reach for ``nccl_payload_breakdown`` and
+                              ``overlap_breakdown`` to find the real
+                              driver; the leaf NVTX is uninformative
+
+IMPORTANT (the lesson from §4 B audit gap #14): classification is by
+**leaf NVTX label**, not ancestor-path match. NVTX path containment
+is *temporal* — any scope that happened to still be open when the
+kernel launched. A filter like ``nvtx_path LIKE '%Torch-Compiled%'``
+would falsely tag eager calls whose enclosing compile-region NVTX
+hadn't closed yet at launch time. A real fastvideo audit shipped the
+wrong fix recommendation on exactly that mistake (96% of NCCL kernels
+matched the path filter, but only 5.4% were actually inductor-captured
+by their leaf label).
+"""
+
+from ..base import Skill
+
+# Inductor-captured leaf marker — observed in PyTorch ≥ 2.1 compiled graphs.
+# When PyTorch lowers a collective through Dynamo + Inductor, the launching
+# NVTX scope at kernel time is the compiled fx-graph call frame.
+_INDUCTOR_LEAF_MARKERS = ("## Call CompiledFxGraph",)
+
+# Eager-call leaf prefixes. ``c10d::`` is the public C++ binding namespace
+# (e.g. ``c10d::all_reduce_``), ``nccl`` covers raw NCCL wrappers and the
+# functional collectives runtime calls (e.g. ``nccl:all_reduce``).
+_EAGER_LEAF_PREFIXES = ("c10d::", "nccl")
+
+
+def _classify_leaf(leaf: str) -> str:
+    """Map a leaf NVTX label to one of the three call-mode buckets."""
+    if not leaf:
+        return "temporal_only"
+    if any(leaf.startswith(p) for p in _EAGER_LEAF_PREFIXES):
+        return "eager"
+    if any(m in leaf for m in _INDUCTOR_LEAF_MARKERS):
+        return "inductor_captured"
+    return "temporal_only"
+
+
+def _is_nccl_kernel(name: str) -> bool:
+    """Match NCCL kernels by lowercase substring — covers `ncclKernel_*`,
+    `ncclDevKernel_*`, and `nccl_AllReduce_*` variants across NCCL versions."""
+    return bool(name) and "nccl" in name.lower()
+
+
+def _execute(conn, **kwargs):
+    from ...nvtx_attribution import attribute_kernels_to_nvtx
+
+    trim_start = kwargs.get("trim_start_ns")
+    trim_end = kwargs.get("trim_end_ns")
+    trim = (
+        (int(trim_start), int(trim_end))
+        if trim_start is not None and trim_end is not None
+        else None
+    )
+    sqlite_path = kwargs.get("_sqlite_path")
+
+    rows = attribute_kernels_to_nvtx(conn, sqlite_path=sqlite_path, trim=trim, limit=None)
+
+    buckets: dict[str, dict[str, int]] = {
+        "eager": {"count": 0, "ns": 0},
+        "inductor_captured": {"count": 0, "ns": 0},
+        "temporal_only": {"count": 0, "ns": 0},
+    }
+    for r in rows:
+        if not _is_nccl_kernel(r.get("kernel_name", "")):
+            continue
+        bucket = _classify_leaf(r.get("nvtx_text", "") or "")
+        buckets[bucket]["count"] += 1
+        buckets[bucket]["ns"] += int(r.get("k_dur_ns") or 0)
+
+    total_count = sum(b["count"] for b in buckets.values())
+    total_ns = sum(b["ns"] for b in buckets.values())
+
+    if total_count == 0:
+        return [{
+            "error": (
+                "No NCCL kernels found in this profile (filter: kernel name "
+                "contains 'nccl'). Single-GPU profiles or captures without "
+                "NCCL tracing will land here."
+            ),
+        }]
+
+    return [
+        {
+            "_summary": True,
+            "total_nccl_kernels": total_count,
+            "total_nccl_ms": round(total_ns / 1e6, 3),
+        },
+        *[
+            {
+                "bucket": name,
+                "count": b["count"],
+                "ms": round(b["ns"] / 1e6, 3),
+                "pct": round(b["count"] / total_count * 100, 1),
+                "ms_pct": round(b["ns"] / total_ns * 100, 1) if total_ns > 0 else 0.0,
+            }
+            for name, b in buckets.items()
+        ],
+    ]
+
+
+def _format(rows):
+    if not rows or "error" in rows[0]:
+        return f"(NCCL compile context: {rows[0].get('error', 'no data') if rows else 'no data'})"
+    s = rows[0]
+    lines = [
+        "── NCCL Call-Mode Breakdown (by leaf NVTX) ──",
+        f"  Total NCCL kernels: {s['total_nccl_kernels']:,}  ({s['total_nccl_ms']:.3f} ms)",
+        "",
+        f"  {'bucket':<20}  {'count':>8}  {'ms':>12}  {'count_pct':>10}  {'ms_pct':>10}",
+        "  " + "─" * 66,
+    ]
+    for r in rows[1:]:
+        lines.append(
+            f"  {r['bucket']:<20}  {r['count']:>8}  {r['ms']:>12.3f}  "
+            f"{r['pct']:>9.1f}%  {r['ms_pct']:>9.1f}%"
+        )
+    return "\n".join(lines)
+
+
+SKILL = Skill(
+    name="nccl_compile_context_breakdown",
+    title="NCCL Call-Mode Breakdown (eager vs inductor-captured vs temporal-only)",
+    description=(
+        "Classifies NCCL kernels by the leaf NVTX label open at launch time: "
+        "eager (c10d::* / nccl* leaf), inductor_captured (## Call CompiledFxGraph "
+        "leaf), or temporal_only (anything else). Decides whether a collective "
+        "perf fix lives in user code (stream wrap, async_op) or in inductor "
+        "config (functional collectives, reorder_for_compute_comm_overlap). "
+        "Classifies by LEAF label, not ancestor-path containment — see module "
+        "docstring for why."
+    ),
+    category="communication",
+    execute_fn=_execute,
+    format_fn=_format,
+    tags=[
+        "nccl", "communication", "distributed", "torch-compile", "inductor",
+        "call-mode", "eager", "nvtx",
+    ],
+)

--- a/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
@@ -1,48 +1,27 @@
 """Classify NCCL kernels by their leaf NVTX label (call mode).
 
-Answers a single question: of the NCCL kernels in this profile, what
-fraction were called eagerly (user code reaching c10d / NCCL directly),
-captured inside an inductor-compiled graph, or running under some
-unrelated NVTX scope?
+Buckets each NCCL kernel into one of three call modes based on the
+leaf NVTX scope open at launch time. The dominant bucket selects the
+fix path:
 
-The fix recommendation depends on the dominant bucket:
+  - eager             → caller-side: ``async_op=True`` / dedicated stream
+  - inductor_captured → ``torch._inductor.config`` (functional
+                        collectives, ``reorder_for_compute_comm_overlap``)
+  - temporal_only     → leaf NVTX uninformative; reach for
+                        ``nccl_payload_breakdown`` / ``overlap_breakdown``
 
-  - eager-dominant         → caller-side fix: wrap collectives with
-                              ``async_op=True`` or move them to a
-                              dedicated stream
-  - inductor-dominant      → ``torch._inductor.config`` knobs:
-                              functional collectives,
-                              ``reorder_for_compute_comm_overlap``
-  - temporal_only-dominant → reach for ``nccl_payload_breakdown`` and
-                              ``overlap_breakdown`` to find the real
-                              driver; the leaf NVTX is uninformative
-
-IMPORTANT (the lesson from §4 B audit gap #14): classification is by
-**leaf NVTX label**, not ancestor-path match. NVTX path containment
-is *temporal* — any scope that happened to still be open when the
-kernel launched. A filter like ``nvtx_path LIKE '%Torch-Compiled%'``
-would falsely tag eager calls whose enclosing compile-region NVTX
-hadn't closed yet at launch time. A real fastvideo audit shipped the
-wrong fix recommendation on exactly that mistake (96% of NCCL kernels
-matched the path filter, but only 5.4% were actually inductor-captured
-by their leaf label).
+Classifies by **leaf** label, not ancestor-path containment. See
+``nvtx_kernel_map``'s module docstring for why (temporal vs lexical
+containment).
 """
 
 from ..base import Skill
 
-# Inductor-captured leaf marker — observed in PyTorch ≥ 2.1 compiled graphs.
-# When PyTorch lowers a collective through Dynamo + Inductor, the launching
-# NVTX scope at kernel time is the compiled fx-graph call frame.
 _INDUCTOR_LEAF_MARKERS = ("## Call CompiledFxGraph",)
-
-# Eager-call leaf prefixes. ``c10d::`` is the public C++ binding namespace
-# (e.g. ``c10d::all_reduce_``), ``nccl`` covers raw NCCL wrappers and the
-# functional collectives runtime calls (e.g. ``nccl:all_reduce``).
 _EAGER_LEAF_PREFIXES = ("c10d::", "nccl")
 
 
 def _classify_leaf(leaf: str) -> str:
-    """Map a leaf NVTX label to one of the three call-mode buckets."""
     if not leaf:
         return "temporal_only"
     if any(leaf.startswith(p) for p in _EAGER_LEAF_PREFIXES):
@@ -53,8 +32,6 @@ def _classify_leaf(leaf: str) -> str:
 
 
 def _is_nccl_kernel(name: str) -> bool:
-    """Match NCCL kernels by lowercase substring — covers `ncclKernel_*`,
-    `ncclDevKernel_*`, and `nccl_AllReduce_*` variants across NCCL versions."""
     return bool(name) and "nccl" in name.lower()
 
 
@@ -88,13 +65,7 @@ def _execute(conn, **kwargs):
     total_ns = sum(b["ns"] for b in buckets.values())
 
     if total_count == 0:
-        return [{
-            "error": (
-                "No NCCL kernels found in this profile (filter: kernel name "
-                "contains 'nccl'). Single-GPU profiles or captures without "
-                "NCCL tracing will land here."
-            ),
-        }]
+        return [{"error": "No NCCL kernels found (single-GPU or no NCCL tracing)."}]
 
     return [
         {
@@ -138,19 +109,12 @@ SKILL = Skill(
     name="nccl_compile_context_breakdown",
     title="NCCL Call-Mode Breakdown (eager vs inductor-captured vs temporal-only)",
     description=(
-        "Classifies NCCL kernels by the leaf NVTX label open at launch time: "
-        "eager (c10d::* / nccl* leaf), inductor_captured (## Call CompiledFxGraph "
-        "leaf), or temporal_only (anything else). Decides whether a collective "
-        "perf fix lives in user code (stream wrap, async_op) or in inductor "
-        "config (functional collectives, reorder_for_compute_comm_overlap). "
-        "Classifies by LEAF label, not ancestor-path containment — see module "
-        "docstring for why."
+        "Classifies NCCL kernels by leaf NVTX label into eager / "
+        "inductor_captured / temporal_only buckets. Decides whether a "
+        "collective perf fix lives in user code or in torch._inductor.config."
     ),
     category="communication",
     execute_fn=_execute,
     format_fn=_format,
-    tags=[
-        "nccl", "communication", "distributed", "torch-compile", "inductor",
-        "call-mode", "eager", "nvtx",
-    ],
+    tags=["nccl", "communication", "distributed", "torch-compile", "nvtx"],
 )

--- a/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
@@ -47,7 +47,12 @@ def _execute(conn, **kwargs):
     )
     sqlite_path = kwargs.get("_sqlite_path")
 
-    rows = attribute_kernels_to_nvtx(conn, sqlite_path=sqlite_path, trim=trim, limit=None)
+    # kernel_name_substring is the SQL-pushdown hint (advisory); the
+    # _is_nccl_kernel loop below covers backends that ignore it.
+    rows = attribute_kernels_to_nvtx(
+        conn, sqlite_path=sqlite_path, trim=trim, limit=None,
+        kernel_name_substring="nccl",
+    )
 
     buckets: dict[str, dict[str, int]] = {
         "eager": {"count": 0, "ns": 0},

--- a/src/nsys_ai/skills/builtins/nvtx_kernel_map.py
+++ b/src/nsys_ai/skills/builtins/nvtx_kernel_map.py
@@ -1,4 +1,29 @@
-"""Map NVTX annotation ranges to their GPU kernel children."""
+"""Map NVTX annotation ranges to their GPU kernel children.
+
+Output schema (per row):
+
+  ``nvtx_text``  — the **leaf** NVTX label: the innermost NVTX scope
+                   that was still open at the kernel's launch time.
+  ``nvtx_path``  — the full ancestor stack (root → leaf, ``" > "``
+                   separated), present in DuckDB-cache outputs.
+  ``kernel_name`` / ``start_ms`` / ``end_ms`` — self-explanatory.
+
+WARNING — NVTX path containment is **temporal**, not lexical. A
+kernel whose ``nvtx_path`` contains ``"Torch-Compiled Region"`` does
+NOT mean Inductor compiled that kernel — it only means a compile-
+region NVTX happened to still be open *somewhere up the stack* when
+the kernel launched. Eager calls inside the same thread can land
+under the same path until the outer scope closes. A real fastvideo
+audit shipped a wrong-path fix recommendation by treating path
+containment as lexical: ``nvtx_path LIKE '%Torch-Compiled%'`` matched
+96% of NCCL kernels, but only 5.4% were actually inductor-captured
+(``## Call CompiledFxGraph`` as the **leaf**).
+
+Rule of thumb: when the question is "what code path executed this
+op", classify by the **leaf** (``nvtx_text``), not by substring match
+on ``nvtx_path``. The ``nccl_compile_context_breakdown`` skill is the
+canonical example.
+"""
 
 from ..base import Skill, SkillParam
 

--- a/src/nsys_ai/skills/builtins/nvtx_kernel_map.py
+++ b/src/nsys_ai/skills/builtins/nvtx_kernel_map.py
@@ -51,6 +51,7 @@ def _execute(conn, **kwargs):
     return [
         {
             "nvtx_text": r["nvtx_text"],
+            "nvtx_path": r.get("nvtx_path", ""),
             "kernel_name": r["kernel_name"],
             "start_ms": round(r["k_start"] / 1e6, 3),
             "end_ms": round(r["k_end"] / 1e6, 3),

--- a/tests/test_nccl_compile_context_breakdown.py
+++ b/tests/test_nccl_compile_context_breakdown.py
@@ -1,0 +1,195 @@
+"""Tests for nccl_compile_context_breakdown skill.
+
+Verifies the classification of NCCL kernels by their **leaf** NVTX label
+into eager / inductor_captured / temporal_only buckets — the lesson from
+§4 B audit gap #14 (NVTX path containment is temporal, not lexical).
+"""
+
+import sqlite3
+
+import pytest
+
+# Minimal Nsight-like schema for in-memory tests (mirrors tests/conftest.py).
+_SCHEMA_SQL = """
+CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT NOT NULL);
+CREATE TABLE TARGET_INFO_GPU (
+    id INTEGER PRIMARY KEY, name TEXT, busLocation TEXT DEFAULT '',
+    totalMemory INTEGER DEFAULT 0, smCount INTEGER DEFAULT 0,
+    chipName TEXT DEFAULT '', memoryBandwidth INTEGER DEFAULT 0
+);
+CREATE TABLE TARGET_INFO_CUDA_DEVICE (
+    gpuId INTEGER, cudaId INTEGER, pid INTEGER DEFAULT 0,
+    uuid TEXT DEFAULT '', numMultiprocessors INTEGER DEFAULT 0
+);
+CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+    globalPid INTEGER DEFAULT 0, deviceId INTEGER DEFAULT 0,
+    streamId INTEGER DEFAULT 0, correlationId INTEGER DEFAULT 0,
+    start INTEGER NOT NULL, end INTEGER NOT NULL,
+    shortName INTEGER NOT NULL, demangledName INTEGER DEFAULT 0,
+    gridX INTEGER DEFAULT 1, gridY INTEGER DEFAULT 1, gridZ INTEGER DEFAULT 1,
+    blockX INTEGER DEFAULT 1, blockY INTEGER DEFAULT 1, blockZ INTEGER DEFAULT 1
+);
+CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+    globalTid INTEGER DEFAULT 0, correlationId INTEGER DEFAULT 0,
+    start INTEGER NOT NULL, end INTEGER NOT NULL, nameId INTEGER DEFAULT 0
+);
+CREATE TABLE NVTX_EVENTS (
+    globalTid INTEGER DEFAULT 0, start INTEGER NOT NULL,
+    end INTEGER DEFAULT -1, text TEXT DEFAULT '',
+    eventType INTEGER DEFAULT 59, rangeId INTEGER DEFAULT 0,
+    textId INTEGER DEFAULT NULL
+);
+"""
+
+# Three NCCL kernels each under a distinct innermost NVTX scope:
+#   kernel A (1_000_000 ns)  inside leaf "c10d::all_reduce"
+#   kernel B (4_000_000 ns)  inside leaf "## Call CompiledFxGraph"
+#   kernel C (10_000_000 ns) inside leaf "backward"     (no deeper scope)
+# Plus one non-NCCL compute kernel under the eager leaf — must be filtered out.
+_SEED_SQL = """
+INSERT INTO StringIds VALUES
+    (10, 'ncclKernel_AllReduce_RING'),
+    (20, 'sm80_gemm_f16f16'),
+    (24, 'cudaLaunchKernel');
+
+INSERT INTO TARGET_INFO_GPU VALUES
+    (0, 'NVIDIA Test', '', 8589934592, 108, 'TestChip', 0);
+INSERT INTO TARGET_INFO_CUDA_DEVICE VALUES (0, 0, 100, '', 108);
+
+INSERT INTO NVTX_EVENTS (globalTid, start, end, text, eventType, rangeId) VALUES
+    (100,  0,        100000000, 'iteration',                  59, 0),
+    (100,  1000000,   30000000, 'forward',                    59, 1),
+    (100,  5000000,    8000000, 'c10d::all_reduce',           59, 2),
+    (100, 15000000,   25000000, '## Call CompiledFxGraph',    59, 3),
+    (100, 40000000,   90000000, 'backward',                   59, 4);
+
+-- NCCL kernels (shortName 10) on stream 8
+INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES
+    (100, 0, 8,  1,  6000000,  7000000, 10, 10, 1,1,1, 512,1,1),
+    (100, 0, 8,  2, 18000000, 22000000, 10, 10, 1,1,1, 512,1,1),
+    (100, 0, 8,  3, 50000000, 60000000, 10, 10, 1,1,1, 512,1,1);
+
+-- One compute kernel under the eager leaf — must NOT be counted as NCCL.
+INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES
+    (100, 0, 7,  4,  6200000,  6800000, 20, 20, 32,1,1, 256,1,1);
+
+-- Runtime entries tie each kernel launch to thread 100 so attribution can
+-- locate the open NVTX scope at launch time.
+INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES
+    (100, 1,  5500000,  6000000, 24),
+    (100, 2, 17000000, 18000000, 24),
+    (100, 3, 45000000, 50000000, 24),
+    (100, 4,  5700000,  6200000, 24);
+"""
+
+
+@pytest.fixture
+def three_bucket_conn():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_SCHEMA_SQL)
+    conn.executescript(_SEED_SQL)
+    yield conn
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Unit tests on the classification helpers (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_leaf_eager_prefixes():
+    from nsys_ai.skills.builtins.nccl_compile_context_breakdown import _classify_leaf
+
+    assert _classify_leaf("c10d::all_reduce") == "eager"
+    assert _classify_leaf("c10d::reduce_scatter_tensor") == "eager"
+    assert _classify_leaf("nccl:all_reduce") == "eager"
+    assert _classify_leaf("ncclAllReduce") == "eager"
+
+
+def test_classify_leaf_inductor_marker():
+    from nsys_ai.skills.builtins.nccl_compile_context_breakdown import _classify_leaf
+
+    assert _classify_leaf("## Call CompiledFxGraph") == "inductor_captured"
+    # Substring also matches (the marker can appear with a suffix in real traces).
+    assert _classify_leaf("## Call CompiledFxGraph forward_0") == "inductor_captured"
+
+
+def test_classify_leaf_temporal_only_fallback():
+    from nsys_ai.skills.builtins.nccl_compile_context_breakdown import _classify_leaf
+
+    assert _classify_leaf("") == "temporal_only"
+    assert _classify_leaf("backward") == "temporal_only"
+    assert _classify_leaf("forward") == "temporal_only"
+    assert _classify_leaf("Torch-Compiled Region") == "temporal_only"  # ancestor, not leaf
+
+
+def test_is_nccl_kernel_filter():
+    from nsys_ai.skills.builtins.nccl_compile_context_breakdown import _is_nccl_kernel
+
+    assert _is_nccl_kernel("ncclKernel_AllReduce_RING_LL_Sum")
+    assert _is_nccl_kernel("nccl_AllReduce_kernel")
+    assert _is_nccl_kernel("ncclDevKernel_Generic")
+    assert not _is_nccl_kernel("sm80_gemm_f16f16")
+    assert not _is_nccl_kernel("")
+
+
+# ---------------------------------------------------------------------------
+# End-to-end skill execution on the three-bucket fixture
+# ---------------------------------------------------------------------------
+
+
+def test_skill_classifies_three_buckets(three_bucket_conn):
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("nccl_compile_context_breakdown")
+    rows = skill.execute(three_bucket_conn)
+
+    # rows[0] is the summary; rows[1:] are the buckets.
+    summary = rows[0]
+    assert summary["_summary"] is True
+    assert summary["total_nccl_kernels"] == 3  # 3 NCCL kernels, compute kernel excluded
+
+    buckets = {r["bucket"]: r for r in rows[1:]}
+    assert set(buckets) == {"eager", "inductor_captured", "temporal_only"}
+
+    # Each leaf NVTX scope contains exactly one NCCL kernel.
+    assert buckets["eager"]["count"] == 1
+    assert buckets["inductor_captured"]["count"] == 1
+    assert buckets["temporal_only"]["count"] == 1
+
+    # Durations come from the seeded kernel spans.
+    assert buckets["eager"]["ms"] == 1.0           # 6_000_000 → 7_000_000
+    assert buckets["inductor_captured"]["ms"] == 4.0  # 18_000_000 → 22_000_000
+    assert buckets["temporal_only"]["ms"] == 10.0     # 50_000_000 → 60_000_000
+
+    # Percentages sum to ~100 (count-pct and ms-pct independently).
+    assert sum(b["pct"] for b in buckets.values()) == pytest.approx(100.0, abs=0.3)
+    assert sum(b["ms_pct"] for b in buckets.values()) == pytest.approx(100.0, abs=0.3)
+
+
+def test_skill_no_nccl_kernels_returns_error():
+    """When the profile has no NCCL kernels, the skill returns an explicit error
+    row instead of producing a misleading 0/0/0 breakdown."""
+    from nsys_ai.skills.registry import get_skill
+
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_SCHEMA_SQL)
+    conn.executescript("""
+        INSERT INTO StringIds VALUES (20, 'sm80_gemm_f16f16'), (24, 'cudaLaunchKernel');
+        INSERT INTO TARGET_INFO_GPU VALUES (0, 'NVIDIA Test', '', 0, 108, 'TestChip', 0);
+        INSERT INTO TARGET_INFO_CUDA_DEVICE VALUES (0, 0, 100, '', 108);
+        INSERT INTO NVTX_EVENTS (globalTid, start, end, text, eventType, rangeId) VALUES
+            (100, 0, 10000000, 'forward', 59, 0);
+        INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES
+            (100, 0, 7, 1, 1000000, 2000000, 20, 20, 32,1,1, 256,1,1);
+        INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES
+            (100, 1, 500000, 1000000, 24);
+    """)
+    try:
+        skill = get_skill("nccl_compile_context_breakdown")
+        rows = skill.execute(conn)
+        assert len(rows) == 1
+        assert "error" in rows[0]
+        assert "No NCCL kernels" in rows[0]["error"]
+    finally:
+        conn.close()

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -31,6 +31,7 @@ def test_list_skills():
         "nccl_anomaly",
         "nccl_breakdown",
         "nccl_communicator_analysis",
+        "nccl_compile_context_breakdown",
         "nccl_payload_breakdown",
         "nvtx_kernel_map",
         "nvtx_layer_breakdown",


### PR DESCRIPTION
## Summary

- New skill `nccl_compile_context_breakdown` classifies NCCL kernels by their **leaf** NVTX label into three call-mode buckets: `eager` (leaf matches `c10d::*` / `nccl*`), `inductor_captured` (leaf contains `## Call CompiledFxGraph`), or `temporal_only` (anything else). The dominant bucket selects the fix path — caller-side vs `torch._inductor.config` vs neither.
- Adds a temporal-containment warning to `nvtx_kernel_map`'s module docstring so future skills don't filter NCCL kernels by ancestor-path substring (the foot-gun this skill exists to avoid).
- Starts `CHANGELOG.md` (Keep a Changelog format) covering the post-v0.2.3 window.

## Changes

- `src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py` — new skill. Built on `attribute_kernels_to_nvtx`; filters kernels whose name contains `nccl`, classifies each by leaf NVTX text. Output is a summary row + three bucket rows with `count`, `ms`, `pct`, `ms_pct`. Explicit error row when the profile has no NCCL kernels.
- `src/nsys_ai/skills/builtins/nvtx_kernel_map.py` — module docstring now spells out: `nvtx_text` is the leaf (innermost scope open at launch); `nvtx_path` containment is temporal, not lexical; classify by leaf when the question is "what code path executed this op".
- `tests/test_nccl_compile_context_breakdown.py` — 6 tests: leaf-classification helpers, NCCL-kernel filter, end-to-end three-bucket fixture (one NCCL kernel per bucket + one non-NCCL kernel to verify the filter), and the no-NCCL-kernels error path.
- `tests/test_skills.py` — append `nccl_compile_context_breakdown` to the expected skill list.
- `CHANGELOG.md` — new; Keep a Changelog format.

## Why classify by leaf, not by ancestor path

A previous fastvideo profile audit used `nvtx_path LIKE '%Torch-Compiled%'` to identify inductor-captured NCCL kernels. It matched 96% of NCCL kernels in that trace. The corrected leaf-based classification on the same trace showed only **5.4%** were actually inductor-captured (`## Call CompiledFxGraph` as the **leaf**); the other 91% were eager calls whose enclosing compile-region NVTX merely hadn't closed yet at kernel-launch time. NVTX path containment is **temporal**, not lexical — any scope still open up the stack when the kernel launched. Classifying by the leaf label is the only correct axis for this question.

## Test plan

- [x] Tests added: 6 new + 1 updated in `tests/`
- [x] `python -m nsys_ai --help` — CLI loads
- [x] `pytest tests/ -q` — 869 passed, 135 skipped
- [x] `ruff check src/ tests/` clean
- [x] `bandit -r src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py` — no issues

## Out of scope

- Wiring `nccl_compile_context_breakdown` into the default skill pack (`EvidenceBuilder._SKILL_PIPELINE`). The skill is discoverable via the registry but not invoked by default.
- Cross-referencing the temporal-vs-lexical lesson from `docs/agent_skills/PRINCIPLES.md`. The `nvtx_kernel_map` docstring is the load-bearing fix; the principles doc can pick it up later.

## Linked issues

None.