### PR TITLE
feat(diff): attach TraceSelection to top-K kernel regressions

### DIFF
--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -10,8 +10,9 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 
+from .annotation import TraceSelection
 from .fingerprint import get_profile_id
 from .overlap import overlap_analysis
 from .profile import Profile
@@ -83,6 +84,7 @@ class KernelDiff:
     after_share: float
     delta_share: float
     classification: str  # regression|improvement|new|removed|neutral
+    selection: TraceSelection | None = None
 
 
 @dataclass(frozen=True)
@@ -354,6 +356,18 @@ def _classify_delta(delta_ns: int, before_ns: int, after_ns: int) -> str:
     return "neutral"
 
 
+def _diff_selection(kd: KernelDiff, profile_id: str, gpu: int | None) -> TraceSelection:
+    key_hash = hashlib.sha256(kd.key.encode("utf-8")).hexdigest()[:12]
+    delta_ms = kd.delta_ns / 1e6
+    return TraceSelection(
+        id=f"sel_diff_{key_hash}",
+        profile_id=profile_id,
+        source="diff",
+        gpu_ids=[gpu] if gpu is not None else None,
+        label=f"{kd.name} {delta_ms:+.2f}ms",
+    )
+
+
 def diff_profiles(
     before_prof: Profile,
     after_prof: Profile,
@@ -455,6 +469,16 @@ def diff_profiles(
     improvements = [k for k in kernel_diffs if k.delta_ns < 0]
     regressions.sort(key=sort_key, reverse=True)
     improvements.sort(key=sort_key)  # most negative first
+    limited_regressions = regressions[: max(0, int(limit))]
+    limited_improvements = improvements[: max(0, int(limit))]
+    limited_regressions = [
+        replace(k, selection=_diff_selection(k, after.profile_id, gpu))
+        for k in limited_regressions
+    ]
+    limited_improvements = [
+        replace(k, selection=_diff_selection(k, after.profile_id, gpu))
+        for k in limited_improvements
+    ]
 
     overlap_before = before.overlap
     overlap_after = after.overlap
@@ -507,8 +531,8 @@ def diff_profiles(
         overlap_before=overlap_before,
         overlap_after=overlap_after,
         overlap_delta=overlap_delta,
-        top_regressions=regressions[: max(0, int(limit))],
-        top_improvements=improvements[: max(0, int(limit))],
+        top_regressions=limited_regressions,
+        top_improvements=limited_improvements,
         verdict=verdict,
         comparability_confidence=comparability_confidence,
         category_attribution=category_attribution,

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -356,8 +356,25 @@ def _classify_delta(delta_ns: int, before_ns: int, after_ns: int) -> str:
     return "neutral"
 
 
-def _diff_selection(kd: KernelDiff, profile_id: str, gpu: int | None) -> TraceSelection:
-    key_hash = hashlib.sha256(kd.key.encode("utf-8")).hexdigest()[:12]
+def _diff_selection(
+    kd: KernelDiff,
+    profile_id: str,
+    gpu: int | None,
+    diff_id: str,
+) -> TraceSelection:
+    selection_key = json.dumps(
+        {
+            "diff_id": diff_id,
+            "kernel_key": kd.key,
+            "before_total_ns": kd.before_total_ns,
+            "after_total_ns": kd.after_total_ns,
+            "before_count": kd.before_count,
+            "after_count": kd.after_count,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    key_hash = hashlib.sha256(selection_key).hexdigest()[:12]
     delta_ms = kd.delta_ns / 1e6
     return TraceSelection(
         id=f"sel_diff_{key_hash}",
@@ -469,14 +486,26 @@ def diff_profiles(
     improvements = [k for k in kernel_diffs if k.delta_ns < 0]
     regressions.sort(key=sort_key, reverse=True)
     improvements.sort(key=sort_key)  # most negative first
+    diff_id = _make_diff_id(
+        before.profile_id,
+        after.profile_id,
+        {
+            "gpu": gpu,
+            "trim_before": trim_before,
+            "trim_after": trim_after,
+            "limit": limit,
+            "sort": sort,
+            "nvtx_limit": nvtx_limit,
+        },
+    )
     limited_regressions = regressions[: max(0, int(limit))]
     limited_improvements = improvements[: max(0, int(limit))]
     limited_regressions = [
-        replace(k, selection=_diff_selection(k, after.profile_id, gpu))
+        replace(k, selection=_diff_selection(k, after.profile_id, gpu, diff_id))
         for k in limited_regressions
     ]
     limited_improvements = [
-        replace(k, selection=_diff_selection(k, after.profile_id, gpu))
+        replace(k, selection=_diff_selection(k, after.profile_id, gpu, diff_id))
         for k in limited_improvements
     ]
 
@@ -509,19 +538,6 @@ def diff_profiles(
         if step_time_before_ms > 0:
             step_time_delta_pct = round(delta / step_time_before_ms * 100.0, 2)
     verdict = compute_verdict(step_time_delta_pct, comparability_confidence)
-    diff_id = _make_diff_id(
-        before.profile_id,
-        after.profile_id,
-        {
-            "gpu": gpu,
-            "trim_before": trim_before,
-            "trim_after": trim_after,
-            "limit": limit,
-            "sort": sort,
-            "nvtx_limit": nvtx_limit,
-        },
-    )
-
     return ProfileDiffSummary(
         before=before,
         after=after,

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -495,6 +495,7 @@ def to_diff_json(data: ProfileDiffSummary) -> str:
                 "before_share": k.before_share,
                 "after_share": k.after_share,
                 "delta_share": k.delta_share,
+                "selection": k.selection.to_dict() if k.selection else None,
             }
             for k in data.top_regressions
         ],
@@ -512,6 +513,7 @@ def to_diff_json(data: ProfileDiffSummary) -> str:
                 "before_share": k.before_share,
                 "after_share": k.after_share,
                 "delta_share": k.delta_share,
+                "selection": k.selection.to_dict() if k.selection else None,
             }
             for k in data.top_improvements
         ],

--- a/src/nsys_ai/diff_tools.py
+++ b/src/nsys_ai/diff_tools.py
@@ -60,6 +60,7 @@ def _top_k_payload(summary: ProfileDiffSummary, top_n: int = 5) -> tuple[list, l
             "name": k.name,
             "delta_ns": k.delta_ns,
             "delta_ms": round(k.delta_ns / 1e6, 3),
+            "selection": k.selection.to_dict() if k.selection else None,
             **impact(k),
         }
         for k in summary.top_regressions[:top_n]
@@ -69,6 +70,7 @@ def _top_k_payload(summary: ProfileDiffSummary, top_n: int = 5) -> tuple[list, l
             "name": k.name,
             "delta_ns": k.delta_ns,
             "delta_ms": round(k.delta_ns / 1e6, 3),
+            "selection": k.selection.to_dict() if k.selection else None,
             **impact(k),
         }
         for k in summary.top_improvements[:top_n]
@@ -499,11 +501,19 @@ def get_global_diff(
             "delta": round(wall_a - wall_b, 2),
         },
         "top_regressions": [
-            {"name": k.name, "delta_ms": round(k.delta_ns / 1e6, 3)}
+            {
+                "name": k.name,
+                "delta_ms": round(k.delta_ns / 1e6, 3),
+                "selection": k.selection.to_dict() if k.selection else None,
+            }
             for k in summary2.top_regressions[:10]
         ],
         "top_improvements": [
-            {"name": k.name, "delta_ms": round(k.delta_ns / 1e6, 3)}
+            {
+                "name": k.name,
+                "delta_ms": round(k.delta_ns / 1e6, 3),
+                "selection": k.selection.to_dict() if k.selection else None,
+            }
             for k in summary2.top_improvements[:10]
         ],
         "warnings": summary.warnings,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -165,6 +165,116 @@ def test_diff_engine_math(tmp_path):
     assert kC.classification == "new"
 
 
+def test_diff_top_regression_has_trace_selection(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        diff = diff_profiles(b, a, gpu=0, limit=10)
+
+    selection = diff.top_regressions[0].selection
+    assert selection is not None
+    assert selection.source == "diff"
+    assert selection.profile_id == diff.after.profile_id
+    assert selection.gpu_ids == [0]
+    assert "kA" in selection.label
+    assert "+20.00ms" in selection.label
+
+
+def test_diff_top_regression_selection_serializes_to_json(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--gpu",
+            "0",
+            "--format",
+            "json",
+            "--no-ai",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    selection = payload["top_regressions"][0]["selection"]
+    assert selection["id"].startswith("sel_diff_")
+    assert selection["source"] == "diff"
+    assert selection["profile_id"] == payload["after"]["profile_id"]
+    assert selection["gpu_ids"] == [0]
+    assert "kA" in selection["label"]
+
+
+def test_diff_selection_round_trips_through_trace_selection_dict(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.annotation import TraceSelection
+    from nsys_ai.diff import diff_profiles
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        diff = diff_profiles(b, a, gpu=0, limit=10)
+
+    selection = diff.top_regressions[0].selection
+    assert selection is not None
+    assert TraceSelection.from_dict(selection.to_dict()) == selection
+
+
+def test_diff_node_wide_selection_omits_gpu_ids(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        diff = diff_profiles(b, a, gpu=None, limit=10)
+
+    selection = diff.top_regressions[0].selection
+    assert selection is not None
+    assert selection.gpu_ids is None
+    assert "gpu_ids" not in selection.to_dict()
+
+
+def test_diff_without_top_regressions_has_empty_selection_lists(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.diff_render import to_diff_json
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        diff = diff_profiles(b, a, gpu=0, limit=10)
+
+    assert diff.top_regressions == []
+    assert diff.top_improvements == []
+    payload = json.loads(to_diff_json(diff))
+    assert payload["top_regressions"] == []
+    assert payload["top_improvements"] == []
+
+
 def test_diff_cli_json_output(tmp_path):
     before = tmp_path / "before.sqlite"
     after = tmp_path / "after.sqlite"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -237,6 +237,29 @@ def test_diff_selection_round_trips_through_trace_selection_dict(tmp_path):
     assert TraceSelection.from_dict(selection.to_dict()) == selection
 
 
+def test_diff_selection_id_includes_diff_context(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    before_a = tmp_path / "before_a.sqlite"
+    before_b = tmp_path / "before_b.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before_a), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(before_b), kernels=[(0, 5_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before_a)) as b1, profile_mod.open(str(after)) as a:
+        first = diff_profiles(b1, a, gpu=0, limit=10)
+    with profile_mod.open(str(before_b)) as b2, profile_mod.open(str(after)) as a:
+        second = diff_profiles(b2, a, gpu=0, limit=10)
+
+    first_selection = first.top_regressions[0].selection
+    second_selection = second.top_regressions[0].selection
+    assert first_selection is not None
+    assert second_selection is not None
+    assert first_selection.id != second_selection.id
+
+
 def test_diff_node_wide_selection_omits_gpu_ids(tmp_path):
     from nsys_ai import profile as profile_mod
     from nsys_ai.diff import diff_profiles
@@ -638,6 +661,47 @@ def test_diff_tools_run_diff_tool_and_openai_tools(tmp_path):
     prompt = build_diff_system_prompt(ctx, "/before.sqlite", "/after.sqlite", snapshot=None)
     assert "Before profile:" in prompt and "After profile:" in prompt
     assert "/before.sqlite" in prompt and "/after.sqlite" in prompt
+
+
+def test_diff_tools_global_diff_payload_includes_selection(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_global_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="step")
+        payload = get_global_diff(ctx, target_gpu=0)
+
+    selection = payload["top_regressions"][0]["selection"]
+    assert selection["id"].startswith("sel_diff_")
+    assert selection["source"] == "diff"
+    assert selection["profile_id"].startswith("nsys1:")
+    assert selection["gpu_ids"] == [0]
+    assert "kA" in selection["label"]
+
+
+def test_diff_tools_top_k_payload_includes_selection(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.diff_tools import _top_k_payload
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        summary = diff_profiles(b, a, gpu=0, limit=10)
+
+    regressions, _improvements, _others_ms = _top_k_payload(summary, top_n=5)
+    selection = regressions[0]["selection"]
+    assert selection["source"] == "diff"
+    assert selection["profile_id"] == summary.after.profile_id
+    assert selection["gpu_ids"] == [0]
 
 
 def test_diff_tools_phase_c_prompt_export():


### PR DESCRIPTION
Closes the loop from "verdict says regression" to "where in the trace" — each top-K kernel regression/improvement now carries a v0.1 TraceSelection so GUI / TUI / agent-loop consumers can jump straight to the region.

- KernelDiff gains an optional `selection: TraceSelection | None` field; only the top-K (regressions + improvements) are populated, the full kernel_diffs list stays plain.
- selection.source="diff", anchored to the after-profile id, gpu_ids=[gpu] (omitted for node-wide diff), label="<name> +X.XXms". Stable id from sha256(kernel key) so demangled names with ::/<>/, stay id-safe.
- to_diff_json emits `selection` on each top_regressions / top_improvements entry (null when absent); existing envelope keys unchanged.
- Scope: name+GPU anchor only; per-instance time bounds (start/end) are a planned follow-up.

5 new tests (fields, CLI JSON serialization, to_dict/from_dict round-trip, node-wide gpu omission, no-regression empty lists). Full suite 956 pass.

<!--
Thanks for sending a PR! Keep this template tight — empty sections are fine.
Delete any section that does not apply, but please at least keep Summary and Test plan.
-->

## Summary

Add `TraceSelection` pointers to diff top-K kernel changes so downstream UI, TUI, and agent-loop consumers can navigate from a diff result back to the relevant profile context.

This is the v1/A-scope implementation: diff remains kernel-aggregate based, so selections identify the after-profile and optional GPU scope without claiming a precise time window for kernels that may be spread across the trace.


## Changes

- Add optional `selection` to `KernelDiff`.
- Populate `TraceSelection(source="diff")` for `top_regressions` and `top_improvements`.
- Serialize `selection` in `to_diff_json`.
- Add tests for:
  - regression selection metadata
  - JSON serialization
  - `TraceSelection` round-trip
  - node-wide diff with no `gpu_ids`
  - empty top-K lists

## Validation

- `python -m pytest tests/test_diff.py -q`
- `python -m pytest tests/ -q`
- `python -m ruff check src/nsys_ai/diff.py src/nsys_ai/diff_render.py tests/test_diff.py`
- `python -m nsys_ai --help`
- `git diff --check`

## Test plan

- [x] 8 new tests in `tests/test_diff.py`: field presence, CLI JSON
      serialization, `to_dict`/`from_dict` round-trip, node-wide GPU omission,
      no-regression empty lists, diff-context-aware selection IDs, and
      `diff_tools.py` payload selection coverage
- [x] `pytest tests/ -q` → 959 passed, 146 skipped
- [x] `ruff check src/ tests/` clean
