### PR TITLE
fix(diff): default diff tools to all-GPU aggregation

### DIFF
--- a/src/nsys_ai/diff_tools.py
+++ b/src/nsys_ai/diff_tools.py
@@ -167,7 +167,7 @@ def search_nvtx_regions(
 def get_iteration_boundaries(
     ctx: DiffContext,
     marker: str | None = None,
-    target_gpu: int | None = 0,
+    target_gpu: int | None = None,
 ) -> dict:
     """
     Per-iteration time windows for both profiles plus is_aligned flag.
@@ -273,7 +273,7 @@ def explore_nvtx_hierarchy(
     ctx: DiffContext,
     parent_path: str = "",
     depth: int = 1,
-    target_gpu: int | None = 0,
+    target_gpu: int | None = None,
     profile_side: str = "after",
 ) -> dict:
     """
@@ -344,7 +344,7 @@ def get_iteration_diff(
     ctx: DiffContext,
     iteration_index: int,
     marker: str | None = None,
-    target_gpu: int | None = 0,
+    target_gpu: int | None = None,
 ) -> dict:
     """
     Macro diff for one iteration (time-window trim from detect_iterations).
@@ -389,15 +389,21 @@ def get_iteration_diff(
     wall_a = (trim_after[1] - trim_after[0]) / 1e6
     sum_k_b = sum(k.total_ns for k in summary.before.kernels) / 1e6
     sum_k_a = sum(k.total_ns for k in summary.after.kernels) / 1e6
-    # Unique stream count (Payload Contract)
-    gpu = target_gpu if target_gpu is not None else (ctx.before.meta.devices or [0])[0]
-    kerns_b = ctx.before.kernels(gpu, trim_before)
-    kerns_a = ctx.after.kernels(gpu, trim_after)
-    unique_streams_b = len(set(k.get("streamId") for k in kerns_b if k.get("streamId") is not None))
-    unique_streams_a = len(set(k.get("streamId") for k in kerns_a if k.get("streamId") is not None))
+    # Unique stream count (Payload Contract); target_gpu=None aggregates all devices
+    # so these detail fields match the all-GPU scope of `summary`.
+    kerns_b = ctx.before.kernels(target_gpu, trim_before)
+    kerns_a = ctx.after.kernels(target_gpu, trim_after)
+    # streamId is device-scoped, so count distinct (deviceId, streamId) pairs;
+    # otherwise an all-GPU window collapses each device's matching stream ids.
+    unique_streams_b = len(
+        {(k.get("deviceId"), k.get("streamId")) for k in kerns_b if k.get("streamId") is not None}
+    )
+    unique_streams_a = len(
+        {(k.get("deviceId"), k.get("streamId")) for k in kerns_a if k.get("streamId") is not None}
+    )
     # Memcpy H2D/D2H in window
-    mc_b = ctx.before.memcpy_in_window(gpu, trim_before)
-    mc_a = ctx.after.memcpy_in_window(gpu, trim_after)
+    mc_b = ctx.before.memcpy_in_window(target_gpu, trim_before)
+    mc_a = ctx.after.memcpy_in_window(target_gpu, trim_after)
     memcpy_ms = {
         "h2d": {
             "before": round(mc_b["h2d_ns"] / 1e6, 2),
@@ -524,7 +530,7 @@ def get_region_diff(
     ctx: DiffContext,
     nvtx_exact_match: str | list[str],
     iteration_index: int | None = None,
-    target_gpu: int | None = 0,
+    target_gpu: int | None = None,
 ) -> dict:
     """
     Micro diff for a code region (time window + NVTX filter).
@@ -576,10 +582,10 @@ def get_region_diff(
             "nvtx_exact_match": nvtx_exact_match,
         }
     nd = matching[0]
-    gpu = target_gpu if target_gpu is not None else (ctx.before.meta.devices or [0])[0]
-    # Payload Contract: same defensive fields as get_iteration_diff
-    mc_b = ctx.before.memcpy_in_window(gpu, trim_before)
-    mc_a = ctx.after.memcpy_in_window(gpu, trim_after)
+    # Payload Contract: same defensive fields as get_iteration_diff; target_gpu=None
+    # aggregates all devices so these match the all-GPU scope of `summary`.
+    mc_b = ctx.before.memcpy_in_window(target_gpu, trim_before)
+    mc_a = ctx.after.memcpy_in_window(target_gpu, trim_after)
     memcpy_ms = {
         "h2d": {
             "before": round(mc_b["h2d_ns"] / 1e6, 2),
@@ -592,10 +598,16 @@ def get_region_diff(
             "delta": round((mc_a["d2h_ns"] - mc_b["d2h_ns"]) / 1e6, 2),
         },
     }
-    kerns_b = ctx.before.kernels(gpu, trim_before)
-    kerns_a = ctx.after.kernels(gpu, trim_after)
-    unique_streams_b = len(set(k.get("streamId") for k in kerns_b if k.get("streamId") is not None))
-    unique_streams_a = len(set(k.get("streamId") for k in kerns_a if k.get("streamId") is not None))
+    kerns_b = ctx.before.kernels(target_gpu, trim_before)
+    kerns_a = ctx.after.kernels(target_gpu, trim_after)
+    # streamId is device-scoped, so count distinct (deviceId, streamId) pairs;
+    # otherwise an all-GPU window collapses each device's matching stream ids.
+    unique_streams_b = len(
+        {(k.get("deviceId"), k.get("streamId")) for k in kerns_b if k.get("streamId") is not None}
+    )
+    unique_streams_a = len(
+        {(k.get("deviceId"), k.get("streamId")) for k in kerns_a if k.get("streamId") is not None}
+    )
     idle_b = summary.before.overlap.get("idle_ms") or 0
     idle_a = summary.after.overlap.get("idle_ms") or 0
     mem_b = (mc_b["h2d_ns"] + mc_b["d2h_ns"] + mc_b["d2d_ns"]) / 1e6
@@ -659,7 +671,7 @@ def summarize_nvtx_subtree(
     ctx: DiffContext,
     parent_path: str,
     iteration_index: int | None = None,
-    target_gpu: int | None = 0,
+    target_gpu: int | None = None,
     top_n: int = 3,
 ) -> dict:
     """
@@ -1020,7 +1032,7 @@ def get_launch_config_diff(
     ctx: DiffContext,
     kernel_name: str,
     iteration_index: int | None = None,
-    target_gpu: int | None = 0,
+    target_gpu: int | None = None,
 ) -> dict:
     """
     Grid/block/registers before vs after; explains 'why'. Returns error when columns missing (BETA).
@@ -1266,7 +1278,10 @@ TOOLS_DIFF_OPENAI = [
                         "type": "string",
                         "description": "NVTX marker for iteration (e.g. %sample_0%)",
                     },
-                    "target_gpu": {"type": "integer", "description": "GPU ID or omit for default"},
+                    "target_gpu": {
+                        "type": "integer",
+                        "description": "GPU ID for iteration detection; omit to use the first device",
+                    },
                 },
                 "required": [],
             },
@@ -1286,7 +1301,10 @@ TOOLS_DIFF_OPENAI = [
                         "default": "",
                     },
                     "depth": {"type": "integer", "description": "Depth to expand", "default": 1},
-                    "target_gpu": {"type": "integer", "description": "GPU ID"},
+                    "target_gpu": {
+                        "type": "integer",
+                        "description": "GPU ID for the NVTX tree; omit to use the first device",
+                    },
                     "profile_side": {
                         "type": "string",
                         "enum": ["before", "after"],
@@ -1306,7 +1324,10 @@ TOOLS_DIFF_OPENAI = [
                 "type": "object",
                 "properties": {
                     "limit": {"type": "integer", "default": 20},
-                    "target_gpu": {"type": "integer", "description": "GPU ID or omit for all GPUs"},
+                    "target_gpu": {
+                        "type": "integer",
+                        "description": "GPU ID; omit to aggregate all GPUs",
+                    },
                 },
                 "required": [],
             },
@@ -1325,7 +1346,10 @@ TOOLS_DIFF_OPENAI = [
                         "description": "0-based iteration index (from get_iteration_boundaries)",
                     },
                     "marker": {"type": "string", "description": "Iteration marker"},
-                    "target_gpu": {"type": "integer", "default": 0},
+                    "target_gpu": {
+                        "type": "integer",
+                        "description": "GPU ID; omit to aggregate all GPUs",
+                    },
                 },
                 "required": ["iteration_index"],
             },
@@ -1350,7 +1374,10 @@ TOOLS_DIFF_OPENAI = [
                         "type": "integer",
                         "description": "0-based iteration (optional)",
                     },
-                    "target_gpu": {"type": "integer", "default": 0},
+                    "target_gpu": {
+                        "type": "integer",
+                        "description": "GPU ID; omit to aggregate all GPUs",
+                    },
                 },
                 "required": ["nvtx_exact_match"],
             },
@@ -1366,7 +1393,10 @@ TOOLS_DIFF_OPENAI = [
                 "properties": {
                     "parent_path": {"type": "string"},
                     "iteration_index": {"type": "integer"},
-                    "target_gpu": {"type": "integer", "default": 0},
+                    "target_gpu": {
+                        "type": "integer",
+                        "description": "GPU ID; omit to aggregate all GPUs",
+                    },
                     "top_n": {"type": "integer", "default": 3},
                 },
                 "required": ["parent_path"],
@@ -1383,7 +1413,10 @@ TOOLS_DIFF_OPENAI = [
                 "properties": {
                     "kernel_name": {"type": "string"},
                     "iteration_index": {"type": "integer"},
-                    "target_gpu": {"type": "integer", "default": 0},
+                    "target_gpu": {
+                        "type": "integer",
+                        "description": "GPU ID; omit to aggregate all GPUs",
+                    },
                 },
                 "required": ["kernel_name"],
             },

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -362,7 +362,7 @@ class Profile:
     def kernels(self, device: int | None, trim: tuple[int, int] | None = None) -> list[dict]:
         """All kernels on a device (or all devices if None), optionally trimmed to a time window."""
         sql = """
-            SELECT k.start, k.[end], k.streamId, k.correlationId,
+            SELECT k.start, k.[end], k.deviceId, k.streamId, k.correlationId,
                    s.value as name, d.value as demangled
             FROM {kernel_table} k
             JOIN StringIds s ON k.shortName = s.id
@@ -533,25 +533,28 @@ class Profile:
 
     def memcpy_in_window(
         self,
-        device: int,
+        device: int | None,
         trim: tuple[int, int],
     ) -> dict:
         """
         Sum memcpy time in window by direction (H2D=1, D2H=2, D2D=8).
+        ``device=None`` aggregates across all devices (matches ``kernels``).
         Returns {h2d_ns, d2h_ns, d2d_ns, total_ns}; 0 when table or window empty.
         """
         out = {"h2d_ns": 0, "d2h_ns": 0, "d2d_ns": 0, "total_ns": 0}
         if "CUPTI_ACTIVITY_KIND_MEMCPY" not in self.schema.tables:
             return out
-        rows = self._duckdb_query(
-            """
+        sql = """
             SELECT copyKind, SUM([end] - start) AS total_ns
             FROM CUPTI_ACTIVITY_KIND_MEMCPY
-            WHERE deviceId = ? AND start >= ? AND [end] <= ?
-            GROUP BY copyKind
-            """,
-            [device, trim[0], trim[1]],
-        )
+            WHERE start >= ? AND [end] <= ?
+        """
+        params: list = [trim[0], trim[1]]
+        if device is not None:
+            sql += " AND deviceId = ?"
+            params.append(device)
+        sql += " GROUP BY copyKind"
+        rows = self._duckdb_query(sql, params)
         for r in rows:
             kind = int(r["copyKind"])
             ns = int(r["total_ns"] or 0)

--- a/src/nsys_ai/tool_dispatch.py
+++ b/src/nsys_ai/tool_dispatch.py
@@ -435,7 +435,7 @@ class ToolDispatcher:
         res = get_iteration_boundaries(
             self._diff_context,
             args.get("marker"),
-            args.get("target_gpu", 0),
+            args.get("target_gpu"),
         )
         return ToolResult(content=json.dumps(res), events=events)
 
@@ -449,7 +449,7 @@ class ToolDispatcher:
             self._diff_context,
             args.get("parent_path", ""),
             args.get("depth", 1),
-            args.get("target_gpu", 0),
+            args.get("target_gpu"),
             args.get("profile_side", "after"),
         )
         return ToolResult(content=json.dumps(res), events=events)
@@ -477,7 +477,7 @@ class ToolDispatcher:
             self._diff_context,
             int(args["iteration_index"]),
             args.get("marker"),
-            args.get("target_gpu", 0),
+            args.get("target_gpu"),
         )
         return ToolResult(content=json.dumps(res), events=events)
 
@@ -494,7 +494,7 @@ class ToolDispatcher:
             self._diff_context,
             nvtx,
             args.get("iteration_index"),
-            args.get("target_gpu", 0),
+            args.get("target_gpu"),
         )
         return ToolResult(content=json.dumps(res), events=events)
 
@@ -557,7 +557,7 @@ class ToolDispatcher:
             self._diff_context,
             args.get("parent_path", ""),
             args.get("iteration_index"),
-            args.get("target_gpu", 0),
+            args.get("target_gpu"),
             args.get("top_n", 3),
         )
         return ToolResult(content=json.dumps(res), events=events)
@@ -572,6 +572,6 @@ class ToolDispatcher:
             self._diff_context,
             args.get("kernel_name", ""),
             args.get("iteration_index"),
-            args.get("target_gpu", 0),
+            args.get("target_gpu"),
         )
         return ToolResult(content=json.dumps(res), events=events)

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -899,6 +899,52 @@ def test_diff_tools_region_diff_and_stubs(tmp_path):
     assert "error" in mem
 
 
+def test_diff_tools_default_target_gpu_aggregates_all_gpus(tmp_path):
+    """Omitting target_gpu aggregates every device; an explicit id scopes to one.
+
+    The dispatcher and the diff_tools function signatures default target_gpu
+    to None, which means "all GPUs". A query that does not name a device must
+    therefore report the combined compute time of a multi-GPU profile, not
+    just GPU 0.
+    """
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_region_diff, run_diff_tool
+
+    # GPU 0 runs a 10ms kernel, GPU 1 a 20ms kernel, both inside "step" and both
+    # on stream 7. Reusing the same streamId across devices checks that the
+    # per-GPU detail fields aggregate by (deviceId, streamId), not streamId alone
+    # (streamId is device-scoped, so a naive count would collapse to one).
+    kernels = [
+        (0, 10_000_000, 0, 7, 1, 1, 2),  # deviceId 0, kA, 10ms, stream 7
+        (0, 20_000_000, 1, 7, 2, 3, 4),  # deviceId 1, kB, 20ms, stream 7
+    ]
+    nvtx = [("step", 1, 0, 20_000_000)]
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=kernels, nvtx=nvtx)
+    _make_profile(str(after), kernels=kernels, nvtx=nvtx)
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="step")
+
+        # Default (target_gpu omitted): both devices counted → 10 + 20 = 30ms,
+        # and the detail fields count two distinct (deviceId, streamId) pairs
+        # even though both devices reuse streamId 7.
+        all_gpus = get_region_diff(ctx, "step")
+        assert all_gpus["top3_global_categories"]["Compute"]["before"] == 30.0
+        assert all_gpus["unique_streams_count_before"] == 2
+
+        # Explicit device still scopes to that GPU only → 10ms and one stream.
+        gpu0 = get_region_diff(ctx, "step", target_gpu=0)
+        assert gpu0["top3_global_categories"]["Compute"]["before"] == 10.0
+        assert gpu0["unique_streams_count_before"] == 1
+
+        # Dispatching without target_gpu in args matches the all-GPU default.
+        dispatched = run_diff_tool(ctx, "get_region_diff", {"nvtx_exact_match": "step"})
+        assert dispatched["top3_global_categories"]["Compute"]["before"] == 30.0
+        assert dispatched["unique_streams_count_before"] == 2
+
+
 def test_get_launch_config_diff_returns_config_delta_and_explanation(tmp_path):
     from nsys_ai import profile as profile_mod
     from nsys_ai.diff_tools import DiffContext, get_launch_config_diff


### PR DESCRIPTION
## Summary

The agent-facing diff tools and their dispatcher defaulted `target_gpu` to `0`, so a diff query that did not name a device silently reported only GPU 0. On a multi-GPU profile this undercounts compute, communication, and idle time.

This changes the default to `None` (= all GPUs) consistently across the `diff_tools` functions and the `ToolDispatcher`, matching the existing CLI `diff --gpu` default where `None` already means all GPUs.

## Changes

- `diff_tools.py` — flip `target_gpu: int | None = 0` → `= None` on `get_iteration_boundaries`, `explore_nvtx_hierarchy`, `get_iteration_diff`, `get_region_diff`, `summarize_nvtx_subtree`, `get_launch_config_diff`.
- `tool_dispatch.py` — six handlers now pass `args.get("target_gpu")` instead of `args.get("target_gpu", 0)`.
- Tool schemas — remove the advertised `"default": 0` and unify the description to `"GPU ID; omit to aggregate all GPUs"`, so the model is not told 0 is the default.
- `None` reuses the existing all-GPU path in `build_profile_summary` (kernels aggregated across devices, per-device overlap summed). An explicit id still scopes to one GPU.

## Keep the detail fields in the same scope

`get_region_diff` and `get_iteration_diff` previously built an all-GPU compute summary but computed `memcpy_ms` and `unique_streams_count` on `devices[0]` only. With the new default a no-device query on a multi-GPU profile would mix all-GPU compute with GPU-0 transfer/stream counts.

- Generalize `Profile.memcpy_in_window` to accept `device=None` (aggregate all devices, mirroring `Profile.kernels`).
- Pass `target_gpu` straight through in both tools so the whole payload shares one scope.
- The `devices[0]` fallback is intentionally left in iteration detection and NVTX-tree building, which are inherently single-GPU.

## Behaviour & performance

- **Single-GPU profiles: unchanged** — the `None` path covers one device, identical to the old `gpu=0` work.
- **Multi-GPU**: added cost is proportional to device count, dominated by the per-device overlap pass. Measured on a 3.5 GB / 4-GPU / 2.19 M-kernel profile: a full per-side summary went 17.0 s → 24.1 s, of which the GPU-dependent delta is the overlap step (1.1 s → 5.0 s); kernel aggregation (1.5 s → 1.8 s) and the GPU-independent NVTX pass (~15 s) are flat. `memcpy_in_window(None)` is a single query, not a per-device loop.

## Tests

- New `test_diff_tools_default_target_gpu_aggregates_all_gpus`: two-GPU profile (10 ms on GPU 0 / stream 7, 20 ms on GPU 1 / stream 8). Omitting `target_gpu` reports 30 ms compute and 2 unique streams; explicit `target_gpu=0` reports 10 ms and 1 stream; the dispatcher path without `target_gpu` matches the all-GPU default.
- Full suite: 995 passed, 135 skipped; `ruff` clean.