### PR TITLE
feat: add structured overlap breakdown findings

### DIFF
--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -171,13 +171,87 @@ def _format(rows):
     return "\n".join(lines)
 
 
-def _to_findings(rows: list[dict]) -> list:
-    from nsys_ai.annotation import Finding
+_LOW_OVERLAP_EXPLANATION = (
+    "NCCL communication is exposed on the timeline instead of being hidden "
+    "under compute. Low overlap usually means communication is on the critical "
+    "path for step time."
+)
+_COMM_DOMINATED_EXPLANATION = (
+    "Communication time is larger than useful compute time in this window. "
+    "This often points to exposed collectives, poor overlap, or an imbalanced "
+    "parallelism strategy."
+)
+_SUGGESTED_ACTIONS = [
+    "Check whether NCCL and compute run on separate streams with compatible dependencies",
+    "Inspect whether collectives are launched early enough to overlap with backward compute",
+    "Compare per-rank overlap to identify stragglers or imbalance",
+    "Try narrowing to one iteration or NVTX phase to confirm where communication is exposed",
+]
+_FALSE_POSITIVE_NOTES = [
+    "Short windows can understate overlap if they clip compute or communication intervals",
+    "Profiles with very little NCCL time may not need optimization even when overlap is low",
+]
+
+
+def _overlap_confidence(overlap_pct: float, nccl_ms: float, total_ms: float) -> float:
+    """Heuristic confidence for low communication-overlap findings."""
+    if nccl_ms <= 0 or total_ms <= 0:
+        return 0.4
+    nccl_share = min(nccl_ms / total_ms, 1.0)
+    overlap_signal = max(0.0, min((30.0 - overlap_pct) / 30.0, 1.0))
+    return round(min(0.95, 0.55 + 0.25 * overlap_signal + 0.15 * nccl_share), 3)
+
+
+def _ratio_confidence(ratio: float) -> float:
+    """Heuristic confidence for communication-dominated findings."""
+    if ratio < 0.25:
+        return 0.95
+    if ratio < 0.5:
+        return 0.85
+    return 0.7
+
+
+def _common_evidence_values(r: dict, *, nccl_ms: float) -> tuple[dict, dict]:
+    values = {
+        "compute_only_ms": round(float(r.get("compute_only_ms", 0) or 0), 3),
+        "nccl_only_ms": round(float(r.get("nccl_only_ms", 0) or 0), 3),
+        "overlap_ms": round(float(r.get("overlap_ms", 0) or 0), 3),
+        "nccl_total_ms": round(float(nccl_ms), 3),
+        "idle_ms": round(float(r.get("idle_ms", 0) or 0), 3),
+        "total_ms": round(float(r.get("total_ms", 0) or 0), 3),
+        "overlap_pct": round(float(r.get("overlap_pct", 0) or 0), 3),
+    }
+    units = {
+        "compute_only_ms": "ms",
+        "nccl_only_ms": "ms",
+        "overlap_ms": "ms",
+        "nccl_total_ms": "ms",
+        "idle_ms": "ms",
+        "total_ms": "ms",
+        "overlap_pct": "percent",
+    }
+    if r.get("sync_ms") is not None:
+        values["sync_ms"] = round(float(r.get("sync_ms", 0) or 0), 3)
+        units["sync_ms"] = "ms"
+    if r.get("same_stream_diagnosis"):
+        values["same_streams"] = list(r.get("same_stream_diagnosis") or [])
+        if r.get("same_stream_compute_pct") is not None:
+            values["same_stream_compute_pct"] = round(float(r["same_stream_compute_pct"]), 3)
+            units["same_stream_compute_pct"] = "percent"
+        if r.get("same_stream_nccl_pct") is not None:
+            values["same_stream_nccl_pct"] = round(float(r["same_stream_nccl_pct"]), 3)
+            units["same_stream_nccl_pct"] = "percent"
+    return values, units
+
+
+def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
+    from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
 
     findings = []
     if not rows or "error" in rows[0]:
         return findings
 
+    profile_id = (context or {}).get("profile_id", "unknown")
     r = rows[0]
     nccl_ms = r.get("nccl_only_ms", 0) + r.get("overlap_ms", 0)
     compute_ms = r.get("compute_only_ms", 0)
@@ -208,6 +282,26 @@ def _to_findings(rows: list[dict]) -> list:
                     f"share these streams.)"
                 )
 
+        finding_id = f"overlap_low_gpu{device}_{start_ns}"
+        selection = TraceSelection(
+            id=f"sel_{finding_id}",
+            profile_id=profile_id,
+            source="skill:overlap_breakdown",
+            start_ns=start_ns,
+            end_ns=end_ns,
+            gpu_ids=[device],
+            label=f"Low Compute/NCCL Overlap ({overlap_pct}%)",
+        )
+        ev_values, ev_units = _common_evidence_values(r, nccl_ms=nccl_ms)
+        evidence_row = EvidenceRow(
+            id=f"ev_{finding_id}",
+            source_skill="overlap_breakdown",
+            values=ev_values,
+            units=ev_units,
+            selection_id=selection.id,
+            provenance={"row_kind": "low_overlap", "device": device},
+        )
+
         findings.append(
             Finding(
                 type="region",
@@ -217,6 +311,15 @@ def _to_findings(rows: list[dict]) -> list:
                 gpu_id=device,
                 severity="warning",
                 note=note,
+                id=finding_id,
+                category="communication",
+                confidence=_overlap_confidence(float(overlap_pct), float(nccl_ms), float(total_ms)),
+                evidence=[evidence_row],
+                selection=selection,
+                explanation=_LOW_OVERLAP_EXPLANATION,
+                suggested_actions=list(_SUGGESTED_ACTIONS),
+                false_positive_notes=list(_FALSE_POSITIVE_NOTES),
+                provenance={"skill": "overlap_breakdown", "row_kind": "low_overlap"},
             )
         )
 
@@ -224,6 +327,28 @@ def _to_findings(rows: list[dict]) -> list:
     if nccl_ms > 0 and compute_ms > 0:
         ratio = compute_ms / nccl_ms
         if ratio < 0.5:
+            finding_id = f"overlap_comm_dominated_gpu{device}_{start_ns}"
+            selection = TraceSelection(
+                id=f"sel_{finding_id}",
+                profile_id=profile_id,
+                source="skill:overlap_breakdown",
+                start_ns=start_ns,
+                end_ns=end_ns,
+                gpu_ids=[device],
+                label=f"Communication Dominated (ratio={ratio:.2f})",
+            )
+            ev_values, ev_units = _common_evidence_values(r, nccl_ms=nccl_ms)
+            ev_values["compute_nccl_ratio"] = round(float(ratio), 3)
+            ev_units["compute_nccl_ratio"] = "ratio"
+            evidence_row = EvidenceRow(
+                id=f"ev_{finding_id}",
+                source_skill="overlap_breakdown",
+                values=ev_values,
+                units=ev_units,
+                selection_id=selection.id,
+                provenance={"row_kind": "communication_dominated", "device": device},
+            )
+
             findings.append(
                 Finding(
                     type="region",
@@ -237,6 +362,18 @@ def _to_findings(rows: list[dict]) -> list:
                         f"(healthy > 2.0). Compute: {compute_ms:.1f}ms, "
                         f"NCCL: {nccl_ms:.1f}ms."
                     ),
+                    id=finding_id,
+                    category="communication",
+                    confidence=_ratio_confidence(float(ratio)),
+                    evidence=[evidence_row],
+                    selection=selection,
+                    explanation=_COMM_DOMINATED_EXPLANATION,
+                    suggested_actions=list(_SUGGESTED_ACTIONS),
+                    false_positive_notes=list(_FALSE_POSITIVE_NOTES),
+                    provenance={
+                        "skill": "overlap_breakdown",
+                        "row_kind": "communication_dominated",
+                    },
                 )
             )
 

--- a/tests/test_overlap_breakdown.py
+++ b/tests/test_overlap_breakdown.py
@@ -25,8 +25,10 @@ has 1 NCCL only (not same-stream). Across the device:
     same-stream NCCL on stream 7 = 1 (50 %)
 """
 
+import json
 import sqlite3
 
+from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
 from nsys_ai.skills.builtins.overlap_breakdown import SKILL
 
 
@@ -170,6 +172,27 @@ def test_format_no_multi_device_hint_single_device(minimal_nsys_conn):
 # ---------------------------------------------------------------------------
 
 
+def _overlap_row(**overrides):
+    row = {
+        "compute_only_ms": 20.0,
+        "nccl_only_ms": 80.0,
+        "overlap_ms": 10.0,
+        "idle_ms": 5.0,
+        "total_ms": 115.0,
+        "overlap_pct": 11.1,
+        "span_start_ns": 1_000,
+        "span_end_ns": 9_000,
+        "device_id": 2,
+        "compute_kernels": 4,
+        "nccl_kernels": 2,
+        "same_stream_diagnosis": ["7"],
+        "same_stream_compute_pct": 75.0,
+        "same_stream_nccl_pct": 50.0,
+    }
+    row.update(overrides)
+    return row
+
+
 def test_findings_note_includes_same_stream_pct(minimal_nsys_conn):
     rows = SKILL.execute_fn(minimal_nsys_conn)
     findings = SKILL.to_findings_fn(rows)
@@ -183,6 +206,94 @@ def test_findings_note_includes_same_stream_pct(minimal_nsys_conn):
     assert "100" in note and "50" in note, (
         f"expected 100% / 50% proportions in finding note, got:\n{note}"
     )
+
+
+def test_low_overlap_finding_has_v01_evidence_shape():
+    findings = SKILL.to_findings_fn(
+        [_overlap_row()],
+        context={"profile_id": "nsys1:sha256:test"},
+    )
+    low = [f for f in findings if f.id and f.id.startswith("overlap_low_gpu2_")]
+    assert low, f"expected low-overlap finding, got {[f.label for f in findings]}"
+
+    f = low[0]
+    assert f.type == "region"
+    assert f.label == "Low Compute/NCCL Overlap (11.1%)"
+    assert f.start_ns == 1_000
+    assert f.end_ns == 9_000
+    assert f.gpu_id == 2
+    assert f.severity == "warning"
+    assert f.category == "communication"
+    assert isinstance(f.confidence, float)
+    assert 0.0 <= f.confidence <= 1.0
+    assert f.explanation and "NCCL" in f.explanation
+    assert f.suggested_actions
+    assert f.false_positive_notes
+    assert f.provenance == {"skill": "overlap_breakdown", "row_kind": "low_overlap"}
+
+    assert isinstance(f.selection, TraceSelection)
+    assert f.selection.profile_id == "nsys1:sha256:test"
+    assert f.selection.source == "skill:overlap_breakdown"
+    assert f.selection.start_ns == 1_000
+    assert f.selection.end_ns == 9_000
+    assert f.selection.gpu_ids == [2]
+
+    assert f.evidence and isinstance(f.evidence[0], EvidenceRow)
+    ev = f.evidence[0]
+    assert ev.source_skill == "overlap_breakdown"
+    assert ev.selection_id == f.selection.id
+    assert ev.values["overlap_pct"] == 11.1
+    assert ev.values["nccl_only_ms"] == 80.0
+    assert ev.values["overlap_ms"] == 10.0
+    assert ev.values["nccl_total_ms"] == 90.0
+    assert ev.values["same_streams"] == ["7"]
+    assert ev.values["same_stream_compute_pct"] == 75.0
+    assert ev.values["same_stream_nccl_pct"] == 50.0
+    assert ev.units["overlap_pct"] == "percent"
+    assert ev.units["nccl_only_ms"] == "ms"
+
+
+def test_communication_dominated_finding_has_ratio_evidence():
+    findings = SKILL.to_findings_fn(
+        [_overlap_row(compute_only_ms=30.0, nccl_only_ms=100.0, overlap_ms=0.0)],
+        context={"profile_id": "p"},
+    )
+    dominated = [f for f in findings if f.id and f.id.startswith("overlap_comm_dominated")]
+    assert dominated, f"expected communication-dominated finding, got {[f.label for f in findings]}"
+
+    f = dominated[0]
+    assert f.label == "Communication Dominated (ratio=0.30)"
+    assert f.category == "communication"
+    assert f.severity == "critical"
+    assert f.selection.profile_id == "p"
+    assert f.provenance["row_kind"] == "communication_dominated"
+    ev = f.evidence[0]
+    assert ev.values["compute_nccl_ratio"] == 0.3
+    assert ev.units["compute_nccl_ratio"] == "ratio"
+    assert ev.provenance["row_kind"] == "communication_dominated"
+
+
+def test_overlap_finding_round_trips_through_json():
+    findings = SKILL.to_findings_fn(
+        [_overlap_row()],
+        context={"profile_id": "/tmp/profile.sqlite"},
+    )
+    for f in findings:
+        d = f.to_dict()
+        assert isinstance(d["selection"], dict)
+        assert isinstance(d["evidence"], list)
+        restored = Finding.from_dict(json.loads(json.dumps(d)))
+        assert restored.id == f.id
+        assert restored.category == "communication"
+        assert isinstance(restored.selection, TraceSelection)
+        assert restored.selection.profile_id == "/tmp/profile.sqlite"
+        assert isinstance(restored.evidence[0], EvidenceRow)
+
+
+def test_overlap_findings_without_context_use_unknown_profile_id():
+    findings = SKILL.to_findings_fn([_overlap_row()])
+    assert findings
+    assert findings[0].selection.profile_id == "unknown"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Upgrade `overlap_breakdown` to emit v0.1 structured Findings for low Compute/NCCL overlap and communication-dominated windows.
- Preserve existing timeline display fields while adding machine-readable evidence, selection metadata, confidence, category, and provenance.
- Add focused tests for the new structured evidence shape and JSON round-trip behavior.

## Changes

- `src/nsys_ai/skills/builtins/overlap_breakdown.py`
  - Adds structured `EvidenceRow` values and units for overlap metrics.
  - Adds `TraceSelection` metadata for the affected GPU/time window.
  - Adds `category="communication"`, confidence, explanations, suggested actions, false-positive notes, and provenance.
  - Keeps existing labels, notes, severity, and timeline region behavior unchanged.
- `tests/test_overlap_breakdown.py`
  - Adds tests for low-overlap v0.1 Finding fields.
  - Adds tests for communication-dominated ratio evidence.
  - Adds tests for context/profile ID propagation and JSON round-trip.

## Backward compatibility

Yes. Existing legacy Finding display fields are preserved, and the new v0.1 fields are additive.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path (if applicable)

Ran targeted validation:

```bash
myenv/bin/python -m pytest tests/test_overlap_breakdown.py -v --tb=short
myenv/bin/python -m pytest tests/test_overlap_breakdown.py tests/test_gpu_idle_gaps_findings.py tests/test_annotation_models.py tests/test_analyze_format_json.py -v --tb=short
myenv/bin/python -m nsys_ai --help