### PR TITLE
fix(cutracer): clone from facebookexperimental org, pin v0.2.1

### DIFF
--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -342,8 +342,9 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
 
     No-op (beyond a probe) when the clone is already at ``CUTRACER_TAG``.
     Raises ``RuntimeError`` if the worktree has uncommitted local changes
-    (rather than discarding them), or if the ``git remote set-url``, fetch, or
-    checkout step fails.
+    (rather than discarding them), if cleanliness cannot be verified (``git
+    status`` itself fails), or if the ``git remote set-url``, fetch, or checkout
+    step fails.
     """
     current = subprocess.run(  # nosec B603 B607
         ["git", "describe", "--tags", "--exact-match"],
@@ -351,6 +352,9 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
         capture_output=True,
         text=True,
     )
+    # A non-zero `git describe` here is the normal "HEAD is not exactly at a
+    # tag" case (an old clone) and is the trigger for reconciliation — not an
+    # error. A genuinely broken repo is caught by the `git status` check below.
     if current.returncode == 0 and current.stdout.strip() == CUTRACER_TAG:
         if progress:
             print(f"  Using existing clone at: {clone_dir} (@ {CUTRACER_TAG})")
@@ -358,14 +362,22 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
 
     # Refuse to clobber a dirty worktree — a user may have patched the clone
     # for debugging. Surface it and let them decide, rather than silently
-    # discarding their work in the checkout below.
+    # discarding their work in the checkout below. A failed `git status` means
+    # we cannot verify cleanliness (corrupt repo, permissions), so bail clearly
+    # rather than proceed to a checkout that might destroy data.
     status = subprocess.run(  # nosec B603 B607
         ["git", "status", "--porcelain"],
         cwd=clone_dir,
         capture_output=True,
         text=True,
     )
-    if status.returncode == 0 and status.stdout.strip():
+    if status.returncode != 0:
+        raise RuntimeError(
+            f"git status in {clone_dir} failed (exit {status.returncode}); "
+            f"cannot verify a clean worktree before checkout:\n"
+            f"{status.stderr or ''}"
+        )
+    if status.stdout.strip():
         raise RuntimeError(
             f"CUTracer clone at {clone_dir} has uncommitted local changes; "
             f"refusing to check out {CUTRACER_TAG} over them. Commit or stash "

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -39,7 +39,10 @@ log = logging.getLogger(__name__)
 INSTALL_DIR = Path.home() / ".nsys-ai" / "cutracer"
 NVBIT_REPO = "https://github.com/NVlabs/NVBit/releases/download"
 NVBIT_VERSION = "1.7.1"
-CUTRACER_GITHUB = "https://github.com/facebookresearch/CUTracer"
+# The CUTracer repo migrated from the facebookresearch org to facebookexperimental.
+CUTRACER_GITHUB = "https://github.com/facebookexperimental/CUTracer"
+# Pinned release tag for reproducible builds (clone --branch). Bump on upstream releases.
+CUTRACER_TAG = "v0.2.1"
 
 # CUDA major.minor → NVBit release asset name pattern
 # NVBit ships separate builds for each CUDA toolkit version.
@@ -333,7 +336,7 @@ def _clone_and_build(
     *,
     progress: bool = True,
 ) -> Path:
-    """Clone facebookresearch/CUTracer from GitHub and build cutracer.so.
+    """Clone facebookexperimental/CUTracer from GitHub and build cutracer.so.
 
     This is the primary install path — the repo's own ``install_third_party.sh``
     handles NVBit and nlohmann/json download, so no separate NVBit step needed.
@@ -350,10 +353,10 @@ def _clone_and_build(
     else:
         if progress:
             print("  Cloning CUTracer from GitHub …")
-            print(f"    {CUTRACER_GITHUB}")
+            print(f"    {CUTRACER_GITHUB} @ {CUTRACER_TAG}")
         clone_dir.parent.mkdir(parents=True, exist_ok=True)
         r = subprocess.run(  # nosec B603 B607
-            ["git", "clone", "--depth=1", CUTRACER_GITHUB, str(clone_dir)],
+            ["git", "clone", "--depth=1", "--branch", CUTRACER_TAG, CUTRACER_GITHUB, str(clone_dir)],
             capture_output=not progress,
             text=True,
         )
@@ -514,7 +517,7 @@ def install(
 
     # 3. Find or clone CUTracer source and build
     #
-    # Primary path:   GitHub clone (facebookresearch/CUTracer) — handles its
+    # Primary path:   GitHub clone (facebookexperimental/CUTracer) — handles its
     #                 own NVBit download via install_third_party.sh.
     # Fallback path:  pre-existing local source + separate NVBit download.
     cutracer_src = find_cutracer_source()

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -417,11 +417,17 @@ def _clone_and_build(
 
     # ── Clone ────────────────────────────────────────────────────────────────
     if clone_dir.exists() and (clone_dir / "Makefile").exists():
-        # A pre-existing clone may sit at any ref — an old HEAD from before
-        # tag pinning, or the previous facebookresearch org. Reusing it as-is
-        # would silently build whatever is checked out and defeat the pin, so
-        # reconcile it to CUTRACER_TAG before building.
-        _ensure_pinned_checkout(clone_dir, so_dest, progress=progress)
+        if (clone_dir / ".git").exists():
+            # A pre-existing git clone may sit at any ref — an old HEAD from
+            # before tag pinning, or the previous facebookresearch org. Reusing
+            # it as-is would silently build whatever is checked out and defeat
+            # the pin, so reconcile it to CUTRACER_TAG before building.
+            _ensure_pinned_checkout(clone_dir, so_dest, progress=progress)
+        elif progress:
+            # A non-git source tree (e.g. an extracted tarball) that happens to
+            # have a Makefile — tag pinning does not apply and git ops would
+            # fail here, so build it as-is (the pre-pinning behavior).
+            print(f"  Using existing non-git source tree at: {clone_dir}")
     else:
         if progress:
             print("  Cloning CUTracer from GitHub …")

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -357,13 +357,20 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
     if progress:
         print(f"  Existing clone is not at {CUTRACER_TAG} — fetching + checking out …")
     # Org migration: make sure origin points at the current repo before fetch
-    # (an old clone may still reference facebookresearch).
-    subprocess.run(  # nosec B603 B607
+    # (an old clone may still reference facebookresearch). Checking the return
+    # code matters: a silent failure here would leave origin on the old URL and
+    # still "succeed" via GitHub's redirect, defeating the migration fix.
+    set_url = subprocess.run(  # nosec B603 B607
         ["git", "remote", "set-url", "origin", CUTRACER_GITHUB],
         cwd=clone_dir,
         capture_output=not progress,
         text=True,
     )
+    if set_url.returncode != 0:
+        raise RuntimeError(
+            f"git remote set-url origin failed (exit {set_url.returncode}):\n"
+            f"{getattr(set_url, 'stderr', '')}"
+        )
     fetch = subprocess.run(  # nosec B603 B607
         ["git", "fetch", "--depth=1", "origin", "tag", CUTRACER_TAG],
         cwd=clone_dir,

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -341,7 +341,8 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
     the new ref instead of short-circuiting on a binary from the old checkout.
 
     No-op (beyond a probe) when the clone is already at ``CUTRACER_TAG``.
-    Raises ``RuntimeError`` if the fetch or checkout fails.
+    Raises ``RuntimeError`` if the ``git remote set-url``, fetch, or checkout
+    step fails.
     """
     current = subprocess.run(  # nosec B603 B607
         ["git", "describe", "--tags", "--exact-match"],

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -331,6 +331,67 @@ def find_cutracer_source() -> Path | None:
 # ---------------------------------------------------------------------------
 
 
+def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -> None:
+    """Reconcile an existing CUTracer clone to ``CUTRACER_TAG``.
+
+    A clone left over from a prior install may be at an arbitrary ref (an old
+    HEAD, or the former ``facebookresearch`` org). If it is not already at the
+    pinned tag, repoint ``origin`` at the current URL, fetch the tag, and check
+    it out — then drop any stale ``cutracer.so`` so the caller recompiles from
+    the new ref instead of short-circuiting on a binary from the old checkout.
+
+    No-op (beyond a probe) when the clone is already at ``CUTRACER_TAG``.
+    Raises ``RuntimeError`` if the fetch or checkout fails.
+    """
+    current = subprocess.run(  # nosec B603 B607
+        ["git", "describe", "--tags", "--exact-match"],
+        cwd=clone_dir,
+        capture_output=True,
+        text=True,
+    )
+    if current.returncode == 0 and current.stdout.strip() == CUTRACER_TAG:
+        if progress:
+            print(f"  Using existing clone at: {clone_dir} (@ {CUTRACER_TAG})")
+        return
+
+    if progress:
+        print(f"  Existing clone is not at {CUTRACER_TAG} — fetching + checking out …")
+    # Org migration: make sure origin points at the current repo before fetch
+    # (an old clone may still reference facebookresearch).
+    subprocess.run(  # nosec B603 B607
+        ["git", "remote", "set-url", "origin", CUTRACER_GITHUB],
+        cwd=clone_dir,
+        capture_output=not progress,
+        text=True,
+    )
+    fetch = subprocess.run(  # nosec B603 B607
+        ["git", "fetch", "--depth=1", "origin", "tag", CUTRACER_TAG],
+        cwd=clone_dir,
+        capture_output=not progress,
+        text=True,
+    )
+    if fetch.returncode != 0:
+        raise RuntimeError(
+            f"git fetch of {CUTRACER_TAG} failed (exit {fetch.returncode}):\n"
+            f"{getattr(fetch, 'stderr', '')}"
+        )
+    checkout = subprocess.run(  # nosec B603 B607
+        ["git", "checkout", "-f", CUTRACER_TAG],
+        cwd=clone_dir,
+        capture_output=not progress,
+        text=True,
+    )
+    if checkout.returncode != 0:
+        raise RuntimeError(
+            f"git checkout of {CUTRACER_TAG} failed (exit {checkout.returncode}):\n"
+            f"{getattr(checkout, 'stderr', '')}"
+        )
+    # Stale artifact from the previous ref would otherwise be reused by the
+    # `so_dest.exists()` short-circuit below.
+    if so_dest.exists():
+        so_dest.unlink()
+
+
 def _clone_and_build(
     clone_dir: Path,
     *,
@@ -348,8 +409,11 @@ def _clone_and_build(
 
     # ── Clone ────────────────────────────────────────────────────────────────
     if clone_dir.exists() and (clone_dir / "Makefile").exists():
-        if progress:
-            print(f"  Using existing clone at: {clone_dir}")
+        # A pre-existing clone may sit at any ref — an old HEAD from before
+        # tag pinning, or the previous facebookresearch org. Reusing it as-is
+        # would silently build whatever is checked out and defeat the pin, so
+        # reconcile it to CUTRACER_TAG before building.
+        _ensure_pinned_checkout(clone_dir, so_dest, progress=progress)
     else:
         if progress:
             print("  Cloning CUTracer from GitHub …")

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -341,8 +341,9 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
     the new ref instead of short-circuiting on a binary from the old checkout.
 
     No-op (beyond a probe) when the clone is already at ``CUTRACER_TAG``.
-    Raises ``RuntimeError`` if the ``git remote set-url``, fetch, or checkout
-    step fails.
+    Raises ``RuntimeError`` if the worktree has uncommitted local changes
+    (rather than discarding them), or if the ``git remote set-url``, fetch, or
+    checkout step fails.
     """
     current = subprocess.run(  # nosec B603 B607
         ["git", "describe", "--tags", "--exact-match"],
@@ -354,6 +355,22 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
         if progress:
             print(f"  Using existing clone at: {clone_dir} (@ {CUTRACER_TAG})")
         return
+
+    # Refuse to clobber a dirty worktree — a user may have patched the clone
+    # for debugging. Surface it and let them decide, rather than silently
+    # discarding their work in the checkout below.
+    status = subprocess.run(  # nosec B603 B607
+        ["git", "status", "--porcelain"],
+        cwd=clone_dir,
+        capture_output=True,
+        text=True,
+    )
+    if status.returncode == 0 and status.stdout.strip():
+        raise RuntimeError(
+            f"CUTracer clone at {clone_dir} has uncommitted local changes; "
+            f"refusing to check out {CUTRACER_TAG} over them. Commit or stash "
+            f"the changes, or delete the directory for a clean pinned build."
+        )
 
     if progress:
         print(f"  Existing clone is not at {CUTRACER_TAG} — fetching + checking out …")
@@ -370,7 +387,7 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
     if set_url.returncode != 0:
         raise RuntimeError(
             f"git remote set-url origin failed (exit {set_url.returncode}):\n"
-            f"{getattr(set_url, 'stderr', '')}"
+            f"{set_url.stderr or ''}"
         )
     fetch = subprocess.run(  # nosec B603 B607
         ["git", "fetch", "--depth=1", "origin", "tag", CUTRACER_TAG],
@@ -381,10 +398,12 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
     if fetch.returncode != 0:
         raise RuntimeError(
             f"git fetch of {CUTRACER_TAG} failed (exit {fetch.returncode}):\n"
-            f"{getattr(fetch, 'stderr', '')}"
+            f"{fetch.stderr or ''}"
         )
+    # Worktree is verified clean above, so a plain checkout suffices — no need
+    # for a destructive `-f` that would discard tracked edits.
     checkout = subprocess.run(  # nosec B603 B607
-        ["git", "checkout", "-f", CUTRACER_TAG],
+        ["git", "checkout", CUTRACER_TAG],
         cwd=clone_dir,
         capture_output=not progress,
         text=True,
@@ -392,7 +411,7 @@ def _ensure_pinned_checkout(clone_dir: Path, so_dest: Path, *, progress: bool) -
     if checkout.returncode != 0:
         raise RuntimeError(
             f"git checkout of {CUTRACER_TAG} failed (exit {checkout.returncode}):\n"
-            f"{getattr(checkout, 'stderr', '')}"
+            f"{checkout.stderr or ''}"
         )
     # Stale artifact from the previous ref would otherwise be reused by the
     # `so_dest.exists()` short-circuit below.

--- a/src/nsys_ai/cutracer/runner.py
+++ b/src/nsys_ai/cutracer/runner.py
@@ -218,6 +218,9 @@ def format_modal_app(
     if modal_cfg is None:
         modal_cfg = ModalConfig()
 
+    # Single source of truth for the upstream repo URL + pinned release tag.
+    from nsys_ai.cutracer.installer import CUTRACER_GITHUB, CUTRACER_TAG
+
     filter_csv = ",".join(config.kernel_filter) if config.kernel_filter else ""
     output_dir_str = str(config.output_dir)
     # Use repr() for Python string literals inside the generated script;
@@ -282,7 +285,7 @@ image = (
     ){extra_pip_lines}
     .run_commands(
         # Clone and build CUTracer NVBit .so (cached layer after first image build)
-        "git clone --depth=1 https://github.com/facebookresearch/CUTracer /opt/CUTracer",
+        "git clone --depth=1 --branch {CUTRACER_TAG} {CUTRACER_GITHUB} /opt/CUTracer",
         "cd /opt/CUTracer && ./install_third_party.sh",
         "cd /opt/CUTracer && make",
         "mkdir -p /root/.nsys-ai/cutracer/lib && cp /opt/CUTracer/lib/cutracer.so /root/.nsys-ai/cutracer/lib/",

--- a/tests/test_cutracer_installer.py
+++ b/tests/test_cutracer_installer.py
@@ -306,6 +306,33 @@ class TestEnsurePinnedCheckout:
         assert ["git", "checkout"] not in cmds
         assert so_dest.exists()
 
+    def test_raises_when_git_status_fails(self, tmp_path):
+        """A failed `git status` means cleanliness is unverifiable — bail
+        clearly rather than proceed to a possibly destructive checkout."""
+        from nsys_ai.cutracer.installer import _ensure_pinned_checkout
+
+        clone = tmp_path / "CUTracer"
+        (clone / "lib").mkdir(parents=True)
+        so_dest = clone / "lib" / "cutracer.so"
+        so_dest.write_bytes(b"\x7fELF")
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "describe"]:
+                return MagicMock(returncode=0, stdout="deadbeef\n", stderr="")
+            if cmd[:2] == ["git", "status"]:
+                return MagicMock(returncode=128, stdout="", stderr="fatal: corrupt")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            with pytest.raises(RuntimeError, match="git status"):
+                _ensure_pinned_checkout(clone, so_dest, progress=False)
+
+        # No fetch/checkout attempted, stale .so left intact.
+        cmds = [c.args[0][:2] for c in mock_run.call_args_list]
+        assert ["git", "fetch"] not in cmds
+        assert ["git", "checkout"] not in cmds
+        assert so_dest.exists()
+
     def test_error_message_normalizes_none_stderr(self, tmp_path):
         """With progress=True, capture_output is False and .stderr is None —
         the error message must not leak the literal 'None'."""

--- a/tests/test_cutracer_installer.py
+++ b/tests/test_cutracer_installer.py
@@ -335,6 +335,49 @@ class TestEnsurePinnedCheckout:
                 _ensure_pinned_checkout(clone, so_dest, progress=False)
 
 
+class TestCloneAndBuildExistingTree:
+    def test_non_git_makefile_tree_skips_reconciliation(self, tmp_path):
+        """A non-git source tree (e.g. extracted tarball) with a Makefile must
+        build as-is, not attempt git reconciliation (which would error)."""
+        from nsys_ai.cutracer import installer
+
+        clone = tmp_path / "CUTracer"
+        clone.mkdir()
+        (clone / "Makefile").write_text("all:\n")
+        # Pre-stage so the build short-circuits: nvbit present, .so already built.
+        (clone / "third_party" / "nvbit").mkdir(parents=True)
+        (clone / "lib").mkdir()
+        (clone / "lib" / "cutracer.so").write_bytes(b"\x7fELF")
+        # No .git → must be treated as a non-git tree.
+
+        with patch.object(installer, "_ensure_pinned_checkout") as mock_reconcile:
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+                result = installer._clone_and_build(clone, progress=False)
+
+        mock_reconcile.assert_not_called()
+        assert result == clone / "lib" / "cutracer.so"
+
+    def test_git_makefile_tree_triggers_reconciliation(self, tmp_path):
+        """A git clone with a Makefile must be reconciled to the pinned tag."""
+        from nsys_ai.cutracer import installer
+
+        clone = tmp_path / "CUTracer"
+        clone.mkdir()
+        (clone / "Makefile").write_text("all:\n")
+        (clone / ".git").mkdir()
+        (clone / "third_party" / "nvbit").mkdir(parents=True)
+        (clone / "lib").mkdir()
+        (clone / "lib" / "cutracer.so").write_bytes(b"\x7fELF")
+
+        with patch.object(installer, "_ensure_pinned_checkout") as mock_reconcile:
+            with patch("subprocess.run") as mock_run:
+                mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+                installer._clone_and_build(clone, progress=False)
+
+        mock_reconcile.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # install (high-level, dry-run)
 # ---------------------------------------------------------------------------

--- a/tests/test_cutracer_installer.py
+++ b/tests/test_cutracer_installer.py
@@ -280,6 +280,24 @@ class TestEnsurePinnedCheckout:
         # Stale .so removed so the build step recompiles from the new ref.
         assert not so_dest.exists()
 
+    def test_raises_on_set_url_failure(self, tmp_path):
+        from nsys_ai.cutracer.installer import _ensure_pinned_checkout
+
+        clone = tmp_path / "CUTracer"
+        clone.mkdir()
+        so_dest = clone / "lib" / "cutracer.so"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "describe"]:
+                return MagicMock(returncode=0, stdout="deadbeef\n", stderr="")
+            if cmd[:3] == ["git", "remote", "set-url"]:
+                return MagicMock(returncode=1, stdout="", stderr="no origin")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="set-url"):
+                _ensure_pinned_checkout(clone, so_dest, progress=False)
+
     def test_raises_on_fetch_failure(self, tmp_path):
         from nsys_ai.cutracer.installer import _ensure_pinned_checkout
 

--- a/tests/test_cutracer_installer.py
+++ b/tests/test_cutracer_installer.py
@@ -231,6 +231,93 @@ class TestBuildSo:
 
 
 # ---------------------------------------------------------------------------
+# _ensure_pinned_checkout (existing-clone reconciliation)
+# ---------------------------------------------------------------------------
+
+
+class TestEnsurePinnedCheckout:
+    def test_already_at_tag_is_reused_without_fetch(self, tmp_path):
+        from nsys_ai.cutracer.installer import CUTRACER_TAG, _ensure_pinned_checkout
+
+        clone = tmp_path / "CUTracer"
+        clone.mkdir()
+        so_dest = clone / "lib" / "cutracer.so"
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout=f"{CUTRACER_TAG}\n", stderr=""
+            )
+            _ensure_pinned_checkout(clone, so_dest, progress=False)
+
+        # Only the `git describe` probe should run — no fetch/checkout.
+        assert mock_run.call_count == 1
+        assert mock_run.call_args_list[0].args[0][:2] == ["git", "describe"]
+
+    def test_wrong_ref_triggers_fetch_checkout_and_drops_stale_so(self, tmp_path):
+        from nsys_ai.cutracer.installer import (
+            CUTRACER_GITHUB,
+            CUTRACER_TAG,
+            _ensure_pinned_checkout,
+        )
+
+        clone = tmp_path / "CUTracer"
+        (clone / "lib").mkdir(parents=True)
+        so_dest = clone / "lib" / "cutracer.so"
+        so_dest.write_bytes(b"\x7fELF")  # stale artifact from old ref
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "describe"]:
+                return MagicMock(returncode=0, stdout="deadbeef\n", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            _ensure_pinned_checkout(clone, so_dest, progress=False)
+
+        cmds = [c.args[0] for c in mock_run.call_args_list]
+        assert ["git", "remote", "set-url", "origin", CUTRACER_GITHUB] in cmds
+        assert ["git", "fetch", "--depth=1", "origin", "tag", CUTRACER_TAG] in cmds
+        assert ["git", "checkout", "-f", CUTRACER_TAG] in cmds
+        # Stale .so removed so the build step recompiles from the new ref.
+        assert not so_dest.exists()
+
+    def test_raises_on_fetch_failure(self, tmp_path):
+        from nsys_ai.cutracer.installer import _ensure_pinned_checkout
+
+        clone = tmp_path / "CUTracer"
+        clone.mkdir()
+        so_dest = clone / "lib" / "cutracer.so"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "describe"]:
+                return MagicMock(returncode=0, stdout="deadbeef\n", stderr="")
+            if cmd[:2] == ["git", "fetch"]:
+                return MagicMock(returncode=1, stdout="", stderr="network down")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="git fetch"):
+                _ensure_pinned_checkout(clone, so_dest, progress=False)
+
+    def test_raises_on_checkout_failure(self, tmp_path):
+        from nsys_ai.cutracer.installer import _ensure_pinned_checkout
+
+        clone = tmp_path / "CUTracer"
+        clone.mkdir()
+        so_dest = clone / "lib" / "cutracer.so"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "describe"]:
+                return MagicMock(returncode=0, stdout="deadbeef\n", stderr="")
+            if cmd[:2] == ["git", "checkout"]:
+                return MagicMock(returncode=1, stdout="", stderr="conflict")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            with pytest.raises(RuntimeError, match="git checkout"):
+                _ensure_pinned_checkout(clone, so_dest, progress=False)
+
+
+# ---------------------------------------------------------------------------
 # install (high-level, dry-run)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_cutracer_installer.py
+++ b/tests/test_cutracer_installer.py
@@ -276,9 +276,58 @@ class TestEnsurePinnedCheckout:
         cmds = [c.args[0] for c in mock_run.call_args_list]
         assert ["git", "remote", "set-url", "origin", CUTRACER_GITHUB] in cmds
         assert ["git", "fetch", "--depth=1", "origin", "tag", CUTRACER_TAG] in cmds
-        assert ["git", "checkout", "-f", CUTRACER_TAG] in cmds
+        # Plain checkout (no -f) on a clean worktree.
+        assert ["git", "checkout", CUTRACER_TAG] in cmds
         # Stale .so removed so the build step recompiles from the new ref.
         assert not so_dest.exists()
+
+    def test_dirty_worktree_refuses_checkout(self, tmp_path):
+        from nsys_ai.cutracer.installer import _ensure_pinned_checkout
+
+        clone = tmp_path / "CUTracer"
+        (clone / "lib").mkdir(parents=True)
+        so_dest = clone / "lib" / "cutracer.so"
+        so_dest.write_bytes(b"\x7fELF")  # must NOT be deleted on refusal
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "describe"]:
+                return MagicMock(returncode=0, stdout="deadbeef\n", stderr="")
+            if cmd[:2] == ["git", "status"]:
+                return MagicMock(returncode=0, stdout=" M src/foo.cu\n", stderr="")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run) as mock_run:
+            with pytest.raises(RuntimeError, match="uncommitted local changes"):
+                _ensure_pinned_checkout(clone, so_dest, progress=False)
+
+        # No fetch/checkout attempted, stale .so left intact.
+        cmds = [c.args[0][:2] for c in mock_run.call_args_list]
+        assert ["git", "fetch"] not in cmds
+        assert ["git", "checkout"] not in cmds
+        assert so_dest.exists()
+
+    def test_error_message_normalizes_none_stderr(self, tmp_path):
+        """With progress=True, capture_output is False and .stderr is None —
+        the error message must not leak the literal 'None'."""
+        from nsys_ai.cutracer.installer import _ensure_pinned_checkout
+
+        clone = tmp_path / "CUTracer"
+        clone.mkdir()
+        so_dest = clone / "lib" / "cutracer.so"
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["git", "describe"]:
+                return MagicMock(returncode=0, stdout="deadbeef\n", stderr="")
+            if cmd[:2] == ["git", "status"]:
+                return MagicMock(returncode=0, stdout="", stderr=None)
+            if cmd[:2] == ["git", "fetch"]:
+                return MagicMock(returncode=1, stdout=None, stderr=None)
+            return MagicMock(returncode=0, stdout=None, stderr=None)
+
+        with patch("subprocess.run", side_effect=fake_run):
+            with pytest.raises(RuntimeError) as exc:
+                _ensure_pinned_checkout(clone, so_dest, progress=True)
+        assert "None" not in str(exc.value)
 
     def test_raises_on_set_url_failure(self, tmp_path):
         from nsys_ai.cutracer.installer import _ensure_pinned_checkout

--- a/tests/test_cutracer_runner.py
+++ b/tests/test_cutracer_runner.py
@@ -286,7 +286,8 @@ class TestFormatModalApp:
         plan, config = _make_plan_and_config(tmp_path)
         script = format_modal_app(plan, config)
         assert "git clone" in script
-        assert "facebookresearch/CUTracer" in script
+        assert "facebookexperimental/CUTracer" in script
+        assert "--branch v0.2.1" in script
         assert "install_third_party.sh" in script
         assert "nsys-ai cutracer install" not in script
 

--- a/tests/test_cutracer_runner.py
+++ b/tests/test_cutracer_runner.py
@@ -281,13 +281,15 @@ class TestFormatModalApp:
 
     def test_contains_github_clone(self, tmp_path):
         """Generated Modal script should clone from GitHub, not use nsys-ai cutracer install."""
+        from nsys_ai.cutracer.installer import CUTRACER_TAG
         from nsys_ai.cutracer.runner import format_modal_app
 
         plan, config = _make_plan_and_config(tmp_path)
         script = format_modal_app(plan, config)
         assert "git clone" in script
         assert "facebookexperimental/CUTracer" in script
-        assert "--branch v0.2.1" in script
+        # Track the pinned-tag constant so this stays in sync when it bumps.
+        assert f"--branch {CUTRACER_TAG}" in script
         assert "install_third_party.sh" in script
         assert "nsys-ai cutracer install" not in script
 


### PR DESCRIPTION
## What

CUTracer migrated its GitHub org from `facebookresearch` to `facebookexperimental` (upstream commit "Migrate GitHub org", 2026-05-04). The hardcoded clone URL still pointed at the old org, which only works via GitHub's redirect and is not guaranteed to keep working.

## Changes

- `installer.py` — `CUTRACER_GITHUB` now points at `facebookexperimental/CUTracer`; added `CUTRACER_TAG = "v0.2.1"` and clone with `--branch` for reproducible local builds.
- `runner.py` — the generated Modal app's `git clone` now uses the same URL + pinned tag (single source of truth via the installer constants), instead of cloning a moving `HEAD`.
- `tests/test_cutracer_runner.py` — updated the org assertion and added a `--branch v0.2.1` assertion.

## Verification

- Confirmed upstream `facebookexperimental/CUTracer` exists, latest release is **v0.2.1** (2026-04-23), and build steps (`libzstd-dev` + `install_third_party.sh` + `make`) and output naming (`kernel_*_hist.csv`) are unchanged — so nothing else in the pipeline needs adjusting.
- `ruff check` clean; 112 cutracer tests pass.