### PR TITLE
fix(cli): restore bare profile timeline shortcut

### DIFF
--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -88,7 +88,6 @@ def _looks_like_profile_path(value: str) -> bool:
         and (
             value.endswith(".sqlite")
             or value.endswith(".nsys-rep")
-            or value.endswith(".nsys-rep.zst")
         )
     )
 

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -44,6 +44,7 @@ def show_help():
     print("  Commands:")
     print("  ─────────────────────────────────────────────────────────")
     print("    nsys-ai                       Show this help")
+    print("    nsys-ai <profile>             Open web timeline UI (default)")
     print("    nsys-ai help                  This help text")
     print()
     print("  Analysis:")
@@ -83,11 +84,12 @@ def show_help():
 
 
 def _looks_like_profile_path(value: str) -> bool:
+    lower_value = value.lower()
     return (
         not value.startswith("-")
         and (
-            value.endswith(".sqlite")
-            or value.endswith(".nsys-rep")
+            lower_value.endswith(".sqlite")
+            or lower_value.endswith(".nsys-rep")
         )
     )
 

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -82,8 +82,28 @@ def show_help():
 # ---------------------------------------------------------------------------
 
 
+def _looks_like_profile_path(value: str) -> bool:
+    return (
+        not value.startswith("-")
+        and (
+            value.endswith(".sqlite")
+            or value.endswith(".nsys-rep")
+            or value.endswith(".nsys-rep.zst")
+        )
+    )
+
+
+def _normalize_default_profile_command(argv: list[str]) -> list[str]:
+    """Route ``nsys-ai <profile>`` through the public timeline-web command."""
+    if len(argv) > 1 and _looks_like_profile_path(argv[1]):
+        return [argv[0], "timeline-web", *argv[1:]]
+    return argv
+
+
 def main():
     from .parsers import _build_legacy_parser, _build_parser
+
+    sys.argv = _normalize_default_profile_command(sys.argv)
 
     legacy_commands = {
         "analyze",
@@ -113,24 +133,6 @@ def main():
     args = parser.parse_args()
 
     if not args.command:
-        # Zero-arg / unknown: if first arg looks like a profile path, open timeline-web;
-        # otherwise show help (intentional: no interactive launcher; see PR/docs for rationale).
-        remaining = sys.argv[1:]
-        if remaining and not remaining[0].startswith("-"):
-            candidate = remaining[0]
-            if (
-                candidate.endswith(".sqlite")
-                or candidate.endswith(".nsys-rep")
-                or candidate.endswith(".nsys-rep.zst")
-            ):
-                from nsys_ai import profile as _profile
-                from nsys_ai.web import serve_timeline
-
-                with _profile.open(candidate) as prof:
-                    devices = prof.meta.devices if prof.meta.devices else [0]
-                    serve_timeline(prof, devices, None, port=8144, open_browser=True)
-                return
-
         show_help()
         return
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,47 @@ def test_subcommands():
     assert ",agent}" not in usage_line
 
 
+def test_default_profile_command_routes_to_timeline_web():
+    """Bare profile paths should keep working as the default web timeline command."""
+    from nsys_ai.cli.app import _normalize_default_profile_command
+
+    assert _normalize_default_profile_command(["nsys-ai", "profile.nsys-rep"]) == [
+        "nsys-ai",
+        "timeline-web",
+        "profile.nsys-rep",
+    ]
+    assert _normalize_default_profile_command(
+        ["nsys-ai", "profile.nsys-rep", "--no-browser"]
+    ) == [
+        "nsys-ai",
+        "timeline-web",
+        "profile.nsys-rep",
+        "--no-browser",
+    ]
+
+
+def test_default_profile_command_accepts_sqlite_and_zst():
+    """The documented shorthand applies to all profile path forms."""
+    from nsys_ai.cli.app import _normalize_default_profile_command
+
+    assert _normalize_default_profile_command(["nsys-ai", "profile.sqlite"])[1] == "timeline-web"
+    assert (
+        _normalize_default_profile_command(["nsys-ai", "profile.nsys-rep.zst"])[1]
+        == "timeline-web"
+    )
+
+
+def test_default_profile_command_leaves_subcommands_unchanged():
+    """Named commands still parse through the normal public/legacy command tables."""
+    from nsys_ai.cli.app import _normalize_default_profile_command
+
+    assert _normalize_default_profile_command(["nsys-ai", "open", "profile.nsys-rep"]) == [
+        "nsys-ai",
+        "open",
+        "profile.nsys-rep",
+    ]
+
+
 def test_chat_subcommand_help():
     """chat subcommand should have --help and accept a profile argument."""
     result = subprocess.run(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,16 @@ def test_subcommands():
     assert ",agent}" not in usage_line
 
 
+def test_custom_help_mentions_default_profile_shortcut():
+    """The getting-started help should advertise the bare profile shortcut."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "help"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "nsys-ai <profile>" in result.stdout
+    assert "Open web timeline UI (default)" in result.stdout
+
+
 def test_default_profile_command_routes_to_timeline_web():
     """Bare profile paths should keep working as the default web timeline command."""
     from nsys_ai.cli.app import _normalize_default_profile_command
@@ -79,6 +89,11 @@ def test_default_profile_command_accepts_supported_profile_paths_only():
     from nsys_ai.cli.app import _normalize_default_profile_command
 
     assert _normalize_default_profile_command(["nsys-ai", "profile.sqlite"])[1] == "timeline-web"
+    assert _normalize_default_profile_command(["nsys-ai", "PROFILE.SQLITE"]) == [
+        "nsys-ai",
+        "timeline-web",
+        "PROFILE.SQLITE",
+    ]
     assert _normalize_default_profile_command(["nsys-ai", "profile.nsys-rep.zst"]) == [
         "nsys-ai",
         "profile.nsys-rep.zst",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -74,15 +74,15 @@ def test_default_profile_command_routes_to_timeline_web():
     ]
 
 
-def test_default_profile_command_accepts_sqlite_and_zst():
-    """The documented shorthand applies to all profile path forms."""
+def test_default_profile_command_accepts_supported_profile_paths_only():
+    """The documented shorthand applies only to profile paths the opener supports."""
     from nsys_ai.cli.app import _normalize_default_profile_command
 
     assert _normalize_default_profile_command(["nsys-ai", "profile.sqlite"])[1] == "timeline-web"
-    assert (
-        _normalize_default_profile_command(["nsys-ai", "profile.nsys-rep.zst"])[1]
-        == "timeline-web"
-    )
+    assert _normalize_default_profile_command(["nsys-ai", "profile.nsys-rep.zst"]) == [
+        "nsys-ai",
+        "profile.nsys-rep.zst",
+    ]
 
 
 def test_default_profile_command_leaves_subcommands_unchanged():


### PR DESCRIPTION
## Summary

- Restores the documented `nsys-ai <profile>` shortcut for opening the default web timeline UI.
- Fixes a CLI regression where bare `.nsys-rep` and `.sqlite` paths were rejected as invalid subcommands before fallback routing could run.
- Adds focused tests for shorthand routing, supported suffix handling, help discoverability, and case-insensitive profile suffix matching.

## Changes

- `src/nsys_ai/cli/app.py`
  - Adds profile-path detection for supported `.sqlite` and `.nsys-rep` inputs.
  - Normalizes `nsys-ai <profile> ...` to `nsys-ai timeline-web <profile> ...` before argparse runs.
  - Removes now-unreachable post-parse fallback logic.
  - Documents the default `nsys-ai <profile>` shortcut in custom `nsys-ai help` output.
  - Matches supported profile suffixes case-insensitively.
  - Does not route unsupported `.nsys-rep.zst` paths.

- `tests/test_cli.py`
  - Adds coverage for bare profile routing to `timeline-web`.
  - Verifies `--no-browser` is preserved.
  - Verifies explicit subcommands like `nsys-ai open <profile>` remain unchanged.
  - Verifies `nsys-ai help` advertises the default bare-profile shortcut.
  - Verifies uppercase supported suffixes like `PROFILE.SQLITE` are routed.
  - Verifies unsupported `.nsys-rep.zst` paths are left untouched.

## Backward compatibility

Yes. This restores previously documented behavior and keeps explicit subcommand usage unchanged.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [ ] `pytest tests/ -v --tb=short` passes locally
- [ ] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path by verifying `nsys-ai <profile.nsys-rep>` is normalized to `nsys-ai timeline-web <profile.nsys-rep>`

Validated:
- `PYTHONPATH=src conda run -n llm_sys_py311 python -m pytest tests/test_cli.py -v --tb=short` — `17 passed`
- `PYTHONPATH=src conda run -n llm_sys_py311 python -m nsys_ai --help` — passed

## Out of scope

- Does not change the behavior of `timeline-web` itself.
- Does not implement decompression or support for `.nsys-rep.zst`.
- Does not update README wording, since the documented command was intended to work.
- Does not modify legacy CLI command routing.