### PR TITLE
audit(l40s): L40S FastVideo skill audit, gaps, and batch script

### DIFF
--- a/audit/.gitignore
+++ b/audit/.gitignore
@@ -1,4 +1,2 @@
-l40s-perf_compile/json/
-l40s-perf_compile/logs/
-l40s-perf_compile/text/
-*.sqlite
+/*
+!/.gitignore

--- a/audit/.gitignore
+++ b/audit/.gitignore
@@ -1,0 +1,4 @@
+l40s-perf_compile/json/
+l40s-perf_compile/logs/
+l40s-perf_compile/text/
+*.sqlite

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,0 +1,66 @@
+# Skill audits
+
+Reproducible audits of nsys-ai built-in skills against public Nsight profiles.
+
+## L40S FastVideo audit (Direction 1)
+
+**Profile:** `perf_compile.sqlite` from [rich7421/fastvideo-wan-l40s-nsys](https://huggingface.co/datasets/rich7421/fastvideo-wan-l40s-nsys)  
+**Workload:** FastVideo `Wan2.1-T2V-1.3B`, 4× L40S (PCIe Gen4, no NVLink) — system-level, comm-bound, same-stream NCCL/compute  
+**Reports:** [l40s-fastvideo-skill-audit.md](l40s-fastvideo-skill-audit.md), [l40s-fastvideo-gaps.md](l40s-fastvideo-gaps.md)
+
+### Dataset files (not in git)
+
+| File | Description |
+|------|-------------|
+| `profiles/perf_compile.sqlite` | **Primary audit profile** (`torch.compile` on) |
+| `profiles/perf.sqlite` | Non-compile baseline |
+| `analysis_measurements.md` | Maintainer reference measurements |
+| `plots/` | Static plots (stream 7, NCCL bimodal, etc.) |
+
+### Download profile
+
+```bash
+pip install huggingface_hub
+hf download rich7421/fastvideo-wan-l40s-nsys --repo-type dataset \
+  --local-dir ~/.cache/nsys-ai-datasets/fastvideo-wan-l40s-nsys
+
+export L40S_PROFILE=~/.cache/nsys-ai-datasets/fastvideo-wan-l40s-nsys/profiles/perf_compile.sqlite
+```
+
+### Run audit batch
+
+```bash
+cd /path/to/nsys-ai
+pip install -e '.[dev]'
+
+python scripts/batch_audit_skills.py "$L40S_PROFILE" audit/l40s-perf_compile
+```
+
+The audit table has two layers: **Batch** (mechanical run from `batch_audit_skills.py`) and **Grade** (human score vs ground truth in `analysis_measurements.md`). Batch JSON under `audit/` is gitignored; re-run the script to refresh `_batch_summary.json`.
+
+Outputs go under `audit/l40s-perf_compile/` (gitignored: `json/`, `logs/`, `text/`). Only `docs/audits/` and `scripts/` belong in the PR.
+
+**Do not commit:** `nsys-ai profiling.pdf`, profile `.sqlite`, or `audit/**` output files.
+
+### Headline numbers (`perf_compile.sqlite`, device 0)
+
+| Metric | Value |
+|--------|-------|
+| Overlap | ~0% |
+| Same stream | 100% compute + NCCL on **stream 7** |
+| NCCL payload | ~8,936 GiB |
+| NCCL msg p50 / p99 | 13.18 / 39.55 MiB |
+| Idle | ~13.9% |
+
+### Orientation
+
+```bash
+nsys-ai info "$L40S_PROFILE"
+nsys-ai skill run overlap_breakdown "$L40S_PROFILE"
+nsys-ai skill run nccl_payload_breakdown "$L40S_PROFILE" --format json
+nsys-ai skill run profile_health_manifest "$L40S_PROFILE" --format json
+nsys-ai timeline-web "$L40S_PROFILE"
+nsys-ai evidence build "$L40S_PROFILE" --format json -o /tmp/findings.json
+```
+
+Ground truth detail: dataset `analysis_measurements.md` and mentoring deck `nsys-ai profiling.pdf` (do not commit the PDF).

--- a/docs/audits/README.md
+++ b/docs/audits/README.md
@@ -1,66 +1,24 @@
 # Skill audits
 
-Reproducible audits of nsys-ai built-in skills against public Nsight profiles.
+Notes from running built-in skills on public Nsight SQLite profiles.
 
-## L40S FastVideo audit (Direction 1)
+## L40S FastVideo (`perf_compile.sqlite`)
 
-**Profile:** `perf_compile.sqlite` from [rich7421/fastvideo-wan-l40s-nsys](https://huggingface.co/datasets/rich7421/fastvideo-wan-l40s-nsys)  
-**Workload:** FastVideo `Wan2.1-T2V-1.3B`, 4× L40S (PCIe Gen4, no NVLink) — system-level, comm-bound, same-stream NCCL/compute  
-**Reports:** [l40s-fastvideo-skill-audit.md](l40s-fastvideo-skill-audit.md), [l40s-fastvideo-gaps.md](l40s-fastvideo-gaps.md)
+- [l40s-fastvideo-skill-audit.md](l40s-fastvideo-skill-audit.md) — 35 skills, grades, gaps
+- [l40s-fastvideo-gaps.md](l40s-fastvideo-gaps.md) — follow-up issues
 
-### Dataset files (not in git)
-
-| File | Description |
-|------|-------------|
-| `profiles/perf_compile.sqlite` | **Primary audit profile** (`torch.compile` on) |
-| `profiles/perf.sqlite` | Non-compile baseline |
-| `analysis_measurements.md` | Maintainer reference measurements |
-| `plots/` | Static plots (stream 7, NCCL bimodal, etc.) |
-
-### Download profile
+Dataset: [rich7421/fastvideo-wan-l40s-nsys](https://huggingface.co/datasets/rich7421/fastvideo-wan-l40s-nsys). Use `profiles/perf_compile.sqlite` for the audit.
 
 ```bash
-pip install huggingface_hub
 hf download rich7421/fastvideo-wan-l40s-nsys --repo-type dataset \
   --local-dir ~/.cache/nsys-ai-datasets/fastvideo-wan-l40s-nsys
 
 export L40S_PROFILE=~/.cache/nsys-ai-datasets/fastvideo-wan-l40s-nsys/profiles/perf_compile.sqlite
-```
 
-### Run audit batch
-
-```bash
-cd /path/to/nsys-ai
 pip install -e '.[dev]'
-
-python scripts/batch_audit_skills.py "$L40S_PROFILE" audit/l40s-perf_compile
+python scripts/batch_audit_skills.py "$L40S_PROFILE"
 ```
 
-The audit table has two layers: **Batch** (mechanical run from `batch_audit_skills.py`) and **Grade** (human score vs ground truth in `analysis_measurements.md`). Batch JSON under `audit/` is gitignored; re-run the script to refresh `_batch_summary.json`.
+Default output: `audit/l40s-perf_compile/`. Pass a second argument to use another directory under `audit/`. Everything under `audit/` is gitignored except `audit/.gitignore` — do not commit batch JSON or the profile.
 
-Outputs go under `audit/l40s-perf_compile/` (gitignored: `json/`, `logs/`, `text/`). Only `docs/audits/` and `scripts/` belong in the PR.
-
-**Do not commit:** `nsys-ai profiling.pdf`, profile `.sqlite`, or `audit/**` output files.
-
-### Headline numbers (`perf_compile.sqlite`, device 0)
-
-| Metric | Value |
-|--------|-------|
-| Overlap | ~0% |
-| Same stream | 100% compute + NCCL on **stream 7** |
-| NCCL payload | ~8,936 GiB |
-| NCCL msg p50 / p99 | 13.18 / 39.55 MiB |
-| Idle | ~13.9% |
-
-### Orientation
-
-```bash
-nsys-ai info "$L40S_PROFILE"
-nsys-ai skill run overlap_breakdown "$L40S_PROFILE"
-nsys-ai skill run nccl_payload_breakdown "$L40S_PROFILE" --format json
-nsys-ai skill run profile_health_manifest "$L40S_PROFILE" --format json
-nsys-ai timeline-web "$L40S_PROFILE"
-nsys-ai evidence build "$L40S_PROFILE" --format json -o /tmp/findings.json
-```
-
-Ground truth detail: dataset `analysis_measurements.md` and mentoring deck `nsys-ai profiling.pdf` (do not commit the PDF).
+Reference numbers live in the dataset’s `analysis_measurements.md` and in the audit table.

--- a/docs/audits/l40s-fastvideo-gaps.md
+++ b/docs/audits/l40s-fastvideo-gaps.md
@@ -1,0 +1,27 @@
+# L40S FastVideo — follow-up gaps
+
+Profile: `perf_compile.sqlite` · [Dataset](https://huggingface.co/datasets/rich7421/fastvideo-wan-l40s-nsys) · Audit: [l40s-fastvideo-skill-audit.md](l40s-fastvideo-skill-audit.md)
+
+## P0 — Top finding / diagnose path
+
+1. **`profile_health_manifest`** — `_infer_bottleneck()` treats high CPU sync before low overlap. On this profile it returns “High CPU Synchronization Blocking” on a 20 s trim even though overlap is 0% and NCCL/compute share stream 7. Should surface same-stream NCCL when `same_stream_diagnosis` is set.
+
+2. **Manifest auto-trim** — Default 20 s window understates idle (~1.9% vs ~13.9% full span) and diverges from overlap numbers in `analysis_measurements.md` (full ~677 s run).
+
+3. **`evidence build` finding rank** — `evidence build --format json` produces 401 findings. The stream-7 serialization finding (`"Low Compute/NCCL Overlap (0.0%)"`) is at position **390/401**, buried below ~377 "Slow Iteration" regions and several idle-gap entries. The finding does contain stream ID (7), overlap pct (0%), and NCCL-only ms (271,563 ms of 677,344 ms span), but no NVTX scope (Ulysses `all_to_all_4D` not mentioned). Fix: elevate the `overlap_breakdown` same-stream finding to a top-ranked composite finding above per-iteration slow regions.
+
+## P1 — Defaults and coverage
+
+4. **Multi-GPU** — `overlap_breakdown` analyzes device 0 by default; devices 1–3 use stream 17, not stream 7. Need per-device overlap (or one summary) without four manual `-p device=N` runs.
+
+5. **`iteration_timing`** — Emits `heuristic_step_*` labels when NVTX markers do not match; output should say when labels are synthesized.
+
+6. **Parameter-gated skills** — `arithmetic_intensity`, `theoretical_flops`, `region_mfu`, `speedup_estimator` error without required `-p` values. Errors should list required params and an example for inference profiles.
+
+## P2 — Output shape
+
+7. **Comm skills** — No note that this node is PCIe (no NVLink) when overlap is near zero and payload is large.
+
+8. **`top_kernels`** — Totals span all GPUs; per-device or per-rank breakdown would match how the dataset reports kernel share.
+
+9. **`nvtx_layer_breakdown`** — Top regions on the compile profile are torch compile / `aten::to`, not Ulysses `all_to_all_4D`. Filter or depth option for denoising-stage children would help.

--- a/docs/audits/l40s-fastvideo-skill-audit.md
+++ b/docs/audits/l40s-fastvideo-skill-audit.md
@@ -1,0 +1,68 @@
+# L40S FastVideo skill audit
+
+Profile: [`perf_compile.sqlite`](https://huggingface.co/datasets/rich7421/fastvideo-wan-l40s-nsys) (FastVideo Wan2.1, 4× L40S, `torch.compile` on)  
+Skill list: `tests/test_skills.py::test_list_skills` (35 built-ins)  
+Reproduce: [README.md](README.md) · Follow-ups: [l40s-fastvideo-gaps.md](l40s-fastvideo-gaps.md)
+
+## Ground truth (device 0)
+
+Compute and NCCL run on **CUDA stream 7** with **~0% overlap** (~311k ms compute-only, ~272k ms NCCL-only on a ~677 s span). NCCL payload **~8,936 GiB**. Expected fix: dedicated NCCL stream in the app, not a single-kernel tune.
+
+## Grades
+
+| Grade | Meaning |
+|-------|---------|
+| PASS | Output matches the ground truth above (or correctly reports no issue) |
+| PARTIAL | Runs but misses the main story, weak defaults, or incomplete output |
+| SKIP | Needs extra inputs (`theoretical_flops`, `trace_dir`, etc.) or N/A here |
+| FAIL | Wrong or broken vs ground truth (none on this profile) |
+
+**Batch** = `python scripts/batch_audit_skills.py "$L40S_PROFILE"` → `_batch_summary.json` (local, gitignored).
+
+## Results
+
+| Skill | Batch | Render | Grade | Gap |
+|-------|-------|--------|-------|-----|
+| `overlap_breakdown` | OK | summary | PASS | — |
+| `nccl_payload_breakdown` | OK | rows | PASS | — |
+| `nccl_breakdown` | OK | rows | PASS | Defaults to device 0 |
+| `nccl_communicator_analysis` | OK | summary | PASS | — |
+| `nccl_anomaly` | OK | rows | PARTIAL | Does not identify dominant collectives by name |
+| `kernel_overlap_matrix` | OK | rows | PASS | — |
+| `stream_concurrency` | OK | rows | PARTIAL | Does not call out stream 7 serialization |
+| `sync_cost_analysis` | OK | summary | PASS | High sync % pushes manifest to rank sync first |
+| `profile_health_manifest` | OK | summary | PARTIAL | 20 s auto-trim; `suspected_bottleneck` is CPU sync, not stream 7 |
+| `root_cause_matcher` | OK | rows | PARTIAL | May not rank same-stream NCCL first |
+| `gpu_idle_gaps` | OK | rows | PARTIAL | Idle on stream 7 not summarized as ~13.9% headline |
+| `pipeline_bubble_metrics` | OK | rows | PARTIAL | Same |
+| `iteration_timing` | OK | rows | PARTIAL | Generic step labels |
+| `iteration_detail` | OK | summary | PARTIAL | Batch uses `iteration=0`; slow iter needs `--iteration` |
+| `top_kernels` | OK | rows | PARTIAL | Aggregates all GPUs |
+| `nvtx_layer_breakdown` | OK | rows | PARTIAL | Compile NVTX noise; Ulysses layer names not top |
+| `nvtx_kernel_map` | OK | rows | PARTIAL | Noisy regions on compile profile |
+| `memory_transfers` | OK | rows | PASS | — |
+| `h2d_distribution` | OK | rows | PASS | — |
+| `memory_bandwidth` | OK | rows | PASS | — |
+| `kernel_launch_overhead` | OK | rows | PASS | — |
+| `kernel_launch_pattern` | OK | rows | PARTIAL | Does not link streams to overlap story |
+| `kernel_instances` | OK | rows | PASS | — |
+| `thread_utilization` | EMPTY | EMPTY | PARTIAL | No rows returned |
+| `cpu_gpu_pipeline` | OK | rows | PASS | — |
+| `host_sync_parent_ranges` | OK | rows | PARTIAL | ~34 s on full profile |
+| `gc_impact` | OK | rows | PASS | — |
+| `module_loading` | OK | rows | PASS | — |
+| `arithmetic_intensity` | ERROR_JSON | error | SKIP | Requires `theoretical_flops` |
+| `theoretical_flops` | ERROR_JSON | error | SKIP | Requires model dimensions |
+| `region_mfu` | ERROR_JSON | error | SKIP | Requires `theoretical_flops` + region name |
+| `speedup_estimator` | ERROR_JSON | error | SKIP | Requires `iteration_ms` |
+| `tensor_core_usage` | OK | rows | PASS | — |
+| `cutracer_analysis` | SKIP | SKIP | SKIP | Requires `trace_dir` |
+| `schema_inspect` | OK | rows | PASS | — |
+
+**PASS 16 · PARTIAL 14 · SKIP 5 · FAIL 0**
+
+## Notes
+
+- **`overlap_breakdown`** is the skill that states stream 7 and 0% overlap clearly on the full profile.
+- **`profile_health_manifest`** reports 0% overlap in its overlap block but names **High CPU Synchronization Blocking** as `suspected_bottleneck` on a 20 s trimmed window (`idle_pct` 1.9% vs ~13.9% on the full span).
+- **`evidence build --format json`** produces 401 findings. The stream-7 serialization finding (`"Low Compute/NCCL Overlap (0.0%)"`, with stream=7, 0% overlap, 271,563 ms NCCL-only out of 677,344 ms span, same-stream diagnosis) appears at position **390/401** — buried below ~377 "Slow Iteration" regions and several idle-gap entries. It has no NVTX scope context (no Ulysses `all_to_all_4D` mention). This confirms P0 #3 in [gaps.md](l40s-fastvideo-gaps.md): the finding exists but is not a top finding.

--- a/docs/audits/l40s-fastvideo-skill-audit.md
+++ b/docs/audits/l40s-fastvideo-skill-audit.md
@@ -46,7 +46,7 @@ Compute and NCCL run on **CUDA stream 7** with **~0% overlap** (~311k ms compute
 | `kernel_launch_overhead` | OK | rows | PASS | — |
 | `kernel_launch_pattern` | OK | rows | PARTIAL | Does not link streams to overlap story |
 | `kernel_instances` | OK | rows | PASS | — |
-| `thread_utilization` | EMPTY | EMPTY | PARTIAL | No rows returned |
+| `thread_utilization` | EMPTY | EMPTY | PARTIAL | `COMPOSITE_EVENTS` missing or empty on this export — no CPU thread utilization rows |
 | `cpu_gpu_pipeline` | OK | rows | PASS | — |
 | `host_sync_parent_ranges` | OK | rows | PARTIAL | ~34 s on full profile |
 | `gc_impact` | OK | rows | PASS | — |

--- a/scripts/batch_audit_skills.py
+++ b/scripts/batch_audit_skills.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# ruff: noqa: E501
+"""Run all built-in skills once against an Nsight profile (single DB connection).
+
+Uses the same ``open_cached_db()`` path as ``nsys-ai skill run`` (DuckDB/Parquet
+with SQLite fallback). Writes per-skill JSON, logs, and ``_batch_summary.json``.
+
+Usage: python scripts/batch_audit_skills.py <profile.sqlite> [output_dir]
+
+Default output_dir: audit/l40s-perf_compile (override for other profiles).
+
+Records every registry skill (currently 35): all executed except explicit
+SKIP for ``cutracer_analysis`` (needs trace_dir).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+SKIP = {"cutracer_analysis"}
+
+# Extra kwargs for batch runs (CLI would prompt for required params).
+BATCH_EXTRA: dict[str, dict] = {
+    "iteration_detail": {"iteration": 0, "device": 0},
+}
+
+# Run diagnosis-critical skills first (overlap/NCCL before slow host-sync SQL).
+PRIORITY_FIRST = [
+    "overlap_breakdown",
+    "nccl_payload_breakdown",
+    "nccl_breakdown",
+    "nccl_communicator_analysis",
+    "profile_health_manifest",
+    "root_cause_matcher",
+    "iteration_timing",
+    "iteration_detail",
+    "nvtx_layer_breakdown",
+    "pipeline_bubble_metrics",
+    "top_kernels",
+    "kernel_overlap_matrix",
+    "stream_concurrency",
+    "sync_cost_analysis",
+]
+
+
+def _open_skill_connection(profile_path: str):
+    """Match ``nsys-ai skill run`` connection setup (cached DuckDB, else SQLite)."""
+    import duckdb
+
+    from nsys_ai.parquet_cache import open_cached_db
+
+    try:
+        return open_cached_db(profile_path)
+    except (duckdb.Error, RuntimeError, OSError):
+        return sqlite3.connect(profile_path)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print("usage: batch_audit_skills.py <profile.sqlite> [output_dir]", file=sys.stderr)
+        return 2
+
+    profile_path = (sys.argv[1] or "").strip()
+    if not profile_path:
+        print(
+            "error: profile path is empty (is L40S_PROFILE set?)\n"
+            "  export L40S_PROFILE=~/.cache/nsys-ai-datasets/fastvideo-wan-l40s-nsys/profiles/perf_compile.sqlite\n"
+            "  python scripts/batch_audit_skills.py \"$L40S_PROFILE\"",
+            file=sys.stderr,
+        )
+        return 2
+    profile_path = str(Path(profile_path).expanduser().resolve())
+    if not Path(profile_path).is_file():
+        print(f"error: profile not found: {profile_path}", file=sys.stderr)
+        return 2
+
+    out_dir = Path(sys.argv[2] if len(sys.argv) > 2 else "audit/l40s-perf_compile")
+    json_dir = out_dir / "json"
+    log_dir = out_dir / "logs"
+    json_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    from nsys_ai.skills import list_skills
+    from nsys_ai.skills.registry import get_skill
+
+    all_names = list_skills()
+    ordered = [n for n in PRIORITY_FIRST if n in all_names]
+    ordered += [n for n in all_names if n not in ordered]
+
+    summary = []
+    conn = _open_skill_connection(profile_path)
+    execute_kwargs = {"_sqlite_path": profile_path}
+
+    try:
+        for name in ordered:
+            if name in SKIP:
+                out_path = json_dir / f"{name}.json"
+                skip_row = {
+                    "skill": name,
+                    "category": "utility",
+                    "exit_code": -1,
+                    "runtime_s": 0,
+                    "json_path": str(out_path),
+                    "status_hint": "SKIP",
+                    "skip_reason": "requires trace_dir (CUTracer histograms)",
+                }
+                summary.append(skip_row)
+                out_path.write_text(
+                    json.dumps([{"error": skip_row["skip_reason"]}], indent=2)
+                )
+                print(f"{name}: SKIP", file=sys.stderr)
+                continue
+
+            skill = get_skill(name)
+            if skill is None:
+                summary.append(
+                    {"skill": name, "exit_code": 1, "runtime_s": 0, "status_hint": "NOT_FOUND"}
+                )
+                continue
+
+            t0 = time.perf_counter()
+            hint = "OK"
+            exit_code = 0
+            rows: list = []
+            err_text = ""
+            run_kwargs = {**execute_kwargs, **BATCH_EXTRA.get(name, {})}
+            try:
+                rows = skill.execute(conn, **run_kwargs)
+            except ValueError as exc:
+                exit_code = 1
+                hint = "ERROR_JSON"
+                err_text = str(exc)
+                rows = [{"error": err_text}]
+            except Exception as exc:
+                exit_code = 1
+                hint = "EXCEPTION"
+                err_text = str(exc)
+                rows = [{"error": err_text}]
+
+            elapsed = time.perf_counter() - t0
+            out_path = json_dir / f"{name}.json"
+            with out_path.open("w") as f:
+                json.dump(rows, f, indent=2, default=str)
+
+            log_path = log_dir / f"{name}.log"
+            log_path.write_text(err_text or skill.format_rows(rows))
+
+            if rows and isinstance(rows[0], dict) and "error" in rows[0]:
+                hint = "ERROR_JSON"
+            elif not rows:
+                hint = "EMPTY"
+
+            summary.append(
+                {
+                    "skill": name,
+                    "category": skill.category,
+                    "exit_code": exit_code,
+                    "runtime_s": round(elapsed, 2),
+                    "json_path": str(out_path),
+                    "status_hint": hint,
+                }
+            )
+            print(f"{name}: {hint} ({elapsed:.1f}s)", file=sys.stderr)
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    summary_path = json_dir / "_batch_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2))
+    print(f"Wrote {summary_path} ({len(summary)} skills)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/batch_audit_skills.py
+++ b/scripts/batch_audit_skills.py
@@ -49,10 +49,12 @@ PRIORITY_FIRST = [
 
 def _open_skill_connection(profile_path: str):
     """Match ``nsys-ai skill run`` connection setup (cached DuckDB, else SQLite)."""
-    import duckdb
+    try:
+        import duckdb
 
-    from nsys_ai.parquet_cache import open_cached_db
-
+        from nsys_ai.parquet_cache import open_cached_db
+    except ImportError:
+        return sqlite3.connect(profile_path)
     try:
         return open_cached_db(profile_path)
     except (duckdb.Error, RuntimeError, OSError):


### PR DESCRIPTION
## Summary

Full skill audit of the L40S FastVideo profile (`perf_compile.sqlite`, 4× L40S, FastVideo Wan2.1, `torch.compile` on) against all 35 built-in nsys-ai skills. Documents output quality, render format, and prioritized gaps for follow-up.

Dataset: [rich7421/fastvideo-wan-l40s-nsys](https://huggingface.co/datasets/rich7421/fastvideo-wan-l40s-nsys)

## What's included

- **`docs/audits/l40s-fastvideo-skill-audit.md`** — per-skill grade table (Batch · Render · Grade · Gap); **PASS 16 · PARTIAL 14 · SKIP 5 · FAIL 0**
- **`docs/audits/l40s-fastvideo-gaps.md`** — 9 prioritized gaps (P0–P2)
- **`docs/audits/README.md`** — reproduction guide
- **`scripts/batch_audit_skills.py`** — single-run batch driver (replaces old `audit_l40s_skills.sh` + `audit_l40s_skills_fast.py`)
- **`audit/.gitignore`** — excludes per-run JSON/log/text output

## Ground truth (device 0)

Compute and NCCL share **stream 7** with **~0% overlap** (~311k ms compute-only, ~272k ms NCCL-only on a 677 s span). NCCL payload ~8,936 GiB at ~24 GB/s (PCIe Gen4, no NVLink).

## Key gaps found

**P0**
- `_infer_bottleneck()` ranks CPU sync before same-stream NCCL — returns wrong `suspected_bottleneck` on this profile
- 20 s auto-trim understates full-profile idle (1.9% vs 13.9%) and diverges from `overlap_breakdown` numbers
- `evidence build` stream-7 serialization finding is ranked **390/401** — buried below ~377 "Slow Iteration" regions

**P1**
- `overlap_breakdown` defaults to device 0 only; devices 1–3 (stream 17) require manual `-p device=N`
- `iteration_timing` synthesized `heuristic_step_*` labels not flagged in output
- Parameter-gated skills (`arithmetic_intensity`, `theoretical_flops`, etc.) return bare errors with no usage guidance

**P2**
- No PCIe/NVLink topology note in comm skills when bandwidth matches PCIe limits
- `top_kernels` aggregates all GPUs with no per-device breakdown
- `nvtx_layer_breakdown` compile-phase noise buries denoising-stage regions

## Test plan

- [ ] `python scripts/batch_audit_skills.py <perf_compile.sqlite>` completes without errors
- [ ] `docs/audits/l40s-fastvideo-skill-audit.md` renders correctly in GitHub
- [ ] `docs/audits/l40s-fastvideo-gaps.md` gap numbering matches audit table grades