### PR TITLE
fix(profile_health): use wall-clock NCCL for the dominance trigger

### DIFF
--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -803,12 +803,13 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     total_nccl_ms = float(nccl.get("total_nccl_ms", 0) or 0)
     compute_only_ms = float(overlap.get("compute_only_ms", 0) or 0)
     low_overlap = overlap_pct < _COMM_BOUND_OVERLAP_PCT and nccl_only_ms > 0
-    # Compare wall-clock NCCL (``nccl_only_ms`` — the unhidden, non-overlapped
-    # interval from overlap_breakdown) against wall-clock compute. The
-    # earlier per-stream sum ``total_nccl_ms`` overcounts when NCCL runs
-    # concurrently on multiple streams, which makes the comparison apples-
-    # to-oranges versus the wall-clock compute denominator and produces
-    # spurious dominance findings on multi-stream NCCL workloads.
+    # Compare wall-clock NCCL (``nccl_only_ms`` — the unhidden,
+    # non-overlapped interval from overlap_breakdown) against wall-clock
+    # compute. The earlier per-stream sum ``total_nccl_ms`` overcounts
+    # when NCCL runs concurrently on multiple streams, which makes the
+    # comparison apples-to-oranges versus the wall-clock compute
+    # denominator and produces spurious dominance findings on
+    # multi-stream NCCL workloads.
     nccl_dominates_compute = nccl_only_ms > 0 and nccl_only_ms > compute_only_ms
     if low_overlap or nccl_dominates_compute:
         # Two distinct triggers can fire this; capture which in provenance

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -803,7 +803,13 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     total_nccl_ms = float(nccl.get("total_nccl_ms", 0) or 0)
     compute_only_ms = float(overlap.get("compute_only_ms", 0) or 0)
     low_overlap = overlap_pct < _COMM_BOUND_OVERLAP_PCT and nccl_only_ms > 0
-    nccl_dominates_compute = total_nccl_ms > 0 and total_nccl_ms > compute_only_ms
+    # Compare wall-clock NCCL (``nccl_only_ms`` — the unhidden, non-overlapped
+    # interval from overlap_breakdown) against wall-clock compute. The
+    # earlier per-stream sum ``total_nccl_ms`` overcounts when NCCL runs
+    # concurrently on multiple streams, which makes the comparison apples-
+    # to-oranges versus the wall-clock compute denominator and produces
+    # spurious dominance findings on multi-stream NCCL workloads.
+    nccl_dominates_compute = nccl_only_ms > 0 and nccl_only_ms > compute_only_ms
     if low_overlap or nccl_dominates_compute:
         # Two distinct triggers can fire this; capture which in provenance
         # so downstream consumers (and Copilot-style reviewers) can tell
@@ -820,7 +826,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         if low_overlap and nccl_dominates_compute:
             label_text = (
                 f"Communication-bound (overlap {overlap_pct:.0f}%, "
-                f"NCCL {total_nccl_ms:.0f}ms vs compute {compute_only_ms:.0f}ms)"
+                f"NCCL {nccl_only_ms:.0f}ms vs compute {compute_only_ms:.0f}ms)"
             )
         elif low_overlap:
             label_text = (
@@ -830,7 +836,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         else:
             label_text = (
                 f"Communication-bound: NCCL dominates "
-                f"({total_nccl_ms:.0f}ms NCCL vs {compute_only_ms:.0f}ms compute)"
+                f"({nccl_only_ms:.0f}ms NCCL vs {compute_only_ms:.0f}ms compute)"
             )
         _emit(
             finding_id="profile_comm_bound",
@@ -854,9 +860,9 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
             },
             note=(
                 f"Compute/NCCL overlap is {overlap_pct:.0f}% (threshold "
-                f"{int(_COMM_BOUND_OVERLAP_PCT)}%); NCCL total {total_nccl_ms:.0f}ms "
-                f"vs compute-only {compute_only_ms:.0f}ms. Dominant collective: "
-                f"{nccl.get('dominant_type', 'unknown')}."
+                f"{int(_COMM_BOUND_OVERLAP_PCT)}%); NCCL unhidden "
+                f"{nccl_only_ms:.0f}ms vs compute-only {compute_only_ms:.0f}ms. "
+                f"Dominant collective: {nccl.get('dominant_type', 'unknown')}."
             ),
             explanation=_COMM_EXPLANATION,
             actions=_COMM_ACTIONS,

--- a/tests/test_profile_health_manifest_findings.py
+++ b/tests/test_profile_health_manifest_findings.py
@@ -125,13 +125,26 @@ class TestCommBound:
         assert "low_overlap" in f.provenance["triggers"]
 
     def test_fires_on_nccl_exceeds_compute(self):
+        # The dominance trigger compares wall-clock NCCL (``nccl_only_ms``)
+        # against wall-clock compute, both from overlap_breakdown.
         m = _healthy_manifest()
         m["overlap"]["compute_only_ms"] = 100.0
-        m["nccl"]["total_nccl_ms"] = 500.0
+        m["overlap"]["nccl_only_ms"] = 500.0
         findings = _to_findings([m])
         f = next((f for f in findings if f.id == "profile_comm_bound"), None)
         assert f is not None
         assert "nccl_exceeds_compute" in f.provenance["triggers"]
+
+    def test_high_total_nccl_ms_alone_does_not_fire(self):
+        # ``total_nccl_ms`` is a per-stream sum and overcounts when NCCL
+        # runs concurrently on multiple streams. A wall-clock-dominant
+        # comparison (``nccl_only_ms`` vs ``compute_only_ms``) avoids the
+        # false positive that the per-stream sum used to trigger.
+        m = _healthy_manifest()
+        m["overlap"]["nccl_only_ms"] = 50.0          # wall-clock, well under compute
+        m["overlap"]["compute_only_ms"] = 200.0
+        m["nccl"]["total_nccl_ms"] = 5000.0          # huge per-stream sum
+        assert all(f.id != "profile_comm_bound" for f in _to_findings([m]))
 
     def test_low_overlap_with_no_nccl_does_not_fire(self):
         # Single-rank profile: overlap_pct is meaningless when nccl_only_ms=0.
@@ -159,14 +172,12 @@ class TestCommBound:
     def test_label_reflects_only_active_trigger(self):
         # When only nccl_exceeds_compute fires (overlap healthy), the label
         # must not cite "overlap 100%" because that's a non-signal. Same the
-        # other way for low_overlap with compute dominant. Regression for
-        # Copilot review MED #5.
+        # other way for low_overlap with compute dominant.
         m = _healthy_manifest()
-        # Trigger only nccl_dominates: overlap healthy, nccl > compute
+        # Trigger only nccl_dominates: overlap healthy, nccl_only > compute
         m["overlap"]["overlap_pct"] = 80
-        m["overlap"]["nccl_only_ms"] = 0
+        m["overlap"]["nccl_only_ms"] = 500.0
         m["overlap"]["compute_only_ms"] = 100.0
-        m["nccl"]["total_nccl_ms"] = 500.0
         f = next(f for f in _to_findings([m]) if f.id == "profile_comm_bound")
         assert "NCCL dominates" in f.label
         assert "overlap" not in f.label.lower()
@@ -176,17 +187,15 @@ class TestCommBound:
         m["overlap"]["overlap_pct"] = 10
         m["overlap"]["nccl_only_ms"] = 200.0
         m["overlap"]["compute_only_ms"] = 1000.0
-        m["nccl"]["total_nccl_ms"] = 200.0
         f = next(f for f in _to_findings([m]) if f.id == "profile_comm_bound")
         assert "low overlap" in f.label
         assert "dominates" not in f.label.lower()
 
-        # Both triggers: combined label
+        # Both triggers: combined label cites wall-clock NCCL vs compute.
         m = _healthy_manifest()
         m["overlap"]["overlap_pct"] = 10
-        m["overlap"]["nccl_only_ms"] = 200.0
+        m["overlap"]["nccl_only_ms"] = 500.0
         m["overlap"]["compute_only_ms"] = 100.0
-        m["nccl"]["total_nccl_ms"] = 500.0
         f = next(f for f in _to_findings([m]) if f.id == "profile_comm_bound")
         assert "overlap 10%" in f.label
         assert "NCCL 500ms vs compute 100ms" in f.label


### PR DESCRIPTION
## Summary

The `nccl_exceeds_compute` branch of `profile_comm_bound` compared `nccl.total_nccl_ms` (a **per-stream sum** across NCCL streams) against `overlap.compute_only_ms` (a **wall-clock, non-overlapped** interval). That's apples-to-oranges: when NCCL collectives run concurrently on multiple streams, `total_nccl_ms` overcounts the wall clock by the number of concurrent streams, while `compute_only_ms` stays bounded by the wall clock. The mismatch can trigger spurious `comm_bound` findings on multi-stream NCCL workloads even when the actual NCCL wall time is well below compute wall time.

Use wall-clock NCCL (`overlap.nccl_only_ms` — the unhidden, non-overlapped NCCL interval already produced by `overlap_breakdown`) for the comparison. Both sides now come from the same wall-clock breakdown so the comparison is well-defined.

## Changes

- `src/nsys_ai/skills/builtins/profile_health_manifest.py`
  - `nccl_dominates_compute = nccl_only_ms > 0 and nccl_only_ms > compute_only_ms` (was `total_nccl_ms > 0 and total_nccl_ms > compute_only_ms`).
  - Label and note for the dominance branches now report `nccl_only_ms` instead of `total_nccl_ms`, so the human-readable summary reflects what the trigger actually compared.
  - The evidence row still exposes both `nccl_only_ms` and `total_nccl_ms` for downstream debugging.
- `tests/test_profile_health_manifest_findings.py`
  - `test_fires_on_nccl_exceeds_compute` — updated to set `nccl_only_ms` (the field the trigger now reads).
  - `test_label_reflects_only_active_trigger` — updated to set `nccl_only_ms` for the dominance-only and combined sub-cases; the combined label now expects `NCCL 500ms vs compute 100ms` referring to wall-clock values.
  - **New** `test_high_total_nccl_ms_alone_does_not_fire` — regression: a large `total_nccl_ms` (per-stream overcount) with a small `nccl_only_ms` (real wall-clock) must not fire `profile_comm_bound`.

## Backward compatibility

- `_execute` row output is unchanged.
- `_format` text output is unchanged (`_infer_bottleneck` is not touched by this change).
- Evidence row schema is unchanged — both `nccl_only_ms` and `total_nccl_ms` remain available; only the *trigger comparison* switches to wall-clock.
- `provenance.triggers` keys (`low_overlap`, `nccl_exceeds_compute`) are unchanged.

## Test plan

- [x] `pytest tests/test_profile_health_manifest_findings.py tests/test_profile_health_manifest.py -q` — 61 passed
- [x] `pytest tests/ -q` — 923 passed, 146 skipped, 0 failed
- [x] `ruff check src/ tests/` — clean
- [x] Manual verification on `perf_h100_sp2_fa3.sqlite` (multi-GPU H100 with single NCCL stream per rank): finding still fires correctly via `triggers=['low_overlap']` (the new wall-clock check correctly identifies `nccl_only_ms=597ms < compute_only_ms=19240ms`, so `nccl_exceeds_compute` does not spuriously add to the trigger set).
