### PR TITLE
feat(skills): add structured profile_health_manifest findings

### DIFF
--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -73,6 +73,11 @@ class EvidenceBuilder:
         "memory_anomalies": ("memory_bandwidth", {"limit": 5}),
         "h2d_spikes": ("h2d_distribution", {}),
         "nccl_breakdown": ("nccl_breakdown", {}),
+        # Roll-up characterization of the whole profile (comm-bound,
+        # sync-bound, idle-dominant, coverage gaps). Reads only the
+        # already-assembled manifest dict, so its findings are
+        # independent of the other pipeline entries' to_findings status.
+        "profile_health": ("profile_health_manifest", {}),
     }
 
     def build(self, only: list[str] | None = None) -> EvidenceReport:

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -53,6 +53,19 @@ _AUTO_TRIM_TARGET_WINDOW_NS = 20 * 10**9             # 20 s
 # the same on/off semantics across env vars in this repo.
 _AUTO_TRIM_FALSE_TOKENS = frozenset({"0", "false", "no", "off"})
 
+# ── Roll-up finding thresholds ──────────────────────────────────────
+# Shared between _infer_bottleneck (the human-readable string) and
+# _to_findings (the structured roll-up emitter) so a tweak in one place
+# can't drift from the other. Same constants-at-module-top convention as
+# PR #149 (kernel_launch_overhead) and PR #153 (top_kernels).
+_OVERHEAD_CONTAMINATED_PCT = 1.0
+_SYNC_BOUND_DENSITY_PCT = 20.0
+_COMM_BOUND_OVERLAP_PCT = 30.0
+_IDLE_DOMINANT_PCT = 15.0
+_KERNEL_HOTSPOT_PCT = 60.0
+_ITER_VARIANCE_SPIKE_RATIO = 1.5
+_MIN_ITERATIONS_FOR_NVTX_COVERAGE = 3
+
 
 def _auto_trim_enabled() -> bool:
     """Read NSYS_AI_MANIFEST_AUTO_TRIM with 0/false/no/off → disabled."""
@@ -519,13 +532,12 @@ def _infer_bottleneck(m: dict) -> str:
     """Heuristic bottleneck inference from manifest data."""
     sync = m.get("sync", {})
     sync_density = sync.get("sync_density_pct", 0)
-    # The new threshold
-    if sync_density > 20.0:
+    if sync_density > _SYNC_BOUND_DENSITY_PCT:
         return f"High CPU Synchronization Blocking ({sync_density:.1f}% of span)"
 
     dq = m.get("data_quality", {})
     overhead_pct_val = dq.get("overhead_pct_raw", dq.get("overhead_pct", 0))
-    if overhead_pct_val > 1.0:
+    if overhead_pct_val > _OVERHEAD_CONTAMINATED_PCT:
         return f"Profiler Overhead ({dq.get('overhead_pct', overhead_pct_val)}%) contaminated the profile"
 
     overlap = m.get("overlap", {})
@@ -533,11 +545,11 @@ def _infer_bottleneck(m: dict) -> str:
     nccl = m.get("nccl", {})
 
     # Check NCCL serialization first (most impactful)
-    if overlap.get("overlap_pct", 100) < 30 and overlap.get("nccl_only_ms", 0) > 0:
-        return "NCCL serialization (overlap < 30%)"
+    if overlap.get("overlap_pct", 100) < _COMM_BOUND_OVERLAP_PCT and overlap.get("nccl_only_ms", 0) > 0:
+        return f"NCCL serialization (overlap < {int(_COMM_BOUND_OVERLAP_PCT)}%)"
 
     # Check idle gaps
-    if idle.get("idle_pct", 0) > 15:
+    if idle.get("idle_pct", 0) > _IDLE_DOMINANT_PCT:
         return f"GPU idle bubbles ({idle['idle_pct']}% of profile)"
 
     # Check if one kernel dominates
@@ -545,7 +557,7 @@ def _infer_bottleneck(m: dict) -> str:
     total = m.get("total_kernel_ms", 0)
     if top_k and total > 0:
         top_pct = top_k[0]["total_ms"] / total * 100
-        if top_pct > 60:
+        if top_pct > _KERNEL_HOTSPOT_PCT:
             return f"Kernel hotspot: {top_k[0]['name']} ({top_pct:.0f}%)"
 
     # Check NCCL dominance
@@ -556,11 +568,401 @@ def _infer_bottleneck(m: dict) -> str:
     nvtx = m.get("nvtx", {})
     median_ms = nvtx.get("median_iter_ms", 0)
     slowest_ms = nvtx.get("slowest_iter_ms", 0)
-    if median_ms > 0 and slowest_ms > median_ms * 1.5:
+    if median_ms > 0 and slowest_ms > median_ms * _ITER_VARIANCE_SPIKE_RATIO:
         ratio = slowest_ms / median_ms
         return f"Iteration variance spike (slowest {slowest_ms:.0f}ms = {ratio:.1f}× median)"
 
     return ""
+
+
+_OVERHEAD_EXPLANATION = (
+    "Per-event CUPTI instrumentation cost exceeded 1% of profile span, which "
+    "perturbs kernel durations and launch timings enough to mask real "
+    "regressions. Re-capture with torch.cuda.profiler.start/stop() + "
+    "--capture-range=cudaProfilerApi to scope nsys to the region of interest."
+)
+_SYNC_EXPLANATION = (
+    "Synchronous CPU→GPU waits (cudaStreamSynchronize, cudaMemcpy, .item(), "
+    ".cpu()) consumed >20% of wall time. Look for unnecessary host-side "
+    "tensor reads, non-pinned host memory in the dataloader, or eager "
+    "evaluation inside the hot loop."
+)
+_COMM_EXPLANATION = (
+    "Compute/NCCL overlap fell below 30% with non-trivial NCCL traffic on a "
+    "separate stream — the rank is serializing communication after compute "
+    "instead of hiding it. Candidate levers: dedicated NCCL stream + "
+    "wait_stream ordering, Ulysses-Ring hybrid SP partitioning, larger "
+    "fused all-reduces."
+)
+_IDLE_EXPLANATION = (
+    "GPU was idle for >15% of the profile, indicating launch-bound segments "
+    "or host-side blocking gaps between kernels. Inspect gpu_idle_gaps "
+    "findings for the specific stalls; consider CUDA Graphs / torch.compile "
+    "for launch overhead, dataloader workers / pinned memory for host stalls."
+)
+_HOTSPOT_EXPLANATION = (
+    "A single kernel accounts for >60% of total kernel time — optimization "
+    "effort spent anywhere else is Amdahl-limited. Triage this kernel first: "
+    "check TC eligibility, fusion opportunities, dtype, occupancy."
+)
+_ITER_SPIKE_EXPLANATION = (
+    "At least one steady-state iteration ran ≥1.5× the median, indicating "
+    "non-uniform per-step cost (CFG batching, conditional branches, sync "
+    "outliers, or the first NCCL collective of a new communicator). The "
+    "median is what matters for throughput; the spike often signals a "
+    "specific anti-pattern."
+)
+_NVTX_COVERAGE_EXPLANATION = (
+    "The profile has no NVTX annotations or fewer than 3 detected iterations, "
+    "which means iteration_timing / nvtx_kernel_map / overlap-by-region "
+    "skills cannot anchor their analysis. Wrap the training loop in "
+    "torch.cuda.nvtx.range_push/pop or use the existing FastVideo "
+    "annotate_profile_regions context manager before re-capturing."
+)
+
+_OVERHEAD_ACTIONS = (
+    "Use torch.cuda.profiler.start/stop() around the region of interest.",
+    "Pass --capture-range=cudaProfilerApi to nsys profile.",
+    "Disable per-event CUPTI features (--cuda-trace=runtime,driver only).",
+)
+_SYNC_ACTIONS = (
+    "Audit .item() / .cpu() / .tolist() calls inside the hot loop.",
+    "Switch host-side buffers to pinned memory with non_blocking=True copies.",
+    "Move loss / metric reductions out of the inner loop.",
+)
+_COMM_ACTIONS = (
+    "Route NCCL collectives onto a dedicated stream with wait_stream ordering.",
+    "Evaluate Hybrid Ulysses-Ring SP partitioning for the dominant dimension.",
+    "Profile per-stream NCCL breakdown to identify the serialized collective.",
+)
+_IDLE_ACTIONS = (
+    "Inspect gpu_idle_gaps findings for the specific stall location.",
+    "Enable torch.compile (or CUDA Graphs) on the launch-bound segment.",
+    "Verify dataloader is non-blocking and uses pinned memory.",
+)
+_HOTSPOT_ACTIONS = (
+    "Confirm Tensor-Core eligibility (dtype, dims, layout) for this kernel.",
+    "Check for fusion opportunities with adjacent ops under torch.compile.",
+    "Profile occupancy and register pressure with Nsight Compute.",
+)
+_ITER_SPIKE_ACTIONS = (
+    "Inspect iteration_timing for the specific slow iteration's stack.",
+    "Check whether the spike aligns with a CFG batch / first-of-kind collective.",
+    "Compare median vs slowest with NVTX annotations to localize the divergence.",
+)
+_NVTX_COVERAGE_ACTIONS = (
+    "Wrap the training loop in torch.cuda.nvtx.range_push/range_pop.",
+    "Use the framework's existing region-annotation context manager.",
+    "Re-capture with at least 5 steady-state iterations after warmup.",
+)
+
+
+def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
+    """Emit roll-up findings characterizing the profile as a whole.
+
+    Reads only the already-assembled manifest dict — never reaches into
+    sub-skill findings — so this skill's findings are independent of any
+    sub-skill's _to_findings status. Seven roll-up types map to the
+    step-time decomposition (compute/communication/idle/sync) plus
+    profile_quality coverage. ``_infer_bottleneck`` still produces the
+    single human-readable string for ``_format``; this emits the full
+    structured set.
+    """
+    from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
+
+    findings: list = []
+    if not rows:
+        return findings
+    m = rows[0]
+    profile_id = (context or {}).get("profile_id", "unknown")
+
+    def _emit(
+        *,
+        finding_id: str,
+        label: str,
+        severity: str,
+        category: str,
+        values: dict,
+        units: dict,
+        note: str,
+        explanation: str,
+        actions: tuple[str, ...],
+        provenance_extra: dict | None = None,
+    ) -> None:
+        # All roll-ups are profile-global characterizations (no time
+        # anchor); ``start_ns=0`` is the established "no anchor" sentinel
+        # — see top_kernels.top_kernels_concentrated for the same
+        # convention — and ``type="highlight"`` signals to consumers that
+        # this is not a trace location.
+        selection = TraceSelection(
+            id=f"sel_{finding_id}",
+            profile_id=profile_id,
+            source="skill:profile_health_manifest",
+            label=label,
+        )
+        provenance = {"skill": "profile_health_manifest", "row_kind": finding_id}
+        if provenance_extra:
+            provenance.update(provenance_extra)
+        ev = EvidenceRow(
+            id=f"ev_{finding_id}",
+            source_skill="profile_health_manifest",
+            values=values,
+            units=units,
+            selection_id=selection.id,
+            provenance={"row_kind": finding_id},
+        )
+        findings.append(
+            Finding(
+                type="highlight",
+                label=label,
+                start_ns=0,
+                end_ns=None,
+                severity=severity,
+                note=note,
+                id=finding_id,
+                category=category,
+                evidence=[ev],
+                selection=selection,
+                explanation=explanation,
+                suggested_actions=list(actions),
+                provenance=provenance,
+            )
+        )
+
+    # ── 1. Profiler overhead contamination ─────────────────────────
+    dq = m.get("data_quality", {}) or {}
+    overhead_pct = float(dq.get("overhead_pct_raw", dq.get("overhead_pct", 0)) or 0)
+    if overhead_pct > _OVERHEAD_CONTAMINATED_PCT:
+        overhead_ms = float(dq.get("profiler_overhead_ms", 0) or 0)
+        _emit(
+            finding_id="profile_overhead_contaminated",
+            label=f"Profiler overhead contaminated profile ({overhead_pct:.1f}%)",
+            severity="critical",
+            category="profile_quality",
+            values={
+                "overhead_pct": round(overhead_pct, 2),
+                "overhead_ms": round(overhead_ms, 2),
+                "threshold_pct": _OVERHEAD_CONTAMINATED_PCT,
+            },
+            units={"overhead_pct": "percent", "overhead_ms": "ms", "threshold_pct": "percent"},
+            note=(
+                f"Per-event profiler overhead is {overhead_pct:.1f}% of profile span "
+                f"({overhead_ms:.1f}ms). Above {_OVERHEAD_CONTAMINATED_PCT}% the captured "
+                "kernel durations are no longer trustworthy."
+            ),
+            explanation=_OVERHEAD_EXPLANATION,
+            actions=_OVERHEAD_ACTIONS,
+        )
+
+    # ── 2. CPU sync blocking ────────────────────────────────────────
+    sync = m.get("sync", {}) or {}
+    sync_density = float(sync.get("sync_density_pct", 0) or 0)
+    if sync_density > _SYNC_BOUND_DENSITY_PCT:
+        sync_wall_ms = float(sync.get("total_sync_wall_ms", 0) or 0)
+        _emit(
+            finding_id="profile_sync_bound",
+            label=f"CPU sync blocks {sync_density:.1f}% of wall time",
+            severity="warning",
+            category="sync",
+            values={
+                "sync_density_pct": round(sync_density, 2),
+                "sync_wall_ms": round(sync_wall_ms, 2),
+                "threshold_pct": _SYNC_BOUND_DENSITY_PCT,
+            },
+            units={
+                "sync_density_pct": "percent",
+                "sync_wall_ms": "ms",
+                "threshold_pct": "percent",
+            },
+            note=(
+                f"Synchronous CPU→GPU waits consume {sync_density:.1f}% of wall time "
+                f"({sync_wall_ms:.1f}ms). Threshold {_SYNC_BOUND_DENSITY_PCT}%."
+            ),
+            explanation=_SYNC_EXPLANATION,
+            actions=_SYNC_ACTIONS,
+        )
+
+    # ── 3. Communication-bound ──────────────────────────────────────
+    overlap = m.get("overlap", {}) or {}
+    nccl = m.get("nccl", {}) or {}
+    overlap_pct = float(overlap.get("overlap_pct", 100) or 100)
+    nccl_only_ms = float(overlap.get("nccl_only_ms", 0) or 0)
+    total_nccl_ms = float(nccl.get("total_nccl_ms", 0) or 0)
+    compute_only_ms = float(overlap.get("compute_only_ms", 0) or 0)
+    nccl_dominates_compute = total_nccl_ms > 0 and total_nccl_ms > compute_only_ms
+    if (
+        overlap_pct < _COMM_BOUND_OVERLAP_PCT and nccl_only_ms > 0
+    ) or nccl_dominates_compute:
+        # Two distinct triggers can fire this; capture which in provenance
+        # so downstream consumers (and Copilot-style reviewers) can tell
+        # the low-overlap signal from the NCCL-dominance signal.
+        triggers = []
+        if overlap_pct < _COMM_BOUND_OVERLAP_PCT and nccl_only_ms > 0:
+            triggers.append("low_overlap")
+        if nccl_dominates_compute:
+            triggers.append("nccl_exceeds_compute")
+        _emit(
+            finding_id="profile_comm_bound",
+            label=(
+                f"Communication-bound (overlap {overlap_pct:.0f}%, "
+                f"NCCL {total_nccl_ms:.0f}ms vs compute {compute_only_ms:.0f}ms)"
+            ),
+            severity="warning",
+            category="communication",
+            values={
+                "overlap_pct": round(overlap_pct, 2),
+                "nccl_only_ms": round(nccl_only_ms, 2),
+                "total_nccl_ms": round(total_nccl_ms, 2),
+                "compute_only_ms": round(compute_only_ms, 2),
+                "dominant_collective": nccl.get("dominant_type", "unknown"),
+                "overlap_threshold_pct": _COMM_BOUND_OVERLAP_PCT,
+            },
+            units={
+                "overlap_pct": "percent",
+                "nccl_only_ms": "ms",
+                "total_nccl_ms": "ms",
+                "compute_only_ms": "ms",
+                "overlap_threshold_pct": "percent",
+            },
+            note=(
+                f"Compute/NCCL overlap is {overlap_pct:.0f}% (threshold "
+                f"{int(_COMM_BOUND_OVERLAP_PCT)}%); NCCL total {total_nccl_ms:.0f}ms "
+                f"vs compute-only {compute_only_ms:.0f}ms. Dominant collective: "
+                f"{nccl.get('dominant_type', 'unknown')}."
+            ),
+            explanation=_COMM_EXPLANATION,
+            actions=_COMM_ACTIONS,
+            provenance_extra={"triggers": triggers},
+        )
+
+    # ── 4. GPU idle dominant ────────────────────────────────────────
+    idle = m.get("idle", {}) or {}
+    idle_pct = float(idle.get("idle_pct", 0) or 0)
+    if idle_pct > _IDLE_DOMINANT_PCT:
+        gap_count = int(idle.get("gap_count", 0) or 0)
+        total_idle_ms = float(idle.get("total_idle_ms", 0) or 0)
+        _emit(
+            finding_id="profile_idle_dominant",
+            label=f"GPU idle {idle_pct:.0f}% of profile ({gap_count} gaps)",
+            severity="warning",
+            category="idle",
+            values={
+                "idle_pct": round(idle_pct, 2),
+                "gap_count": gap_count,
+                "total_idle_ms": round(total_idle_ms, 2),
+                "threshold_pct": _IDLE_DOMINANT_PCT,
+            },
+            units={
+                "idle_pct": "percent",
+                "total_idle_ms": "ms",
+                "threshold_pct": "percent",
+            },
+            note=(
+                f"GPU idle for {idle_pct:.0f}% of profile across {gap_count} gaps "
+                f"({total_idle_ms:.0f}ms total). Threshold {int(_IDLE_DOMINANT_PCT)}%."
+            ),
+            explanation=_IDLE_EXPLANATION,
+            actions=_IDLE_ACTIONS,
+        )
+
+    # ── 5. Kernel hotspot ───────────────────────────────────────────
+    top_k = m.get("top_kernels", []) or []
+    total_kernel_ms = float(m.get("total_kernel_ms", 0) or 0)
+    if top_k and total_kernel_ms > 0:
+        top_ms = float(top_k[0].get("total_ms", 0) or 0)
+        top_pct = 100.0 * top_ms / total_kernel_ms if total_kernel_ms > 0 else 0
+        if top_pct > _KERNEL_HOTSPOT_PCT:
+            kname = top_k[0].get("name", "<unknown>")
+            count = int(top_k[0].get("count", 0) or 0)
+            _emit(
+                finding_id="profile_kernel_hotspot",
+                label=f"Kernel hotspot: {kname[:48]} ({top_pct:.0f}%)",
+                severity="warning",
+                category="compute",
+                values={
+                    "kernel_name": kname,
+                    "kernel_total_ms": round(top_ms, 2),
+                    "kernel_invocations": count,
+                    "pct_of_total_kernel_ms": round(top_pct, 2),
+                    "threshold_pct": _KERNEL_HOTSPOT_PCT,
+                },
+                units={
+                    "kernel_total_ms": "ms",
+                    "pct_of_total_kernel_ms": "percent",
+                    "threshold_pct": "percent",
+                },
+                note=(
+                    f"Kernel '{kname}' is {top_pct:.0f}% of total kernel time "
+                    f"({top_ms:.0f}ms over {count} invocations). Threshold "
+                    f"{int(_KERNEL_HOTSPOT_PCT)}%."
+                ),
+                explanation=_HOTSPOT_EXPLANATION,
+                actions=_HOTSPOT_ACTIONS,
+            )
+
+    # ── 6. Iteration variance spike ─────────────────────────────────
+    nvtx = m.get("nvtx", {}) or {}
+    median_ms = float(nvtx.get("median_iter_ms", 0) or 0)
+    slowest_ms = float(nvtx.get("slowest_iter_ms", 0) or 0)
+    if median_ms > 0 and slowest_ms > median_ms * _ITER_VARIANCE_SPIKE_RATIO:
+        ratio = slowest_ms / median_ms
+        iter_count = int(nvtx.get("iteration_count", 0) or 0)
+        _emit(
+            finding_id="profile_iteration_variance_spike",
+            label=f"Iteration variance: slowest {ratio:.1f}× median",
+            severity="warning",
+            category="nvtx",
+            values={
+                "median_iter_ms": round(median_ms, 2),
+                "slowest_iter_ms": round(slowest_ms, 2),
+                "ratio": round(ratio, 2),
+                "iteration_count": iter_count,
+                "threshold_ratio": _ITER_VARIANCE_SPIKE_RATIO,
+            },
+            units={
+                "median_iter_ms": "ms",
+                "slowest_iter_ms": "ms",
+                "ratio": "x",
+                "threshold_ratio": "x",
+            },
+            note=(
+                f"Slowest steady-state iteration ({slowest_ms:.0f}ms) is "
+                f"{ratio:.1f}× the median ({median_ms:.0f}ms) across "
+                f"{iter_count} iterations. Threshold {_ITER_VARIANCE_SPIKE_RATIO}×."
+            ),
+            explanation=_ITER_SPIKE_EXPLANATION,
+            actions=_ITER_SPIKE_ACTIONS,
+        )
+
+    # ── 7. Insufficient NVTX coverage ───────────────────────────────
+    has_nvtx = bool(nvtx.get("has_nvtx", False))
+    iter_count = int(nvtx.get("iteration_count", 0) or 0)
+    if not has_nvtx or iter_count < _MIN_ITERATIONS_FOR_NVTX_COVERAGE:
+        reason = "no NVTX annotations" if not has_nvtx else (
+            f"only {iter_count} iteration(s) detected "
+            f"(<{_MIN_ITERATIONS_FOR_NVTX_COVERAGE} required for steady-state)"
+        )
+        _emit(
+            finding_id="profile_insufficient_nvtx_coverage",
+            label=f"Insufficient NVTX coverage: {reason}",
+            severity="info",
+            category="profile_quality",
+            values={
+                "has_nvtx": has_nvtx,
+                "iteration_count": iter_count,
+                "min_iterations": _MIN_ITERATIONS_FOR_NVTX_COVERAGE,
+            },
+            units={},
+            note=(
+                f"Profile cannot anchor iteration / region analysis: {reason}. "
+                "Downstream skills (iteration_timing, nvtx_kernel_map) will "
+                "have reduced fidelity."
+            ),
+            explanation=_NVTX_COVERAGE_EXPLANATION,
+            actions=_NVTX_COVERAGE_ACTIONS,
+        )
+
+    return findings
 
 
 def _format(rows):
@@ -695,6 +1097,7 @@ SKILL = Skill(
     category="utility",
     execute_fn=_execute,
     format_fn=_format,
+    to_findings_fn=_to_findings,
     params=[
         SkillParam("device", "GPU device ID", "int", False, 0),
     ],

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -575,48 +575,53 @@ def _infer_bottleneck(m: dict) -> str:
     return ""
 
 
+# Explanation strings interpolate the threshold constants at module load
+# so the prose stays in sync with the thresholds it cites. Hardcoded
+# values would silently drift if a threshold were ever tuned.
 _OVERHEAD_EXPLANATION = (
-    "Per-event CUPTI instrumentation cost exceeded 1% of profile span, which "
-    "perturbs kernel durations and launch timings enough to mask real "
-    "regressions. Re-capture with torch.cuda.profiler.start/stop() + "
+    f"Per-event CUPTI instrumentation cost exceeded {_OVERHEAD_CONTAMINATED_PCT}% of "
+    "profile span, which perturbs kernel durations and launch timings enough to "
+    "mask real regressions. Re-capture with torch.cuda.profiler.start/stop() + "
     "--capture-range=cudaProfilerApi to scope nsys to the region of interest."
 )
 _SYNC_EXPLANATION = (
     "Synchronous CPU→GPU waits (cudaStreamSynchronize, cudaMemcpy, .item(), "
-    ".cpu()) consumed >20% of wall time. Look for unnecessary host-side "
-    "tensor reads, non-pinned host memory in the dataloader, or eager "
-    "evaluation inside the hot loop."
+    f".cpu()) consumed >{_SYNC_BOUND_DENSITY_PCT}% of wall time. Look for "
+    "unnecessary host-side tensor reads, non-pinned host memory in the "
+    "dataloader, or eager evaluation inside the hot loop."
 )
 _COMM_EXPLANATION = (
-    "Compute/NCCL overlap fell below 30% with non-trivial NCCL traffic on a "
-    "separate stream — the rank is serializing communication after compute "
-    "instead of hiding it. Candidate levers: dedicated NCCL stream + "
-    "wait_stream ordering, Ulysses-Ring hybrid SP partitioning, larger "
-    "fused all-reduces."
+    f"Compute/NCCL overlap fell below {int(_COMM_BOUND_OVERLAP_PCT)}% with "
+    "non-trivial NCCL traffic on a separate stream — the rank is serializing "
+    "communication after compute instead of hiding it. Candidate levers: "
+    "dedicated NCCL stream + wait_stream ordering, Ulysses-Ring hybrid SP "
+    "partitioning, larger fused all-reduces."
 )
 _IDLE_EXPLANATION = (
-    "GPU was idle for >15% of the profile, indicating launch-bound segments "
-    "or host-side blocking gaps between kernels. Inspect gpu_idle_gaps "
-    "findings for the specific stalls; consider CUDA Graphs / torch.compile "
-    "for launch overhead, dataloader workers / pinned memory for host stalls."
+    f"GPU was idle for >{int(_IDLE_DOMINANT_PCT)}% of the profile, indicating "
+    "launch-bound segments or host-side blocking gaps between kernels. Inspect "
+    "gpu_idle_gaps findings for the specific stalls; consider CUDA Graphs / "
+    "torch.compile for launch overhead, dataloader workers / pinned memory "
+    "for host stalls."
 )
 _HOTSPOT_EXPLANATION = (
-    "A single kernel accounts for >60% of total kernel time — optimization "
-    "effort spent anywhere else is Amdahl-limited. Triage this kernel first: "
-    "check TC eligibility, fusion opportunities, dtype, occupancy."
+    f"A single kernel accounts for >{int(_KERNEL_HOTSPOT_PCT)}% of total kernel "
+    "time — optimization effort spent anywhere else is Amdahl-limited. Triage "
+    "this kernel first: check TC eligibility, fusion opportunities, dtype, "
+    "occupancy."
 )
 _ITER_SPIKE_EXPLANATION = (
-    "At least one steady-state iteration ran ≥1.5× the median, indicating "
-    "non-uniform per-step cost (CFG batching, conditional branches, sync "
-    "outliers, or the first NCCL collective of a new communicator). The "
-    "median is what matters for throughput; the spike often signals a "
-    "specific anti-pattern."
+    f"At least one steady-state iteration ran ≥{_ITER_VARIANCE_SPIKE_RATIO}× the "
+    "median, indicating non-uniform per-step cost (CFG batching, conditional "
+    "branches, sync outliers, or the first NCCL collective of a new "
+    "communicator). The median is what matters for throughput; the spike often "
+    "signals a specific anti-pattern."
 )
 _NVTX_COVERAGE_EXPLANATION = (
-    "The profile has no NVTX annotations or fewer than 3 detected iterations, "
-    "which means iteration_timing / nvtx_kernel_map / overlap-by-region "
-    "skills cannot anchor their analysis. Wrap the training loop in "
-    "torch.cuda.nvtx.range_push/pop or use the existing FastVideo "
+    f"The profile has no NVTX annotations or fewer than {_MIN_ITERATIONS_FOR_NVTX_COVERAGE} "
+    "detected iterations, which means iteration_timing / nvtx_kernel_map / "
+    "overlap-by-region skills cannot anchor their analysis. Wrap the training "
+    "loop in torch.cuda.nvtx.range_push/pop or use the existing FastVideo "
     "annotate_profile_regions context manager before re-capturing."
 )
 
@@ -797,24 +802,39 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     nccl_only_ms = float(overlap.get("nccl_only_ms", 0) or 0)
     total_nccl_ms = float(nccl.get("total_nccl_ms", 0) or 0)
     compute_only_ms = float(overlap.get("compute_only_ms", 0) or 0)
+    low_overlap = overlap_pct < _COMM_BOUND_OVERLAP_PCT and nccl_only_ms > 0
     nccl_dominates_compute = total_nccl_ms > 0 and total_nccl_ms > compute_only_ms
-    if (
-        overlap_pct < _COMM_BOUND_OVERLAP_PCT and nccl_only_ms > 0
-    ) or nccl_dominates_compute:
+    if low_overlap or nccl_dominates_compute:
         # Two distinct triggers can fire this; capture which in provenance
         # so downstream consumers (and Copilot-style reviewers) can tell
         # the low-overlap signal from the NCCL-dominance signal.
         triggers = []
-        if overlap_pct < _COMM_BOUND_OVERLAP_PCT and nccl_only_ms > 0:
+        if low_overlap:
             triggers.append("low_overlap")
         if nccl_dominates_compute:
             triggers.append("nccl_exceeds_compute")
-        _emit(
-            finding_id="profile_comm_bound",
-            label=(
+        # Build the label from whichever trigger(s) fired so the
+        # human-readable summary reflects the actual signal — citing
+        # "overlap 100%" when only nccl_exceeds_compute triggered would
+        # be misleading.
+        if low_overlap and nccl_dominates_compute:
+            label_text = (
                 f"Communication-bound (overlap {overlap_pct:.0f}%, "
                 f"NCCL {total_nccl_ms:.0f}ms vs compute {compute_only_ms:.0f}ms)"
-            ),
+            )
+        elif low_overlap:
+            label_text = (
+                f"Communication-bound: low overlap {overlap_pct:.0f}% "
+                f"(NCCL {nccl_only_ms:.0f}ms unhidden)"
+            )
+        else:
+            label_text = (
+                f"Communication-bound: NCCL dominates "
+                f"({total_nccl_ms:.0f}ms NCCL vs {compute_only_ms:.0f}ms compute)"
+            )
+        _emit(
+            finding_id="profile_comm_bound",
+            label=label_text,
             severity="warning",
             category="communication",
             values={
@@ -878,7 +898,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     total_kernel_ms = float(m.get("total_kernel_ms", 0) or 0)
     if top_k and total_kernel_ms > 0:
         top_ms = float(top_k[0].get("total_ms", 0) or 0)
-        top_pct = 100.0 * top_ms / total_kernel_ms if total_kernel_ms > 0 else 0
+        top_pct = 100.0 * top_ms / total_kernel_ms
         if top_pct > _KERNEL_HOTSPOT_PCT:
             kname = top_k[0].get("name", "<unknown>")
             count = int(top_k[0].get("count", 0) or 0)

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -785,7 +785,15 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     # ── 3. Communication-bound ──────────────────────────────────────
     overlap = m.get("overlap", {}) or {}
     nccl = m.get("nccl", {}) or {}
-    overlap_pct = float(overlap.get("overlap_pct", 100) or 100)
+    # `overlap_pct` of exactly 0.0 is a legitimate (and important) signal
+    # — full serialization of compute and NCCL on one stream. The naive
+    # ``x or 100`` idiom would mistake 0.0 for "missing" and silence the
+    # comm_bound finding precisely when it should fire hardest. Caught
+    # during L40S validation on the uncompiled perf.sqlite profile, where
+    # overlap_pct=0.0 and nccl_only_ms=8654ms should have tripped the
+    # low-overlap trigger but didn't.
+    raw_overlap_pct = overlap.get("overlap_pct")
+    overlap_pct = 100.0 if raw_overlap_pct is None else float(raw_overlap_pct)
     nccl_only_ms = float(overlap.get("nccl_only_ms", 0) or 0)
     total_nccl_ms = float(nccl.get("total_nccl_ms", 0) or 0)
     compute_only_ms = float(overlap.get("compute_only_ms", 0) or 0)

--- a/tests/test_analyze_format_json.py
+++ b/tests/test_analyze_format_json.py
@@ -117,7 +117,14 @@ class TestAnalyzeFormatJson:
         args = _make_args(minimal_nsys_db_path, format="json")
         stdout, _ = _capture(_cmd_analyze, args, profile_module)
         payload = json.loads(stdout)
-        idle = [f for f in payload["findings"] if f.get("category") == "idle"]
+        # Filter by source rather than category: `idle` category is shared
+        # across skills (gpu_idle_gaps and profile_health_manifest's
+        # profile_idle_dominant both legitimately emit it), so category is
+        # not a uniqueness key for "idle-gap findings" specifically.
+        idle = [
+            f for f in payload["findings"]
+            if f.get("selection", {}).get("source") == "skill:gpu_idle_gaps"
+        ]
         envelope_id = payload["profile_id"]
         for f in idle:
             assert f.get("id"), "Finding must have an id when v0.1-aware"

--- a/tests/test_profile_health_manifest_findings.py
+++ b/tests/test_profile_health_manifest_findings.py
@@ -156,6 +156,41 @@ class TestCommBound:
         assert f is not None, "comm_bound must fire when overlap_pct is exactly 0.0"
         assert "low_overlap" in f.provenance["triggers"]
 
+    def test_label_reflects_only_active_trigger(self):
+        # When only nccl_exceeds_compute fires (overlap healthy), the label
+        # must not cite "overlap 100%" because that's a non-signal. Same the
+        # other way for low_overlap with compute dominant. Regression for
+        # Copilot review MED #5.
+        m = _healthy_manifest()
+        # Trigger only nccl_dominates: overlap healthy, nccl > compute
+        m["overlap"]["overlap_pct"] = 80
+        m["overlap"]["nccl_only_ms"] = 0
+        m["overlap"]["compute_only_ms"] = 100.0
+        m["nccl"]["total_nccl_ms"] = 500.0
+        f = next(f for f in _to_findings([m]) if f.id == "profile_comm_bound")
+        assert "NCCL dominates" in f.label
+        assert "overlap" not in f.label.lower()
+
+        # Trigger only low_overlap: overlap < 30 with nccl traffic, compute big
+        m = _healthy_manifest()
+        m["overlap"]["overlap_pct"] = 10
+        m["overlap"]["nccl_only_ms"] = 200.0
+        m["overlap"]["compute_only_ms"] = 1000.0
+        m["nccl"]["total_nccl_ms"] = 200.0
+        f = next(f for f in _to_findings([m]) if f.id == "profile_comm_bound")
+        assert "low overlap" in f.label
+        assert "dominates" not in f.label.lower()
+
+        # Both triggers: combined label
+        m = _healthy_manifest()
+        m["overlap"]["overlap_pct"] = 10
+        m["overlap"]["nccl_only_ms"] = 200.0
+        m["overlap"]["compute_only_ms"] = 100.0
+        m["nccl"]["total_nccl_ms"] = 500.0
+        f = next(f for f in _to_findings([m]) if f.id == "profile_comm_bound")
+        assert "overlap 10%" in f.label
+        assert "NCCL 500ms vs compute 100ms" in f.label
+
     def test_missing_overlap_pct_defaults_healthy(self):
         # Defensive: if overlap_breakdown errored out and overlap dict has
         # no overlap_pct key at all, default to 100 (healthy) so a missing
@@ -242,7 +277,7 @@ class TestInsufficientNvtxCoverage:
         m["nvtx"]["iteration_count"] = _MIN_ITERATIONS_FOR_NVTX_COVERAGE - 1
         findings = _to_findings([m])
         assert any(
-            f.id == "profile_insufficient_nvtx_coverage" for f in _to_findings([m])
+            f.id == "profile_insufficient_nvtx_coverage" for f in findings
         )
         f = next(f for f in findings if f.id == "profile_insufficient_nvtx_coverage")
         # The reason string should mention the iteration count, not "no NVTX".

--- a/tests/test_profile_health_manifest_findings.py
+++ b/tests/test_profile_health_manifest_findings.py
@@ -142,6 +142,32 @@ class TestCommBound:
         m["overlap"]["compute_only_ms"] = 500.0
         assert all(f.id != "profile_comm_bound" for f in _to_findings([m]))
 
+    def test_zero_overlap_with_nccl_fires(self):
+        # Regression: a Python ``x or 100`` default would mistake 0.0 for
+        # "missing" and silence comm_bound on full-serialization profiles.
+        # Caught during L40S validation on the uncompiled perf.sqlite,
+        # where overlap_pct=0.0 with nccl_only_ms=8654ms must trigger
+        # low_overlap.
+        m = _healthy_manifest()
+        m["overlap"]["overlap_pct"] = 0.0
+        m["overlap"]["nccl_only_ms"] = 500.0
+        findings = _to_findings([m])
+        f = next((f for f in findings if f.id == "profile_comm_bound"), None)
+        assert f is not None, "comm_bound must fire when overlap_pct is exactly 0.0"
+        assert "low_overlap" in f.provenance["triggers"]
+
+    def test_missing_overlap_pct_defaults_healthy(self):
+        # Defensive: if overlap_breakdown errored out and overlap dict has
+        # no overlap_pct key at all, default to 100 (healthy) so a missing
+        # measurement doesn't produce a false-positive low-overlap finding.
+        m = _healthy_manifest()
+        del m["overlap"]["overlap_pct"]
+        m["overlap"]["nccl_only_ms"] = 500.0
+        # nccl < compute so the dominance trigger also stays silent
+        m["overlap"]["compute_only_ms"] = 1000.0
+        m["nccl"]["total_nccl_ms"] = 500.0
+        assert all(f.id != "profile_comm_bound" for f in _to_findings([m]))
+
 
 class TestIdleDominant:
     def test_fires_above_threshold(self):

--- a/tests/test_profile_health_manifest_findings.py
+++ b/tests/test_profile_health_manifest_findings.py
@@ -1,0 +1,302 @@
+"""Tests for the structured roll-up findings emitted by profile_health_manifest.
+
+These exercise `_to_findings` directly against synthetic manifest dicts so
+the seven roll-up types can be unit-tested without an .sqlite profile.
+End-to-end validation against `rich7421/fastvideo-wan-l40s-nsys` lives in
+`pod-runbook-profile-health-manifest-findings.md`.
+"""
+
+from nsys_ai.skills.builtins.profile_health_manifest import (
+    _COMM_BOUND_OVERLAP_PCT,
+    _IDLE_DOMINANT_PCT,
+    _ITER_VARIANCE_SPIKE_RATIO,
+    _KERNEL_HOTSPOT_PCT,
+    _MIN_ITERATIONS_FOR_NVTX_COVERAGE,
+    _OVERHEAD_CONTAMINATED_PCT,
+    _SYNC_BOUND_DENSITY_PCT,
+    _to_findings,
+)
+from nsys_ai.skills.registry import get_skill
+
+
+def _healthy_manifest() -> dict:
+    """A manifest that should fire zero findings (all sub-thresholds healthy)."""
+    return {
+        "gpu": "NVIDIA L40S",
+        "profile_span_ms": 5000.0,
+        "top_kernels": [
+            {"name": "kernel_a", "total_ms": 100.0, "count": 10},
+            {"name": "kernel_b", "total_ms": 80.0, "count": 8},
+            {"name": "kernel_c", "total_ms": 70.0, "count": 7},
+        ],
+        "total_kernel_ms": 500.0,
+        "overlap": {
+            "compute_only_ms": 300.0,
+            "nccl_only_ms": 100.0,
+            "overlap_pct": 75,
+            "idle_ms": 50.0,
+        },
+        "nccl": {
+            "streams": 2,
+            "collectives": 50,
+            "dominant_type": "AllReduce",
+            "dominant_pct": 60,
+            "total_nccl_ms": 150.0,
+        },
+        "sync": {"sync_density_pct": 5.0, "total_sync_wall_ms": 50.0},
+        "idle": {"gap_count": 10, "idle_pct": 5.0, "total_idle_ms": 250.0},
+        "nvtx": {
+            "has_nvtx": True,
+            "iteration_count": 10,
+            "median_iter_ms": 100.0,
+            "slowest_iter_ms": 110.0,
+        },
+        "data_quality": {"overhead_pct_raw": 0.1, "overhead_pct": 0.1, "profiler_overhead_ms": 5.0},
+    }
+
+
+# ── Trust Contract: silence over weak claims ─────────────────────────
+
+
+class TestTrustContract:
+    def test_empty_rows_returns_empty(self):
+        assert _to_findings([]) == []
+
+    def test_healthy_manifest_fires_nothing(self):
+        # A profile inside every threshold should produce zero findings;
+        # any false-positive here means a threshold drifted.
+        assert _to_findings([_healthy_manifest()]) == []
+
+    def test_skill_registers_to_findings_fn(self):
+        skill = get_skill("profile_health_manifest")
+        assert skill is not None
+        assert skill.to_findings_fn is _to_findings
+
+
+# ── Individual roll-up findings ──────────────────────────────────────
+
+
+class TestOverheadContaminated:
+    def test_fires_above_threshold(self):
+        m = _healthy_manifest()
+        m["data_quality"]["overhead_pct_raw"] = _OVERHEAD_CONTAMINATED_PCT + 0.5
+        findings = _to_findings([m])
+        ids = [f.id for f in findings]
+        assert "profile_overhead_contaminated" in ids
+        f = next(f for f in findings if f.id == "profile_overhead_contaminated")
+        assert f.severity == "critical"
+        assert f.category == "profile_quality"
+        assert f.type == "highlight"
+        assert f.start_ns == 0  # no time anchor
+        assert f.end_ns is None
+
+    def test_silent_at_threshold(self):
+        m = _healthy_manifest()
+        m["data_quality"]["overhead_pct_raw"] = _OVERHEAD_CONTAMINATED_PCT
+        assert all(f.id != "profile_overhead_contaminated" for f in _to_findings([m]))
+
+
+class TestSyncBound:
+    def test_fires_above_threshold(self):
+        m = _healthy_manifest()
+        m["sync"]["sync_density_pct"] = _SYNC_BOUND_DENSITY_PCT + 5.0
+        findings = _to_findings([m])
+        ids = [f.id for f in findings]
+        assert "profile_sync_bound" in ids
+        f = next(f for f in findings if f.id == "profile_sync_bound")
+        assert f.category == "sync"
+        assert f.evidence[0].values["sync_density_pct"] == _SYNC_BOUND_DENSITY_PCT + 5.0
+
+    def test_silent_at_threshold(self):
+        m = _healthy_manifest()
+        m["sync"]["sync_density_pct"] = _SYNC_BOUND_DENSITY_PCT
+        assert all(f.id != "profile_sync_bound" for f in _to_findings([m]))
+
+
+class TestCommBound:
+    def test_fires_on_low_overlap(self):
+        m = _healthy_manifest()
+        m["overlap"]["overlap_pct"] = _COMM_BOUND_OVERLAP_PCT - 5
+        m["overlap"]["nccl_only_ms"] = 200.0
+        findings = _to_findings([m])
+        f = next((f for f in findings if f.id == "profile_comm_bound"), None)
+        assert f is not None
+        assert f.category == "communication"
+        assert "low_overlap" in f.provenance["triggers"]
+
+    def test_fires_on_nccl_exceeds_compute(self):
+        m = _healthy_manifest()
+        m["overlap"]["compute_only_ms"] = 100.0
+        m["nccl"]["total_nccl_ms"] = 500.0
+        findings = _to_findings([m])
+        f = next((f for f in findings if f.id == "profile_comm_bound"), None)
+        assert f is not None
+        assert "nccl_exceeds_compute" in f.provenance["triggers"]
+
+    def test_low_overlap_with_no_nccl_does_not_fire(self):
+        # Single-rank profile: overlap_pct is meaningless when nccl_only_ms=0.
+        m = _healthy_manifest()
+        m["overlap"]["overlap_pct"] = 0
+        m["overlap"]["nccl_only_ms"] = 0
+        m["nccl"]["total_nccl_ms"] = 0
+        m["overlap"]["compute_only_ms"] = 500.0
+        assert all(f.id != "profile_comm_bound" for f in _to_findings([m]))
+
+
+class TestIdleDominant:
+    def test_fires_above_threshold(self):
+        m = _healthy_manifest()
+        m["idle"]["idle_pct"] = _IDLE_DOMINANT_PCT + 5.0
+        findings = _to_findings([m])
+        f = next((f for f in findings if f.id == "profile_idle_dominant"), None)
+        assert f is not None
+        assert f.category == "idle"
+
+
+class TestKernelHotspot:
+    def test_fires_when_top_dominates(self):
+        m = _healthy_manifest()
+        # One kernel = 70% of total kernel time
+        m["top_kernels"] = [{"name": "fa_fwd", "total_ms": 700.0, "count": 100}]
+        m["total_kernel_ms"] = 1000.0
+        findings = _to_findings([m])
+        f = next((f for f in findings if f.id == "profile_kernel_hotspot"), None)
+        assert f is not None
+        assert f.category == "compute"
+        assert f.evidence[0].values["kernel_name"] == "fa_fwd"
+        assert f.evidence[0].values["pct_of_total_kernel_ms"] == 70.0
+
+    def test_silent_on_balanced_workload(self):
+        m = _healthy_manifest()
+        # Top kernel = exactly threshold% → should NOT fire (strict >)
+        m["top_kernels"] = [{"name": "k", "total_ms": _KERNEL_HOTSPOT_PCT, "count": 1}]
+        m["total_kernel_ms"] = 100.0
+        assert all(f.id != "profile_kernel_hotspot" for f in _to_findings([m]))
+
+    def test_silent_when_total_zero(self):
+        # Defensive: aggregate_kernels could return error rows.
+        m = _healthy_manifest()
+        m["total_kernel_ms"] = 0
+        assert all(f.id != "profile_kernel_hotspot" for f in _to_findings([m]))
+
+
+class TestIterationVarianceSpike:
+    def test_fires_on_spike(self):
+        m = _healthy_manifest()
+        m["nvtx"]["median_iter_ms"] = 100.0
+        m["nvtx"]["slowest_iter_ms"] = 100.0 * (_ITER_VARIANCE_SPIKE_RATIO + 0.5)
+        findings = _to_findings([m])
+        f = next((f for f in findings if f.id == "profile_iteration_variance_spike"), None)
+        assert f is not None
+        assert f.category == "nvtx"
+        assert f.evidence[0].values["ratio"] >= _ITER_VARIANCE_SPIKE_RATIO
+
+    def test_silent_with_zero_median(self):
+        # Defensive: missing iteration_timing → median 0 → no division.
+        m = _healthy_manifest()
+        m["nvtx"]["median_iter_ms"] = 0
+        m["nvtx"]["slowest_iter_ms"] = 100.0
+        assert all(
+            f.id != "profile_iteration_variance_spike" for f in _to_findings([m])
+        )
+
+
+class TestInsufficientNvtxCoverage:
+    def test_fires_without_nvtx(self):
+        m = _healthy_manifest()
+        m["nvtx"] = {"has_nvtx": False}
+        findings = _to_findings([m])
+        f = next((f for f in findings if f.id == "profile_insufficient_nvtx_coverage"), None)
+        assert f is not None
+        assert f.severity == "info"
+        assert f.category == "profile_quality"
+
+    def test_fires_below_min_iterations(self):
+        m = _healthy_manifest()
+        m["nvtx"]["iteration_count"] = _MIN_ITERATIONS_FOR_NVTX_COVERAGE - 1
+        findings = _to_findings([m])
+        assert any(
+            f.id == "profile_insufficient_nvtx_coverage" for f in _to_findings([m])
+        )
+        f = next(f for f in findings if f.id == "profile_insufficient_nvtx_coverage")
+        # The reason string should mention the iteration count, not "no NVTX".
+        assert "iteration" in f.label.lower()
+
+    def test_silent_at_min_iterations(self):
+        m = _healthy_manifest()
+        m["nvtx"]["iteration_count"] = _MIN_ITERATIONS_FOR_NVTX_COVERAGE
+        m["nvtx"]["has_nvtx"] = True
+        assert all(
+            f.id != "profile_insufficient_nvtx_coverage" for f in _to_findings([m])
+        )
+
+
+# ── Cross-finding invariants ─────────────────────────────────────────
+
+
+class TestStructuralInvariants:
+    def test_all_findings_have_required_envelope(self):
+        # Trigger every finding type at once.
+        m = _healthy_manifest()
+        m["data_quality"]["overhead_pct_raw"] = 5.0
+        m["sync"]["sync_density_pct"] = 30.0
+        m["overlap"]["overlap_pct"] = 10
+        m["overlap"]["nccl_only_ms"] = 200.0
+        m["idle"]["idle_pct"] = 25.0
+        m["top_kernels"] = [{"name": "k", "total_ms": 900.0, "count": 1}]
+        m["total_kernel_ms"] = 1000.0
+        m["nvtx"]["median_iter_ms"] = 100.0
+        m["nvtx"]["slowest_iter_ms"] = 200.0
+        m["nvtx"]["has_nvtx"] = False  # also trip coverage
+        findings = _to_findings([m])
+        # 7 distinct types possible; all should fire (or all but one if
+        # has_nvtx=False zeros out the iteration spike inputs — but we
+        # set median/slowest on the same dict so it still fires).
+        ids = {f.id for f in findings}
+        expected = {
+            "profile_overhead_contaminated",
+            "profile_sync_bound",
+            "profile_comm_bound",
+            "profile_idle_dominant",
+            "profile_kernel_hotspot",
+            "profile_iteration_variance_spike",
+            "profile_insufficient_nvtx_coverage",
+        }
+        assert ids == expected, f"missing: {expected - ids}, extra: {ids - expected}"
+
+        for f in findings:
+            # Envelope invariants every roll-up must satisfy.
+            assert f.type == "highlight"
+            assert f.start_ns == 0
+            assert f.end_ns is None
+            assert f.id and f.id.startswith("profile_")
+            assert f.category in {
+                "compute",
+                "communication",
+                "idle",
+                "sync",
+                "nvtx",
+                "profile_quality",
+            }
+            assert f.severity in {"critical", "warning", "info"}
+            assert f.evidence and len(f.evidence) == 1
+            assert f.selection is not None
+            assert f.selection.id == f"sel_{f.id}"
+            assert f.evidence[0].selection_id == f.selection.id
+            assert f.evidence[0].source_skill == "profile_health_manifest"
+            assert f.provenance["skill"] == "profile_health_manifest"
+            assert f.explanation
+            assert f.suggested_actions and len(f.suggested_actions) >= 1
+
+    def test_findings_serialize_to_dict(self):
+        # Ensures the Finding/EvidenceRow/TraceSelection round-trip cleanly
+        # for downstream JSON consumption (the agent + diff CLI consume to_dict()).
+        m = _healthy_manifest()
+        m["data_quality"]["overhead_pct_raw"] = 5.0
+        findings = _to_findings([m])
+        for f in findings:
+            d = f.to_dict()
+            assert "id" in d
+            assert "evidence" in d
+            assert "selection" in d
+            assert "suggested_actions" in d


### PR DESCRIPTION
## Summary

Adds the v0.1 structured-findings layer to `profile_health_manifest`, completing the Focus Area B set alongside `top_kernels` (#153), `nccl_breakdown` (#148), and `kernel_launch_overhead` (#149). Emits seven roll-up findings characterizing the profile as a whole:

| Finding | Category | Severity | Trigger (from manifest dict) |
|---|---|---|---|
| `profile_overhead_contaminated` | profile_quality | critical | `data_quality.overhead_pct_raw > 1.0` |
| `profile_sync_bound` | sync | warning | `sync.sync_density_pct > 20.0` |
| `profile_comm_bound` | communication | warning | `overlap_pct < 30` AND `nccl_only_ms > 0`, OR `total_nccl_ms > compute_only_ms` |
| `profile_idle_dominant` | idle | warning | `idle.idle_pct > 15.0` |
| `profile_kernel_hotspot` | compute | warning | `top_kernel.ms / total_kernel_ms > 60%` |
| `profile_iteration_variance_spike` | nvtx | warning | `slowest_iter_ms > 1.5 × median_iter_ms` |
| `profile_insufficient_nvtx_coverage` | profile_quality | info | `!has_nvtx OR iteration_count < 3` |

All seven derive purely from the manifest dict that `_execute` already assembles — no new sub-skill calls and no coupling to sister skills' `_to_findings` status (so this merges independently of #148 / #149).

## Backward compatibility

- `_execute` output: byte-identical (no new keys, no removed keys).
- `_format` text output: byte-identical (uses the same `_infer_bottleneck` single-string for `suspected_bottleneck`).
- `_infer_bottleneck` priority order: unchanged (sync → overhead → overlap → idle → hotspot → nccl-dominance → variance). The function is now sourced from module-level threshold constants shared with `_to_findings`, mirroring the constants convention from #149.

Note: `_infer_bottleneck` returns a single string ranked by user-facing action priority, while `_to_findings` returns every finding that fires ranked by data-trust impact (so `overhead_contaminated=critical` even when `_infer_bottleneck` picks `sync_bound`; overhead invalidates the sync number, so they serve different purposes).

EvidenceBuilder gains one pipeline entry (`profile_health` → `profile_health_manifest`) so the CLI `evidence build` path surfaces the new findings.

## Validation — L40S Wan2.1 profiles (Kuan's `rich7421/fastvideo-wan-l40s-nsys`)

Analysis pod: AMD EPYC 7763 / 116 GiB RAM cgroup cap / RTX 3090 (unused — we analyze the .sqlite, not run GPU workloads). Both `.sqlite` profiles are 1.8 – 2.1 GB, 20 s capture window, originally captured on L40S.

| Finding | `perf_compile.sqlite` | `perf.sqlite` (uncompiled) | Direction |
|---|---|---|---|
| overhead_contaminated | **28.6%** (critical) | **1.6%** (critical) | Compile capture adds CUPTI events |
| sync_bound | **37%** | **89.7%** | CUDAGraph hides most eager-mode sync |
| comm_bound | **fires** (`nccl_exceeds_compute`: nccl 10109ms > compute 9396ms) | **fires** (`low_overlap`: overlap=0%, nccl 8654ms) | Both triggers exercised on real profiles |
| idle_dominant | silent | silent | Idle <15% in both |
| kernel_hotspot | silent | silent | No single kernel >60% |
| iteration_variance_spike | **fires** (slowest=1280× median; first-iter recompile) | silent | Recompile spike absent in uncompiled — exactly as predicted |
| insufficient_nvtx_coverage | silent | silent | Kuan annotates 16 iterations |

A real bug was caught and fixed during this validation: the `float(overlap.get("overlap_pct", 100) or 100)` idiom silently treated `overlap_pct=0.0` (a legitimate full-serialization signal) as "missing" and replaced it with 100. The uncompiled profile's `overlap_pct=0.0, nccl_only_ms=8654ms` should have tripped the low_overlap branch but was masked. Fix in commit 08e1884 with two regression tests.

`_infer_bottleneck` agreement on both profiles:
- compiled: `"High CPU Synchronization Blocking (37.0% of span)"`
- uncompiled: `"High CPU Synchronization Blocking (89.7% of span)"`

## Tests

- 23 new tests in `tests/test_profile_health_manifest_findings.py` covering: trust contract (silence on healthy / empty input), per-finding fire/silent thresholds, structural envelope invariants, `to_dict()` round-trip, and two regression tests for the overlap_pct=0.0 edge case.
- Existing 36-test `test_profile_health_manifest.py` suite passes unchanged (verifies backward compat).
- Full suite: 881 passed, 20 pre-existing TUI async failures unrelated to this change.
- `ruff check` clean.