### PR TITLE
feat(skills): add structured top_kernels findings

### DIFF
--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -69,6 +69,7 @@ class EvidenceBuilder:
         "idle_gaps": ("gpu_idle_gaps", {"limit": 5, "min_gap_ns": 1000000}),
         "nccl_stalls": ("kernel_instances", {"name": "nccl", "limit": 3}),
         "kernel_hotspots": ("kernel_instances", {"limit": 3}),
+        "top_kernel_aggregates": ("top_kernels", {"limit": 15}),
         "overlap_ratio": ("overlap_breakdown", {}),
         "memory_anomalies": ("memory_bandwidth", {"limit": 5}),
         "h2d_spikes": ("h2d_distribution", {}),

--- a/src/nsys_ai/skills/builtins/top_kernels.py
+++ b/src/nsys_ai/skills/builtins/top_kernels.py
@@ -254,20 +254,39 @@ def _variability_confidence(ratio: float, invocations: int) -> float:
 def _span_from_row(r: dict) -> tuple[bool, int | None, int | None]:
     """Read ``span_start_ns`` / ``span_end_ns`` off a top_kernels row.
 
-    Returns ``(has_span, start_ns_or_None, end_ns_or_None)``. The boolean
-    is the authoritative source for whether to emit ``Finding.type="region"``
-    or ``"highlight"`` and is reused by both the ``Finding`` and the
-    ``TraceSelection`` constructors so the time-anchor decision is taken
-    in one place. ``Finding.start_ns`` is typed ``int`` (required), so
-    callers fall back to ``0`` on the no-span branch and rely on
-    ``type="highlight"`` to signal "not time-anchored" downstream;
-    ``TraceSelection`` accepts ``None`` directly.
+    Returns ``(has_span, start_ns_or_None, end_ns_or_None)``. Used to
+    populate the ``TraceSelection`` metadata on per-kernel findings; the
+    selection's start/end mark the kernel's full invocation envelope in
+    the trace, which is informational rather than a tight localization.
+    ``Finding.start_ns`` is typed ``int`` (required), so per-kernel
+    findings always emit ``0`` with ``type="highlight"`` to signal
+    "not a tight region" downstream — the span often covers most of
+    the profile for recurring kernels, so claiming ``"region"`` would
+    over-state the localization.
     """
     s = r.get("span_start_ns")
     e = r.get("span_end_ns")
     if s is None or e is None:
         return False, None, None
     return True, int(s), int(e)
+
+
+def _is_nccl_kernel(name: str) -> bool:
+    """True for NCCL communication kernels (SendRecv, AllReduce, …).
+
+    Delegates to ``overlap.classify_kernel`` so we share NCCL detection
+    with ``nccl_breakdown`` / ``overlap_breakdown``. NCCL kernels are
+    skipped in the per-kernel ``top_kernels`` findings because (a) their
+    natural category is ``communication`` not ``compute``, (b) the
+    compute-side suggested actions (FlashAttention / cuBLASLt / Tensor
+    Cores) don't apply to comm kernels, and (c) ``nccl_breakdown``
+    already owns NCCL signal (per-collective dominance and variability
+    findings). The ``top_kernels_concentrated`` finding intentionally
+    still considers NCCL kernels — it's a distributional property of
+    the top-K, and excluding NCCL would understate the head's weight.
+    """
+    from nsys_ai.overlap import classify_kernel
+    return classify_kernel(name).startswith("nccl_")
 
 
 def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
@@ -296,13 +315,15 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     n_kernels = len(rows)
     top = rows[0]
 
-    # Finding 1: single kernel dominates.
+    # Finding 1: single kernel dominates. NCCL kernels are skipped here
+    # (see ``_is_nccl_kernel``); ``nccl_breakdown`` owns comm-side findings.
     top_total_ms = float(top.get("total_ms", 0) or 0)
     top_pct = 100.0 * top_total_ms / total_top_ms
-    if top_pct >= _DOMINATES_PCT_THRESHOLD:
-        kname = top.get("kernel_name", "<unknown>")
+    top_kname = top.get("kernel_name", "<unknown>")
+    if top_pct >= _DOMINATES_PCT_THRESHOLD and not _is_nccl_kernel(top_kname):
+        kname = top_kname
         invocations = int(top.get("invocations", 0) or 0)
-        has_span, span_start_ns, span_end_ns = _span_from_row(top)
+        _, span_start_ns, span_end_ns = _span_from_row(top)
         finding_id = f"top_kernel_dominates_{_safe_id(kname)}"
         selection = TraceSelection(
             id=f"sel_{finding_id}",
@@ -328,10 +349,15 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         )
         findings.append(
             Finding(
-                type="region" if has_span else "highlight",
+                # type="highlight" (not "region") because span covers the
+                # kernel's full invocation envelope — for steady-state
+                # kernels this is most of the profile, so "region" would
+                # over-state the localization. Selection still carries
+                # the envelope as informational metadata.
+                type="highlight",
                 label=f"Top kernel dominates ({top_pct:.1f}%): {kname[:48]}",
-                start_ns=span_start_ns if has_span else 0,
-                end_ns=span_end_ns,
+                start_ns=0,
+                end_ns=None,
                 severity="warning",
                 note=(
                     f"Kernel '{kname}' accounts for {top_pct:.1f}% of total "
@@ -404,8 +430,13 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 )
             )
 
-    # Finding 3: Tensor Core eligible but inactive.
+    # Finding 3: Tensor Core eligible but inactive. NCCL kernels are
+    # never TC-eligible by definition, but skip them explicitly for
+    # consistency with the other per-kernel finding loops.
     for r in rows:
+        kname = r.get("kernel_name", "<unknown>")
+        if _is_nccl_kernel(kname):
+            continue
         tc_eligible = r.get("tc_eligible")
         tc_active = r.get("tc_active")
         # tc_eligible is None on the SQLite-fallback path — silence over false claim.
@@ -417,8 +448,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         invocations = int(r.get("invocations", 0) or 0)
         if total_ms < _TC_INACTIVE_MIN_TOTAL_MS:
             continue
-        kname = r.get("kernel_name", "<unknown>")
-        has_span, span_start_ns, span_end_ns = _span_from_row(r)
+        _, span_start_ns, span_end_ns = _span_from_row(r)
         finding_id = f"tc_eligible_inactive_{_safe_id(kname)}"
         selection = TraceSelection(
             id=f"sel_{finding_id}",
@@ -444,10 +474,13 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         )
         findings.append(
             Finding(
-                type="region" if has_span else "highlight",
+                # See note in top_kernel_dominates emit — span = full
+                # invocation envelope, so use ``highlight`` to avoid
+                # over-stating localization.
+                type="highlight",
                 label=f"TC eligible, inactive: {kname[:48]} ({total_ms:.0f}ms)",
-                start_ns=span_start_ns if has_span else 0,
-                end_ns=span_end_ns,
+                start_ns=0,
+                end_ns=None,
                 severity="warning",
                 note=(
                     f"Kernel '{kname}' is Tensor-Core eligible but ran in a "
@@ -466,8 +499,14 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
             )
         )
 
-    # Finding 4: high variability on a top kernel.
+    # Finding 4: high variability on a top kernel. NCCL kernels are
+    # skipped here too — ``nccl_breakdown`` has
+    # ``nccl_high_variability_<collective>`` which surfaces the same
+    # signal in the right category.
     for r in rows:
+        kname = r.get("kernel_name", "<unknown>")
+        if _is_nccl_kernel(kname):
+            continue
         invocations = int(r.get("invocations", 0) or 0)
         if invocations < _VARIABILITY_MIN_INVOCATIONS:
             continue
@@ -478,8 +517,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         ratio = max_ms / avg_ms
         if ratio < _VARIABILITY_MIN_RATIO:
             continue
-        kname = r.get("kernel_name", "<unknown>")
-        has_span, span_start_ns, span_end_ns = _span_from_row(r)
+        _, span_start_ns, span_end_ns = _span_from_row(r)
         finding_id = f"top_kernel_high_variability_{_safe_id(kname)}"
         selection = TraceSelection(
             id=f"sel_{finding_id}",
@@ -505,10 +543,13 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         )
         findings.append(
             Finding(
-                type="region" if has_span else "highlight",
+                # See note in top_kernel_dominates emit — span = full
+                # invocation envelope, so use ``highlight`` to avoid
+                # over-stating localization.
+                type="highlight",
                 label=f"High variability ({ratio:.1f}x): {kname[:48]}",
-                start_ns=span_start_ns if has_span else 0,
-                end_ns=span_end_ns,
+                start_ns=0,
+                end_ns=None,
                 severity="info",
                 note=(
                     f"Kernel '{kname}' max={max_ms:.1f}ms vs avg={avg_ms:.1f}ms "

--- a/src/nsys_ai/skills/builtins/top_kernels.py
+++ b/src/nsys_ai/skills/builtins/top_kernels.py
@@ -57,7 +57,9 @@ def _execute(conn, **kwargs):
                    ROUND(MIN("end" - start) / 1e6, 2) AS min_ms,
                    ROUND(MAX("end" - start) / 1e6, 2) AS max_ms,
                    SUM(is_tc_eligible) > 0 AS tc_eligible,
-                   SUM(uses_tc) > 0 AS tc_active
+                   SUM(uses_tc) > 0 AS tc_active,
+                   MIN(start) AS span_start_ns,
+                   MAX("end") AS span_end_ns
             FROM kernels
             WHERE 1=1 {trim_clause}
             GROUP BY name
@@ -74,6 +76,8 @@ def _execute(conn, **kwargs):
             "max_ms",
             "tc_eligible",
             "tc_active",
+            "span_start_ns",
+            "span_end_ns",
         ]
         return [dict(zip(cols, r)) for r in rows]
     else:
@@ -96,7 +100,9 @@ def _execute(conn, **kwargs):
                    ROUND(MIN(k."end" - k.start) / 1e6, 2) AS min_ms,
                    ROUND(MAX(k."end" - k.start) / 1e6, 2) AS max_ms,
                    NULL AS tc_eligible,
-                   NULL AS tc_active
+                   NULL AS tc_active,
+                   MIN(k.start) AS span_start_ns,
+                   MAX(k."end") AS span_end_ns
             FROM {kernel_table} k
             LEFT JOIN StringIds s ON k.shortName = s.id
             LEFT JOIN StringIds d ON k.demangledName = d.id
@@ -115,8 +121,364 @@ def _execute(conn, **kwargs):
             "max_ms",
             "tc_eligible",
             "tc_active",
+            "span_start_ns",
+            "span_end_ns",
         ]
         return [dict(zip(cols, r)) if isinstance(r, tuple) else dict(r) for r in rows]
+
+
+# ── Structured findings (v0.1) ──────────────────────────────────────
+
+_DOMINATES_EXPLANATION = (
+    "One kernel accounts for a disproportionate fraction of total kernel "
+    "time. Optimization leverage here is high — improving this kernel "
+    "shifts step time directly."
+)
+_CONCENTRATED_EXPLANATION = (
+    "The top-3 kernels concentrate most kernel-time mass. The workload "
+    "has a focused hot path; optimization effort outside the top-K has "
+    "low leverage."
+)
+_TC_INACTIVE_EXPLANATION = (
+    "Kernel is eligible to use Tensor Cores (TC) but fell back to a "
+    "non-TC code path. Common causes: dtype is FP32 instead of FP16/BF16, "
+    "non-aligned matrix shapes, or a non-TC cuBLAS / cuBLASLt routing "
+    "decision."
+)
+_HIGH_VARIABILITY_EXPLANATION = (
+    "Kernel duration is highly variable (max/avg ratio above 5×). "
+    "Common causes: input-shape variance (dynamic shapes), kernel "
+    "selection switching across invocations, or stragglers when the "
+    "kernel runs concurrently with other work."
+)
+
+_DOMINATES_ACTIONS = [
+    "Profile the kernel internals (Nsight Compute) for memory-bound vs compute-bound",
+    "Check whether a faster algorithm or library exists (FlashAttention, fused norms, cuBLASLt)",
+    "Confirm dtype, tile shape, and Tensor Core eligibility for matmul kernels",
+]
+_CONCENTRATED_ACTIONS = [
+    "Focus optimization on the top-3 — gains outside the head have low leverage",
+    "Check whether the top-3 share a common kernel family (attention, GEMM, norm) — upgrading the family lifts all three",
+]
+_TC_INACTIVE_ACTIONS = [
+    "Verify input dtype is FP16/BF16 (not FP32) for matmul kernels",
+    "Confirm matrix dims are multiples of 8 (FP16) or 16 (BF16) on the inner axis",
+    "Check whether the cuBLAS/cuBLASLt heuristic selected a Tensor Core kernel vs a SIMT fallback",
+]
+_HIGH_VARIABILITY_ACTIONS = [
+    "Inspect input shapes across invocations — dynamic shapes can re-pick a kernel each call",
+    "Check for concurrent kernels sharing the same SMs (compute-compute contention)",
+    "Look for first-call warmup vs steady-state cost — exclude warmup from averages",
+]
+
+_DOMINATES_FP_NOTES = [
+    "A single dominant kernel is not always a bug — workloads with one heavy GEMM are correctly characterized this way",
+    "Short profiles can over-emphasize the largest kernel; multi-iteration windows are more reliable",
+]
+_CONCENTRATED_FP_NOTES = [
+    "Concentration is expected in inference workloads with a small set of recurring blocks",
+]
+_TC_INACTIVE_FP_NOTES = [
+    "tc_eligible can be unknown on the pure-SQLite fallback path (no cache); findings only fire when the analyzer is confident the kernel is TC-eligible",
+    "Some matmul kernels are intentionally non-TC for numerical reasons (small-K, mixed-precision accumulation)",
+]
+_HIGH_VARIABILITY_FP_NOTES = [
+    "Low invocation count (<20) makes max/avg ratios noisy; the finding fires only above the sample-size guard",
+    "First-call vs steady-state — recompile, warmup, and lazy initialization can inflate max without indicating a problem",
+]
+
+
+def _safe_id(name: str) -> str:
+    """Sanitize a kernel name for use inside a finding/selection id."""
+    out = "".join(c if c.isalnum() or c in "._-" else "_" for c in name)
+    return out[:64] or "unknown"
+
+
+def _dominance_confidence(pct: float, invocations: int) -> float:
+    """Higher pct + more samples → higher confidence."""
+    if invocations < 10:
+        return round(min(0.5, 0.2 + 0.03 * invocations), 3)
+    # ~30% → 0.7; ~50% → 0.8; ~70% → 0.9
+    base = 0.6 + 0.005 * max(pct - 30.0, 0.0)
+    return round(min(0.95, base), 3)
+
+
+def _concentrated_confidence(pct_top3: float, n_kernels: int) -> float:
+    if n_kernels < 5:
+        return 0.5
+    return round(min(0.9, 0.5 + 0.005 * max(pct_top3 - 60.0, 0.0)), 3)
+
+
+def _tc_inactive_confidence(total_ms: float, invocations: int) -> float:
+    """Higher total_ms + more invocations → higher confidence."""
+    if invocations < 5 or total_ms < 10.0:
+        return 0.5
+    return round(min(0.9, 0.6 + 0.003 * max(total_ms - 10.0, 0.0) + 0.004 * min(invocations, 50)), 3)
+
+
+def _variability_confidence(ratio: float, invocations: int) -> float:
+    if invocations < 20:
+        return 0.4  # below the guard — should not fire
+    return round(min(0.9, 0.55 + 0.05 * max(ratio - 5.0, 0.0)), 3)
+
+
+def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
+    """Emit structured findings from top_kernels rows.
+
+    Four finding types: a single kernel that dominates the top-K total
+    time, a concentrated top-3, a Tensor-Core-eligible kernel that ran
+    on a non-TC path, and a top kernel with high duration variability.
+    Empty input or all-zero totals return ``[]`` (Trust Contract:
+    silence over weak claims).
+    """
+    from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
+
+    findings: list = []
+    if not rows:
+        return findings
+    rows = [r for r in rows if "error" not in r]
+    if not rows:
+        return findings
+
+    profile_id = (context or {}).get("profile_id", "unknown")
+    total_top_ms = sum(float(r.get("total_ms", 0) or 0) for r in rows)
+    if total_top_ms <= 0:
+        return findings
+
+    n_kernels = len(rows)
+    top = rows[0]
+
+    # Finding 1: single kernel dominates.
+    top_total_ms = float(top.get("total_ms", 0) or 0)
+    top_pct = 100.0 * top_total_ms / total_top_ms
+    if top_pct >= 30.0:
+        kname = top.get("kernel_name", "<unknown>")
+        invocations = int(top.get("invocations", 0) or 0)
+        start_ns = int(top.get("span_start_ns") or 0)
+        end_ns = int(top.get("span_end_ns") or 0)
+        finding_id = f"top_kernel_dominates_{_safe_id(kname)}"
+        selection = TraceSelection(
+            id=f"sel_{finding_id}",
+            profile_id=profile_id,
+            source="skill:top_kernels",
+            start_ns=start_ns or None,
+            end_ns=end_ns or None,
+            label=f"Top kernel: {kname} ({top_pct:.1f}%)",
+        )
+        ev = EvidenceRow(
+            id=f"ev_{finding_id}",
+            source_skill="top_kernels",
+            values={
+                "kernel_name": kname,
+                "total_ms": round(top_total_ms, 3),
+                "invocations": invocations,
+                "avg_ms": round(float(top.get("avg_ms", 0) or 0), 3),
+                "pct_of_top": round(top_pct, 2),
+            },
+            units={"total_ms": "ms", "avg_ms": "ms", "pct_of_top": "percent"},
+            selection_id=selection.id,
+            provenance={"row_kind": "top_kernel_dominates"},
+        )
+        findings.append(
+            Finding(
+                type="region" if start_ns and end_ns else "highlight",
+                label=f"Top kernel dominates ({top_pct:.1f}%): {kname[:48]}",
+                start_ns=start_ns,
+                end_ns=end_ns or None,
+                severity="warning",
+                note=(
+                    f"Kernel '{kname}' accounts for {top_pct:.1f}% of total "
+                    f"top-{n_kernels} kernel time ({top_total_ms:.1f}ms over "
+                    f"{invocations} invocations)."
+                ),
+                id=finding_id,
+                category="compute",
+                confidence=_dominance_confidence(top_pct, invocations),
+                evidence=[ev],
+                selection=selection,
+                explanation=_DOMINATES_EXPLANATION,
+                suggested_actions=list(_DOMINATES_ACTIONS),
+                false_positive_notes=list(_DOMINATES_FP_NOTES),
+                provenance={"skill": "top_kernels", "row_kind": "top_kernel_dominates"},
+            )
+        )
+
+    # Finding 2: top-3 concentration.
+    if n_kernels >= 3:
+        top3_ms = sum(float(r.get("total_ms", 0) or 0) for r in rows[:3])
+        top3_pct = 100.0 * top3_ms / total_top_ms
+        if top3_pct >= 60.0:
+            names = [r.get("kernel_name", "<unknown>") for r in rows[:3]]
+            finding_id = "top_kernels_concentrated"
+            selection = TraceSelection(
+                id=f"sel_{finding_id}",
+                profile_id=profile_id,
+                source="skill:top_kernels",
+                label=f"Top-3 concentrate {top3_pct:.0f}% of kernel time",
+            )
+            ev = EvidenceRow(
+                id=f"ev_{finding_id}",
+                source_skill="top_kernels",
+                values={
+                    "top3_kernels": names,
+                    "top3_total_ms": round(top3_ms, 3),
+                    "top3_pct": round(top3_pct, 2),
+                    "n_kernels_considered": n_kernels,
+                },
+                units={"top3_total_ms": "ms", "top3_pct": "percent"},
+                selection_id=selection.id,
+                provenance={"row_kind": "top_kernels_concentrated"},
+            )
+            findings.append(
+                Finding(
+                    type="highlight",
+                    label=f"Top-3 kernels = {top3_pct:.0f}% of kernel time",
+                    start_ns=0,
+                    severity="info",
+                    note=(
+                        f"Top-3 kernels concentrate {top3_pct:.1f}% of total "
+                        f"top-{n_kernels} kernel time. Optimization leverage "
+                        f"is in the head of the distribution."
+                    ),
+                    id=finding_id,
+                    category="compute",
+                    confidence=_concentrated_confidence(top3_pct, n_kernels),
+                    evidence=[ev],
+                    selection=selection,
+                    explanation=_CONCENTRATED_EXPLANATION,
+                    suggested_actions=list(_CONCENTRATED_ACTIONS),
+                    false_positive_notes=list(_CONCENTRATED_FP_NOTES),
+                    provenance={"skill": "top_kernels", "row_kind": "top_kernels_concentrated"},
+                )
+            )
+
+    # Finding 3: Tensor Core eligible but inactive.
+    for r in rows:
+        tc_eligible = r.get("tc_eligible")
+        tc_active = r.get("tc_active")
+        # tc_eligible is None on the SQLite-fallback path — silence over false claim.
+        if tc_eligible is None:
+            continue
+        if not tc_eligible or tc_active:
+            continue
+        total_ms = float(r.get("total_ms", 0) or 0)
+        invocations = int(r.get("invocations", 0) or 0)
+        if total_ms < 10.0:
+            continue
+        kname = r.get("kernel_name", "<unknown>")
+        start_ns = int(r.get("span_start_ns") or 0)
+        end_ns = int(r.get("span_end_ns") or 0)
+        finding_id = f"tc_eligible_inactive_{_safe_id(kname)}"
+        selection = TraceSelection(
+            id=f"sel_{finding_id}",
+            profile_id=profile_id,
+            source="skill:top_kernels",
+            start_ns=start_ns or None,
+            end_ns=end_ns or None,
+            label=f"TC eligible, inactive: {kname}",
+        )
+        ev = EvidenceRow(
+            id=f"ev_{finding_id}",
+            source_skill="top_kernels",
+            values={
+                "kernel_name": kname,
+                "total_ms": round(total_ms, 3),
+                "invocations": invocations,
+                "tc_eligible": True,
+                "tc_active": False,
+            },
+            units={"total_ms": "ms"},
+            selection_id=selection.id,
+            provenance={"row_kind": "tc_eligible_inactive"},
+        )
+        findings.append(
+            Finding(
+                type="region" if start_ns and end_ns else "highlight",
+                label=f"TC eligible, inactive: {kname[:48]} ({total_ms:.0f}ms)",
+                start_ns=start_ns,
+                end_ns=end_ns or None,
+                severity="warning",
+                note=(
+                    f"Kernel '{kname}' is Tensor-Core eligible but ran in a "
+                    f"non-TC code path across {invocations} invocations "
+                    f"({total_ms:.1f}ms total)."
+                ),
+                id=finding_id,
+                category="compute",
+                confidence=_tc_inactive_confidence(total_ms, invocations),
+                evidence=[ev],
+                selection=selection,
+                explanation=_TC_INACTIVE_EXPLANATION,
+                suggested_actions=list(_TC_INACTIVE_ACTIONS),
+                false_positive_notes=list(_TC_INACTIVE_FP_NOTES),
+                provenance={"skill": "top_kernels", "row_kind": "tc_eligible_inactive"},
+            )
+        )
+
+    # Finding 4: high variability on a top kernel.
+    for r in rows:
+        invocations = int(r.get("invocations", 0) or 0)
+        if invocations < 20:
+            continue
+        avg_ms = float(r.get("avg_ms", 0) or 0)
+        max_ms = float(r.get("max_ms", 0) or 0)
+        if avg_ms <= 0:
+            continue
+        ratio = max_ms / avg_ms
+        if ratio < 5.0:
+            continue
+        kname = r.get("kernel_name", "<unknown>")
+        start_ns = int(r.get("span_start_ns") or 0)
+        end_ns = int(r.get("span_end_ns") or 0)
+        finding_id = f"top_kernel_high_variability_{_safe_id(kname)}"
+        selection = TraceSelection(
+            id=f"sel_{finding_id}",
+            profile_id=profile_id,
+            source="skill:top_kernels",
+            start_ns=start_ns or None,
+            end_ns=end_ns or None,
+            label=f"Variability ({ratio:.1f}x): {kname}",
+        )
+        ev = EvidenceRow(
+            id=f"ev_{finding_id}",
+            source_skill="top_kernels",
+            values={
+                "kernel_name": kname,
+                "avg_ms": round(avg_ms, 3),
+                "max_ms": round(max_ms, 3),
+                "max_avg_ratio": round(ratio, 2),
+                "invocations": invocations,
+            },
+            units={"avg_ms": "ms", "max_ms": "ms", "max_avg_ratio": "ratio"},
+            selection_id=selection.id,
+            provenance={"row_kind": "top_kernel_high_variability"},
+        )
+        findings.append(
+            Finding(
+                type="region" if start_ns and end_ns else "highlight",
+                label=f"High variability ({ratio:.1f}x): {kname[:48]}",
+                start_ns=start_ns,
+                end_ns=end_ns or None,
+                severity="info",
+                note=(
+                    f"Kernel '{kname}' max={max_ms:.1f}ms vs avg={avg_ms:.1f}ms "
+                    f"({ratio:.1f}× ratio over {invocations} invocations) — "
+                    f"possible shape variance or stragglers."
+                ),
+                id=finding_id,
+                category="compute",
+                confidence=_variability_confidence(ratio, invocations),
+                evidence=[ev],
+                selection=selection,
+                explanation=_HIGH_VARIABILITY_EXPLANATION,
+                suggested_actions=list(_HIGH_VARIABILITY_ACTIONS),
+                false_positive_notes=list(_HIGH_VARIABILITY_FP_NOTES),
+                provenance={"skill": "top_kernels", "row_kind": "top_kernel_high_variability"},
+            )
+        )
+
+    return findings
 
 
 SKILL = Skill(
@@ -131,5 +493,6 @@ SKILL = Skill(
     execute_fn=_execute,
     params=[SkillParam("limit", "Max number of kernels to return", "int", False, 15)],
     format_fn=_format,
+    to_findings_fn=_to_findings,
     tags=["hotspot", "kernel", "duration", "performance", "top", "tensor_core"],
 )

--- a/src/nsys_ai/skills/builtins/top_kernels.py
+++ b/src/nsys_ai/skills/builtins/top_kernels.py
@@ -129,6 +129,34 @@ def _execute(conn, **kwargs):
 
 # ── Structured findings (v0.1) ──────────────────────────────────────
 
+# ── Thresholds ──────────────────────────────────────────────────────
+# Centralized so the firing policy is in one place. Confidence helpers
+# below reuse these where the cutoff and the trigger are the same value.
+
+# Top kernel must account for ≥ this fraction of top-K kernel time to
+# fire ``top_kernel_dominates``.
+_DOMINATES_PCT_THRESHOLD = 30.0
+
+# Top-3 kernels must account for ≥ this fraction of top-K kernel time
+# to fire ``top_kernels_concentrated``.
+_CONCENTRATED_TOP3_PCT_THRESHOLD = 60.0
+
+# Below this total per-kernel time, the cost of fixing TC routing is
+# unlikely to be worth the optimization; suppress ``tc_eligible_inactive``
+# to keep the noise floor low.
+_TC_INACTIVE_MIN_TOTAL_MS = 10.0
+
+# Variability findings require at least this many invocations to keep
+# the max/avg ratio from being dominated by noise (first-call warmup,
+# straggler tails, etc.).
+_VARIABILITY_MIN_INVOCATIONS = 20
+
+# Minimum max/avg duration ratio for ``top_kernel_high_variability`` to
+# fire (5× ≈ heavy tail / bimodal distribution; below this, normal
+# scheduling jitter accounts for the variance).
+_VARIABILITY_MIN_RATIO = 5.0
+
+
 _DOMINATES_EXPLANATION = (
     "One kernel accounts for a disproportionate fraction of total kernel "
     "time. Optimization leverage here is high — improving this kernel "
@@ -218,9 +246,28 @@ def _tc_inactive_confidence(total_ms: float, invocations: int) -> float:
 
 
 def _variability_confidence(ratio: float, invocations: int) -> float:
-    if invocations < 20:
+    if invocations < _VARIABILITY_MIN_INVOCATIONS:
         return 0.4  # below the guard — should not fire
-    return round(min(0.9, 0.55 + 0.05 * max(ratio - 5.0, 0.0)), 3)
+    return round(min(0.9, 0.55 + 0.05 * max(ratio - _VARIABILITY_MIN_RATIO, 0.0)), 3)
+
+
+def _span_from_row(r: dict) -> tuple[bool, int | None, int | None]:
+    """Read ``span_start_ns`` / ``span_end_ns`` off a top_kernels row.
+
+    Returns ``(has_span, start_ns_or_None, end_ns_or_None)``. The boolean
+    is the authoritative source for whether to emit ``Finding.type="region"``
+    or ``"highlight"`` and is reused by both the ``Finding`` and the
+    ``TraceSelection`` constructors so the time-anchor decision is taken
+    in one place. ``Finding.start_ns`` is typed ``int`` (required), so
+    callers fall back to ``0`` on the no-span branch and rely on
+    ``type="highlight"`` to signal "not time-anchored" downstream;
+    ``TraceSelection`` accepts ``None`` directly.
+    """
+    s = r.get("span_start_ns")
+    e = r.get("span_end_ns")
+    if s is None or e is None:
+        return False, None, None
+    return True, int(s), int(e)
 
 
 def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
@@ -252,18 +299,17 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     # Finding 1: single kernel dominates.
     top_total_ms = float(top.get("total_ms", 0) or 0)
     top_pct = 100.0 * top_total_ms / total_top_ms
-    if top_pct >= 30.0:
+    if top_pct >= _DOMINATES_PCT_THRESHOLD:
         kname = top.get("kernel_name", "<unknown>")
         invocations = int(top.get("invocations", 0) or 0)
-        start_ns = int(top.get("span_start_ns") or 0)
-        end_ns = int(top.get("span_end_ns") or 0)
+        has_span, span_start_ns, span_end_ns = _span_from_row(top)
         finding_id = f"top_kernel_dominates_{_safe_id(kname)}"
         selection = TraceSelection(
             id=f"sel_{finding_id}",
             profile_id=profile_id,
             source="skill:top_kernels",
-            start_ns=start_ns or None,
-            end_ns=end_ns or None,
+            start_ns=span_start_ns,
+            end_ns=span_end_ns,
             label=f"Top kernel: {kname} ({top_pct:.1f}%)",
         )
         ev = EvidenceRow(
@@ -282,10 +328,10 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         )
         findings.append(
             Finding(
-                type="region" if start_ns and end_ns else "highlight",
+                type="region" if has_span else "highlight",
                 label=f"Top kernel dominates ({top_pct:.1f}%): {kname[:48]}",
-                start_ns=start_ns,
-                end_ns=end_ns or None,
+                start_ns=span_start_ns if has_span else 0,
+                end_ns=span_end_ns,
                 severity="warning",
                 note=(
                     f"Kernel '{kname}' accounts for {top_pct:.1f}% of total "
@@ -305,10 +351,15 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         )
 
     # Finding 2: top-3 concentration.
+    # Genuinely global — top-3 is an aggregate property of the top-K
+    # distribution, not anchored to a time window. ``Finding.start_ns``
+    # is required-int, so we use ``0`` as the "no time anchor" sentinel;
+    # ``type="highlight"`` (vs ``"region"``) is the semantic signal to
+    # downstream consumers that this is not a trace location.
     if n_kernels >= 3:
         top3_ms = sum(float(r.get("total_ms", 0) or 0) for r in rows[:3])
         top3_pct = 100.0 * top3_ms / total_top_ms
-        if top3_pct >= 60.0:
+        if top3_pct >= _CONCENTRATED_TOP3_PCT_THRESHOLD:
             names = [r.get("kernel_name", "<unknown>") for r in rows[:3]]
             finding_id = "top_kernels_concentrated"
             selection = TraceSelection(
@@ -364,18 +415,17 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
             continue
         total_ms = float(r.get("total_ms", 0) or 0)
         invocations = int(r.get("invocations", 0) or 0)
-        if total_ms < 10.0:
+        if total_ms < _TC_INACTIVE_MIN_TOTAL_MS:
             continue
         kname = r.get("kernel_name", "<unknown>")
-        start_ns = int(r.get("span_start_ns") or 0)
-        end_ns = int(r.get("span_end_ns") or 0)
+        has_span, span_start_ns, span_end_ns = _span_from_row(r)
         finding_id = f"tc_eligible_inactive_{_safe_id(kname)}"
         selection = TraceSelection(
             id=f"sel_{finding_id}",
             profile_id=profile_id,
             source="skill:top_kernels",
-            start_ns=start_ns or None,
-            end_ns=end_ns or None,
+            start_ns=span_start_ns,
+            end_ns=span_end_ns,
             label=f"TC eligible, inactive: {kname}",
         )
         ev = EvidenceRow(
@@ -394,10 +444,10 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         )
         findings.append(
             Finding(
-                type="region" if start_ns and end_ns else "highlight",
+                type="region" if has_span else "highlight",
                 label=f"TC eligible, inactive: {kname[:48]} ({total_ms:.0f}ms)",
-                start_ns=start_ns,
-                end_ns=end_ns or None,
+                start_ns=span_start_ns if has_span else 0,
+                end_ns=span_end_ns,
                 severity="warning",
                 note=(
                     f"Kernel '{kname}' is Tensor-Core eligible but ran in a "
@@ -419,25 +469,24 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     # Finding 4: high variability on a top kernel.
     for r in rows:
         invocations = int(r.get("invocations", 0) or 0)
-        if invocations < 20:
+        if invocations < _VARIABILITY_MIN_INVOCATIONS:
             continue
         avg_ms = float(r.get("avg_ms", 0) or 0)
         max_ms = float(r.get("max_ms", 0) or 0)
         if avg_ms <= 0:
             continue
         ratio = max_ms / avg_ms
-        if ratio < 5.0:
+        if ratio < _VARIABILITY_MIN_RATIO:
             continue
         kname = r.get("kernel_name", "<unknown>")
-        start_ns = int(r.get("span_start_ns") or 0)
-        end_ns = int(r.get("span_end_ns") or 0)
+        has_span, span_start_ns, span_end_ns = _span_from_row(r)
         finding_id = f"top_kernel_high_variability_{_safe_id(kname)}"
         selection = TraceSelection(
             id=f"sel_{finding_id}",
             profile_id=profile_id,
             source="skill:top_kernels",
-            start_ns=start_ns or None,
-            end_ns=end_ns or None,
+            start_ns=span_start_ns,
+            end_ns=span_end_ns,
             label=f"Variability ({ratio:.1f}x): {kname}",
         )
         ev = EvidenceRow(
@@ -456,10 +505,10 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         )
         findings.append(
             Finding(
-                type="region" if start_ns and end_ns else "highlight",
+                type="region" if has_span else "highlight",
                 label=f"High variability ({ratio:.1f}x): {kname[:48]}",
-                start_ns=start_ns,
-                end_ns=end_ns or None,
+                start_ns=span_start_ns if has_span else 0,
+                end_ns=span_end_ns,
                 severity="info",
                 note=(
                     f"Kernel '{kname}' max={max_ms:.1f}ms vs avg={avg_ms:.1f}ms "

--- a/tests/test_top_kernels.py
+++ b/tests/test_top_kernels.py
@@ -5,7 +5,6 @@ synthetic row dicts; it has no DB dependency and matches the shape the
 ``_execute`` SQL emits (after the v0.1 column upgrade that added
 ``span_start_ns`` / ``span_end_ns``).
 """
-from __future__ import annotations
 
 import json
 

--- a/tests/test_top_kernels.py
+++ b/tests/test_top_kernels.py
@@ -1,0 +1,255 @@
+"""Tests for top_kernels structured findings.
+
+The structured-findings path (``_to_findings``) is exercised here with
+synthetic row dicts; it has no DB dependency and matches the shape the
+``_execute`` SQL emits (after the v0.1 column upgrade that added
+``span_start_ns`` / ``span_end_ns``).
+"""
+from __future__ import annotations
+
+import json
+
+from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
+from nsys_ai.skills.builtins.top_kernels import SKILL
+
+
+# ── Row factory ─────────────────────────────────────────────────────
+
+
+def _row(
+    *,
+    kernel_name: str = "ampere_fp16_s16816gemm",
+    invocations: int = 100,
+    total_ms: float = 100.0,
+    avg_ms: float = 1.0,
+    min_ms: float = 0.9,
+    max_ms: float = 1.2,
+    tc_eligible: bool | None = True,
+    tc_active: bool | None = True,
+    span_start_ns: int = 1_000_000,
+    span_end_ns: int = 9_000_000,
+) -> dict:
+    return {
+        "kernel_name": kernel_name,
+        "invocations": invocations,
+        "total_ms": total_ms,
+        "avg_ms": avg_ms,
+        "min_ms": min_ms,
+        "max_ms": max_ms,
+        "tc_eligible": tc_eligible,
+        "tc_active": tc_active,
+        "span_start_ns": span_start_ns,
+        "span_end_ns": span_end_ns,
+    }
+
+
+def _find(findings, prefix):
+    return [f for f in findings if f.id and f.id.startswith(prefix)]
+
+
+# ── Finding 1 — top_kernel_dominates ────────────────────────────────
+
+
+def test_dominates_fires_on_single_heavy_kernel():
+    # Dominant kernel at 60% of top-K total; even, small tail.
+    rows = [
+        _row(kernel_name="big_gemm", total_ms=600.0, invocations=200),
+        _row(kernel_name="small_a", total_ms=200.0, invocations=200),
+        _row(kernel_name="small_b", total_ms=200.0, invocations=200),
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+
+    dom = _find(findings, "top_kernel_dominates_")
+    assert dom, f"expected dominates finding, got {[f.label for f in findings]}"
+    f = dom[0]
+    assert f.category == "compute"
+    assert f.severity == "warning"
+    assert "big_gemm" in f.label
+    assert 0.0 <= f.confidence <= 1.0
+    assert f.explanation and "leverage" in f.explanation
+    assert f.suggested_actions and f.false_positive_notes
+    assert f.provenance == {"skill": "top_kernels", "row_kind": "top_kernel_dominates"}
+
+    assert isinstance(f.selection, TraceSelection)
+    assert f.selection.profile_id == "p"
+    assert f.selection.source == "skill:top_kernels"
+    assert f.selection.start_ns == 1_000_000
+    assert f.selection.end_ns == 9_000_000
+
+    assert f.evidence and isinstance(f.evidence[0], EvidenceRow)
+    ev = f.evidence[0]
+    assert ev.source_skill == "top_kernels"
+    assert ev.values["kernel_name"] == "big_gemm"
+    assert ev.values["total_ms"] == 600.0
+    assert ev.values["pct_of_top"] == 60.0
+    assert ev.units["pct_of_top"] == "percent"
+    assert ev.selection_id == f.selection.id
+
+
+def test_dominates_does_not_fire_when_evenly_distributed():
+    # Equal sizes across 5 kernels: top kernel is only 20%.
+    rows = [_row(kernel_name=f"k{i}", total_ms=100.0) for i in range(5)]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+    assert not _find(findings, "top_kernel_dominates_"), (
+        f"unexpected dominates finding on even distribution: {[f.label for f in findings]}"
+    )
+
+
+# ── Finding 2 — top_kernels_concentrated ────────────────────────────
+
+
+def test_concentrated_fires_when_top3_is_majority():
+    # Top-3 are 80% of the total.
+    rows = [
+        _row(kernel_name="a", total_ms=400.0),
+        _row(kernel_name="b", total_ms=300.0),
+        _row(kernel_name="c", total_ms=100.0),
+        *[_row(kernel_name=f"tail_{i}", total_ms=10.0) for i in range(20)],
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+
+    conc = _find(findings, "top_kernels_concentrated")
+    assert conc, f"expected concentrated finding, got {[f.label for f in findings]}"
+    f = conc[0]
+    assert f.category == "compute"
+    assert f.severity == "info"
+    ev = f.evidence[0]
+    assert ev.values["top3_kernels"] == ["a", "b", "c"]
+    # 800 / (400+300+100 + 20*10) = 800 / 1000 = 80%
+    assert ev.values["top3_pct"] == 80.0
+    assert ev.values["n_kernels_considered"] == 23
+
+
+def test_concentrated_does_not_fire_when_tail_is_heavy():
+    # Top-3 at 30% of total — long heavy tail.
+    rows = [
+        *[_row(kernel_name=f"k{i}", total_ms=100.0) for i in range(3)],
+        *[_row(kernel_name=f"tail_{i}", total_ms=100.0) for i in range(7)],
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+    assert not _find(findings, "top_kernels_concentrated"), (
+        f"unexpected concentrated finding: {[f.label for f in findings]}"
+    )
+
+
+# ── Finding 3 — tc_eligible_inactive ────────────────────────────────
+
+
+def test_tc_inactive_fires_on_eligible_inactive_kernel():
+    rows = [
+        _row(kernel_name="eligible_inactive", total_ms=50.0,
+             tc_eligible=True, tc_active=False, invocations=100),
+        _row(kernel_name="active", total_ms=40.0,
+             tc_eligible=True, tc_active=True),
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+
+    tc = _find(findings, "tc_eligible_inactive_")
+    assert tc, f"expected TC-inactive finding, got {[f.label for f in findings]}"
+    f = tc[0]
+    assert "eligible_inactive" in f.label
+    assert f.category == "compute"
+    assert f.severity == "warning"
+    ev = f.evidence[0]
+    assert ev.values["tc_eligible"] is True
+    assert ev.values["tc_active"] is False
+    assert ev.values["total_ms"] == 50.0
+
+
+def test_tc_unknown_does_not_fire_on_sqlite_fallback():
+    # SQLite fallback path emits tc_eligible=None — must NOT fire (Trust
+    # Contract: silence over false claim).
+    rows = [
+        _row(kernel_name="sqlite_path", total_ms=100.0,
+             tc_eligible=None, tc_active=None),
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+    assert not _find(findings, "tc_eligible_inactive_"), (
+        f"unexpected TC finding on unknown TC eligibility: {[f.label for f in findings]}"
+    )
+
+
+# ── Finding 4 — high variability ────────────────────────────────────
+
+
+def test_high_variability_fires_on_bimodal_top_kernel():
+    rows = [
+        _row(kernel_name="bimodal", invocations=180, avg_ms=1.0, max_ms=8.0,
+             total_ms=180.0, tc_eligible=False),
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+
+    var = _find(findings, "top_kernel_high_variability_")
+    assert var, f"expected variability finding, got {[f.label for f in findings]}"
+    f = var[0]
+    assert f.category == "compute"
+    assert f.severity == "info"
+    ev = f.evidence[0]
+    assert ev.values["max_avg_ratio"] == 8.0
+    assert ev.units["max_avg_ratio"] == "ratio"
+
+
+def test_high_variability_does_not_fire_below_sample_size_guard():
+    # max/avg ratio is 10× but invocations=5 — below the guard, no fire.
+    rows = [
+        _row(kernel_name="few_calls", invocations=5, avg_ms=1.0, max_ms=10.0,
+             total_ms=5.0, tc_eligible=False),
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+    assert not _find(findings, "top_kernel_high_variability_"), (
+        f"unexpected variability finding below guard: {[f.label for f in findings]}"
+    )
+
+
+# ── Empty / no-fire / JSON round-trip / context ─────────────────────
+
+
+def test_empty_input_returns_no_findings():
+    assert SKILL.to_findings_fn([], context={"profile_id": "p"}) == []
+
+
+def test_all_zero_total_ms_returns_no_findings():
+    rows = [_row(kernel_name="zero", total_ms=0.0, invocations=0)]
+    assert SKILL.to_findings_fn(rows, context={"profile_id": "p"}) == []
+
+
+def test_findings_round_trip_through_json():
+    rows = [
+        _row(kernel_name="big_gemm", total_ms=600.0, invocations=200,
+             avg_ms=3.0, max_ms=18.0),
+        _row(kernel_name="medium", total_ms=200.0),
+        _row(kernel_name="small", total_ms=200.0),
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "/tmp/p.sqlite"})
+    assert findings
+    for f in findings:
+        d = f.to_dict()
+        # selection / evidence get nested-dataclass treatment
+        if d.get("selection") is not None:
+            assert isinstance(d["selection"], dict)
+        if d.get("evidence") is not None:
+            assert isinstance(d["evidence"], list)
+        restored = Finding.from_dict(json.loads(json.dumps(d)))
+        assert restored.id == f.id
+        assert restored.category == "compute"
+        if f.selection is not None:
+            assert isinstance(restored.selection, TraceSelection)
+            assert restored.selection.profile_id == "/tmp/p.sqlite"
+        if f.evidence:
+            assert isinstance(restored.evidence[0], EvidenceRow)
+
+
+def test_findings_without_context_use_unknown_profile_id():
+    rows = [
+        _row(kernel_name="big_gemm", total_ms=600.0, invocations=200),
+        _row(kernel_name="small_a", total_ms=200.0),
+        _row(kernel_name="small_b", total_ms=200.0),
+    ]
+    findings = SKILL.to_findings_fn(rows)
+    assert findings
+    dom = _find(findings, "top_kernel_dominates_")
+    assert dom and dom[0].selection.profile_id == "unknown"
+
+
+def test_skill_registers_to_findings_fn():
+    assert SKILL.to_findings_fn is not None

--- a/tests/test_top_kernels.py
+++ b/tests/test_top_kernels.py
@@ -67,7 +67,13 @@ def test_dominates_fires_on_single_heavy_kernel():
     assert f.explanation and "leverage" in f.explanation
     assert f.suggested_actions and f.false_positive_notes
     assert f.provenance == {"skill": "top_kernels", "row_kind": "top_kernel_dominates"}
+    # Per-kernel findings are highlights, not regions — span covers the
+    # full invocation envelope so claiming a tight region would mislead.
+    assert f.type == "highlight"
+    assert f.start_ns == 0
+    assert f.end_ns is None
 
+    # Selection still carries the invocation envelope as metadata.
     assert isinstance(f.selection, TraceSelection)
     assert f.selection.profile_id == "p"
     assert f.selection.source == "skill:top_kernels"
@@ -251,3 +257,90 @@ def test_findings_without_context_use_unknown_profile_id():
 
 def test_skill_registers_to_findings_fn():
     assert SKILL.to_findings_fn is not None
+
+
+# ── NCCL kernels are skipped in per-kernel findings ─────────────────
+
+
+def test_nccl_kernels_are_skipped_in_per_kernel_findings():
+    # SendRecv as the top kernel at 60% — would normally fire dominates,
+    # variability (bimodal max/avg), AND show up as TC-inactive — except
+    # NCCL kernels are owned by nccl_breakdown, not top_kernels.
+    nccl_name = "ncclDevKernel_SendRecv(ncclDevKernelArgsStorage<(unsigned long)4096>)"
+    rows = [
+        _row(kernel_name=nccl_name, total_ms=600.0, invocations=200,
+             avg_ms=3.0, max_ms=30.0,  # max/avg=10x — would fire variability
+             tc_eligible=False, tc_active=False),
+        _row(kernel_name="small_a", total_ms=200.0, invocations=200),
+        _row(kernel_name="small_b", total_ms=200.0, invocations=200),
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+
+    # None of the per-kernel finding types fire on the NCCL row.
+    assert not _find(findings, "top_kernel_dominates_"), (
+        f"top_kernel_dominates fired on an NCCL kernel: {[f.label for f in findings]}"
+    )
+    assert not _find(findings, "top_kernel_high_variability_"), (
+        f"top_kernel_high_variability fired on an NCCL kernel: {[f.label for f in findings]}"
+    )
+    assert not _find(findings, "tc_eligible_inactive_"), (
+        f"tc_eligible_inactive fired on an NCCL kernel: {[f.label for f in findings]}"
+    )
+
+
+def test_nccl_kernel_still_contributes_to_concentrated_finding():
+    # Concentrated is a global aggregate property of the top-K, not a
+    # per-kernel finding — NCCL kernels in the top-3 still count toward
+    # concentration. Excluding them would understate the head's weight.
+    nccl_name = "ncclDevKernel_SendRecv(ncclDevKernelArgsStorage<(unsigned long)4096>)"
+    rows = [
+        _row(kernel_name=nccl_name, total_ms=400.0),
+        _row(kernel_name="big_gemm", total_ms=300.0),
+        _row(kernel_name="flash_fwd", total_ms=100.0),
+        *[_row(kernel_name=f"tail_{i}", total_ms=10.0) for i in range(20)],
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+
+    conc = _find(findings, "top_kernels_concentrated")
+    assert conc, "concentrated finding should still fire when NCCL is in top-3"
+    f = conc[0]
+    ev = f.evidence[0]
+    assert nccl_name in ev.values["top3_kernels"], (
+        "NCCL kernel should still appear in top3_kernels for concentration"
+    )
+
+
+def test_per_kernel_findings_use_highlight_type_with_envelope_in_selection():
+    # All three per-kernel findings (dominates, tc_inactive, variability)
+    # should emit type="highlight" with Finding.start_ns=0 / end_ns=None,
+    # but carry the full invocation envelope on the TraceSelection as
+    # informational metadata.
+    rows = [
+        # dominates fires: 60% of top-K
+        _row(kernel_name="big_gemm", total_ms=600.0, invocations=200,
+             avg_ms=3.0, max_ms=30.0,  # max/avg=10x — also fires variability
+             tc_eligible=True, tc_active=False,  # also fires tc_inactive
+             span_start_ns=1_000, span_end_ns=9_000),
+        _row(kernel_name="medium", total_ms=200.0,
+             span_start_ns=2_000, span_end_ns=8_000),
+        _row(kernel_name="small", total_ms=200.0,
+             span_start_ns=2_000, span_end_ns=8_000),
+    ]
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+
+    per_kernel_prefixes = ("top_kernel_dominates_", "tc_eligible_inactive_",
+                          "top_kernel_high_variability_")
+    per_kernel = [f for f in findings
+                  if any((f.id or "").startswith(p) for p in per_kernel_prefixes)]
+    assert per_kernel, "expected at least one per-kernel finding"
+    for f in per_kernel:
+        assert f.type == "highlight", (
+            f"{f.id} should be 'highlight' not '{f.type}' "
+            f"(span = full invocation envelope, not a tight region)"
+        )
+        assert f.start_ns == 0, f"{f.id} Finding.start_ns should be 0 sentinel"
+        assert f.end_ns is None, f"{f.id} Finding.end_ns should be None"
+        # Selection still carries the envelope for downstream UI navigation.
+        assert f.selection is not None
+        assert f.selection.start_ns == 1_000
+        assert f.selection.end_ns == 9_000

--- a/tests/test_top_kernels.py
+++ b/tests/test_top_kernels.py
@@ -11,7 +11,6 @@ import json
 from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
 from nsys_ai.skills.builtins.top_kernels import SKILL
 
-
 # ── Row factory ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Upgrade `top_kernels` to emit v0.1 structured Findings for four kernel-level hotspot patterns (compute-side only — NCCL kernels are owned by `nccl_breakdown`).
- Register `top_kernels` in the EvidenceBuilder pipeline so findings flow through `analyze` / `evidence` commands.
- Preserve existing row output and `_format` behavior; new SQL fields (`span_start_ns`, `span_end_ns`) are purely additive.
- Add 16 focused tests covering each finding's firing / no-fire behavior, the SQLite-fallback no-fire path, sample-size guards, NCCL filtering, the highlight-vs-region semantic, and JSON round-trip.
- **Validated end-to-end against real FastVideo L40S profile** ([`rich7421/fastvideo-wan-l40s-nsys`](https://huggingface.co/datasets/rich7421/fastvideo-wan-l40s-nsys)).

## Changes

### `src/nsys_ai/skills/builtins/top_kernels.py`

- Adds 4 `_to_findings` detectors:
  - `top_kernel_dominates` — single kernel ≥ 30% of top-K total time (compute hotspot)
  - `top_kernels_concentrated` — top-3 ≥ 60% of top-K total time (Pareto signal)
  - `tc_eligible_inactive` — Tensor-Core-eligible kernel ran on a non-TC path (≥10ms total, sample-size guarded)
  - `top_kernel_high_variability` — max/avg ratio ≥ 5× over ≥ 20 invocations (shape variance / stragglers)
- **NCCL kernels are filtered from the three per-kernel finding loops** (`top_kernel_dominates`, `tc_eligible_inactive`, `top_kernel_high_variability`) via a new `_is_nccl_kernel` helper that delegates to `overlap.classify_kernel`. `nccl_breakdown` (PR #148) already owns NCCL signal (`nccl_sendrecv_dominated`, `nccl_high_variability_<collective>`); skipping here keeps category=compute findings honest and avoids double-surfacing. `top_kernels_concentrated` intentionally still counts NCCL kernels — it's a distributional aggregate of the top-K, and excluding them would understate the head's weight.
- **Per-kernel findings emit `type="highlight"` (not `"region"`).** The kernel's invocation envelope (`MIN(start)..MAX(end)`) typically covers most of the profile for any kernel that recurs in steady state (72–99% coverage observed on L40S), so emitting `type="region"` would over-state localization. `Finding.start_ns=0` + `end_ns=None` paired with `type="highlight"` matches the existing convention used by `top_kernels_concentrated`. The kernel's invocation envelope is still carried on `TraceSelection.start_ns`/`end_ns` as informational metadata so UIs can navigate to it — the `type` field just doesn't promise tight localization.
- Adds confidence helper functions with sample-size guards.
- Adds structured `EvidenceRow` (with units), `TraceSelection`, category, severity, explanation, suggested actions, false-positive notes, and provenance per finding.
- `tc_eligible_inactive` correctly silences itself when `tc_eligible=None` (SQLite-fallback path) — Trust Contract: silence over weak claims.
- All firing thresholds extracted as module-level constants (`_DOMINATES_PCT_THRESHOLD`, `_CONCENTRATED_TOP3_PCT_THRESHOLD`, `_TC_INACTIVE_MIN_TOTAL_MS`, `_VARIABILITY_MIN_INVOCATIONS`, `_VARIABILITY_MIN_RATIO`) so policy is centralized.
- Existing `_execute` rows gain two additive columns (`span_start_ns`, `span_end_ns`); the SQL `GROUP BY` keys, row keys, and `_format` text output are unchanged. Both the DuckDB cache path and the SQLite-fallback path get the new columns.
- Wires `to_findings_fn=_to_findings` into the SKILL definition.

### `src/nsys_ai/evidence_builder.py`

- Registers `top_kernels` in the EvidenceBuilder skill pipeline (additive single-line entry: `top_kernel_aggregates`).

### `tests/test_top_kernels.py` (new file — first test coverage for this skill)

- 16 focused tests covering: each finding firing / not-firing, SQLite-fallback no-fire path, variability sample-size guard, empty input, all-zero totals, JSON round-trip, context-less default, NCCL filtering on per-kernel findings, NCCL inclusion in concentrated, the `type="highlight"` semantic across all per-kernel findings, and skill registration.

## Backward compatibility

Yes. `_execute` rows gain two new keys (`span_start_ns`, `span_end_ns`) — purely additive; existing keys and `_format` text output are byte-identical to before. EvidenceBuilder registration only adds a new pipeline entry; existing entries are untouched.

## Validation against real FastVideo L40S profile

**Methodology.** Ran `nsys-ai analyze --gpu 0 --format json data/l40s/profiles/perf_compile.sqlite` on [`rich7421/fastvideo-wan-l40s-nsys`](https://huggingface.co/datasets/rich7421/fastvideo-wan-l40s-nsys). Validation host: Ubuntu 22.04.5 LTS, AMD EPYC 7763 64-Core (256 logical CPUs), 116 GB pod RAM allocation, Python 3.12.12, DuckDB 1.5.3.

**5 findings fire correctly** on the real Wan2.1-T2V-1.3B inference profile (2 of 4 finding types — `top_kernels_concentrated` + 4 instances of `top_kernel_high_variability`; `top_kernel_dominates` correctly does not fire because the sole ≥30% kernel on this profile is `ncclDevKernel_SendRecv`, which is filtered to `nccl_breakdown`'s coverage; `tc_eligible_inactive` correctly does not fire because none of the top compute kernels are TC-eligible-but-inactive).

**Finding 1: `top_kernels_concentrated` (confidence 0.606)**

- Label: `Top-3 kernels = 81% of kernel time`
- Top-3: `ncclDevKernel_SendRecv` + `flash::flash_fwd_kernel<...>` + `cutlass_80_tensorop_bf16_s16816gemm_relu_bf16_256x128_32x3_tn_align8`
- Evidence: `top3_total_ms=1,794,593.75`, `top3_pct=81.28`, `n_kernels_considered=15`

NCCL is intentionally still included as a top-3 member — concentration is a distributional aggregate of the top-K, and excluding NCCL here would understate the head's weight.

**Findings 2–5: `top_kernel_high_variability_*` on compute kernels (confidence 0.55–0.67)**

| Kernel | max/avg | invocations |
|---|---:|---:|
| `void at::native::elementwise_kernel<…direct_copy_kernel_cuda…>` | 6.2× | 77,100 |
| `void at::native::elementwise_kernel<…BinaryFunctor<MulFunctor<float>>…>` | 5.2× | 53,832 |
| `void cudnn::engines_precompiled::nchwToNhwcKernel<float…>` | 7.4× | 16,752 |
| `void at::native::vectorized_elementwise_kernel<…CUDAFunctor_add<float>…>` | 7.1× | 29,124 |

These surface the compute-side variability that `nccl_breakdown` cannot — heavy-tail / bimodal patterns in PyTorch elementwise kernels and cuDNN layout transforms.

All per-kernel findings carry the kernel's invocation envelope on `TraceSelection.start_ns`/`end_ns` for downstream UI navigation; `Finding.start_ns=0` + `type="highlight"` signals that the envelope is metadata, not a tight localization region.

## Test plan

- [x] 16 new finding tests added; all pass (`pytest tests/test_top_kernels.py -v`)
- [x] Full test suite passes (`pytest tests/ -q` — **896 passed, 145 skipped, 0 failed**)
- [x] `ruff check src/ tests/` clean
- [x] `python -m nsys_ai --help` loads without error
- [x] `nsys-ai skill run top_kernels "$SQLITE"` produces the existing per-kernel text + JSON output (additive `span_start_ns` / `span_end_ns` columns only)
- [x] `nsys-ai analyze --format json` emits the new findings via the `EvidenceBuilder` pipeline (see Validation section)
- [x] End-to-end validation against `rich7421/fastvideo-wan-l40s-nsys` profile (see above)
- [x] NCCL kernels confirmed filtered from per-kernel findings on the real L40S profile (`top_kernel_dominates` / `top_kernel_high_variability` / `tc_eligible_inactive` emit zero NCCL hits; `top_kernels_concentrated` still includes `ncclDevKernel_SendRecv` as a top-3 member as intended)

## Related

- Implements one of the six core skills called out in Focus Area B (Core Skill Finding Upgrade) per ROADMAP.md
- Follows the structure established by #145 (overlap_breakdown), #148 (nccl_breakdown), #149 (kernel_launch_overhead)
