### PR TITLE
fix(profile_health): align overhead_ns scope with auto-trim window

### DIFF
--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -33,6 +33,59 @@ def _compute_interval_union(intervals: list[tuple[int, int]]) -> int:
     return total_ns
 
 
+def compute_profiler_overhead_ns(
+    conn,
+    *,
+    trim_start_ns: int | None = None,
+    trim_end_ns: int | None = None,
+) -> int:
+    """Compute the non-overlapping union of profiler-overhead intervals.
+
+    Probes both ``profiler_overhead`` and ``PROFILER_OVERHEAD`` (the two
+    table names Nsight uses across export versions). When ``trim_start_ns``
+    / ``trim_end_ns`` are supplied, intervals are clipped to that window
+    before the union so the result is bounded by the requested scope.
+    Returns 0 if no overhead table exists or no intervals fall inside
+    the window.
+
+    Called both by :meth:`Skill.execute` (to inject ``overhead_ns`` for
+    sub-skills) and by callers that need to realign the value to a
+    later-determined analysis window.
+    """
+    from ..connection import wrap_connection
+
+    adapter = wrap_connection(conn)
+    for oh_table in ("profiler_overhead", "PROFILER_OVERHEAD"):
+        try:
+            conds = []
+            params: list[object] = []
+            if trim_start_ns is not None:
+                conds.append("[end] >= ?")
+                params.append(int(trim_start_ns))
+            if trim_end_ns is not None:
+                conds.append("start <= ?")
+                params.append(int(trim_end_ns))
+            where_clause = "WHERE " + " AND ".join(conds) if conds else ""
+            cur = adapter.execute(
+                f"SELECT start, [end] FROM {oh_table} {where_clause}",
+                params,
+            )
+            rows = cur.fetchall()
+            intervals = []
+            for row in rows:
+                s, e = int(row[0]), int(row[1])
+                if trim_start_ns is not None:
+                    s = max(s, int(trim_start_ns))
+                if trim_end_ns is not None:
+                    e = min(e, int(trim_end_ns))
+                if s < e:
+                    intervals.append((s, e))
+            return _compute_interval_union(intervals)
+        except DB_ERRORS:
+            continue
+    return 0
+
+
 # Track connections that have already been indexed to avoid repeated work.
 _indexed_connections: set[int] = set()
 
@@ -138,45 +191,17 @@ class Skill:
             # No trim requested — replace with empty string
             resolved["trim_clause"] = ""
 
-        # Compute profiler overhead union duration dynamically.
-        # Probe the known profiler overhead table-name variants directly and
-        # treat DB_ERRORS as "table not present" so we can fall back cleanly.
+        # Compute profiler overhead union duration dynamically. Delegates
+        # to the shared ``compute_profiler_overhead_ns`` helper so callers
+        # that need to realign overhead to a later-determined window
+        # (e.g. ``profile_health_manifest`` after auto-trim) can reuse the
+        # same logic without copy-pasting the table-probe and clipping.
         if "overhead_ns" not in resolved:
-            overhead_ns = 0
-            for oh_table in ("profiler_overhead", "PROFILER_OVERHEAD"):
-                try:
-                    conds = []
-                    params: list[object] = []
-                    if trim_start is not None:
-                        conds.append("[end] >= ?")
-                        params.append(int(trim_start))
-                    if trim_end is not None:
-                        conds.append("start <= ?")
-                        params.append(int(trim_end))
-
-                    where_clause = "WHERE " + " AND ".join(conds) if conds else ""
-                    cur = adapter.execute(
-                        f"SELECT start, [end] FROM {oh_table} {where_clause}",
-                        params,
-                    )
-                    rows = cur.fetchall()
-                    if rows:
-                        intervals = []
-                        for row in rows:
-                            s, e = int(row[0]), int(row[1])
-                            if trim_start is not None:
-                                s = max(s, int(trim_start))
-                            if trim_end is not None:
-                                e = min(e, int(trim_end))
-                            if s < e:
-                                intervals.append((s, e))
-                        overhead_ns = _compute_interval_union(intervals)
-                    break  # Table found and queried successfully
-                except DB_ERRORS:
-                    continue  # Table doesn't exist under this name, try next
+            overhead_ns = compute_profiler_overhead_ns(
+                conn, trim_start_ns=trim_start, trim_end_ns=trim_end
+            )
             if overhead_ns == 0:
                 _log.debug("No profiler overhead data found (table absent or empty)")
-
             resolved["overhead_ns"] = overhead_ns
 
         # Python-level skill: delegate to execute_fn with resolved params.

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -47,6 +47,13 @@ _AUTO_TRIM_PROFILE_SPAN_THRESHOLD_NS = 120 * 10**9   # 120 s
 # to capture at least a few steady-state iterations of any DiT / transformer
 # block, (b) small enough that a 15 M-row NVTX IEJoin completes in seconds.
 _AUTO_TRIM_TARGET_WINDOW_NS = 20 * 10**9             # 20 s
+# Minimum width for an NVTX-derived window to be accepted. Narrower picks
+# typically come from per-op markers (e.g. a 100-µs ``aten::*`` range that
+# happens to repeat ≥ 3 times) rather than a real iteration boundary, and
+# using such a pick collapses sub-skill ratios — overhead-vs-span, NCCL-
+# vs-compute — to meaningless values. Below this floor we fall through to
+# the middle-of-span fallback instead.
+_AUTO_TRIM_MIN_WINDOW_NS = 100 * 10**6               # 100 ms
 
 # Values that turn NSYS_AI_MANIFEST_AUTO_TRIM off. Matches the parsing
 # of NSYS_AI_DEFER_NVTX_KERNEL_MAP in parquet_cache.py so users get
@@ -224,13 +231,20 @@ def _auto_select_trim_window(prof) -> tuple[int, int] | None:
         chosen = rows[idx]
         c_start = int(chosen["start"])
         c_end = int(chosen["end"])
-        # Trim very wide stage ranges down to a 20 s slice in their middle
-        # so sub-skills still get steady-state behaviour but don't grind.
-        if c_end - c_start > _AUTO_TRIM_TARGET_WINDOW_NS:
-            mid = (c_start + c_end) // 2
-            half = _AUTO_TRIM_TARGET_WINDOW_NS // 2
-            return (mid - half, mid + half)
-        return (c_start, c_end)
+        # Accept the NVTX-derived pick only if it's at least as wide as
+        # ``_AUTO_TRIM_MIN_WINDOW_NS``. A sub-100ms pick is almost always
+        # a per-op marker rather than an iteration boundary, and using
+        # such a window makes downstream ratios (overhead-vs-span,
+        # NCCL-vs-compute) statistically empty.
+        if c_end - c_start >= _AUTO_TRIM_MIN_WINDOW_NS:
+            # Trim very wide stage ranges down to a 20 s slice in their middle
+            # so sub-skills still get steady-state behaviour but don't grind.
+            if c_end - c_start > _AUTO_TRIM_TARGET_WINDOW_NS:
+                mid = (c_start + c_end) // 2
+                half = _AUTO_TRIM_TARGET_WINDOW_NS // 2
+                return (mid - half, mid + half)
+            return (c_start, c_end)
+        # else: fall through to the middle-of-span fallback below.
 
     # No usable NVTX iteration marker — take the middle 20 s of the
     # profile so we at least avoid head-of-trace JIT and tail teardown.
@@ -332,6 +346,21 @@ def _execute(conn, **kwargs):
     )
     profile_span_ms = round(profile_span_ns / 1e6, 1) if profile_span_ns > 0 else 0
 
+    # When auto-trim narrows the analysis window, the ``overhead_ns`` value
+    # injected by ``Skill.execute`` was computed against the full profile
+    # range — using it as the numerator over ``profile_span_ns`` (the
+    # narrowed denominator) produces a scope-mismatched ratio (observed
+    # up to 3.5M% on a single-iteration capture). Re-query overhead
+    # clipped to the effective window so numerator and denominator share
+    # the same scope.
+    if auto_trim_meta is not None and profile_span_ns > 0:
+        from ..base import compute_profiler_overhead_ns
+
+        overhead_ns = compute_profiler_overhead_ns(
+            conn,
+            trim_start_ns=effective_start_ns,
+            trim_end_ns=effective_end_ns,
+        )
     overhead_ms = round(overhead_ns / 1e6, 1)
     overhead_pct_raw = (overhead_ns / profile_span_ns * 100) if profile_span_ns > 0 else 0
     overhead_pct = round(overhead_pct_raw, 1)

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -6,6 +6,7 @@ Uses the minimal_nsys_conn and duckdb_conn fixtures from conftest.py.
 import pytest
 
 from nsys_ai.skills.builtins.profile_health_manifest import (
+    _AUTO_TRIM_MIN_WINDOW_NS,
     _AUTO_TRIM_TARGET_WINDOW_NS,
     _auto_select_trim_window,
 )
@@ -178,6 +179,44 @@ class TestManifestAutoTrim:
         # Span midpoint is 200 s; window is [190 s, 210 s]
         assert lo == 200 * 10**9 - _AUTO_TRIM_TARGET_WINDOW_NS // 2
         assert hi == 200 * 10**9 + _AUTO_TRIM_TARGET_WINDOW_NS // 2
+
+    def test_narrow_nvtx_iteration_falls_back_to_middle(self):
+        """Sub-floor NVTX picks (e.g. per-op markers) must not produce a
+        microscopic trim window — downstream ratios would be undefined.
+
+        Pre-fix behaviour: a 9 µs window was selected on a single-iteration
+        H100 capture, which made ``overhead_pct`` blow up to ~3.5 M %.
+        Post-fix: anything under ``_AUTO_TRIM_MIN_WINDOW_NS`` is rejected
+        and the function falls through to the middle-of-span fallback.
+        """
+        narrow = _AUTO_TRIM_MIN_WINDOW_NS // 100  # well below the floor
+        nvtx_rows = [
+            ("op::tiny_marker", 100_000_000_000, 100_000_000_000 + narrow),
+            ("op::tiny_marker", 200_000_000_000, 200_000_000_000 + narrow),
+            ("op::tiny_marker", 300_000_000_000, 300_000_000_000 + narrow),
+        ]
+        prof = self._make_profile_stub(span_ns=400 * 10**9, nvtx_rows=nvtx_rows)
+        picked = _auto_select_trim_window(prof)
+        assert picked is not None
+        lo, hi = picked
+        # Middle-of-span fallback, not the narrow NVTX pick
+        assert hi - lo == _AUTO_TRIM_TARGET_WINDOW_NS
+        assert lo == 200 * 10**9 - _AUTO_TRIM_TARGET_WINDOW_NS // 2
+
+    def test_iteration_exactly_at_min_width_accepted(self):
+        """An iteration at exactly ``_AUTO_TRIM_MIN_WINDOW_NS`` wide is
+        accepted (inclusive boundary). Pins the floor so a future refactor
+        cannot silently turn it into a strict ``>``.
+        """
+        at_floor = _AUTO_TRIM_MIN_WINDOW_NS
+        nvtx_rows = [
+            ("stage::Step", 100_000_000_000, 100_000_000_000 + at_floor),
+            ("stage::Step", 200_000_000_000, 200_000_000_000 + at_floor),
+            ("stage::Step", 300_000_000_000, 300_000_000_000 + at_floor),
+        ]
+        prof = self._make_profile_stub(span_ns=400 * 10**9, nvtx_rows=nvtx_rows)
+        picked = _auto_select_trim_window(prof)
+        assert picked == (200_000_000_000, 200_000_000_000 + at_floor)
 
     def test_degenerate_time_range_returns_none(self):
         """None / inverted / zero-width time_range → no auto-trim."""
@@ -389,3 +428,149 @@ class TestMaxRowsTruncation:
         assert truncated[0]["error"] == "Something went wrong"
         # Error payloads should not be marked as truncated.
         assert not truncated[0].get("_truncated")
+
+
+# ── compute_profiler_overhead_ns helper ──────────────────────────
+
+
+class TestComputeProfilerOverheadNs:
+    """Direct tests for the helper that computes overhead union duration.
+
+    The helper is shared between ``Skill.execute`` (injects ``overhead_ns``
+    for sub-skills) and ``profile_health_manifest._execute`` (re-aligns
+    overhead to the effective window after auto-trim).
+    """
+
+    def _make_conn_with_overhead(self, intervals: list[tuple[int, int]]):
+        """Build an in-memory sqlite with a profiler_overhead table only."""
+        import sqlite3
+
+        conn = sqlite3.connect(":memory:")
+        conn.execute(
+            'CREATE TABLE profiler_overhead (start BIGINT NOT NULL, "end" BIGINT NOT NULL)'
+        )
+        conn.executemany(
+            'INSERT INTO profiler_overhead (start, "end") VALUES (?, ?)',
+            intervals,
+        )
+        return conn
+
+    def test_returns_zero_when_table_absent(self, minimal_nsys_conn):
+        """Profiles without profiler_overhead table → 0 (probe falls through)."""
+        from nsys_ai.skills.base import compute_profiler_overhead_ns
+
+        assert compute_profiler_overhead_ns(minimal_nsys_conn) == 0
+
+    def test_returns_union_without_window(self):
+        """Three disjoint intervals → sum of widths."""
+        from nsys_ai.skills.base import compute_profiler_overhead_ns
+
+        conn = self._make_conn_with_overhead(
+            [(0, 100), (200, 350), (500, 600)]
+        )
+        assert compute_profiler_overhead_ns(conn) == 100 + 150 + 100
+
+    def test_unions_overlapping_intervals(self):
+        """Overlapping intervals collapse — the result is the union, not the sum."""
+        from nsys_ai.skills.base import compute_profiler_overhead_ns
+
+        conn = self._make_conn_with_overhead([(0, 200), (100, 300), (250, 400)])
+        # [0,200] ∪ [100,300] ∪ [250,400] = [0,400] = 400 ns
+        assert compute_profiler_overhead_ns(conn) == 400
+
+    def test_clips_intervals_to_window(self):
+        """Intervals straddling the window are clipped; outside-window dropped.
+
+        This is the scenario PR-side realignment depends on: when manifest
+        auto-trim narrows the window, the helper must report only the
+        overhead falling inside that window.
+        """
+        from nsys_ai.skills.base import compute_profiler_overhead_ns
+
+        # Three intervals: one entirely before the window, one straddling
+        # the start edge, one entirely inside.
+        conn = self._make_conn_with_overhead(
+            [(0, 100), (450, 600), (700, 900)]
+        )
+        # Window [500, 800]:
+        # - (0,100)   → outside, dropped
+        # - (450,600) → clipped to (500,600) = 100 ns
+        # - (700,900) → clipped to (700,800) = 100 ns
+        # Union = 200 ns
+        result = compute_profiler_overhead_ns(
+            conn, trim_start_ns=500, trim_end_ns=800
+        )
+        assert result == 200
+
+    def test_window_with_no_overlap_returns_zero(self):
+        """All intervals outside the window → 0."""
+        from nsys_ai.skills.base import compute_profiler_overhead_ns
+
+        conn = self._make_conn_with_overhead([(0, 100), (200, 300)])
+        assert compute_profiler_overhead_ns(
+            conn, trim_start_ns=1000, trim_end_ns=2000
+        ) == 0
+
+
+# ── Overhead realignment on auto-trim ────────────────────────────
+
+
+class TestManifestOverheadRealignment:
+    """When auto-trim narrows the analysis window, the manifest must
+    re-query ``overhead_ns`` aligned with that window so the resulting
+    ratio is well-defined.
+
+    Pre-fix behaviour: ``Skill.execute`` injected ``overhead_ns``
+    computed over the full profile, ``_execute`` then narrowed the
+    denominator via auto-trim, and the ratio could blow up to millions
+    of percent. Post-fix: when ``auto_trim_meta`` is set, ``_execute``
+    re-queries overhead clipped to ``effective_start_ns``/``effective_end_ns``.
+    """
+
+    def test_auto_trim_realigns_overhead_to_effective_window(
+        self, monkeypatch, minimal_nsys_conn, manifest_skill
+    ):
+        """Monkey-patch the helper to record what window it's called with
+        and assert it matches the auto-trim-selected window."""
+        from nsys_ai.skills.builtins import profile_health_manifest as phm
+
+        fake_t0 = 1_000_000_000_000
+        fake_t1 = 1_020_000_000_000  # 20 s window
+
+        # Force auto-trim to a known window by stubbing the selector.
+        monkeypatch.setattr(
+            phm, "_auto_select_trim_window", lambda prof: (fake_t0, fake_t1)
+        )
+
+        calls: list[tuple[int | None, int | None]] = []
+
+        def fake_compute(conn, *, trim_start_ns=None, trim_end_ns=None):
+            calls.append((trim_start_ns, trim_end_ns))
+            # Return a small, sane value so the rest of the manifest
+            # doesn't choke on the synthesized overhead.
+            return 100  # 100 ns of overhead inside the window
+
+        # Replace the helper *via the base module* — the manifest imports
+        # it lazily inside ``_execute``, so we have to patch the source.
+        from nsys_ai.skills import base as base_module
+
+        monkeypatch.setattr(base_module, "compute_profiler_overhead_ns", fake_compute)
+
+        # Run the manifest. The minimal_nsys_conn fixture is short, so
+        # auto-trim wouldn't normally run — but we forced the selector
+        # to return a window above, which makes _execute treat it as
+        # auto-trimmed.
+        rows = manifest_skill.execute(minimal_nsys_conn, device=0)
+
+        # The realignment call must have happened with the effective
+        # window (i.e. the trim_start_ns/trim_end_ns returned by the
+        # selector clamped to the profile time_range).
+        assert len(calls) >= 1, "compute_profiler_overhead_ns was not called for realignment"
+        # The last call is the realignment one; any earlier call would
+        # be from Skill.execute's own injection path.
+        last_start, last_end = calls[-1]
+        assert last_start is not None and last_end is not None
+        assert last_end - last_start > 0
+        # The realigned overhead_ms reflects the fake 100 ns return value
+        dq = rows[0].get("data_quality", {})
+        assert dq.get("profiler_overhead_ms") == round(100 / 1e6, 1)

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -530,47 +530,99 @@ class TestManifestOverheadRealignment:
     def test_auto_trim_realigns_overhead_to_effective_window(
         self, monkeypatch, minimal_nsys_conn, manifest_skill
     ):
-        """Monkey-patch the helper to record what window it's called with
-        and assert it matches the auto-trim-selected window."""
+        """The realignment branch must override the initially-injected
+        overhead with one recomputed against the auto-trim window.
+
+        Strategy: pick an auto-trim window *inside* the fixture's profile
+        range so the effective window doesn't collapse to zero after
+        clamping (the fixture's time_range is roughly 1 ms - 9 ms). Then
+        return *distinguishable* values from the helper for the
+        ``(None, None)`` injection path vs the windowed realignment path
+        so the final ``profiler_overhead_ms`` directly reveals which
+        path produced it.
+        """
         from nsys_ai.skills.builtins import profile_health_manifest as phm
 
-        fake_t0 = 1_000_000_000_000
-        fake_t1 = 1_020_000_000_000  # 20 s window
-
-        # Force auto-trim to a known window by stubbing the selector.
+        # Inside the fixture's profile range (1 ms - 9 ms); leaves headroom
+        # on both sides so we can also verify the clamp doesn't shrink it.
+        fake_t0 = 2_000_000
+        fake_t1 = 8_000_000  # 6 ms wide
         monkeypatch.setattr(
             phm, "_auto_select_trim_window", lambda prof: (fake_t0, fake_t1)
         )
 
-        calls: list[tuple[int | None, int | None]] = []
+        windowed_calls: list[tuple[int, int]] = []
 
         def fake_compute(conn, *, trim_start_ns=None, trim_end_ns=None):
-            calls.append((trim_start_ns, trim_end_ns))
-            # Return a small, sane value so the rest of the manifest
-            # doesn't choke on the synthesized overhead.
-            return 100  # 100 ns of overhead inside the window
+            if trim_start_ns is None and trim_end_ns is None:
+                # Initial injection from Skill.execute — baseline value.
+                return 100_000_000  # 100 ms
+            # Sub-skill calls AND the realignment call share this branch;
+            # record the realignment-shaped window so we can assert it.
+            if (trim_start_ns, trim_end_ns) == (fake_t0, fake_t1):
+                windowed_calls.append((trim_start_ns, trim_end_ns))
+            return 1_000_000  # 1 ms — distinct from the baseline above
 
-        # Replace the helper *via the base module* — the manifest imports
-        # it lazily inside ``_execute``, so we have to patch the source.
         from nsys_ai.skills import base as base_module
 
         monkeypatch.setattr(base_module, "compute_profiler_overhead_ns", fake_compute)
 
-        # Run the manifest. The minimal_nsys_conn fixture is short, so
-        # auto-trim wouldn't normally run — but we forced the selector
-        # to return a window above, which makes _execute treat it as
-        # auto-trimmed.
         rows = manifest_skill.execute(minimal_nsys_conn, device=0)
 
-        # The realignment call must have happened with the effective
-        # window (i.e. the trim_start_ns/trim_end_ns returned by the
-        # selector clamped to the profile time_range).
-        assert len(calls) >= 1, "compute_profiler_overhead_ns was not called for realignment"
-        # The last call is the realignment one; any earlier call would
-        # be from Skill.execute's own injection path.
-        last_start, last_end = calls[-1]
-        assert last_start is not None and last_end is not None
-        assert last_end - last_start > 0
-        # The realigned overhead_ms reflects the fake 100 ns return value
+        # The helper must have been called with the auto-trim window at
+        # least once (sub-skills + realignment all hit this shape).
+        assert windowed_calls, (
+            "compute_profiler_overhead_ns was never called with the auto-trim window"
+        )
+
+        # If realignment ran, the manifest's ``overhead_ns`` was overwritten
+        # to the windowed return value (1 ms). If realignment had been
+        # skipped — the bug shape — the value would still be 100 ms from
+        # the initial injection.
         dq = rows[0].get("data_quality", {})
-        assert dq.get("profiler_overhead_ms") == round(100 / 1e6, 1)
+        assert dq.get("profiler_overhead_ms") == 1.0, (
+            "realignment did not override the injected overhead_ns "
+            f"(profiler_overhead_ms={dq.get('profiler_overhead_ms')})"
+        )
+        # Sanity: effective window had positive width, so the branch was reachable.
+        assert rows[0].get("profile_span_ms", 0) > 0
+
+    def test_auto_trim_window_outside_profile_range_skips_realignment(
+        self, monkeypatch, minimal_nsys_conn, manifest_skill
+    ):
+        """When the auto-trim picker returns a window outside the actual
+        profile time_range, the clamp collapses the effective span to 0
+        and the realignment branch is correctly skipped — the injected
+        overhead value flows through unchanged. Pins the guard so a
+        zero-width window can't produce a division-by-zero or a stale
+        realigned value.
+        """
+        from nsys_ai.skills.builtins import profile_health_manifest as phm
+
+        # Far outside the fixture's range (1 ms - 9 ms) so the clamp
+        # makes effective_end < effective_start.
+        monkeypatch.setattr(
+            phm,
+            "_auto_select_trim_window",
+            lambda prof: (1_000_000_000_000, 1_020_000_000_000),
+        )
+
+        def fake_compute(conn, *, trim_start_ns=None, trim_end_ns=None):
+            if trim_start_ns is None and trim_end_ns is None:
+                return 100_000_000  # 100 ms — what survives if realignment is skipped
+            return 1_000_000  # 1 ms — what would appear if realignment fired
+
+        from nsys_ai.skills import base as base_module
+
+        monkeypatch.setattr(base_module, "compute_profiler_overhead_ns", fake_compute)
+
+        rows = manifest_skill.execute(minimal_nsys_conn, device=0)
+
+        # Effective window collapsed → realignment must be skipped, so
+        # the initial injection value survives.
+        assert rows[0].get("profile_span_ms") == 0
+        dq = rows[0].get("data_quality", {})
+        assert dq.get("profiler_overhead_ms") == 100.0, (
+            "realignment branch must be skipped when effective span is 0 "
+            f"(profiler_overhead_ms={dq.get('profiler_overhead_ms')})"
+        )


### PR DESCRIPTION
## Summary

Two related correctness fixes to `profile_health_manifest` that were producing nonsense `overhead_pct` values (observed up to **3,583,749%** on a single-iteration H100 capture). Both stem from the same family of bug: auto-trim happens *inside* `_execute`, but the overhead numerator and the span denominator are computed at different points and end up scoped to different time windows.

### 1. Auto-trim minimum-window guard

`_auto_select_trim_window` previously accepted any NVTX iteration with ≥ 3 instances, including per-op markers that can be < 10 µs wide. A sub-100 ms pick collapses every downstream ratio (overhead-vs-span, NCCL-vs-compute) to a meaningless value.

Add `_AUTO_TRIM_MIN_WINDOW_NS = 100 ms`; narrower NVTX picks fall through to the existing middle-of-span fallback.

### 2. Overhead-span scope alignment

`Skill.execute` injects `overhead_ns` computed over base.py's view of the trim window (which is the *full profile* when no explicit trim was passed). `_execute` then decides auto-trim internally and uses that narrower window as the denominator — numerator and denominator end up scoped to different windows.

After auto-trim is applied, re-query `overhead_ns` clipped to the effective window so both share the same scope.

The `profiler_overhead` probe-and-clip logic is extracted into `compute_profiler_overhead_ns` so `Skill.execute` and the new realignment site share a single implementation. Behaviour of `Skill.execute` itself is unchanged (same query, same fallback path).

## Changes

- `src/nsys_ai/skills/base.py`
  - New `compute_profiler_overhead_ns(conn, *, trim_start_ns, trim_end_ns)` helper that returns the non-overlapping union of intervals from `profiler_overhead` / `PROFILER_OVERHEAD`, clipped to the optional window.
  - `Skill.execute`'s inline overhead computation now delegates to the helper (no behaviour change).
- `src/nsys_ai/skills/builtins/profile_health_manifest.py`
  - Add `_AUTO_TRIM_MIN_WINDOW_NS = 100 * 10**6` constant.
  - `_auto_select_trim_window`: reject NVTX-derived picks narrower than `_AUTO_TRIM_MIN_WINDOW_NS`; fall through to middle-of-span fallback.
  - `_execute`: after auto-trim is applied, call `compute_profiler_overhead_ns` clipped to `(effective_start_ns, effective_end_ns)` so the overhead numerator and `profile_span_ns` denominator share the same scope.
- `tests/test_profile_health_manifest.py`
  - `TestManifestAutoTrim` — 2 new tests pinning the min-window guard and its inclusive boundary.
  - `TestComputeProfilerOverheadNs` — 5 unit tests for the helper (absent table, union without window, union of overlapping intervals, window-clipped union, no-overlap window).
  - `TestManifestOverheadRealignment` — integration test that monkey-patches the selector and helper to verify `_execute` calls `compute_profiler_overhead_ns` with the auto-trim window when auto-trim is applied.

## Backward compatibility

- `Skill.execute` retains its original behaviour: same probe order, same fallback to 0, same `overhead_ns` injection.
- `_execute`'s output row shape is unchanged. Only the *value* of `data_quality.overhead_pct` / `overhead_pct_raw` / `profiler_overhead_ms` is corrected on auto-trimmed profiles.
- `_format` text output uses the corrected values automatically — no path-level changes.

## Validation

`perf_h100_sp1.sqlite` (single-iteration H100, the originating bug profile):

| | Before | After |
|---|---|---|
| `auto_trim.window_ms` | 0.0 (9 µs) | **20000.0** (20 s) |
| `profiler_overhead_ms` | 320.6 (full profile) | **0.2** (clipped to window) |
| `overhead_pct_raw` | **3,583,749.4** | **0.00119** |
| `_infer_bottleneck` | `"Profiler Overhead (3,583,749.4%) contaminated the profile"` | `"High CPU Synchronization Blocking (40.1% of span)"` |

The real bottleneck (sync blocking) now surfaces instead of the nonsense overhead claim.

## Test plan

- [x] `pytest tests/test_profile_health_manifest.py tests/test_skills.py -q` — 100 passed
- [x] `pytest tests/ -q` — 930 passed, 146 skipped, 0 failed
- [x] `ruff check src/ tests/` — clean
- [x] Manual verification on `perf_h100_sp1.sqlite`: `auto_trim.window_ms = 20000.0`, `overhead_pct_raw = 0.00119`, no nonsense values in `data_quality` / `_format` / `_infer_bottleneck`.
