### PR TITLE
docs(cutracer): Modal usage guide + trace-size-limit / SASS-failure-warning fixes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Always check `nsys --version` on the target system and cross-reference with the 
 | [07-container-profiling.md](./07-container-profiling.md) | Docker/container profiling setup | User Guide |
 | [08-focused-profiling.md](./08-focused-profiling.md) | Limiting profile scope with cudaProfilerApi and NVTX capture ranges | User Guide |
 | [cutracer-instruction-analysis.md](./cutracer-instruction-analysis.md) | Instruction-level drill-down workflow (`cutracer` + `cutracer_analysis`) | Project Guide |
+| [cutracer-modal.md](./cutracer-modal.md) | Running CUTracer on Modal (serverless GPU, no local GPU needed) | Project Guide |
 | [09-performance-questions-mfu.html](./09-performance-questions-mfu.html) | Curated high-impact performance questions and MFU calculation playbook | Project Guide |
 
 ## How This Knowledge Base Is Used

--- a/docs/cutracer-instruction-analysis.md
+++ b/docs/cutracer-instruction-analysis.md
@@ -108,17 +108,19 @@ nsys-ai skill run cutracer_analysis profile.sqlite --format json \
 
 ## Modal workflow (no local GPU execution)
 
-Generate or run a Modal app via:
+If you have no local GPU, run CUTracer on [Modal](https://modal.com) instead.
+Generate an editable Modal app from your profile:
 
 ```bash
-nsys-ai cutracer run profile.sqlite --launch-cmd "python train.py" --backend modal
+nsys-ai cutracer run profile.sqlite --launch-cmd "python train.py" \
+  --modal-save run_cutracer.py
+modal run run_cutracer.py
 ```
 
-Or execute directly:
-
-```bash
-nsys-ai cutracer run profile.sqlite --launch-cmd "python train.py" --backend modal-run
-```
+The generated image builds `cutracer.so` for you but does **not** include your
+training code or dependencies — you must add them to the script before running.
+See **[cutracer-modal.md](./cutracer-modal.md)** for the full end-to-end guide
+(prerequisites, adding your code, GPU/cost selection, volumes, troubleshooting).
 
 ## Agent guide / auto-guide note
 

--- a/docs/cutracer-modal.md
+++ b/docs/cutracer-modal.md
@@ -1,0 +1,292 @@
+# Running CUTracer on Modal
+
+This guide shows how to run CUTracer instruction-level kernel analysis on
+[Modal](https://modal.com) — a serverless GPU platform — when you do **not**
+have a local NVIDIA GPU.
+
+It complements [cutracer-instruction-analysis.md](./cutracer-instruction-analysis.md),
+which covers the local-GPU workflow and how to read the results. Read that
+first if you are new to the `cutracer` subcommand.
+
+## When to use the Modal backend
+
+Use Modal when **all** of these are true:
+
+- Nsight triage (`top_kernels` / `nsys-ai summary`) points at a heavy custom
+  kernel — a Triton kernel, a hand-written GEMM, `nvjet_*`, etc. — that the
+  high-level trace cannot explain.
+- You want the SASS-level instruction mix (memory- vs compute- vs sync-bound),
+  which requires re-running the workload under instrumentation.
+- You have no local GPU, or you want to instrument on a different GPU
+  architecture than the one on your machine.
+
+CUTracer is a **targeted drill-down**, not a first pass. Do not Modal-trace a
+whole training run — instrument a short, reproducible slice (see
+[Keep the run short](#keep-the-run-short)).
+
+## How it works
+
+`nsys-ai cutracer run ... --backend modal` does not call Modal directly.
+It **generates a complete, self-contained Modal app** (a Python file) from
+your profile. The generated app:
+
+1. Builds a CUDA devel image that clones and compiles the pinned CUTracer
+   release (`cutracer.so`) into a **cached image layer** — the build only
+   runs the first time, then Modal reuses the layer.
+2. Mounts a `modal.Volume` so the output CSVs survive the container.
+3. Runs `cutracer trace -- <your launch command>` on the GPU, filtered to the
+   top-N kernels from your profile.
+4. Post-processes the raw trace into histogram CSVs (resolving SASS opcodes
+   inside the container, where `nvdisasm` is available).
+5. Downloads the `*_hist.csv` files back to a local directory.
+
+You then analyze them locally with `nsys-ai cutracer analyze`.
+
+The generated script is intentionally human-readable and meant to be edited —
+see [Add your training code](#add-your-training-code).
+
+## Prerequisites
+
+```bash
+pip install nsys-ai modal      # nsys-ai generates the script; modal runs it
+modal token new                # first time only — authenticates the Modal CLI
+```
+
+You do **not** need a local CUDA toolkit or `cutracer.so`: the `.so` is built
+inside the Modal image. You only need a profile (`.sqlite` or `.nsys-rep`) to
+pick the target kernels.
+
+## The three Modal modes
+
+| Command | What it does | Use when |
+|---|---|---|
+| `--backend modal` | Prints the generated app to stdout | You want to inspect or redirect it |
+| `--modal-save FILE` | Writes the app to `FILE` (chmod +x) | **Recommended** — you will edit it |
+| `--backend modal-run` | Writes a temp script and runs `modal run` immediately | Your launch command needs no extra code/deps in the image |
+
+In almost all real cases you want **`--modal-save`**, because the generated
+image does not yet contain your training code or its dependencies (see below).
+
+## Quick start
+
+```bash
+# 1. Generate and save an editable Modal app from your profile.
+nsys-ai cutracer run profile.sqlite \
+  --launch-cmd "python train.py --steps 10" \
+  --modal-save run_cutracer.py \
+  --modal-gpu H100 \
+  --top-n 5
+
+# 2. Edit run_cutracer.py to add your training code + deps (see next section).
+
+# 3. Run it on Modal.
+modal run run_cutracer.py
+
+# 4. Analyze the downloaded CSVs locally.
+nsys-ai cutracer analyze profile.sqlite ./cutracer_out --format json
+```
+
+If your launch command genuinely needs nothing beyond `nsys-ai` and CUTracer
+(rare — e.g. a self-contained microbenchmark installed via pip), you can skip
+the edit step and run in one shot:
+
+```bash
+nsys-ai cutracer run profile.sqlite \
+  --launch-cmd "python -m my_published_pkg.bench" \
+  --backend modal-run --modal-gpu A100
+```
+
+## Add your training code
+
+This is the step most people miss. The generated image installs `nsys-ai` and
+`cutracer` and builds the `.so`, but it does **not** contain your `train.py` or
+your training dependencies (PyTorch, your package, datasets, etc.). When the
+container runs `cutracer trace -- python train.py`, that `train.py` must exist
+inside the container.
+
+Open the saved `run_cutracer.py` and edit the `image = (...)` block:
+
+```python
+image = (
+    modal.Image.from_registry("nvcr.io/nvidia/cuda:12.4.0-devel-ubuntu22.04", add_python="3.11")
+    .apt_install("git", "make", "g++", "curl", "libzstd-dev")
+    .pip_install("nsys-ai", "cutracer>=0.2.0")
+    # --- add your training dependencies ---
+    .pip_install("torch", "transformers", "triton")
+    # --- add your training code ---
+    .add_local_dir(".", remote_path="/root")     # or .add_local_file("train.py", "/root/train.py")
+    .run_commands(
+        "git clone --depth=1 --branch v0.2.1 https://github.com/facebookexperimental/CUTracer /opt/CUTracer",
+        "cd /opt/CUTracer && ./install_third_party.sh",
+        "cd /opt/CUTracer && make -j$(nproc)",   # upstream's recommended build
+        "mkdir -p /root/.nsys-ai/cutracer/lib && cp /opt/CUTracer/lib/cutracer.so /root/.nsys-ai/cutracer/lib/",
+    )
+)
+```
+
+Notes:
+
+- `add_local_dir` / `add_local_file` are Modal's mechanisms for shipping local
+  code into the image. See the [Modal images docs](https://modal.com/docs/guide/images).
+- The container's working directory is `/root`; your `--launch-cmd` runs there.
+  Make sure the path in your launch command matches where you mounted the code.
+- If your code is an installed package, prefer `.pip_install(...)` over mounting.
+- You can pre-bundle deps by setting the base image to your own training image
+  instead of the stock CUDA devel image — just keep the `apt_install` packages
+  (`git make g++ curl libzstd-dev`) and the CUTracer build commands.
+
+### Match the CUDA toolkit to your framework
+
+**This is the most common cause of empty/partial SASS output.** SASS resolution
+runs `nvdisasm` (from the image's CUDA toolkit) on the cubins CUTracer dumps. If
+your framework was built against a **newer** CUDA than the base image,
+`nvdisasm` cannot parse those cubins and fails with:
+
+```text
+nvdisasm fatal : <kernel>.cubin is not a supported Elf file
+```
+
+When this happens the run still exits 0, but the affected kernel produces **no
+histogram** — you silently get results only for kernels whose cubins the older
+`nvdisasm` could read. In a real drill-down that often means your hot library
+kernel (e.g. a cuBLAS `*_s16816gemm_*`) is the one that gets dropped.
+
+A current `pip install torch` pulls **CUDA 13** wheels, which do **not** match
+the stock `cuda:12.4.0-devel` base image. To keep them aligned, either:
+
+- bump the base image to match (e.g. `nvcr.io/nvidia/cuda:13.0.0-devel-ubuntu22.04`), or
+- pin a framework build for the image's CUDA. On the stock 12.4 image, install a
+  cu124 torch wheel:
+
+  ```python
+  .pip_install("torch", index_url="https://download.pytorch.org/whl/cu124")
+  ```
+
+  (Verified on Modal: with `torch==2.6.0+cu124` on the 12.4 image, a cuBLAS
+  `ampere_*_s16816gemm_*` cubin disassembles cleanly — `tensor_core_active: true`,
+  `HMMA`-dominated mix — whereas the default CUDA-13 torch fails `nvdisasm` on it.)
+
+After a run, confirm the kernel you care about actually has a CSV:
+
+```bash
+ls cutracer_out/*_hist.csv      # the hot kernel's name should appear here
+```
+
+## GPU types and cost
+
+`--modal-gpu` accepts any Modal GPU string. Common choices:
+
+| `--modal-gpu` | Notes |
+|---|---|
+| `H100` | Default. Fastest; highest $/hr. |
+| `A100` | Good middle ground. |
+| `A10G` | Cheapest; fine for small kernels / smoke runs. |
+| `L4`, `L40S`, `T4` | Also supported by Modal. |
+
+CUTracer instrumentation adds roughly **1.5×** runtime overhead. A rough cost
+estimate, where `span_s` is your instrumented run's wall time:
+
+```text
+gpu_seconds = span_s × 1.5
+cost_usd    = gpu_seconds × per_second_rate
+```
+
+Approximate per-second rates (verify against
+[Modal's current pricing](https://modal.com/pricing)):
+
+```text
+H100  ≈ $0.00127/s  (~$4.56/hr)
+A100  ≈ $0.00071/s  (~$2.55/hr)
+A10G  ≈ $0.00031/s  (~$1.10/hr)
+```
+
+Because you pay per GPU-second, keeping the instrumented run short matters more
+than the GPU choice.
+
+## Keep the run short
+
+You pay per GPU-second, so instrument only enough to capture the hot kernel's
+instruction mix — a few iterations, not the whole job. Levers, most effective first:
+
+1. **Short launch command.** Make `--launch-cmd` stop early (e.g.
+   `python train.py --steps 3`). This is the main control over how much is traced.
+2. **Kernel filter (kept by default).** The generated `kernel_filter` is derived
+   from your profile's top-N kernels — keep it (see the size warning below).
+3. **Hard size cap.** `--trace-size-limit-mb N` makes CUTracer stop writing trace
+   once the on-disk size reaches N MB (the running kernel is unaffected).
+
+```bash
+nsys-ai cutracer run profile.sqlite \
+  --launch-cmd "python train.py --steps 3" \
+  --trace-size-limit-mb 1000 \
+  --modal-save run_cutracer.py
+```
+
+`--trim START_S END_S` only restricts which kernels are picked from the
+*profile*; it does not shorten the Modal run. `--max-iters` is **deprecated and a
+no-op** — upstream CUTracer has no `CUTRACER_MAX_ITERS` variable, so use the levers
+above instead.
+
+> **The histogram analysis writes a large raw trace.** `proton_instr_histogram`
+> emits an uncompressed per-instruction NDJSON file **per kernel, per iteration** —
+> commonly **200–460 MB each**. Tracing all kernels for several iterations can pile
+> up multiple GB on the Volume before post-processing. Keep the kernel filter, keep
+> the run short, and set `--trace-size-limit-mb`.
+
+## Output and analysis
+
+The generated `local_entrypoint` downloads every `*_hist.csv` from the Modal
+Volume into `--output-dir` (default `./cutracer_out`). Then:
+
+```bash
+# Human-readable report
+nsys-ai cutracer analyze profile.sqlite ./cutracer_out
+
+# JSON (for agents / scripting)
+nsys-ai cutracer analyze profile.sqlite ./cutracer_out --format json
+
+# Or run the skill directly
+nsys-ai skill run cutracer_analysis profile.sqlite --format json \
+  -p trace_dir=./cutracer_out
+```
+
+See [cutracer-instruction-analysis.md §How to read results](./cutracer-instruction-analysis.md#how-to-read-results)
+for interpreting `bottleneck`, `instruction_mix_pct`, `bank_conflict_hint`,
+`tensor_core_active`, and `top_stalls`.
+
+## The Modal Volume
+
+Output is written to a `modal.Volume` named `cutracer-histograms` by default
+(override with `--modal-volume NAME`). The volume **persists across runs** and
+CSVs accumulate in it. Implications:
+
+- Re-running with the same volume keeps older CSVs around; clear the volume or
+  use a fresh `--modal-volume` name per experiment if you want isolation.
+- Inspect or clean it with the Modal CLI:
+
+  ```bash
+  modal volume ls cutracer-histograms
+  modal volume rm cutracer-histograms <path>
+  ```
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `no *_hist.csv files found in volume` | Training command failed, or wrote no traced kernels | Check the Modal run logs; confirm the launch command runs standalone; verify the kernel filter matched real kernels (`nsys-ai cutracer plan profile.sqlite`) |
+| `nvdisasm fatal : <kernel>.cubin is not a supported Elf file` | Image CUDA toolkit is older than the toolkit your framework was built with | [Match the CUDA toolkit to your framework](#match-the-cuda-toolkit-to-your-framework) — bump the base image or pin a matching framework wheel |
+| Got a CSV, but not for the kernel I targeted | That kernel's cubin failed SASS resolution (see the row above); the run still exits 0 with other kernels' CSVs | Fix the CUDA version mismatch, then re-run; confirm with `ls cutracer_out/*_hist.csv` |
+| `analyze` shows `top_stalls: []` and no CPI | `proton_instr_histogram` does not emit a `cycles` column, so stall/CPI scoring is unavailable | Expected with histogram mode; use the instruction mix + `bottleneck` instead |
+| `WARNING: cutracer.so not found ... kernel logger mode only` | The `.so` build did not land in the image | Confirm the `run_commands` build steps are intact and `libzstd-dev` is installed; rebuild the image (`modal run` re-triggers a layer rebuild if changed) |
+| `python: command not found` / module import errors in the container | Your code or deps are not in the image | [Add your training code](#add-your-training-code) via `.add_local_dir` / `.pip_install` |
+| `modal: command not found` | Modal CLI not installed | `pip install modal` |
+| Auth / token errors | Not authenticated | `modal token new` |
+| First run is slow (~5 min before training starts) | First-time CUTracer image build | Expected; the layer is cached and reused on subsequent runs |
+| `bottleneck = "unknown"`, `total_instructions = 0` in analyze | Ran in logger mode (no `.so`) | Same as the `.so not found` row above |
+
+## See also
+
+- [cutracer-instruction-analysis.md](./cutracer-instruction-analysis.md) — local
+  workflow, command overview, reading results.
+- [Modal documentation](https://modal.com/docs) — images, GPU types, volumes.
+- `nsys-ai cutracer run --help` — full flag reference.

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -131,6 +131,13 @@ def _cutracer_run(args, _profile):
     modal_volume = getattr(args, "modal_volume", "cutracer-histograms") or "cutracer-histograms"
     so_path_str = getattr(args, "so_path", None)
     max_iters = getattr(args, "max_iters", None)
+    trace_size_limit_mb = getattr(args, "trace_size_limit_mb", None)
+    if max_iters is not None:
+        print(
+            "warning: --max-iters is not honored by CUTracer (no CUTRACER_MAX_ITERS "
+            "variable); use --trace-size-limit-mb or a shorter --launch-cmd",
+            file=sys.stderr,
+        )
 
     with _profile.open(profile_path) as prof:
         plan = build_plan(
@@ -151,6 +158,7 @@ def _cutracer_run(args, _profile):
         kernel_filter=kernel_filter,
         so_path=_Path(so_path_str) if so_path_str else None,
         max_iters=max_iters,
+        trace_size_limit_mb=trace_size_limit_mb,
     )
 
     if backend in {"modal", "modal-run"} or modal_save:

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -528,7 +528,17 @@ def _build_parser():
         type=int,
         default=None,
         metavar="N",
-        help="Limit CUTracer to N training iterations (sets CUTRACER_MAX_ITERS)",
+        help="(deprecated, no-op) upstream CUTracer has no CUTRACER_MAX_ITERS; "
+        "use --trace-size-limit-mb or a shorter --launch-cmd instead",
+    )
+    sp_run.add_argument(
+        "--trace-size-limit-mb",
+        dest="trace_size_limit_mb",
+        type=int,
+        default=None,
+        metavar="MB",
+        help="Stop tracing once the on-disk trace reaches MB megabytes "
+        "(sets CUTRACER_TRACE_SIZE_LIMIT_MB; the running kernel is unaffected)",
     )
     sp_run.add_argument(
         "--dry-run",

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -538,7 +538,8 @@ def _build_parser():
         default=None,
         metavar="MB",
         help="Stop tracing once the on-disk trace reaches MB megabytes "
-        "(sets CUTRACER_TRACE_SIZE_LIMIT_MB; the running kernel is unaffected)",
+        "(passed as the `cutracer trace --trace-size-limit-mb` flag; the running "
+        "kernel is unaffected)",
     )
     sp_run.add_argument(
         "--dry-run",

--- a/src/nsys_ai/cutracer/runner.py
+++ b/src/nsys_ai/cutracer/runner.py
@@ -62,8 +62,10 @@ class RunConfig:
     shorter ``launch_cmd`` instead. Kept only for back-compat."""
 
     trace_size_limit_mb: int | None = None
-    """If set, sets ``CUTRACER_TRACE_SIZE_LIMIT_MB`` so CUTracer stops writing trace
-    once the on-disk size reaches this many MB (the running kernel is unaffected)."""
+    """If set, passes ``--trace-size-limit-mb`` to ``cutracer trace`` so CUTracer
+    stops writing trace once the on-disk size reaches this many MB (the running
+    kernel is unaffected). Applied as a CLI flag, not an env var: the wrapper
+    overrides ``CUTRACER_TRACE_SIZE_LIMIT_MB`` from this flag."""
 
 
 # ---------------------------------------------------------------------------
@@ -375,44 +377,43 @@ def run_with_cutracer(
     existing_hist = sorted(out_dir.glob("*_hist.csv"))
     if existing_hist:
         print(f"==> Found {{len(existing_hist)}} precomputed *_hist.csv file(s); skipping SASS post-process")
-        vol.commit()
-        return
+    else:
+        # Capture base_name → hash mapping from ndjson filenames before SASS resolution,
+        # so we can reconstruct the kernel_<name>_<hash>_hist.csv naming expected by the parser.
+        hash_map: dict = {{}}
+        for ndf in sorted(out_dir.glob("*.ndjson")):
+            base = re.sub(r"_iter\\d+", "", ndf.stem)
+            parts = base.split("_", 2)
+            if len(parts) >= 3:
+                arch = "_".join(base.split("_")[2:])
+                hash_map[arch] = parts[1]
 
-    # Capture base_name → hash mapping from ndjson filenames before SASS resolution,
-    # so we can reconstruct the kernel_<name>_<hash>_hist.csv naming expected by the parser.
-    hash_map: dict = {{}}
-    for ndf in sorted(out_dir.glob("*.ndjson")):
-        base = re.sub(r"_iter\\d+", "", ndf.stem)
-        parts = base.split("_", 2)
-        if len(parts) >= 3:
-            arch = "_".join(base.split("_")[2:])
-            hash_map[arch] = parts[1]
+        hists = sass_resolve_dir(out_dir)
+        if not hists:
+            print("WARNING: sass_resolve_dir returned no histograms — check cutracer/nvdisasm output")
 
-    hists = sass_resolve_dir(out_dir)
-    if not hists:
-        print("WARNING: sass_resolve_dir returned no histograms — check cutracer/nvdisasm output")
-
-    for arch_suffix, hist in hists.items():
-        hash_part = hash_map.get(arch_suffix, "0")
-        csv_path = out_dir / f"kernel_{{arch_suffix}}_{{hash_part}}_hist.csv"
-        with open(csv_path, "w", newline="") as cf:
-            writer = csv.writer(cf)
-            writer.writerow(["warp_id", "region_id", "instruction", "count", "cycles"])
-            for mn, cnt in sorted(hist.instruction_counts.items(), key=lambda x: -x[1]):
-                writer.writerow([0, 0, mn, cnt, hist.instruction_cycles.get(mn, 0)])
-        total = sum(hist.instruction_counts.values())
-        print(f"==> Wrote {{csv_path.name}} ({{total:,}} instructions, {{len(hist.instruction_counts)}} opcodes)")
+        for arch_suffix, hist in hists.items():
+            hash_part = hash_map.get(arch_suffix, "0")
+            csv_path = out_dir / f"kernel_{{arch_suffix}}_{{hash_part}}_hist.csv"
+            with open(csv_path, "w", newline="") as cf:
+                writer = csv.writer(cf)
+                writer.writerow(["warp_id", "region_id", "instruction", "count", "cycles"])
+                for mn, cnt in sorted(hist.instruction_counts.items(), key=lambda x: -x[1]):
+                    writer.writerow([0, 0, mn, cnt, hist.instruction_cycles.get(mn, 0)])
+            total = sum(hist.instruction_counts.values())
+            print(f"==> Wrote {{csv_path.name}} ({{total:,}} instructions, {{len(hist.instruction_counts)}} opcodes)")
 
     # -----------------------------------------------------------------------
-    # SASS resolution coverage — a cubin with no histogram failed nvdisasm
-    # (commonly a CUDA toolkit mismatch: the image's nvdisasm is older than the
-    # framework's CUDA build). Surface this loudly so a dropped HOT kernel is not
-    # mistaken for a clean run — the trace exits 0 even when resolution fails.
+    # SASS resolution coverage (runs for both the precomputed-hist and the
+    # SASS-fallback paths) — a captured cubin with no histogram failed nvdisasm,
+    # commonly a CUDA toolkit mismatch where the image's nvdisasm is older than
+    # the framework's CUDA build. Surface this loudly so a dropped HOT kernel is
+    # not mistaken for a clean run — the trace exits 0 even when resolution fails.
     # -----------------------------------------------------------------------
     cubins = sorted(out_dir.glob("*.cubin"))
     written = {{p.name for p in out_dir.glob("*_hist.csv")}}
-    print(f"==> SASS resolution: {{len(hists)}} kernel(s) resolved, {{len(cubins)}} cubin(s) captured")
-    if cubins and len(hists) < len(cubins):
+    print(f"==> SASS resolution: {{len(written)}} histogram(s), {{len(cubins)}} cubin(s) captured")
+    if cubins and len(written) < len(cubins):
         failed = []
         for cb in cubins:
             frag = cb.stem.split("_", 2)[-1] if cb.stem.count("_") >= 2 else cb.stem

--- a/src/nsys_ai/cutracer/runner.py
+++ b/src/nsys_ai/cutracer/runner.py
@@ -23,7 +23,6 @@ Modal
 
 from __future__ import annotations
 
-import os
 import shlex
 
 # subprocess is used for argv-based cutracer invocations.
@@ -58,7 +57,13 @@ class RunConfig:
     """CUTracer instrumentation mode."""
 
     max_iters: int | None = None
-    """If set, sets ``CUTRACER_MAX_ITERS`` to limit profiling to N iterations."""
+    """Deprecated / no-op. Upstream CUTracer (v0.2.1) has no ``CUTRACER_MAX_ITERS``
+    variable, so this does not limit iterations. Use ``trace_size_limit_mb`` or a
+    shorter ``launch_cmd`` instead. Kept only for back-compat."""
+
+    trace_size_limit_mb: int | None = None
+    """If set, sets ``CUTRACER_TRACE_SIZE_LIMIT_MB`` so CUTracer stops writing trace
+    once the on-disk size reaches this many MB (the running kernel is unaffected)."""
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +97,11 @@ def _build_cutracer_cmd(config: RunConfig, so_path: Path | None) -> list[str]:
     if config.kernel_filter:
         cmd += ["--kernel-filters", ",".join(config.kernel_filter)]
     cmd += ["--output-dir", str(config.output_dir.resolve())]
+    # Must be a CLI flag: the ``cutracer trace`` wrapper sets the child's
+    # CUTRACER_TRACE_SIZE_LIMIT_MB from this flag (default 0), clobbering any
+    # value inherited from the parent environment.
+    if config.trace_size_limit_mb is not None:
+        cmd += ["--trace-size-limit-mb", str(config.trace_size_limit_mb)]
     cmd += ["--"] + shlex.split(config.launch_cmd)
     return cmd
 
@@ -141,11 +151,9 @@ def run_local(
         print("  " + " ".join(argv))
         return config.output_dir
 
-    run_env = os.environ.copy()
-    if config.max_iters is not None:
-        run_env["CUTRACER_MAX_ITERS"] = str(config.max_iters)
-
-    result = subprocess.run(argv, shell=False, env=run_env)  # nosec B603 B607
+    # trace_size_limit_mb is applied as a ``cutracer trace`` CLI flag (see
+    # _build_cutracer_cmd), not via the environment, which the wrapper overrides.
+    result = subprocess.run(argv, shell=False)  # nosec B603 B607
     if result.returncode != 0:
         raise subprocess.CalledProcessError(result.returncode, argv)
 
@@ -310,7 +318,7 @@ def run_with_cutracer(
     launch_cmd: str,
     kernel_filter: str,
     analysis: str = "{config.mode}",
-    max_iters: int | None = None,
+    trace_size_limit_mb: int | None = None,
 ) -> None:
     import csv
     import re
@@ -333,6 +341,9 @@ def run_with_cutracer(
         if kernel_filter:
             argv += ["--kernel-filters", kernel_filter]
         argv += ["--output-dir", "/cutracer_out"]
+        # Pass as a CLI flag — the cutracer trace wrapper overrides the size env var.
+        if trace_size_limit_mb is not None:
+            argv += ["--trace-size-limit-mb", str(trace_size_limit_mb)]
     else:
         print(f"WARNING: cutracer.so not found at {{so_path}} — running in kernel logger mode only")
         if kernel_filter:
@@ -350,11 +361,7 @@ def run_with_cutracer(
         print(f"    filter  : {{kernel_filter or '(all)'}}")
     print(f"    argv    : {{' '.join(argv)}}")
 
-    run_env = os.environ.copy()
-    if max_iters is not None:
-        run_env["CUTRACER_MAX_ITERS"] = str(max_iters)
-
-    result = subprocess.run(argv, shell=False, env=run_env)
+    result = subprocess.run(argv, shell=False)
     if result.returncode != 0:
         vol.commit()
         raise SystemExit(f"Training command exited with code {{result.returncode}}")
@@ -396,6 +403,30 @@ def run_with_cutracer(
         total = sum(hist.instruction_counts.values())
         print(f"==> Wrote {{csv_path.name}} ({{total:,}} instructions, {{len(hist.instruction_counts)}} opcodes)")
 
+    # -----------------------------------------------------------------------
+    # SASS resolution coverage — a cubin with no histogram failed nvdisasm
+    # (commonly a CUDA toolkit mismatch: the image's nvdisasm is older than the
+    # framework's CUDA build). Surface this loudly so a dropped HOT kernel is not
+    # mistaken for a clean run — the trace exits 0 even when resolution fails.
+    # -----------------------------------------------------------------------
+    cubins = sorted(out_dir.glob("*.cubin"))
+    written = {{p.name for p in out_dir.glob("*_hist.csv")}}
+    print(f"==> SASS resolution: {{len(hists)}} kernel(s) resolved, {{len(cubins)}} cubin(s) captured")
+    if cubins and len(hists) < len(cubins):
+        failed = []
+        for cb in cubins:
+            frag = cb.stem.split("_", 2)[-1] if cb.stem.count("_") >= 2 else cb.stem
+            if not any(frag in w for w in written):
+                failed.append(cb.name)
+        if failed:
+            print("WARNING: SASS resolution FAILED for these kernel(s) — NO histogram was written:")
+            for f in failed:
+                print(f"    - {{f}}")
+            print("WARNING: usually a CUDA toolkit mismatch (the image's nvdisasm is older than")
+            print("         the framework's CUDA build). See docs/cutracer-modal.md ->")
+            print("         'Match the CUDA toolkit to your framework'.")
+            print("WARNING: if the kernel you targeted is listed above, its results are MISSING.")
+
     vol.commit()  # flush Volume before container exits
 
 
@@ -408,13 +439,13 @@ def main() -> None:
     # TODO: Replace with your actual training command (short profiling run, not full training).
     launch_cmd = {repr(config.launch_cmd or "python train.py  # TODO: replace")}
     kernel_filter = {repr(filter_csv)}
-    max_iters = {config.max_iters!r}  # set to e.g. 10 to profile only 10 iterations
+    trace_size_limit_mb = {config.trace_size_limit_mb!r}  # e.g. 1000 caps the raw trace at ~1 GB
 
     print("==> Submitting CUTracer run to Modal ...")
     run_with_cutracer.remote(
         launch_cmd=launch_cmd,
         kernel_filter=kernel_filter,
-        max_iters=max_iters,
+        trace_size_limit_mb=trace_size_limit_mb,
     )
 
     # Download histogram CSVs from Modal Volume to local disk

--- a/tests/test_cutracer_runner.py
+++ b/tests/test_cutracer_runner.py
@@ -173,8 +173,32 @@ class TestRunLocal:
                 # Logger mode: no --analysis flag
                 assert "--analysis" not in call_argv
 
-    def test_max_iters_sets_cutracer_env(self, tmp_path):
-        """CUTRACER_MAX_ITERS is passed when ``RunConfig.max_iters`` is set."""
+    def test_trace_size_limit_passes_cli_flag(self, tmp_path):
+        """trace_size_limit_mb is passed as a ``cutracer trace`` CLI flag.
+
+        The env var alone does not work: the ``cutracer trace`` wrapper resets
+        CUTRACER_TRACE_SIZE_LIMIT_MB for the child from its own ``--trace-size-limit-mb``
+        flag (default 0), so it must be passed on the command line.
+        """
+        from nsys_ai.cutracer.runner import RunConfig, run_local
+
+        so = tmp_path / "cutracer.so"
+        so.write_bytes(b"\x7fELF")
+        cfg = RunConfig(
+            launch_cmd="true",
+            output_dir=tmp_path / "out",
+            so_path=so,
+            trace_size_limit_mb=500,
+        )
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0)
+            run_local(cfg, progress=False)
+        call_argv = mock_run.call_args[0][0]
+        assert "--trace-size-limit-mb" in call_argv
+        assert call_argv[call_argv.index("--trace-size-limit-mb") + 1] == "500"
+
+    def test_max_iters_does_not_set_phantom_env(self, tmp_path):
+        """``max_iters`` is a no-op: the phantom CUTRACER_MAX_ITERS is never set."""
         from nsys_ai.cutracer.runner import RunConfig, run_local
 
         so = tmp_path / "cutracer.so"
@@ -189,7 +213,7 @@ class TestRunLocal:
             mock_run.return_value = MagicMock(returncode=0)
             run_local(cfg, progress=False)
         env = mock_run.call_args.kwargs.get("env") or {}
-        assert env.get("CUTRACER_MAX_ITERS") == "42"
+        assert "CUTRACER_MAX_ITERS" not in env
 
 
 # ---------------------------------------------------------------------------
@@ -212,7 +236,7 @@ def _make_plan_and_config(tmp_path):
         launch_cmd="python train.py",
         output_dir=tmp_path / "cutracer_out",
         kernel_filter=["flash_bwd_dq_dk_dv_loop", "flash_fwd_kernel"],
-        max_iters=5,
+        trace_size_limit_mb=500,
     )
     return plan, config
 
@@ -301,13 +325,17 @@ class TestFormatModalApp:
         assert "nsys-ai cutracer analyze" in script
         assert "/data/trace.sqlite" in script
 
-    def test_contains_max_iters(self, tmp_path):
+    def test_contains_trace_size_limit(self, tmp_path):
         from nsys_ai.cutracer.runner import format_modal_app
 
         plan, config = _make_plan_and_config(tmp_path)
         script = format_modal_app(plan, config)
-        assert "CUTRACER_MAX_ITERS" in script
-        assert "5" in script  # max_iters=5
+        # Passed as a cutracer trace CLI flag, not via the (overridden) env var.
+        assert "--trace-size-limit-mb" in script
+        assert "500" in script  # trace_size_limit_mb=500
+        assert "CUTRACER_TRACE_SIZE_LIMIT_MB" not in script
+        # the phantom iterations env var must not leak back into the script
+        assert "CUTRACER_MAX_ITERS" not in script
 
     def test_contains_vol_iterdir(self, tmp_path):
         from nsys_ai.cutracer.runner import format_modal_app


### PR DESCRIPTION
## Docs
- Add `docs/cutracer-modal.md` — end-to-end guide for running CUTracer on Modal: prerequisites, the `--backend modal` / `--modal-save` / `--backend modal-run` modes, adding training code and dependencies to the generated image, matching the CUDA toolkit for SASS resolution, GPU/cost, bounding trace size, the output volume, and troubleshooting.
- Link it from `docs/README.md` and `docs/cutracer-instruction-analysis.md`.

## `cutracer run`
- Add `--trace-size-limit-mb`, passed as a `cutracer trace` CLI flag, to bound the raw `proton_instr_histogram` NDJSON output.
- The generated Modal script now reports SASS resolution coverage and warns, listing any captured cubin that produced no histogram.
- Mark `--max-iters` as a no-op (upstream CUTracer has no `CUTRACER_MAX_ITERS`); it now warns and points to `--trace-size-limit-mb`.

## Tests
- Update `tests/test_cutracer_runner.py` for the new flag and the no-op `--max-iters`.