### PR TITLE
feat(diff): add --exit-on-regression for CI gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,9 @@ nsys-ai diff before.sqlite after.sqlite --format markdown -o diff.md
 
 # JSON output for scripting
 nsys-ai diff before.sqlite after.sqlite --format json --no-ai
+
+# Fail CI when the diff verdict reports a likely regression
+nsys-ai diff before.sqlite after.sqlite --format json --exit-on-regression
 ```
 
 The report shows:
@@ -338,6 +341,7 @@ Options:
 | `--limit N` | 15 | Top regressions/improvements to show |
 | `--sort` | `delta` | `delta` \| `percent` \| `total` |
 | `--no-ai` | — | Skip AI narration (numeric diff only) |
+| `--exit-on-regression` | — | Exit with status 1 when verdict is `regression_likely` |
 
 ---
 

--- a/docs/agent_skills/INDEX.md
+++ b/docs/agent_skills/INDEX.md
@@ -37,6 +37,9 @@ nsys-ai diff before.sqlite after.sqlite
 # Machine-readable JSON
 nsys-ai diff before.sqlite after.sqlite --format json
 
+# Fail a CI job on a likely regression verdict
+nsys-ai diff before.sqlite after.sqlite --format json --exit-on-regression
+
 # Specific iteration (skip warmup iteration 0)
 nsys-ai diff before.sqlite after.sqlite --iteration 1 --format json
 
@@ -48,7 +51,7 @@ nsys-ai diff before.sqlite after.sqlite --chat
 ```
 
 **Output formats**: `terminal` (default), `markdown`, `json`
-**Key flags**: `--gpu N`, `--trim START END` (seconds), `--iteration N`, `--marker NAME`
+**Key flags**: `--gpu N`, `--trim START END` (seconds), `--iteration N`, `--marker NAME`, `--exit-on-regression`
 
 ### Report — Full analysis report
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -530,7 +530,7 @@ def _cmd_diff(args, _profile):
             idx = args.iteration
             if idx >= len(bnds):
                 print(f"Error: iteration {idx} out of range (0..{len(bnds) - 1})", file=sys.stderr)
-                return
+                sys.exit(1)
             bnd = bnds[idx]
             if bnd["before"]["start_ns"] is not None and bnd["before"]["end_ns"] is not None:
                 trim_before = (bnd["before"]["start_ns"], bnd["before"]["end_ns"])
@@ -541,7 +541,7 @@ def _cmd_diff(args, _profile):
                     "Error: no time window for this iteration in one or both profiles",
                     file=sys.stderr,
                 )
-                return
+                sys.exit(1)
 
     with _profile.open(args.before) as before, _profile.open(args.after) as after:
         if trim_before is not None and trim_after is not None:

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -491,6 +491,7 @@ def _cmd_diff(args, _profile):
     from nsys_ai.diff_tools import DiffContext, get_iteration_boundaries
 
     no_ai = getattr(args, "no_ai", False)
+    gate_summary = None
 
     def _narrative_for(summary):
         if args.format not in ("terminal", "markdown"):
@@ -553,6 +554,7 @@ def _cmd_diff(args, _profile):
                 limit=args.limit,
                 sort=args.sort,
             )
+            gate_summary = summary
             narrative = _narrative_for(summary)
             if args.format == "terminal":
                 out = format_diff_terminal(summary, narrative=narrative)
@@ -571,6 +573,7 @@ def _cmd_diff(args, _profile):
                 limit=args.limit,
                 sort=args.sort,
             )
+            gate_summary = summary
             narrative = _narrative_for(summary)
             if args.format == "terminal":
                 out = format_diff_terminal(summary, narrative=narrative)
@@ -590,6 +593,7 @@ def _cmd_diff(args, _profile):
                 limit=args.limit,
                 sort=args.sort,
             )
+            gate_summary = global_summary
             # For per-GPU we keep top-k small to avoid overwhelming output.
             per_gpu_limit = min(args.limit, 3)
             devices = sorted(set(before.meta.devices) | set(after.meta.devices))
@@ -624,6 +628,18 @@ def _cmd_diff(args, _profile):
         print(f"Diff written to {args.output}")
     else:
         print(out, end="")
+
+    if getattr(args, "exit_on_regression", False) and gate_summary is not None:
+        if gate_summary.verdict == "regression_likely":
+            print(
+                "Diff gate failed: "
+                f"verdict={gate_summary.verdict} "
+                f"step_time_delta_ms={gate_summary.step_time_delta_ms:+.3f} "
+                f"step_time_delta_pct={gate_summary.step_time_delta_pct:+.2f}% "
+                f"comparability_confidence={gate_summary.comparability_confidence:.3f}.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
 
 def _run_diff_chat(args, _profile):

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -338,6 +338,11 @@ def _build_parser():
         action="store_true",
         help="Start interactive AI chat for diff analysis (Phase C tools)",
     )
+    p.add_argument(
+        "--exit-on-regression",
+        action="store_true",
+        help="Exit with status 1 when the diff verdict is regression_likely (CI gate)",
+    )
     p.set_defaults(handler=_cmd_diff)
 
     p = sub.add_parser("diff-web", help="Serve web diff viewer for two profiles")

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -322,6 +322,112 @@ def test_diff_cli_chat_help():
     assert "chat" in result.stdout.lower()
 
 
+def test_diff_cli_exit_on_regression_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--exit-on-regression" in result.stdout
+    assert "ci gate" in result.stdout.lower()
+
+
+def test_diff_cli_exit_on_regression_fails_gate(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 12_000_000, 0, 7, 1, 1, 2)])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--gpu",
+            "0",
+            "--format",
+            "json",
+            "--exit-on-regression",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert json.loads(result.stdout)["verdict"] == "regression_likely"
+    assert "Diff gate failed" in result.stderr
+    assert "step_time_delta_ms=+2.000" in result.stderr
+    assert "step_time_delta_pct=+20.00%" in result.stderr
+    assert "comparability_confidence=1.000" in result.stderr
+
+
+def test_diff_cli_exit_on_regression_allows_improvement(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 12_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--gpu",
+            "0",
+            "--format",
+            "json",
+            "--exit-on-regression",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["verdict"] == "improvement_likely"
+
+
+def test_diff_cli_exit_on_regression_allows_inconclusive(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(
+        str(after),
+        kernels=[
+            (0, 12_000_000, 0, 7, 1, 1, 2),
+            (12_000_000, 24_000_000, 0, 7, 2, 1, 2),
+            (24_000_000, 36_000_000, 0, 7, 3, 1, 2),
+        ],
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--gpu",
+            "0",
+            "--format",
+            "json",
+            "--exit-on-regression",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["verdict"] == "inconclusive"
+    assert payload["comparability_confidence"] < 0.5
+    assert "Diff gate failed" not in result.stderr
+
+
 def test_diff_tools_run_diff_tool_and_openai_tools(tmp_path):
     """Stage 6: run_diff_tool dispatches; TOOLS_DIFF_OPENAI and build_diff_system_prompt exist."""
     from nsys_ai import profile as profile_mod

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -428,6 +428,64 @@ def test_diff_cli_exit_on_regression_allows_inconclusive(tmp_path):
     assert "Diff gate failed" not in result.stderr
 
 
+def test_diff_cli_iteration_out_of_range_exits_nonzero(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_runtime(str(before), marker="step")
+    _make_profile_with_runtime(str(after), marker="step")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--gpu",
+            "0",
+            "--iteration",
+            "1",
+            "--marker",
+            "step",
+            "--exit-on-regression",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "iteration 1 out of range" in result.stderr
+
+
+def test_diff_cli_iteration_missing_window_exits_nonzero(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_runtime(str(before), marker="step")
+    _make_profile(str(after), kernels=[])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--gpu",
+            "0",
+            "--iteration",
+            "0",
+            "--marker",
+            "step",
+            "--exit-on-regression",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "no time window for this iteration" in result.stderr
+
+
 def test_diff_tools_run_diff_tool_and_openai_tools(tmp_path):
     """Stage 6: run_diff_tool dispatches; TOOLS_DIFF_OPENAI and build_diff_system_prompt exist."""
     from nsys_ai import profile as profile_mod


### PR DESCRIPTION
## Summary

Adds a CI-friendly gate to `nsys-ai diff`:

- adds `--exit-on-regression`
- exits with status `1` when the diff verdict is `regression_likely`
- keeps `neutral`, `improvement_likely`, and `inconclusive` as passing outcomes
- prints gate failure details to stderr, including step-time delta and comparability confidence
- documents the new flag in README and agent skills docs

## Behavior

Example:

```bash
nsys-ai diff before.sqlite after.sqlite --format json --exit-on-regression
```

If the verdict is `regression_likely`, the command still emits the normal diff output, then fails the process with a message like:

```text
Diff gate failed: verdict=regression_likely step_time_delta_ms=+2.000 step_time_delta_pct=+20.00% comparability_confidence=1.000.
```

`inconclusive` intentionally remains a passing outcome for now, because low-confidence comparisons should not fail CI unless we add a stricter policy flag later.

## Tests

- `python3 -m pytest tests/test_diff.py -q`
- `python3 -m pytest tests/ -v --tb=short`
- `python3 -m ruff check src/nsys_ai/cli/parsers.py src/nsys_ai/cli/handlers.py tests/test_diff.py`
- `git diff --check`