### PR TITLE
fix(profile_health): silence impossible profile-overhead findings

### DIFF
--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -66,6 +66,14 @@ _KERNEL_HOTSPOT_PCT = 60.0
 _ITER_VARIANCE_SPIKE_RATIO = 1.5
 _MIN_ITERATIONS_FOR_NVTX_COVERAGE = 3
 
+# Upper sanity bound for the profile-overhead finding. ``overhead_pct``
+# greater than 100% is mathematically impossible (the numerator cannot
+# exceed the denominator); when it appears, the value is a symptom of
+# an upstream scope mismatch (numerator and denominator computed over
+# different time windows) rather than a real profiler-overhead problem.
+# Silence the finding instead of surfacing the nonsense value.
+_OVERHEAD_PCT_SANITY_MAX = 100.0
+
 
 def _auto_trim_enabled() -> bool:
     """Read NSYS_AI_MANIFEST_AUTO_TRIM with 0/false/no/off → disabled."""
@@ -737,7 +745,11 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     # ── 1. Profiler overhead contamination ─────────────────────────
     dq = m.get("data_quality", {}) or {}
     overhead_pct = float(dq.get("overhead_pct_raw", dq.get("overhead_pct", 0)) or 0)
-    if overhead_pct > _OVERHEAD_CONTAMINATED_PCT:
+    # Silence rather than emit a finding when the ratio is impossible
+    # (``overhead_pct > 100``); that value can only come from a scope
+    # mismatch upstream, and surfacing it as a ``critical`` finding does
+    # more harm than good.
+    if _OVERHEAD_CONTAMINATED_PCT < overhead_pct <= _OVERHEAD_PCT_SANITY_MAX:
         overhead_ms = float(dq.get("profiler_overhead_ms", 0) or 0)
         _emit(
             finding_id="profile_overhead_contaminated",

--- a/tests/test_profile_health_manifest_findings.py
+++ b/tests/test_profile_health_manifest_findings.py
@@ -13,6 +13,7 @@ from nsys_ai.skills.builtins.profile_health_manifest import (
     _KERNEL_HOTSPOT_PCT,
     _MIN_ITERATIONS_FOR_NVTX_COVERAGE,
     _OVERHEAD_CONTAMINATED_PCT,
+    _OVERHEAD_PCT_SANITY_MAX,
     _SYNC_BOUND_DENSITY_PCT,
     _to_findings,
 )
@@ -94,6 +95,31 @@ class TestOverheadContaminated:
         m = _healthy_manifest()
         m["data_quality"]["overhead_pct_raw"] = _OVERHEAD_CONTAMINATED_PCT
         assert all(f.id != "profile_overhead_contaminated" for f in _to_findings([m]))
+
+    def test_silent_when_pct_exceeds_sanity_max(self):
+        # An overhead_pct above 100% can only come from a scope mismatch
+        # upstream (numerator and denominator computed over different
+        # windows). Observed in the wild as a 3.5M% "critical" claim on a
+        # single-iteration capture — silence over nonsense.
+        m = _healthy_manifest()
+        m["data_quality"]["overhead_pct_raw"] = _OVERHEAD_PCT_SANITY_MAX + 1.0
+        assert all(f.id != "profile_overhead_contaminated" for f in _to_findings([m]))
+
+    def test_silent_when_pct_extreme(self):
+        # Same guard, but at the actual value observed in the original
+        # report — make sure the absurd-large case never sneaks through.
+        m = _healthy_manifest()
+        m["data_quality"]["overhead_pct_raw"] = 3_583_749.4
+        assert all(f.id != "profile_overhead_contaminated" for f in _to_findings([m]))
+
+    def test_fires_at_sanity_max_upper_bound(self):
+        # The guard uses <= so an overhead_pct of exactly 100% — the
+        # mathematical upper bound — is still allowed through. This pins
+        # the inclusive boundary so a future refactor can't silently
+        # drop it.
+        m = _healthy_manifest()
+        m["data_quality"]["overhead_pct_raw"] = _OVERHEAD_PCT_SANITY_MAX
+        assert any(f.id == "profile_overhead_contaminated" for f in _to_findings([m]))
 
 
 class TestSyncBound:


### PR DESCRIPTION
## Summary

Silence the `profile_overhead_contaminated` finding when `overhead_pct` exceeds the mathematical upper bound (100%).

The finding currently emits a `critical`-severity claim for any value above 1%, but the raw value can run far above 100% — observed at **3,583,749%** on a single-iteration H100 capture (`perf_h100_sp1.sqlite`) — because the upstream `overhead_ns` is computed over the full profile range while `profile_span_ns` is possibly auto-trimmed, so the numerator and denominator use different time windows.

Surfacing the literal value as a `critical` finding is worse than not firing at all:

- it makes the analyzer look broken to users,
- it masks the legitimate findings on the same profile,
- it provides no actionable signal.

The underlying scope mismatch upstream is a separate concern; this change is a **finding-side guard only**.

## Changes

- `src/nsys_ai/skills/builtins/profile_health_manifest.py`
  - Add `_OVERHEAD_PCT_SANITY_MAX = 100.0` constant with a docstring comment explaining why values above this are impossible.
  - In `_to_findings` Finding , replace `overhead_pct > _OVERHEAD_CONTAMINATED_PCT` with `_OVERHEAD_CONTAMINATED_PCT < overhead_pct <= _OVERHEAD_PCT_SANITY_MAX` so impossible ratios are silenced rather than emitted as `critical` findings.
- `tests/test_profile_health_manifest_findings.py`
  - 3 regression tests under `TestOverheadContaminated`:
    - `test_silent_when_pct_exceeds_sanity_max` — 101% silenced
    - `test_silent_when_pct_extreme` — the exact observed 3,583,749.4% silenced
    - `test_fires_at_sanity_max_upper_bound` — 100% (the inclusive boundary) still fires

## Backward compatibility

Yes. The new guard only suppresses values above 100%, which are physically impossible. Every previously-emitted finding (`overhead_pct` in `(1.0, 100.0]`) still fires identically. `_execute` row output, `_format` text output, and `_infer_bottleneck` priority order are all unchanged.

## Test plan

- [x] `pytest tests/test_profile_health_manifest_findings.py tests/test_profile_health_manifest.py -v` — 63 passed (60 baseline + 3 new)
- [x] `pytest tests/ -q` — 925 passed, 146 skipped, 0 failed
- [x] `ruff check src/ tests/` — clean
- [x] Manual verification on `perf_h100_sp1.sqlite` (the originating profile): the bogus `profile_overhead_contaminated (3,583,749.4%)` finding is no longer emitted; the legitimate `profile_insufficient_nvtx_coverage` info finding still appears as expected.
