### PR TITLE
feat(diff): implement get_launch_config_diff (grid/block/registers before vs after)

### DIFF
--- a/src/nsys_ai/diff_tools.py
+++ b/src/nsys_ai/diff_tools.py
@@ -901,7 +901,9 @@ def _resolve_launch_config_windows(
     if iteration_index is None:
         return ctx.trim, ctx.trim, None
     bounds = get_iteration_boundaries(ctx, marker=ctx.marker, target_gpu=target_gpu)
-    if iteration_index >= len(bounds["boundaries"]):
+    # Reject negatives explicitly: Python would otherwise let -1 silently index
+    # the last iteration, contradicting the "out of range" contract.
+    if iteration_index < 0 or iteration_index >= len(bounds["boundaries"]):
         return (
             None,
             None,

--- a/src/nsys_ai/diff_tools.py
+++ b/src/nsys_ai/diff_tools.py
@@ -692,6 +692,328 @@ def summarize_nvtx_subtree(
     }
 
 
+_LAUNCH_GRID_COLS = ("gridX", "gridY", "gridZ")
+_LAUNCH_BLOCK_COLS = ("blockX", "blockY", "blockZ")
+_LAUNCH_REGISTER_COLS = ("registersPerThread",)
+_LAUNCH_STATIC_SHARED_COLS = ("staticSharedMemory", "staticSharedMemoryBytes")
+_LAUNCH_DYNAMIC_SHARED_COLS = ("dynamicSharedMemory", "dynamicSharedMemoryBytes")
+
+
+def _kernel_table_columns(prof: Profile) -> list[str]:
+    kt = prof.schema.kernel_table
+    if not kt:
+        return []
+    try:
+        return prof.adapter.get_table_columns(kt)
+    except Exception:
+        # Keep the older explicit probe paths as a fallback for any adapter
+        # that does not expose get_table_columns correctly.
+        try:
+            if prof.db is not None:
+                col_rows = prof._duckdb_query(f"DESCRIBE {kt}")
+                return [r.get("column_name") or r.get("name") or "" for r in col_rows]
+            with prof._lock:
+                return [r[1] for r in prof.conn.execute(f"PRAGMA table_info({kt})").fetchall()]
+        except Exception:
+            return []
+
+
+def _first_existing(cols: set[str], candidates: tuple[str, ...]) -> str | None:
+    for col in candidates:
+        if col in cols:
+            return col
+    return None
+
+
+def _launch_config_columns(cols: list[str]) -> dict[str, str]:
+    colset = set(cols)
+    selected: dict[str, str] = {}
+    for col in _LAUNCH_GRID_COLS + _LAUNCH_BLOCK_COLS:
+        if col in colset:
+            selected[col] = col
+    reg_col = _first_existing(colset, _LAUNCH_REGISTER_COLS)
+    if reg_col:
+        selected["registersPerThread"] = reg_col
+    static_col = _first_existing(colset, _LAUNCH_STATIC_SHARED_COLS)
+    if static_col:
+        selected["staticSharedMemory"] = static_col
+    dynamic_col = _first_existing(colset, _LAUNCH_DYNAMIC_SHARED_COLS)
+    if dynamic_col:
+        selected["dynamicSharedMemory"] = dynamic_col
+    return selected
+
+
+def _product(values: list[int | None]) -> int | None:
+    if any(v is None for v in values):
+        return None
+    out = 1
+    for value in values:
+        out *= int(value or 0)
+    return out
+
+
+def _format_dims(values: list[int | None] | None) -> str:
+    if not values:
+        return "?"
+    return "x".join("?" if v is None else str(v) for v in values)
+
+
+def _format_bytes(value: int | None) -> str:
+    if value is None:
+        return "?"
+    if value == 0:
+        return "0B"
+    if value % 1024 == 0:
+        kib = value // 1024
+        if kib % 1024 == 0:
+            return f"{kib // 1024}MiB"
+        return f"{kib}KiB"
+    return f"{value}B"
+
+
+def _scalar_delta(before: int | None, after: int | None) -> int | None:
+    if before is None or after is None:
+        return None
+    return after - before
+
+
+def _delta_entry(before, after):
+    if before is None or after is None:
+        delta = None
+    elif isinstance(before, list) and isinstance(after, list):
+        delta = [
+            _scalar_delta(b, a)
+            for b, a in zip(before, after, strict=False)
+        ]
+    else:
+        delta = after - before
+    return {"before": before, "after": after, "delta": delta}
+
+
+def _shared_total(row: dict) -> int | None:
+    static = row.get("staticSharedMemory")
+    dynamic = row.get("dynamicSharedMemory")
+    if static is None and dynamic is None:
+        return None
+    return int(static or 0) + int(dynamic or 0)
+
+
+def _normalize_launch_row(row: dict | None, selected_cols: dict[str, str]) -> dict | None:
+    if row is None:
+        return None
+    config: dict = {
+        "matched_name": row.get("matched_name"),
+        "sample_count": int(row.get("sample_count") or 0),
+        "total_ms": round((int(row.get("total_ns") or 0)) / 1e6, 3),
+        "avg_ms": round((float(row.get("avg_ns") or 0.0)) / 1e6, 6),
+    }
+    distinct_configs = row.get("distinct_configs")
+    if distinct_configs is not None:
+        config["distinct_configs"] = int(distinct_configs)
+    total_invocations = int(row.get("total_invocations") or 0)
+    if total_invocations > 0:
+        config["total_invocations"] = total_invocations
+        config["dominant_share"] = round(config["sample_count"] / total_invocations, 4)
+
+    for col in _LAUNCH_GRID_COLS + _LAUNCH_BLOCK_COLS:
+        if col in selected_cols:
+            value = row.get(col)
+            config[col] = int(value) if value is not None else None
+
+    if any(col in config for col in _LAUNCH_GRID_COLS):
+        config["grid"] = [config.get(col) for col in _LAUNCH_GRID_COLS]
+        config["total_blocks"] = _product(config["grid"])
+    if any(col in config for col in _LAUNCH_BLOCK_COLS):
+        config["block"] = [config.get(col) for col in _LAUNCH_BLOCK_COLS]
+        config["threads_per_block"] = _product(config["block"])
+    if config.get("total_blocks") is not None and config.get("threads_per_block") is not None:
+        config["total_threads"] = int(config["total_blocks"]) * int(config["threads_per_block"])
+
+    for col in ("registersPerThread", "staticSharedMemory", "dynamicSharedMemory"):
+        if col in selected_cols:
+            value = row.get(col)
+            config[col] = int(value) if value is not None else None
+    shared = _shared_total(config)
+    if shared is not None:
+        config["sharedMemoryBytes"] = shared
+    return config
+
+
+def _query_launch_config(
+    prof: Profile,
+    kernel_name: str,
+    selected_cols: dict[str, str],
+    trim: tuple[int, int] | None,
+    target_gpu: int | None,
+) -> dict | None:
+    if not prof.schema.kernel_table or not selected_cols:
+        return None
+
+    select_parts = ["COALESCE(d.value, s.value, ?) AS matched_name"]
+    group_parts = []
+    for output_name, source_col in selected_cols.items():
+        select_parts.append(f"k.{source_col} AS {output_name}")
+        group_parts.append(f"k.{source_col}")
+    select_parts.extend(
+        [
+            "COUNT(*) AS sample_count",
+            "SUM(k.[end] - k.start) AS total_ns",
+            "AVG(k.[end] - k.start) AS avg_ns",
+        ]
+    )
+
+    sql = f"""
+        SELECT {", ".join(select_parts)}
+        FROM {prof.schema.kernel_table} k
+        LEFT JOIN StringIds s ON k.shortName = s.id
+        LEFT JOIN StringIds d ON k.demangledName = d.id
+        WHERE (s.value = ? OR d.value = ?)
+    """
+    params: list = [kernel_name, kernel_name, kernel_name]
+    if target_gpu is not None:
+        sql += " AND k.deviceId = ?"
+        params.append(target_gpu)
+    if trim is not None:
+        sql += " AND k.start >= ? AND k.[end] <= ?"
+        params.extend([int(trim[0]), int(trim[1])])
+    if group_parts:
+        sql += " GROUP BY " + ", ".join(group_parts) + ", matched_name"
+    sql += " ORDER BY total_ns DESC, sample_count DESC"
+
+    rows = prof._duckdb_query(sql, params)
+    if not rows:
+        return None
+    # One row per distinct launch config; the first (by total GPU time) is the
+    # dominant config we report. Carry the distinct-config count + total
+    # invocations so the caller can express how representative the dominant
+    # config is — an honesty signal for kernels launched with several shapes.
+    dominant = dict(rows[0])
+    dominant["distinct_configs"] = len(rows)
+    dominant["total_invocations"] = sum(int(r.get("sample_count") or 0) for r in rows)
+    return dominant
+
+
+def _resolve_launch_config_windows(
+    ctx: DiffContext,
+    iteration_index: int | None,
+    target_gpu: int | None,
+) -> tuple[tuple[int, int] | None, tuple[int, int] | None, dict | None]:
+    if iteration_index is None:
+        return ctx.trim, ctx.trim, None
+    bounds = get_iteration_boundaries(ctx, marker=ctx.marker, target_gpu=target_gpu)
+    if iteration_index >= len(bounds["boundaries"]):
+        return (
+            None,
+            None,
+            {
+                "error": f"iteration_index {iteration_index} out of range (max {len(bounds['boundaries']) - 1})",
+                "iteration_index": iteration_index,
+            },
+        )
+    bnd = bounds["boundaries"][iteration_index]
+    trim_before = (
+        (bnd["before"]["start_ns"], bnd["before"]["end_ns"])
+        if bnd["before"]["start_ns"] is not None
+        else None
+    )
+    trim_after = (
+        (bnd["after"]["start_ns"], bnd["after"]["end_ns"])
+        if bnd["after"]["start_ns"] is not None
+        else None
+    )
+    if trim_before is None or trim_after is None:
+        return (
+            trim_before,
+            trim_after,
+            {
+                "error": "Missing before or after window for this iteration",
+                "iteration_index": iteration_index,
+                "has_before": bnd["has_before"],
+                "has_after": bnd["has_after"],
+            },
+        )
+    return trim_before, trim_after, None
+
+
+def _build_launch_delta(before: dict | None, after: dict | None) -> dict:
+    delta: dict = {}
+    for config_field in (
+        "gridX",
+        "gridY",
+        "gridZ",
+        "grid",
+        "blockX",
+        "blockY",
+        "blockZ",
+        "block",
+        "total_blocks",
+        "threads_per_block",
+        "total_threads",
+        "registersPerThread",
+        "staticSharedMemory",
+        "dynamicSharedMemory",
+        "sharedMemoryBytes",
+    ):
+        b = before.get(config_field) if before else None
+        a = after.get(config_field) if after else None
+        if b is not None or a is not None:
+            delta[config_field] = _delta_entry(b, a)
+    return delta
+
+
+def _changed(delta: dict, field: str) -> bool:
+    entry = delta.get(field)
+    if not entry:
+        return False
+    d = entry.get("delta")
+    if isinstance(d, list):
+        return any(x not in (None, 0) for x in d)
+    return d not in (None, 0)
+
+
+def _launch_config_explanation(kernel_name: str, before: dict | None, after: dict | None, delta: dict) -> str:
+    if before is None and after is None:
+        return f"No launch configuration rows found for kernel '{kernel_name}'."
+    if before is None:
+        return f"Kernel '{kernel_name}' only appears after; launch configuration has no before baseline."
+    if after is None:
+        return f"Kernel '{kernel_name}' only appears before; launch configuration has no after comparison."
+
+    parts: list[str] = []
+    if _changed(delta, "grid"):
+        parts.append(f"grid {_format_dims(before.get('grid'))} -> {_format_dims(after.get('grid'))}")
+    if _changed(delta, "block"):
+        parts.append(f"block {_format_dims(before.get('block'))} -> {_format_dims(after.get('block'))}")
+    if _changed(delta, "registersPerThread"):
+        parts.append(
+            f"registers/thread {before.get('registersPerThread')} -> {after.get('registersPerThread')}"
+        )
+    if _changed(delta, "sharedMemoryBytes"):
+        parts.append(
+            f"shared mem {_format_bytes(before.get('sharedMemoryBytes'))} -> {_format_bytes(after.get('sharedMemoryBytes'))}"
+        )
+    if not parts:
+        return "Launch config is unchanged; slowdown is likely from data, scheduling, memory behavior, or lower-level kernel execution."
+
+    occupancy_reasons = []
+    reg_delta = (delta.get("registersPerThread") or {}).get("delta")
+    shared_delta = (delta.get("sharedMemoryBytes") or {}).get("delta")
+    threads_delta = (delta.get("threads_per_block") or {}).get("delta")
+    blocks_delta = (delta.get("total_blocks") or {}).get("delta")
+    if isinstance(reg_delta, int) and reg_delta > 0:
+        occupancy_reasons.append("higher register pressure")
+    if isinstance(shared_delta, int) and shared_delta > 0:
+        occupancy_reasons.append("more shared memory per block")
+    if isinstance(threads_delta, int) and threads_delta > 0:
+        occupancy_reasons.append("larger blocks")
+    if isinstance(blocks_delta, int) and blocks_delta < 0:
+        occupancy_reasons.append("fewer blocks")
+
+    if occupancy_reasons:
+        return "; ".join(parts) + " -> likely lower occupancy/parallelism from " + ", ".join(occupancy_reasons) + "."
+    return "; ".join(parts) + " -> launch geometry changed; inspect occupancy and memory behavior."
+
+
 def get_launch_config_diff(
     ctx: DiffContext,
     kernel_name: str,
@@ -701,38 +1023,60 @@ def get_launch_config_diff(
     """
     Grid/block/registers before vs after; explains 'why'. Returns error when columns missing (BETA).
     """
-    # Launch-config columns are BETA; detect available columns
-    kt = ctx.before.schema.kernel_table
-    try:
-        if ctx.before.db is not None:
-            # DuckDB path: DESCRIBE is valid
-            col_rows = ctx.before._duckdb_query(f"DESCRIBE {kt}")
-            cols = [r.get("column_name") or r.get("name") or "" for r in col_rows]
-        else:
-            # SQLite fallback: DESCRIBE is not valid, use PRAGMA
-            with ctx.before._lock:
-                cols = [
-                    r[1] for r in ctx.before.conn.execute(f"PRAGMA table_info({kt})").fetchall()
-                ]
-    except Exception:
-        cols = []
-    if not ("gridX" in cols or "blockX" in cols):
+    before_cols = _kernel_table_columns(ctx.before)
+    after_cols = _kernel_table_columns(ctx.after)
+    before_selected = _launch_config_columns(before_cols)
+    after_selected = _launch_config_columns(after_cols)
+    common_keys = sorted(set(before_selected).intersection(after_selected))
+    before_common = {key: before_selected[key] for key in common_keys}
+    after_common = {key: after_selected[key] for key in common_keys}
+
+    if not ("gridX" in before_common or "blockX" in before_common):
         return {
             "error": "not available",
             "reason": "Launch-config columns (gridX/blockX, etc.) not in export",
+            "available_columns": {
+                "before": before_cols,
+                "after": after_cols,
+            },
         }
-    # Optional: query one kernel by name in trim window and return before/after config
-    return {
+
+    trim_before, trim_after, window_error = _resolve_launch_config_windows(
+        ctx, iteration_index, target_gpu
+    )
+    if window_error is not None:
+        return window_error
+
+    before_row = _query_launch_config(ctx.before, kernel_name, before_common, trim_before, target_gpu)
+    after_row = _query_launch_config(ctx.after, kernel_name, after_common, trim_after, target_gpu)
+    before_config = _normalize_launch_row(before_row, before_common)
+    after_config = _normalize_launch_row(after_row, after_common)
+    delta = _build_launch_delta(before_config, after_config)
+    explanation = _launch_config_explanation(kernel_name, before_config, after_config, delta)
+
+    base = {
         "kernel_name": kernel_name,
-        "before": {},
-        "after": {},
+        "target_gpu": target_gpu,
+        "iteration_index": iteration_index,
+        "trim_before_ns": list(trim_before) if trim_before else None,
+        "trim_after_ns": list(trim_after) if trim_after else None,
+        "columns_used": {
+            "before": before_common,
+            "after": after_common,
+        },
+        "before": before_config,
+        "after": after_config,
+        "delta": delta,
+        "explanation": explanation,
         "uses_tensor_core_likely": any(
             p in kernel_name
             for p in ("sm80_xmma_", "volta_fp16_s884gemm", "h884gemm", "xmma", "wmma")
         ),
-        "error": "not available",
-        "reason": "Launch-config diff not yet implemented; schema present",
     }
+    if before_config is None or after_config is None:
+        base["error"] = "not comparable"
+        base["reason"] = explanation
+    return base
 
 
 def get_source_code_context(ctx: DiffContext, nvtx_path: str) -> dict:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -63,15 +63,24 @@ def _make_profile(path: str, *, kernels: list[tuple], nvtx: list[tuple] | None =
     conn.close()
 
 
-def _make_profile_with_launch_config(path: str, *, kernels: list[tuple]):
+def _make_profile_with_launch_config(
+    path: str,
+    *,
+    kernels: list[tuple],
+    shared_cols: tuple[str, str] = ("staticSharedMemory", "dynamicSharedMemory"),
+):
     """
     Minimal profile with launch-config columns.
 
     kernels entries:
       (start_ns, end_ns, deviceId, streamId, correlationId, shortNameId, demangledId,
        gridX, gridY, gridZ, blockX, blockY, blockZ,
-       registersPerThread, staticSharedMemory, dynamicSharedMemory)
+       registersPerThread, <static shared>, <dynamic shared>)
+
+    shared_cols overrides the shared-memory column names so tests can exercise
+    the staticSharedMemoryBytes / dynamicSharedMemoryBytes schema variants.
     """
+    static_col, dynamic_col = shared_cols
     conn = sqlite3.connect(path)
     conn.execute("CREATE TABLE StringIds(id INT PRIMARY KEY, value TEXT)")
     conn.execute(
@@ -80,7 +89,7 @@ def _make_profile_with_launch_config(path: str, *, kernels: list[tuple]):
         "shortName INT, demangledName INT, "
         "gridX INT, gridY INT, gridZ INT, "
         "blockX INT, blockY INT, blockZ INT, "
-        "registersPerThread INT, staticSharedMemory INT, dynamicSharedMemory INT)"
+        f"registersPerThread INT, {static_col} INT, {dynamic_col} INT)"
     )
     conn.execute("CREATE TABLE NVTX_EVENTS(text TEXT, globalTid INT, start INT, [end] INT)")
     # Empty RUNTIME table so iteration detection can run (and cleanly find no
@@ -101,7 +110,7 @@ def _make_profile_with_launch_config(path: str, *, kernels: list[tuple]):
         "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL("
         "start, [end], deviceId, streamId, correlationId, shortName, demangledName, "
         "gridX, gridY, gridZ, blockX, blockY, blockZ, "
-        "registersPerThread, staticSharedMemory, dynamicSharedMemory) "
+        f"registersPerThread, {static_col}, {dynamic_col}) "
         "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
         kernels,
     )
@@ -1043,6 +1052,104 @@ def test_get_launch_config_diff_unchanged_config_points_elsewhere(tmp_path):
     assert out["delta"]["gridX"]["delta"] == 0
     assert out["delta"]["registersPerThread"]["delta"] == 0
     assert "unchanged" in out["explanation"]
+
+
+def test_get_launch_config_diff_reads_shared_memory_bytes_column_variant(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # Newer Nsight exports name the columns staticSharedMemoryBytes /
+    # dynamicSharedMemoryBytes; the tool must detect those variants too.
+    variant = ("staticSharedMemoryBytes", "dynamicSharedMemoryBytes")
+    _make_profile_with_launch_config(
+        str(before),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 16_384)],
+        shared_cols=variant,
+    )
+    _make_profile_with_launch_config(
+        str(after),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 49_152)],
+        shared_cols=variant,
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", target_gpu=0)
+
+    assert "error" not in out
+    # The *Bytes variant is mapped back to the canonical output key.
+    assert out["columns_used"]["before"]["dynamicSharedMemory"] == "dynamicSharedMemoryBytes"
+    assert out["delta"]["sharedMemoryBytes"]["before"] == 16_384
+    assert out["delta"]["sharedMemoryBytes"]["after"] == 49_152
+    assert out["delta"]["sharedMemoryBytes"]["delta"] == 32_768
+
+
+def test_get_launch_config_diff_not_available_when_columns_absent(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # Plain profiles: kernel table has no grid/block launch-config columns.
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", target_gpu=0)
+
+    assert out["error"] == "not available"
+    assert "gridX" not in out["available_columns"]["before"]
+
+
+def test_get_launch_config_diff_not_available_when_columns_asymmetric(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # before HAS launch-config columns, after does NOT -> common set is empty,
+    # so there is nothing comparable and the tool reports "not available".
+    _make_profile_with_launch_config(
+        str(before),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0)],
+    )
+    _make_profile(str(after), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", target_gpu=0)
+
+    assert out["error"] == "not available"
+    # The asymmetry is surfaced for debugging.
+    assert "gridX" in out["available_columns"]["before"]
+    assert "gridX" not in out["available_columns"]["after"]
+
+
+def test_get_launch_config_diff_negative_iteration_index_out_of_range(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_launch_config(
+        str(before),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0)],
+    )
+    _make_profile_with_launch_config(
+        str(after),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0)],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", iteration_index=-1, target_gpu=0)
+
+    # -1 must NOT silently select the last iteration via Python indexing.
+    assert "out of range" in out["error"]
+    assert out["iteration_index"] == -1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -63,6 +63,52 @@ def _make_profile(path: str, *, kernels: list[tuple], nvtx: list[tuple] | None =
     conn.close()
 
 
+def _make_profile_with_launch_config(path: str, *, kernels: list[tuple]):
+    """
+    Minimal profile with launch-config columns.
+
+    kernels entries:
+      (start_ns, end_ns, deviceId, streamId, correlationId, shortNameId, demangledId,
+       gridX, gridY, gridZ, blockX, blockY, blockZ,
+       registersPerThread, staticSharedMemory, dynamicSharedMemory)
+    """
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE StringIds(id INT PRIMARY KEY, value TEXT)")
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL("
+        "start INT, [end] INT, deviceId INT, streamId INT, correlationId INT, "
+        "shortName INT, demangledName INT, "
+        "gridX INT, gridY INT, gridZ INT, "
+        "blockX INT, blockY INT, blockZ INT, "
+        "registersPerThread INT, staticSharedMemory INT, dynamicSharedMemory INT)"
+    )
+    conn.execute("CREATE TABLE NVTX_EVENTS(text TEXT, globalTid INT, start INT, [end] INT)")
+    # Empty RUNTIME table so iteration detection can run (and cleanly find no
+    # iterations) instead of raising on a missing table.
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME(globalTid INT, correlationId INT, start INT, [end] INT)"
+    )
+    conn.executemany(
+        "INSERT INTO StringIds(id, value) VALUES(?,?)",
+        [
+            (1, "kA"),
+            (2, "kA_dem"),
+            (3, "kB"),
+            (4, "kB_dem"),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL("
+        "start, [end], deviceId, streamId, correlationId, shortName, demangledName, "
+        "gridX, gridY, gridZ, blockX, blockY, blockZ, "
+        "registersPerThread, staticSharedMemory, dynamicSharedMemory) "
+        "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+        kernels,
+    )
+    conn.commit()
+    conn.close()
+
+
 def _make_profile_with_runtime(
     path: str,
     *,
@@ -842,6 +888,161 @@ def test_diff_tools_region_diff_and_stubs(tmp_path):
         ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
         mem = get_memory_profile_diff(ctx, target_gpu=0)
     assert "error" in mem
+
+
+def test_get_launch_config_diff_returns_config_delta_and_explanation(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_launch_config(
+        str(before),
+        kernels=[
+            # In-window representative config.
+            (0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0),
+            # Outside ctx.trim and longer; must not win.
+            (200_000_000, 260_000_000, 0, 7, 2, 1, 2, 999, 1, 1, 64, 1, 1, 32, 0, 0),
+        ],
+    )
+    _make_profile_with_launch_config(
+        str(after),
+        kernels=[
+            (0, 20_000_000, 0, 7, 1, 1, 2, 128, 1, 1, 128, 1, 1, 96, 0, 49_152),
+            (200_000_000, 260_000_000, 0, 7, 2, 1, 2, 999, 1, 1, 64, 1, 1, 32, 0, 0),
+        ],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=(0, 100_000_000), marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", target_gpu=0)
+
+    assert "error" not in out
+    assert out["before"]["grid"] == [256, 1, 1]
+    assert out["after"]["grid"] == [128, 1, 1]
+    assert out["delta"]["gridX"] == {"before": 256, "after": 128, "delta": -128}
+    assert out["delta"]["grid"]["delta"] == [-128, 0, 0]
+    assert out["delta"]["registersPerThread"] == {"before": 64, "after": 96, "delta": 32}
+    assert out["delta"]["sharedMemoryBytes"]["after"] == 49_152
+    assert out["before"]["sample_count"] == 1
+    assert "999" not in out["explanation"]
+    assert "registers/thread 64 -> 96" in out["explanation"]
+    assert "occupancy" in out["explanation"]
+
+
+def test_get_launch_config_diff_partial_when_kernel_missing_one_side(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_launch_config(
+        str(before),
+        kernels=[(0, 10, 0, 7, 1, 1, 2, 1, 1, 1, 128, 1, 1, 32, 0, 0)],
+    )
+    _make_profile_with_launch_config(
+        str(after),
+        kernels=[(0, 10, 0, 7, 1, 3, 4, 1, 1, 1, 128, 1, 1, 32, 0, 0)],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", target_gpu=0)
+
+    assert out["error"] == "not comparable"
+    assert out["before"]["matched_name"] == "kA_dem"
+    assert out["after"] is None
+    assert "only appears before" in out["explanation"]
+
+
+def test_get_launch_config_diff_reports_distinct_configs_and_dominant_share(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # before: kA launched with two distinct configs in-window —
+    #   grid 256 x2 (20ms total) -> dominant by GPU time
+    #   grid 128 x1 (5ms total)
+    _make_profile_with_launch_config(
+        str(before),
+        kernels=[
+            (0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0),
+            (10_000_000, 20_000_000, 0, 7, 2, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0),
+            (20_000_000, 25_000_000, 0, 7, 3, 1, 2, 128, 1, 1, 128, 1, 1, 64, 0, 0),
+        ],
+    )
+    # after: kA launched only one way.
+    _make_profile_with_launch_config(
+        str(after),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0)],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=(0, 100_000_000), marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", target_gpu=0)
+
+    assert "error" not in out
+    # Dominant config is the one with the most GPU time (grid 256), not the
+    # smallest or the most recent.
+    assert out["before"]["grid"] == [256, 1, 1]
+    assert out["before"]["distinct_configs"] == 2
+    assert out["before"]["total_invocations"] == 3
+    assert out["before"]["sample_count"] == 2
+    assert out["before"]["dominant_share"] == round(2 / 3, 4)
+    # after launched only one way -> dominant config is fully representative.
+    assert out["after"]["distinct_configs"] == 1
+    assert out["after"]["dominant_share"] == 1.0
+
+
+def test_get_launch_config_diff_iteration_index_out_of_range(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_launch_config(
+        str(before),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0)],
+    )
+    _make_profile_with_launch_config(
+        str(after),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0)],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", iteration_index=99, target_gpu=0)
+
+    assert "out of range" in out["error"]
+    assert out["iteration_index"] == 99
+
+
+def test_get_launch_config_diff_unchanged_config_points_elsewhere(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_launch_config_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # Identical launch config; only the duration grew. The tool should rule
+    # launch config OUT as the cause and point elsewhere.
+    _make_profile_with_launch_config(
+        str(before),
+        kernels=[(0, 10_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0)],
+    )
+    _make_profile_with_launch_config(
+        str(after),
+        kernels=[(0, 20_000_000, 0, 7, 1, 1, 2, 256, 1, 1, 128, 1, 1, 64, 0, 0)],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_launch_config_diff(ctx, "kA", target_gpu=0)
+
+    assert "error" not in out
+    assert out["delta"]["gridX"]["delta"] == 0
+    assert out["delta"]["registersPerThread"]["delta"] == 0
+    assert "unchanged" in out["explanation"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fills in the stubbed `get_launch_config_diff` agent tool so it returns a real launch-config comparison instead of "not yet implemented". This is the **"why"layer** on top of the diff verdict (#130) and TraceSelection (#159): verdict says *whether* a kernel regressed, the selection says *where*, and this says *why* — by comparing grid/block/registers/shared-mem before vs after.

- Detects available launch-config columns (gridX/Y/Z, blockX/Y/Z, registersPerThread, static/dynamicSharedMemory), tolerating partial BETA schemas + name variants; only compares columns present in **both** profiles.
- Picks the **dominant config** per kernel by total GPU time, within the trim / iteration window (reuses `get_iteration_boundaries`).
- Reports `distinct_configs` + `dominant_share` so a kernel launched with several shapes isn't silently summarized by one config.
- Per-field before/after/delta + a conservative occupancy explanation; **"config unchanged" explicitly points elsewhere** (data / scheduling / memory) instead of over-claiming. One-sided kernels → "not comparable".

## Test plan
- [x] 5 tests: delta+explanation w/ windowing, one-sided kernel,
      distinct_configs/dominant_share, iteration-index out of range, unchanged config
- [x] `pytest tests/` → 964 passed
- [x] `ruff check src/ tests/` clean