### PR TITLE
test(eval): seed tests/eval/ — labeled-profile finding-correctness harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ data/nsys-hero/
 !tests/fixtures/mock.sqlite
 *.nsys-rep
 *.nsys-cache/
+*.nsys-cache.build.lock
 *.sqlite.timeline-cache-*.json
 examples/*/output/
 snapshot_report.html

--- a/tests/eval/README.md
+++ b/tests/eval/README.md
@@ -1,0 +1,108 @@
+# Evaluation seed (`tests/eval/`)
+
+Ground truth for **finding correctness**. Each label attaches expected /
+forbidden finding assertions to a profile, so changes to skills and the
+`EvidenceBuilder` pipeline can be scored — not just run.
+
+This is the **seed** referenced by the roadmap (§4 B / §4 F / §4 H). It exists
+because, before it, nothing checked whether `EvidenceBuilder.build()` produced
+the *right* findings: skills were gaining `to_findings_fn` callbacks with no
+regression net, and the §10 quality metrics (false-positive rate, false-negative
+rate, selection overlap) had no data to be computed from.
+
+It is the finding-correctness counterpart to [`tests/trajectories/`](../trajectories/),
+which evaluates the *agent's tool-calling* behavior. Same shape (per-case JSON +
+a pytest runner + skip-when-profile-absent); different target.
+
+## Layout
+
+```
+tests/eval/
+  README.md              this file
+  labels/<name>.json     one label per profile
+tests/test_eval.py       the runner (self-contained; mirrors test_trajectories.py)
+```
+
+## Label schema
+
+```jsonc
+{
+  "id": "eval-mock-001",              // stable test id
+  "profile": "tests/fixtures/mock.sqlite",  // path relative to repo root
+  "device": 0,
+  "description": "...",
+  "source": "where the ground truth came from (audit doc, real run, domain analysis)",
+
+  "expect": [                         // findings that SHOULD be produced
+    { "category": "idle", "min_severity": "warning", "window_ns": [start, end],
+      "required": true }              // "required": gate CI on this; default informational
+  ],
+  "must_not": [                       // findings that must NOT appear (false positives)
+    { "category": "communication" }
+  ],
+  "known_gaps": [                     // documented-but-unfixed; printed, never gates
+    { "observation": "...", "ref": "roadmap §4 B" }
+  ]
+}
+```
+
+Assertion fields (`category`, `min_severity`, `window_ns`) are all optional and
+ANDed. `min_severity` accepts either vocabulary (`info|warning|critical` or
+`info|low|medium|high|critical`). `window_ns` is a **loose overlap** check
+against the finding's `[start_ns, end_ns]`; omit it to ignore location.
+
+### Authoring rule: label, don't snapshot
+
+Labels encode the **intended** result from domain analysis or an audit (e.g.
+`docs/audits/l40s-fastvideo-gaps.md`), **not** a snapshot of current
+`build()` output. Snapshotting would freeze today's behavior — including known
+bugs — as the "correct" answer. Where current output is known-wrong, record it
+under `known_gaps` rather than encoding it as `expect`.
+
+## Scoring & CI gating (seed scope)
+
+| Signal | Meaning | CI |
+|---|---|---|
+| `must_not` matched | a forbidden finding appeared (false positive) | **fails** |
+| `expect` with `"required": true` unmet | a calibrated expected finding is missing | **fails** |
+| `expect` (default) unmet | an expected finding is missing (false negative) | informational |
+| `% categorized`, category histogram | finding-quality metrics | informational |
+| `known_gaps` | documented, not yet fixed | printed only |
+
+`must_not` violations and unmet `required` expectations gate; everything else
+is printed so regressions are visible without freezing unverified behavior.
+Mark an `expect` `"required": true` only once it is a stable, calibrated truth
+(e.g. idle gaps on the committed `mock.sqlite`). Promote more expectations to
+`required` in later PRs as labels settle.
+
+The matcher/scorer itself is unit-tested in `tests/test_eval.py`
+(`TestMatcher` / `TestScore`) so the eval's own logic runs in CI even when every
+labeled profile is absent.
+
+## Profiles & CI
+
+Profiles are resolved relative to the repo root; a label whose profile is
+**absent is skipped**. Only the committed `tests/fixtures/mock.sqlite` runs in
+CI. Large real profiles (e.g. `nano_vllm_qwen3_4b.sqlite`) stay local-only —
+keep their `.sqlite` out of the repo and run the eval locally:
+
+```bash
+pytest tests/test_eval.py -v        # metrics print via capsys.disabled()
+pytest tests/test_eval.py -k mock   # just the CI-reproducible case
+```
+
+## Adding a case
+
+1. Drop the profile where the label's `profile` path resolves (committed only if
+   small, like `mock.sqlite`).
+2. Run `EvidenceBuilder` on it (`nsys-ai analyze <profile> --gpu 0 --format json`)
+   to see real output.
+3. Write `labels/<name>.json` with `expect` / `must_not` drawn from domain truth
+   — not from the raw output. Park known-wrong output under `known_gaps`.
+4. `pytest tests/test_eval.py -k <name> -v`.
+
+## Consumers (future work)
+
+- **§4 B** — regression net for the skill-finding upgrade wave.
+- **§4 F** — leave-one-skill-out marginal contribution for default-pack governance.
+- **§4 H** — verification-agent must-not-claim evaluation.

--- a/tests/eval/labels/mock.json
+++ b/tests/eval/labels/mock.json
@@ -1,0 +1,27 @@
+{
+  "id": "eval-mock-001",
+  "profile": "tests/fixtures/mock.sqlite",
+  "device": 0,
+  "description": "Minimal committed synthetic profile: a few GPU idle gaps plus one large H2D transfer. The only label that runs in CI (its profile is committed); it exists to exercise the harness deterministically and guard against false-positive findings.",
+  "source": "Grounded in EvidenceBuilder.build() output on the committed tests/fixtures/mock.sqlite. Assertions are intentionally coarse (presence, not counts) so they survive minor finding-count drift.",
+  "expect": [
+    {
+      "category": "idle",
+      "min_severity": "warning",
+      "required": true,
+      "note": "GPU idle gaps / idle summary are the dominant real signal in this fixture; stable enough to gate"
+    }
+  ],
+  "must_not": [
+    {
+      "category": "communication",
+      "note": "mock has no NCCL activity; any communication finding here is a false positive"
+    }
+  ],
+  "known_gaps": [
+    {
+      "observation": "the 'Large H2D Transfer' finding has category=null; it should be 'memory'. Uncategorized findings cannot be filtered or attributed to a step-time bucket.",
+      "ref": "roadmap §4 B (per-skill finding upgrade)"
+    }
+  ]
+}

--- a/tests/eval/labels/nano_vllm_qwen3_4b.json
+++ b/tests/eval/labels/nano_vllm_qwen3_4b.json
@@ -1,0 +1,26 @@
+{
+  "id": "eval-nano-vllm-001",
+  "profile": "nano_vllm_qwen3_4b.sqlite",
+  "device": 0,
+  "description": "Qwen3-4B nano-vllm inference profile. Local-only (the .sqlite is not committed), so this label is skipped in CI and runs only when the profile is present at the repo root.",
+  "source": "Grounded in a real EvidenceBuilder.build() run (65 findings): communication and idle signal classes are present; the run is dominated by uncategorized 'Slow Iteration' findings — the same noise pattern documented in docs/audits/l40s-fastvideo-gaps.md.",
+  "expect": [
+    {
+      "category": "communication",
+      "min_severity": "warning",
+      "note": "NCCL/comm findings are present and are real signal"
+    },
+    {
+      "category": "idle",
+      "min_severity": "warning",
+      "note": "GPU idle gaps are present"
+    }
+  ],
+  "must_not": [],
+  "known_gaps": [
+    {
+      "observation": "~55 of ~65 findings have category=null (almost all are 'Slow Iteration N' from iteration_timing). Real signal (communication, idle) is a small minority, mirroring the audit's 'real finding buried at 390/401' problem.",
+      "ref": "roadmap §4 B gaps #6/#7; docs/audits/l40s-fastvideo-gaps.md item #3"
+    }
+  ]
+}

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,0 +1,242 @@
+"""test_eval.py — finding-correctness regression tests against labeled profiles.
+
+This is the **eval seed**. Each label JSON in ``tests/eval/labels/*.json``
+attaches expected / must-not finding assertions to a profile, providing the
+first ground truth for ``EvidenceBuilder`` output. See ``tests/eval/README.md``.
+
+Scoring (seed scope — informational by default, one hard gate):
+
+  - ``expect[]``     unmet  -> false negative   (informational; printed, NOT gated)
+  - ``must_not[]``   matched-> violation         (HARD gate: fails CI)
+  - quality metrics (total, % categorized, category histogram) -> informational
+  - ``known_gaps[]`` documented-but-unfixed observations         -> printed only
+
+Why only ``must_not`` gates: positive expectations and quality ratios are
+still being calibrated; gating them now would freeze unverified behavior
+(roadmap §5). A false positive that a label explicitly forbids is, by
+contrast, a stable regression signal. Gating can tighten once labels settle.
+
+Profiles are resolved relative to the repo root. A label whose profile file is
+absent is skipped, so only the committed ``tests/fixtures/mock.sqlite`` runs in
+CI; large real profiles stay local-only.
+
+Usage::
+
+    pytest tests/test_eval.py -v          # metrics are printed via capsys.disabled()
+    pytest tests/test_eval.py -k mock
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+_LABELS_DIR = _REPO_ROOT / "tests" / "eval" / "labels"
+
+# Severity ladder spanning both the legacy Finding scale
+# ("info" | "warning" | "critical") and the v0.1 Severity literal
+# ("info" | "low" | "medium" | "high" | "critical"). "warning" and "medium"
+# share a rung so a label can use either vocabulary.
+_SEV_ORDER = {"info": 0, "low": 1, "warning": 2, "medium": 2, "high": 3, "critical": 4}
+
+
+# ---------------------------------------------------------------------------
+# Label loading + profile resolution
+# ---------------------------------------------------------------------------
+
+
+def _load_labels() -> list[dict]:
+    if not _LABELS_DIR.is_dir():
+        return []
+    return [json.loads(p.read_text()) for p in sorted(_LABELS_DIR.glob("*.json"))]
+
+
+def _resolve_profile(rel: str) -> Path | None:
+    p = _REPO_ROOT / rel
+    return p if p.is_file() else None
+
+
+# ---------------------------------------------------------------------------
+# Assertion matching
+# ---------------------------------------------------------------------------
+
+
+def _sev_ge(sev: str | None, minimum: str) -> bool:
+    return _SEV_ORDER.get(sev or "info", 0) >= _SEV_ORDER.get(minimum, 0)
+
+
+def _window_overlaps(window, fstart, fend) -> bool:
+    """Loose overlap: assertion ``window_ns`` (``[start, end]``) vs a finding's
+    ``[start_ns, end_ns]``. No window in the assertion means "don't constrain"."""
+    if not window:
+        return True
+    a0 = window[0]
+    a1 = window[1] if len(window) > 1 else a0
+    if fstart is None:
+        return False
+    fend = fend if fend is not None else fstart
+    return a0 <= fend and fstart <= a1
+
+
+def _matches(finding: dict, assertion: dict) -> bool:
+    cat = assertion.get("category")
+    if cat is not None and finding.get("category") != cat:
+        return False
+    minsev = assertion.get("min_severity")
+    if minsev and not _sev_ge(finding.get("severity"), minsev):
+        return False
+    if not _window_overlaps(assertion.get("window_ns"), finding.get("start_ns"), finding.get("end_ns")):
+        return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Build + score
+# ---------------------------------------------------------------------------
+
+
+def _build_findings(label: dict, prof_path: Path) -> list[dict]:
+    from nsys_ai.evidence_builder import EvidenceBuilder
+    from nsys_ai.profile import Profile
+
+    with Profile(str(prof_path)) as prof:
+        report = EvidenceBuilder(prof, device=label.get("device", 0)).build()
+    return [f.to_dict() for f in report.findings]
+
+
+def _score(label: dict, findings: list[dict]) -> dict:
+    unmet = [a for a in label.get("expect", []) if not any(_matches(f, a) for f in findings)]
+    # An expect marked ``"required": true`` is a calibrated, gating assertion;
+    # the rest are informational false negatives while labels stabilize.
+    required_failures = [a for a in unmet if a.get("required")]
+    false_negatives = [a for a in unmet if not a.get("required")]
+    violations = []
+    for a in label.get("must_not", []):
+        hits = sum(1 for f in findings if _matches(f, a))
+        if hits:
+            violations.append({"assertion": a, "n_hits": hits})
+    categorized = sum(1 for f in findings if f.get("category"))
+    hist: dict = {}
+    for f in findings:
+        hist[f.get("category")] = hist.get(f.get("category"), 0) + 1
+    return {
+        "required_failures": required_failures,
+        "false_negatives": false_negatives,
+        "violations": violations,
+        "categorized_pct": (100.0 * categorized / len(findings)) if findings else 0.0,
+        "category_hist": hist,
+    }
+
+
+def _report(label: dict, findings: list[dict], score: dict) -> str:
+    lines = [
+        f"\n[eval:{label['id']}] {label['profile']}",
+        f"  findings={len(findings)}  categorized={score['categorized_pct']:.0f}%"
+        f"  by_category={score['category_hist']}",
+    ]
+    if score["required_failures"]:
+        lines.append(f"  REQUIRED EXPECTATIONS UNMET (gated): {score['required_failures']}")
+    if score["false_negatives"]:
+        lines.append(f"  false negatives (expected but absent; informational): {score['false_negatives']}")
+    if score["violations"]:
+        lines.append(f"  MUST-NOT VIOLATIONS (gated): {score['violations']}")
+    for g in label.get("known_gaps", []):
+        lines.append(f"  known gap: {g.get('observation')}  [{g.get('ref', '')}]")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+_LABELS = _load_labels()
+
+
+@pytest.mark.skipif(not _LABELS, reason="no eval labels in tests/eval/labels/")
+@pytest.mark.parametrize("label", _LABELS, ids=[lbl["id"] for lbl in _LABELS])
+def test_eval_label(label: dict, capsys) -> None:
+    prof_path = _resolve_profile(label["profile"])
+    if prof_path is None:
+        pytest.skip(f"profile not available locally: {label['profile']}")
+
+    findings = _build_findings(label, prof_path)
+    score = _score(label, findings)
+
+    with capsys.disabled():
+        print(_report(label, findings, score))
+
+    # Seed gates: forbidden findings (must_not) and calibrated required
+    # expectations. Non-required expectation misses and quality ratios stay
+    # informational while labels are being calibrated.
+    assert not score["violations"], (
+        f"{label['id']}: forbidden findings present — {score['violations']}"
+    )
+    assert not score["required_failures"], (
+        f"{label['id']}: required findings missing — {score['required_failures']}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Harness unit tests — validate the matcher/scorer itself (no profile needed,
+# so these always run in CI even when every labeled profile is absent).
+# ---------------------------------------------------------------------------
+
+
+class TestMatcher:
+    def test_sev_ge_ladder(self) -> None:
+        assert _sev_ge("critical", "warning")
+        assert _sev_ge("warning", "warning")
+        assert not _sev_ge("info", "warning")
+        assert _sev_ge("medium", "warning")  # "medium" and "warning" share a rung
+        assert not _sev_ge(None, "low")  # missing severity treated as "info"
+
+    def test_window_overlap(self) -> None:
+        assert _window_overlaps([10, 20], 15, 18)  # finding inside window
+        assert _window_overlaps([10, 20], 18, 25)  # partial overlap
+        assert not _window_overlaps([10, 20], 30, 40)  # disjoint
+        assert _window_overlaps(None, 0, 0)  # no window constraint
+        assert _window_overlaps([10], 10, None)  # single-point window vs marker
+        assert not _window_overlaps([10, 20], None, None)  # finding has no start
+
+    def test_matches_category_severity_window(self) -> None:
+        f = {"category": "idle", "severity": "warning", "start_ns": 100, "end_ns": 200}
+        assert _matches(f, {"category": "idle"})
+        assert _matches(f, {"category": "idle", "min_severity": "warning"})
+        assert _matches(f, {"category": "idle", "window_ns": [150, 160]})
+        assert not _matches(f, {"category": "communication"})
+        assert not _matches(f, {"category": "idle", "min_severity": "critical"})
+        assert not _matches(f, {"category": "idle", "window_ns": [300, 400]})
+
+
+class TestScore:
+    def test_required_vs_informational_and_must_not(self) -> None:
+        findings = [{"category": "idle", "severity": "warning", "start_ns": 1, "end_ns": 2}]
+        label = {
+            "expect": [
+                {"category": "idle", "required": True},  # met
+                {"category": "communication"},  # unmet, informational
+            ],
+            "must_not": [{"category": "memory"}],  # no memory finding -> no violation
+        }
+        score = _score(label, findings)
+        assert score["required_failures"] == []
+        assert len(score["false_negatives"]) == 1
+        assert score["false_negatives"][0]["category"] == "communication"
+        assert score["violations"] == []
+        assert score["categorized_pct"] == 100.0
+
+    def test_required_failure_and_violation_detected(self) -> None:
+        findings = [{"category": "communication", "severity": "critical", "start_ns": 5}]
+        label = {
+            "expect": [{"category": "idle", "required": True}],  # unmet -> gating failure
+            "must_not": [{"category": "communication"}],  # present -> violation
+        }
+        score = _score(label, findings)
+        assert len(score["required_failures"]) == 1
+        assert len(score["violations"]) == 1


### PR DESCRIPTION
Seeds `tests/eval/` — ground truth for finding correctness, so changes to skills and the `EvidenceBuilder` pipeline can be scored, not just run.

## Adds
- `tests/eval/labels/*.json` — per-profile `expect` / `must_not` finding assertions, authored from domain truth (not snapshots of current output). Known-wrong output is parked under `known_gaps`.
- `tests/test_eval.py` — self-contained runner (mirrors `tests/trajectories/`): loads labels, runs `EvidenceBuilder`, scores actual vs expected, prints quality metrics (% categorized, category histogram). Includes `TestMatcher` / `TestScore` unit tests so the matcher/scorer runs in CI even when every labeled profile is absent.
- `.gitignore` — ignore `*.nsys-cache.build.lock` (flock artifact the harness creates).

## Scoring / CI
- **Gates (fail CI):** `must_not` violations; unmet `expect` marked `"required": true`.
- **Informational:** other unmet expectations, `% categorized`, category histogram, `known_gaps`.
- Profiles resolve relative to repo root; a label whose profile is absent is skipped, so only the committed `tests/fixtures/mock.sqlite` runs in CI. Large profiles (e.g. `nano_vllm_qwen3_4b.sqlite`) stay local-only.

## Labels
- `mock.sqlite` (CI): idle required-present; no false-positive communication.
- `nano_vllm_qwen3_4b.sqlite` (local-only).

The harness immediately surfaces the uncategorized-finding gap: mock 50% / nano-vllm 15% of findings carry a category.