### PR TITLE
feat(diff): implement get_memory_profile_diff (peak VRAM + alloc/free before vs after)

### DIFF
--- a/src/nsys_ai/diff_tools.py
+++ b/src/nsys_ai/diff_tools.py
@@ -773,14 +773,28 @@ def _format_dims(values: list[int | None] | None) -> str:
 def _format_bytes(value: int | None) -> str:
     if value is None:
         return "?"
+    if value < 0:
+        return "-" + _format_bytes(-value)
     if value == 0:
         return "0B"
     if value % 1024 == 0:
         kib = value // 1024
         if kib % 1024 == 0:
-            return f"{kib // 1024}MiB"
+            mib = kib // 1024
+            if mib % 1024 == 0:
+                return f"{mib // 1024}GiB"
+            return f"{mib}MiB"
         return f"{kib}KiB"
     return f"{value}B"
+
+
+def _format_signed_bytes(value: int | None) -> str:
+    if value is None:
+        return "?"
+    if value == 0:
+        return "0B"
+    sign = "+" if value > 0 else "-"
+    return sign + _format_bytes(abs(value))
 
 
 def _scalar_delta(before: int | None, after: int | None) -> int | None:
@@ -905,7 +919,7 @@ def _query_launch_config(
     return dominant
 
 
-def _resolve_launch_config_windows(
+def _resolve_diff_windows(
     ctx: DiffContext,
     iteration_index: int | None,
     target_gpu: int | None,
@@ -947,6 +961,14 @@ def _resolve_launch_config_windows(
             },
         )
     return trim_before, trim_after, None
+
+
+def _resolve_launch_config_windows(
+    ctx: DiffContext,
+    iteration_index: int | None,
+    target_gpu: int | None,
+) -> tuple[tuple[int, int] | None, tuple[int, int] | None, dict | None]:
+    return _resolve_diff_windows(ctx, iteration_index, target_gpu)
 
 
 def _build_launch_delta(before: dict | None, after: dict | None) -> dict:
@@ -1161,6 +1183,244 @@ def get_gpu_imbalance_stats(
     return {"iteration_index": iteration_index, "per_gpu": per_gpu}
 
 
+_MEMORY_USAGE_TABLE = "CUDA_GPU_MEMORY_USAGE_EVENTS"
+_MEMORY_REQUIRED_COLS = ("start", "bytes", "memoryOperationType")
+_MEMORY_DELTA_FIELDS = (
+    "peak_vram_bytes",
+    "baseline_vram_bytes",
+    "final_vram_bytes",
+    "allocated_bytes",
+    "freed_bytes",
+    "net_delta_bytes",
+    "alloc_count",
+    "free_count",
+    "event_count",
+    "unknown_event_count",
+)
+
+
+def _memory_table_columns(prof: Profile) -> list[str]:
+    if _MEMORY_USAGE_TABLE not in prof.schema.tables:
+        return []
+    try:
+        return prof.adapter.get_table_columns(_MEMORY_USAGE_TABLE)
+    except Exception:
+        try:
+            if prof.db is not None:
+                rows = prof._duckdb_query(f"DESCRIBE {_MEMORY_USAGE_TABLE}")
+                return [r.get("column_name") or r.get("name") or "" for r in rows]
+            with prof._lock:
+                return [
+                    r[1]
+                    for r in prof.conn.execute(
+                        f"PRAGMA table_info({_MEMORY_USAGE_TABLE})"
+                    ).fetchall()
+                ]
+        except Exception:
+            return []
+
+
+def _missing_memory_columns(cols: list[str]) -> list[str]:
+    colset = set(cols)
+    return [col for col in _MEMORY_REQUIRED_COLS if col not in colset]
+
+
+def _normalize_memory_profile_row(
+    row: dict,
+    *,
+    trim: tuple[int, int] | None,
+    target_gpu: int | None,
+) -> dict:
+    baseline = int(row.get("baseline_vram_bytes") or 0)
+    peak_after_event = row.get("peak_after_event_bytes")
+    peak_after_event_int = int(peak_after_event) if peak_after_event is not None else baseline
+    peak = max(baseline, peak_after_event_int)
+    net_delta = int(row.get("net_delta_bytes") or 0)
+    first_event = row.get("first_event_ns")
+    last_event = row.get("last_event_ns")
+
+    out = {
+        "target_gpu": target_gpu,
+        "trim_ns": list(trim) if trim else None,
+        "peak_vram_bytes": peak,
+        "baseline_vram_bytes": baseline,
+        "final_vram_bytes": baseline + net_delta,
+        "allocated_bytes": int(row.get("allocated_bytes") or 0),
+        "freed_bytes": int(row.get("freed_bytes") or 0),
+        "net_delta_bytes": net_delta,
+        "alloc_count": int(row.get("alloc_count") or 0),
+        "free_count": int(row.get("free_count") or 0),
+        "event_count": int(row.get("event_count") or 0),
+        "unknown_event_count": int(row.get("unknown_event_count") or 0),
+    }
+    if first_event is not None and last_event is not None:
+        out["event_window_ns"] = [int(first_event), int(last_event)]
+    return out
+
+
+def _query_memory_profile(
+    prof: Profile,
+    trim: tuple[int, int] | None,
+    target_gpu: int | None,
+) -> dict:
+    where_parts = ["1=1"]
+    event_params: list = []
+    if target_gpu is not None:
+        where_parts.append("deviceId = ?")
+        event_params.append(int(target_gpu))
+    if trim is not None:
+        where_parts.append("start <= ?")
+        event_params.append(int(trim[1]))
+
+    if trim is not None:
+        window_where = "event_start >= ? AND event_start <= ?"
+        window_params: list = [int(trim[0]), int(trim[1])]
+        baseline_expr = (
+            "(SELECT COALESCE(SUM(delta_bytes), 0) FROM events "
+            "WHERE event_start < ?) AS baseline_vram_bytes"
+        )
+        baseline_params: list = [int(trim[0])]
+    else:
+        window_where = "1=1"
+        window_params = []
+        baseline_expr = "0 AS baseline_vram_bytes"
+        baseline_params = []
+
+    # Nsight Systems records memoryOperationType=0 for allocation and 1 for
+    # deallocation. Build a running balance over all events up to the window
+    # end, then count alloc/free events only inside the selected window.
+    sql = f"""
+        WITH events AS (
+            SELECT
+                CAST(start AS BIGINT) AS event_start,
+                CAST(memoryOperationType AS INTEGER) AS op,
+                CAST(COALESCE(bytes, 0) AS BIGINT) AS bytes,
+                CASE
+                    WHEN memoryOperationType = 0 THEN CAST(COALESCE(bytes, 0) AS BIGINT)
+                    WHEN memoryOperationType = 1 THEN -CAST(COALESCE(bytes, 0) AS BIGINT)
+                    ELSE 0
+                END AS delta_bytes
+            FROM {_MEMORY_USAGE_TABLE}
+            WHERE {" AND ".join(where_parts)}
+        ),
+        running AS (
+            SELECT
+                event_start,
+                op,
+                bytes,
+                delta_bytes,
+                SUM(delta_bytes) OVER (
+                    ORDER BY event_start, CASE WHEN op = 1 THEN 0 ELSE 1 END
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                ) AS balance_bytes
+            FROM events
+        ),
+        windowed AS (
+            SELECT * FROM running WHERE {window_where}
+        )
+        SELECT
+            COUNT(*) AS event_count,
+            COALESCE(SUM(CASE WHEN op = 0 THEN 1 ELSE 0 END), 0) AS alloc_count,
+            COALESCE(SUM(CASE WHEN op = 1 THEN 1 ELSE 0 END), 0) AS free_count,
+            COALESCE(SUM(CASE WHEN op NOT IN (0, 1) THEN 1 ELSE 0 END), 0)
+                AS unknown_event_count,
+            COALESCE(SUM(CASE WHEN op = 0 THEN bytes ELSE 0 END), 0) AS allocated_bytes,
+            COALESCE(SUM(CASE WHEN op = 1 THEN bytes ELSE 0 END), 0) AS freed_bytes,
+            COALESCE(SUM(delta_bytes), 0) AS net_delta_bytes,
+            MIN(event_start) AS first_event_ns,
+            MAX(event_start) AS last_event_ns,
+            MAX(balance_bytes) AS peak_after_event_bytes,
+            {baseline_expr}
+        FROM windowed
+    """
+    row = prof._duckdb_query(sql, event_params + window_params + baseline_params)[0]
+    return _normalize_memory_profile_row(row, trim=trim, target_gpu=target_gpu)
+
+
+def _build_memory_delta(before: dict, after: dict) -> dict:
+    delta: dict = {}
+    for metric in _MEMORY_DELTA_FIELDS:
+        delta[metric] = _delta_entry(before.get(metric), after.get(metric))
+    return delta
+
+
+def _memory_columns_used(cols: list[str]) -> list[str]:
+    used = [col for col in _MEMORY_REQUIRED_COLS if col in cols]
+    if "deviceId" in cols:
+        used.append("deviceId")
+    return used
+
+
+def _memory_profile_explanation(before: dict, after: dict, delta: dict) -> str:
+    if before["event_count"] == 0 and after["event_count"] == 0:
+        if before["baseline_vram_bytes"] or after["baseline_vram_bytes"]:
+            return (
+                "No GPU alloc/free events occurred in the selected window; peak VRAM "
+                "stayed at the pre-window balance."
+            )
+        return (
+            "Memory capture is present, but no GPU alloc/free events were found "
+            "in the selected window."
+        )
+
+    parts: list[str] = []
+    peak_delta = delta["peak_vram_bytes"]["delta"]
+    net_delta_change = delta["net_delta_bytes"]["delta"]
+    alloc_count_delta = delta["alloc_count"]["delta"]
+    free_count_delta = delta["free_count"]["delta"]
+
+    if peak_delta:
+        parts.append(
+            "peak VRAM "
+            f"{_format_bytes(before['peak_vram_bytes'])} -> "
+            f"{_format_bytes(after['peak_vram_bytes'])} "
+            f"({_format_signed_bytes(peak_delta)})"
+        )
+    if alloc_count_delta or free_count_delta:
+        parts.append(
+            "alloc/free events "
+            f"{before['alloc_count']}/{before['free_count']} -> "
+            f"{after['alloc_count']}/{after['free_count']}"
+        )
+    if net_delta_change or before["net_delta_bytes"] or after["net_delta_bytes"]:
+        parts.append(
+            "net allocation "
+            f"{_format_signed_bytes(before['net_delta_bytes'])} -> "
+            f"{_format_signed_bytes(after['net_delta_bytes'])}"
+        )
+
+    if not parts:
+        return (
+            "GPU memory profile is unchanged; this diff does not explain the regression "
+            "via allocation footprint or allocator churn."
+        )
+
+    if isinstance(peak_delta, int) and peak_delta > 0:
+        if isinstance(alloc_count_delta, int) and alloc_count_delta > 0:
+            suffix = (
+                " -> higher peak plus more allocation churn suggests memory pressure "
+                "or allocator churn."
+            )
+        else:
+            suffix = " -> higher peak VRAM suggests increased memory pressure."
+    elif isinstance(peak_delta, int) and peak_delta < 0:
+        suffix = " -> lower peak VRAM reduces memory pressure."
+    elif isinstance(net_delta_change, int) and net_delta_change > 0:
+        suffix = (
+            " -> more memory remains allocated by window end; check retained tensors "
+            "or allocator caching."
+        )
+    elif (
+        isinstance(alloc_count_delta, int)
+        and isinstance(free_count_delta, int)
+        and (alloc_count_delta > 0 or free_count_delta > 0)
+    ):
+        suffix = " -> allocation/free churn changed; inspect cudaMalloc/cudaFree behavior."
+    else:
+        suffix = " -> memory behavior changed; inspect allocation lifetime and caching."
+    return "; ".join(parts) + suffix
+
+
 def get_memory_profile_diff(
     ctx: DiffContext,
     iteration_index: int | None = None,
@@ -1169,9 +1429,59 @@ def get_memory_profile_diff(
     """
     Peak VRAM + alloc/free count (Stage 7). Returns error when memory capture not present.
     """
-    if "CUDA_GPU_MEMORY_USAGE_EVENTS" not in ctx.before.schema.tables:
-        return {"error": "not available", "reason": "Memory profiling not enabled (table missing)"}
-    return {"error": "not available", "reason": "Memory diff not yet implemented"}
+    before_has = _MEMORY_USAGE_TABLE in ctx.before.schema.tables
+    after_has = _MEMORY_USAGE_TABLE in ctx.after.schema.tables
+    before_cols = _memory_table_columns(ctx.before) if before_has else []
+    after_cols = _memory_table_columns(ctx.after) if after_has else []
+    if not before_has or not after_has:
+        return {
+            "error": "not available",
+            "reason": "Memory profiling not enabled in both profiles (table missing)",
+            "tables_present": {"before": before_has, "after": after_has},
+            "available_columns": {"before": before_cols, "after": after_cols},
+        }
+
+    missing_before = _missing_memory_columns(before_cols)
+    missing_after = _missing_memory_columns(after_cols)
+    if missing_before or missing_after:
+        return {
+            "error": "not available",
+            "reason": "Memory profiling table is missing required columns",
+            "missing_columns": {"before": missing_before, "after": missing_after},
+            "available_columns": {"before": before_cols, "after": after_cols},
+        }
+
+    if target_gpu is not None and ("deviceId" not in before_cols or "deviceId" not in after_cols):
+        return {
+            "error": "not available",
+            "reason": "target_gpu filtering requires deviceId in memory profiling table",
+            "available_columns": {"before": before_cols, "after": after_cols},
+        }
+
+    trim_before, trim_after, window_error = _resolve_diff_windows(
+        ctx, iteration_index, target_gpu
+    )
+    if window_error is not None:
+        return window_error
+
+    before_stats = _query_memory_profile(ctx.before, trim_before, target_gpu)
+    after_stats = _query_memory_profile(ctx.after, trim_after, target_gpu)
+    delta = _build_memory_delta(before_stats, after_stats)
+    return {
+        "target_gpu": target_gpu,
+        "iteration_index": iteration_index,
+        "trim_before_ns": list(trim_before) if trim_before else None,
+        "trim_after_ns": list(trim_after) if trim_after else None,
+        "table": _MEMORY_USAGE_TABLE,
+        "columns_used": {
+            "before": _memory_columns_used(before_cols),
+            "after": _memory_columns_used(after_cols),
+        },
+        "before": before_stats,
+        "after": after_stats,
+        "delta": delta,
+        "explanation": _memory_profile_explanation(before_stats, after_stats, delta),
+    }
 
 
 # ── Phase C system prompt and tool metadata for agent integration ─────────────

--- a/src/nsys_ai/diff_tools.py
+++ b/src/nsys_ai/diff_tools.py
@@ -1195,8 +1195,11 @@ _MEMORY_DELTA_FIELDS = (
     "alloc_count",
     "free_count",
     "event_count",
+    "host_event_count",
     "unknown_event_count",
 )
+# memKind 0/1 are Pageable / Pinned host memory and never consume VRAM.
+_HOST_MEM_KINDS = (0, 1)
 
 
 def _memory_table_columns(prof: Profile) -> list[str]:
@@ -1230,6 +1233,9 @@ def _normalize_memory_profile_row(
     *,
     trim: tuple[int, int] | None,
     target_gpu: int | None,
+    mem_kind_available: bool,
+    distinct_contexts: int | None,
+    mem_kind_breakdown: list,
 ) -> dict:
     baseline = int(row.get("baseline_vram_bytes") or 0)
     peak_after_event = row.get("peak_after_event_bytes")
@@ -1242,6 +1248,7 @@ def _normalize_memory_profile_row(
     out = {
         "target_gpu": target_gpu,
         "trim_ns": list(trim) if trim else None,
+        "mem_kind_available": mem_kind_available,
         "peak_vram_bytes": peak,
         "baseline_vram_bytes": baseline,
         "final_vram_bytes": baseline + net_delta,
@@ -1251,8 +1258,13 @@ def _normalize_memory_profile_row(
         "alloc_count": int(row.get("alloc_count") or 0),
         "free_count": int(row.get("free_count") or 0),
         "event_count": int(row.get("event_count") or 0),
+        "host_event_count": int(row.get("host_event_count") or 0),
         "unknown_event_count": int(row.get("unknown_event_count") or 0),
     }
+    if distinct_contexts is not None:
+        out["distinct_contexts"] = distinct_contexts
+    if mem_kind_breakdown:
+        out["mem_kind_breakdown"] = mem_kind_breakdown
     if first_event is not None and last_event is not None:
         out["event_window_ns"] = [int(first_event), int(last_event)]
     return out
@@ -1262,22 +1274,39 @@ def _query_memory_profile(
     prof: Profile,
     trim: tuple[int, int] | None,
     target_gpu: int | None,
+    cols: list[str],
 ) -> dict:
-    where_parts = ["1=1"]
-    event_params: list = []
+    colset = set(cols)
+    has_mem_kind = "memKind" in colset
+    has_context = "contextId" in colset
+
+    scope_where = "1=1"
+    scope_params: list = []
     if target_gpu is not None:
-        where_parts.append("deviceId = ?")
-        event_params.append(int(target_gpu))
+        scope_where = "deviceId = ?"
+        scope_params = [int(target_gpu)]
+
+    # Events CTE pulls everything up to the window end so the running balance and
+    # the pre-window baseline are correct; the window filter is applied afterwards.
+    events_where = scope_where
+    events_params = list(scope_params)
     if trim is not None:
-        where_parts.append("start <= ?")
-        event_params.append(int(trim[1]))
+        events_where += " AND start <= ?"
+        events_params.append(int(trim[1]))
+
+    # In-window raw filter, for the per-kind / per-context breakdown sub-queries.
+    inwin_where = scope_where
+    inwin_params = list(scope_params)
+    if trim is not None:
+        inwin_where += " AND start >= ? AND start <= ?"
+        inwin_params += [int(trim[0]), int(trim[1])]
 
     if trim is not None:
         window_where = "event_start >= ? AND event_start <= ?"
         window_params: list = [int(trim[0]), int(trim[1])]
         baseline_expr = (
-            "(SELECT COALESCE(SUM(delta_bytes), 0) FROM events "
-            "WHERE event_start < ?) AS baseline_vram_bytes"
+            "(SELECT COALESCE(SUM(delta_bytes), 0) FROM events WHERE event_start < ?) "
+            "AS baseline_vram_bytes"
         )
         baseline_params: list = [int(trim[0])]
     else:
@@ -1286,31 +1315,40 @@ def _query_memory_profile(
         baseline_expr = "0 AS baseline_vram_bytes"
         baseline_params = []
 
-    # Nsight Systems records memoryOperationType=0 for allocation and 1 for
-    # deallocation. Build a running balance over all events up to the window
-    # end, then count alloc/free events only inside the selected window.
+    # memKind 0/1 = host (pageable/pinned), never VRAM; 2/3 device, 4/6 managed,
+    # 5 device-static are device-resident (documented Nsight ENUM_CUDA_MEM_KIND).
+    # Without the column we cannot tell, so count every event (best effort).
+    is_device = (
+        "CASE WHEN CAST(memKind AS INTEGER) IN (0, 1) THEN 0 ELSE 1 END" if has_mem_kind else "1"
+    )
+
+    # memoryOperationType: 0 = alloc, 1 = free. Allocs sort before frees at equal
+    # timestamps so a same-ts alloc+free still registers the high-water mark.
     sql = f"""
         WITH events AS (
             SELECT
                 CAST(start AS BIGINT) AS event_start,
                 CAST(memoryOperationType AS INTEGER) AS op,
                 CAST(COALESCE(bytes, 0) AS BIGINT) AS bytes,
+                {is_device} AS is_device,
                 CASE
+                    WHEN {is_device} = 0 THEN 0
                     WHEN memoryOperationType = 0 THEN CAST(COALESCE(bytes, 0) AS BIGINT)
                     WHEN memoryOperationType = 1 THEN -CAST(COALESCE(bytes, 0) AS BIGINT)
                     ELSE 0
                 END AS delta_bytes
             FROM {_MEMORY_USAGE_TABLE}
-            WHERE {" AND ".join(where_parts)}
+            WHERE {events_where}
         ),
         running AS (
             SELECT
                 event_start,
                 op,
                 bytes,
+                is_device,
                 delta_bytes,
                 SUM(delta_bytes) OVER (
-                    ORDER BY event_start, CASE WHEN op = 1 THEN 0 ELSE 1 END
+                    ORDER BY event_start, CASE WHEN op = 0 THEN 0 ELSE 1 END
                     ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
                 ) AS balance_bytes
             FROM events
@@ -1320,12 +1358,15 @@ def _query_memory_profile(
         )
         SELECT
             COUNT(*) AS event_count,
-            COALESCE(SUM(CASE WHEN op = 0 THEN 1 ELSE 0 END), 0) AS alloc_count,
-            COALESCE(SUM(CASE WHEN op = 1 THEN 1 ELSE 0 END), 0) AS free_count,
-            COALESCE(SUM(CASE WHEN op NOT IN (0, 1) THEN 1 ELSE 0 END), 0)
+            COALESCE(SUM(CASE WHEN is_device = 0 THEN 1 ELSE 0 END), 0) AS host_event_count,
+            COALESCE(SUM(CASE WHEN is_device = 1 AND op = 0 THEN 1 ELSE 0 END), 0) AS alloc_count,
+            COALESCE(SUM(CASE WHEN is_device = 1 AND op = 1 THEN 1 ELSE 0 END), 0) AS free_count,
+            COALESCE(SUM(CASE WHEN op IS NULL OR op NOT IN (0, 1) THEN 1 ELSE 0 END), 0)
                 AS unknown_event_count,
-            COALESCE(SUM(CASE WHEN op = 0 THEN bytes ELSE 0 END), 0) AS allocated_bytes,
-            COALESCE(SUM(CASE WHEN op = 1 THEN bytes ELSE 0 END), 0) AS freed_bytes,
+            COALESCE(SUM(CASE WHEN is_device = 1 AND op = 0 THEN bytes ELSE 0 END), 0)
+                AS allocated_bytes,
+            COALESCE(SUM(CASE WHEN is_device = 1 AND op = 1 THEN bytes ELSE 0 END), 0)
+                AS freed_bytes,
             COALESCE(SUM(delta_bytes), 0) AS net_delta_bytes,
             MIN(event_start) AS first_event_ns,
             MAX(event_start) AS last_event_ns,
@@ -1333,8 +1374,51 @@ def _query_memory_profile(
             {baseline_expr}
         FROM windowed
     """
-    row = prof._duckdb_query(sql, event_params + window_params + baseline_params)[0]
-    return _normalize_memory_profile_row(row, trim=trim, target_gpu=target_gpu)
+    row = prof._duckdb_query(sql, events_params + window_params + baseline_params)[0]
+
+    distinct_contexts = None
+    if has_context:
+        ctx_rows = prof._duckdb_query(
+            f"SELECT COUNT(DISTINCT contextId) AS n FROM {_MEMORY_USAGE_TABLE} WHERE {inwin_where}",
+            list(inwin_params),
+        )
+        distinct_contexts = int(ctx_rows[0].get("n") or 0) if ctx_rows else 0
+
+    mem_kind_breakdown: list = []
+    if has_mem_kind:
+        bk_rows = prof._duckdb_query(
+            f"""
+            SELECT
+                CAST(memKind AS INTEGER) AS mem_kind,
+                COALESCE(SUM(CASE WHEN memoryOperationType = 0 THEN 1 ELSE 0 END), 0) AS alloc_count,
+                COALESCE(SUM(CASE WHEN memoryOperationType = 1 THEN 1 ELSE 0 END), 0) AS free_count
+            FROM {_MEMORY_USAGE_TABLE}
+            WHERE {inwin_where}
+            GROUP BY CAST(memKind AS INTEGER)
+            ORDER BY mem_kind
+            """,
+            list(inwin_params),
+        )
+        for r in bk_rows:
+            mk = r.get("mem_kind")
+            mk_int = int(mk) if mk is not None else None
+            mem_kind_breakdown.append(
+                {
+                    "mem_kind": mk_int,
+                    "is_host": mk_int in _HOST_MEM_KINDS if mk_int is not None else False,
+                    "alloc_count": int(r.get("alloc_count") or 0),
+                    "free_count": int(r.get("free_count") or 0),
+                }
+            )
+
+    return _normalize_memory_profile_row(
+        row,
+        trim=trim,
+        target_gpu=target_gpu,
+        mem_kind_available=has_mem_kind,
+        distinct_contexts=distinct_contexts,
+        mem_kind_breakdown=mem_kind_breakdown,
+    )
 
 
 def _build_memory_delta(before: dict, after: dict) -> dict:
@@ -1346,8 +1430,9 @@ def _build_memory_delta(before: dict, after: dict) -> dict:
 
 def _memory_columns_used(cols: list[str]) -> list[str]:
     used = [col for col in _MEMORY_REQUIRED_COLS if col in cols]
-    if "deviceId" in cols:
-        used.append("deviceId")
+    for opt in ("deviceId", "memKind", "contextId"):
+        if opt in cols:
+            used.append(opt)
     return used
 
 
@@ -1464,9 +1549,15 @@ def get_memory_profile_diff(
     if window_error is not None:
         return window_error
 
-    before_stats = _query_memory_profile(ctx.before, trim_before, target_gpu)
-    after_stats = _query_memory_profile(ctx.after, trim_after, target_gpu)
+    before_stats = _query_memory_profile(ctx.before, trim_before, target_gpu, before_cols)
+    after_stats = _query_memory_profile(ctx.after, trim_after, target_gpu, after_cols)
     delta = _build_memory_delta(before_stats, after_stats)
+    explanation = _memory_profile_explanation(before_stats, after_stats, delta)
+    if not (before_stats["mem_kind_available"] and after_stats["mem_kind_available"]):
+        explanation += (
+            " Note: the memKind column is absent, so host vs device memory could not be "
+            "separated — these figures may include non-VRAM (host) allocations."
+        )
     return {
         "target_gpu": target_gpu,
         "iteration_index": iteration_index,
@@ -1480,7 +1571,7 @@ def get_memory_profile_diff(
         "before": before_stats,
         "after": after_stats,
         "delta": delta,
-        "explanation": _memory_profile_explanation(before_stats, after_stats, delta),
+        "explanation": explanation,
     }
 
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -126,14 +126,18 @@ def _make_profile_with_memory_usage(
     nvtx: list[tuple] | None = None,
     runtime: list[tuple] | None = None,
     include_memory_table: bool = True,
+    include_mem_kind: bool = True,
 ):
     """
     Minimal profile with CUDA_GPU_MEMORY_USAGE_EVENTS.
 
-    events entries:
-      (start_ns, deviceId, bytes, memoryOperationType)
+    events entries (4 or 6 elements; memKind/contextId default to device kind 2 /
+    context 1 when omitted):
+      (start_ns, deviceId, bytes, memoryOperationType[, memKind, contextId])
 
-    memoryOperationType follows Nsight Systems: 0 = alloc, 1 = free.
+    memoryOperationType follows Nsight Systems: 0 = alloc, 1 = free (None -> NULL).
+    memKind follows ENUM_CUDA_MEM_KIND: 0/1 host, 2/3 device, 4/6 managed, 5 static.
+    Pass include_mem_kind=False to emit the older schema without memKind/contextId.
     """
     conn = sqlite3.connect(path)
     conn.execute("CREATE TABLE StringIds(id INT PRIMARY KEY, value TEXT)")
@@ -179,7 +183,20 @@ def _make_profile_with_memory_usage(
             "INSERT INTO NVTX_EVENTS(text, globalTid, start, [end]) VALUES(?,?,?,?)",
             nvtx,
         )
-    if include_memory_table:
+    if include_memory_table and include_mem_kind:
+        conn.execute(
+            "CREATE TABLE CUDA_GPU_MEMORY_USAGE_EVENTS("
+            "start INT, deviceId INT, bytes INT, memoryOperationType INT, "
+            "memKind INT, contextId INT)"
+        )
+        rows = [e if len(e) >= 6 else (e[0], e[1], e[2], e[3], 2, 1) for e in events]
+        conn.executemany(
+            "INSERT INTO CUDA_GPU_MEMORY_USAGE_EVENTS("
+            "start, deviceId, bytes, memoryOperationType, memKind, contextId) "
+            "VALUES(?,?,?,?,?,?)",
+            rows,
+        )
+    elif include_memory_table:
         conn.execute(
             "CREATE TABLE CUDA_GPU_MEMORY_USAGE_EVENTS("
             "start INT, deviceId INT, bytes INT, memoryOperationType INT)"
@@ -187,7 +204,7 @@ def _make_profile_with_memory_usage(
         conn.executemany(
             "INSERT INTO CUDA_GPU_MEMORY_USAGE_EVENTS(start, deviceId, bytes, memoryOperationType) "
             "VALUES(?,?,?,?)",
-            events,
+            [tuple(e[:4]) for e in events],
         )
     conn.commit()
     conn.close()
@@ -1424,6 +1441,115 @@ def test_get_memory_profile_diff_not_available_when_table_missing(tmp_path):
     assert out["tables_present"] == {"before": True, "after": False}
     assert "bytes" in out["available_columns"]["before"]
     assert out["available_columns"]["after"] == []
+
+
+def test_get_memory_profile_diff_excludes_host_mem_kinds_from_vram(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # (start, deviceId, bytes, op, memKind, contextId): a device alloc (kind 2)
+    # plus a pinned-host alloc (kind 1). Host must NOT count toward VRAM.
+    events = [(10, 0, 1000, 0, 2, 1), (20, 0, 5000, 0, 1, 1)]
+    _make_profile_with_memory_usage(str(before), events=events)
+    _make_profile_with_memory_usage(str(after), events=events)
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_memory_profile_diff(ctx, target_gpu=0)
+
+    assert "error" not in out
+    assert out["before"]["mem_kind_available"] is True
+    assert out["before"]["peak_vram_bytes"] == 1000  # host 5000 excluded
+    assert out["before"]["alloc_count"] == 1  # device alloc only
+    assert out["before"]["host_event_count"] == 1
+    breakdown = {bk["mem_kind"]: bk for bk in out["before"]["mem_kind_breakdown"]}
+    assert set(breakdown) == {1, 2}
+    assert breakdown[1]["is_host"] is True
+    assert breakdown[2]["is_host"] is False
+
+
+def test_get_memory_profile_diff_same_timestamp_alloc_free_keeps_peak(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # alloc 1000 and free 1000 at the SAME timestamp: alloc must apply first so the
+    # high-water mark is 1000, not 0.
+    events = [(10, 0, 1000, 0, 2, 1), (10, 0, 1000, 1, 2, 1)]
+    _make_profile_with_memory_usage(str(before), events=events)
+    _make_profile_with_memory_usage(str(after), events=events)
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_memory_profile_diff(ctx, target_gpu=0)
+
+    assert out["before"]["peak_vram_bytes"] == 1000
+    assert out["before"]["net_delta_bytes"] == 0
+
+
+def test_get_memory_profile_diff_counts_null_op_as_unknown(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # op=None -> NULL memoryOperationType; must be surfaced, not silently dropped.
+    _make_profile_with_memory_usage(
+        str(before), events=[(10, 0, 1000, 0, 2, 1), (20, 0, 500, None, 2, 1)]
+    )
+    _make_profile_with_memory_usage(str(after), events=[(10, 0, 1000, 0, 2, 1)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_memory_profile_diff(ctx, target_gpu=0)
+
+    assert out["before"]["unknown_event_count"] == 1
+
+
+def test_get_memory_profile_diff_reports_distinct_contexts(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # Two CUDA contexts on the same device; total device VRAM is the sum.
+    events = [(10, 0, 1000, 0, 2, 1), (20, 0, 2000, 0, 2, 2)]
+    _make_profile_with_memory_usage(str(before), events=events)
+    _make_profile_with_memory_usage(str(after), events=events)
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_memory_profile_diff(ctx, target_gpu=0)
+
+    assert out["before"]["distinct_contexts"] == 2
+    assert out["before"]["peak_vram_bytes"] == 3000
+
+
+def test_get_memory_profile_diff_best_effort_when_mem_kind_absent(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # Older schema without memKind/contextId columns.
+    _make_profile_with_memory_usage(
+        str(before), events=[(10, 0, 1000, 0)], include_mem_kind=False
+    )
+    _make_profile_with_memory_usage(
+        str(after), events=[(10, 0, 1000, 0)], include_mem_kind=False
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_memory_profile_diff(ctx, target_gpu=0)
+
+    assert "error" not in out
+    assert out["before"]["mem_kind_available"] is False
+    assert out["before"]["peak_vram_bytes"] == 1000  # best effort: counts everything
+    assert "memKind column is absent" in out["explanation"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -118,6 +118,81 @@ def _make_profile_with_launch_config(
     conn.close()
 
 
+def _make_profile_with_memory_usage(
+    path: str,
+    *,
+    events: list[tuple],
+    kernels: list[tuple] | None = None,
+    nvtx: list[tuple] | None = None,
+    runtime: list[tuple] | None = None,
+    include_memory_table: bool = True,
+):
+    """
+    Minimal profile with CUDA_GPU_MEMORY_USAGE_EVENTS.
+
+    events entries:
+      (start_ns, deviceId, bytes, memoryOperationType)
+
+    memoryOperationType follows Nsight Systems: 0 = alloc, 1 = free.
+    """
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE StringIds(id INT PRIMARY KEY, value TEXT)")
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL("
+        "start INT, [end] INT, deviceId INT, streamId INT, correlationId INT, "
+        "shortName INT, demangledName INT)"
+    )
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME(globalTid INT, correlationId INT, start INT, [end] INT)"
+    )
+    conn.execute("CREATE TABLE NVTX_EVENTS(text TEXT, globalTid INT, start INT, [end] INT)")
+    conn.executemany(
+        "INSERT INTO StringIds(id, value) VALUES(?,?)",
+        [
+            (1, "kA"),
+            (2, "kA_dem"),
+            (3, "kB"),
+            (4, "kB_dem"),
+        ],
+    )
+
+    if kernels is None:
+        devices = sorted({int(e[1]) for e in events}) or [0]
+        kernels = [
+            (0, 100_000_000, dev, 7, idx + 1, 1, 2)
+            for idx, dev in enumerate(devices)
+        ]
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL("
+        "start, [end], deviceId, streamId, correlationId, shortName, demangledName) "
+        "VALUES(?,?,?,?,?,?,?)",
+        kernels,
+    )
+    if runtime:
+        conn.executemany(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME(globalTid, correlationId, start, [end]) "
+            "VALUES(?,?,?,?)",
+            runtime,
+        )
+    if nvtx:
+        conn.executemany(
+            "INSERT INTO NVTX_EVENTS(text, globalTid, start, [end]) VALUES(?,?,?,?)",
+            nvtx,
+        )
+    if include_memory_table:
+        conn.execute(
+            "CREATE TABLE CUDA_GPU_MEMORY_USAGE_EVENTS("
+            "start INT, deviceId INT, bytes INT, memoryOperationType INT)"
+        )
+        conn.executemany(
+            "INSERT INTO CUDA_GPU_MEMORY_USAGE_EVENTS(start, deviceId, bytes, memoryOperationType) "
+            "VALUES(?,?,?,?)",
+            events,
+        )
+    conn.commit()
+    conn.close()
+
+
 def _make_profile_with_runtime(
     path: str,
     *,
@@ -1196,6 +1271,159 @@ def test_get_launch_config_diff_negative_iteration_index_out_of_range(tmp_path):
     # -1 must NOT silently select the last iteration via Python indexing.
     assert "out of range" in out["error"]
     assert out["iteration_index"] == -1
+
+
+def test_get_memory_profile_diff_returns_peak_counts_net_delta_and_explanation(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    mib = 1024 * 1024
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_memory_usage(
+        str(before),
+        events=[
+            (0, 0, 1024 * mib, 0),  # pre-window baseline
+            (10, 0, 512 * mib, 0),
+            (20, 0, 128 * mib, 1),
+            (200_000_000, 0, 10_000 * mib, 0),  # outside ctx.trim; must not win peak
+        ],
+    )
+    _make_profile_with_memory_usage(
+        str(after),
+        events=[
+            (0, 0, 1024 * mib, 0),
+            (10, 0, 1024 * mib, 0),
+            (20, 0, 128 * mib, 1),
+            (200_000_000, 0, 10_000 * mib, 0),
+        ],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=(5, 100), marker="sample_0")
+        out = get_memory_profile_diff(ctx, target_gpu=0)
+
+    assert "error" not in out
+    assert out["before"]["baseline_vram_bytes"] == 1024 * mib
+    assert out["before"]["peak_vram_bytes"] == 1536 * mib
+    assert out["after"]["peak_vram_bytes"] == 2048 * mib
+    assert out["delta"]["peak_vram_bytes"] == {
+        "before": 1536 * mib,
+        "after": 2048 * mib,
+        "delta": 512 * mib,
+    }
+    assert out["before"]["alloc_count"] == 1
+    assert out["before"]["free_count"] == 1
+    assert out["before"]["allocated_bytes"] == 512 * mib
+    assert out["before"]["freed_bytes"] == 128 * mib
+    assert out["before"]["net_delta_bytes"] == 384 * mib
+    assert out["after"]["net_delta_bytes"] == 896 * mib
+    assert out["before"]["event_window_ns"] == [10, 20]
+    assert "10000" not in out["explanation"]
+    assert "peak VRAM" in out["explanation"]
+    assert "higher peak" in out["explanation"]
+
+
+def test_get_memory_profile_diff_default_target_gpu_aggregates_all_gpus(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_memory_usage(
+        str(before),
+        events=[
+            (0, 0, 100, 0),
+            (0, 1, 200, 0),
+        ],
+    )
+    _make_profile_with_memory_usage(
+        str(after),
+        events=[
+            (0, 0, 100, 0),
+            (0, 1, 300, 0),
+        ],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        all_gpus = get_memory_profile_diff(ctx)
+        gpu1 = get_memory_profile_diff(ctx, target_gpu=1)
+
+    assert all_gpus["before"]["peak_vram_bytes"] == 300
+    assert all_gpus["after"]["peak_vram_bytes"] == 400
+    assert all_gpus["delta"]["peak_vram_bytes"]["delta"] == 100
+    assert gpu1["before"]["peak_vram_bytes"] == 200
+    assert gpu1["after"]["peak_vram_bytes"] == 300
+    assert gpu1["delta"]["peak_vram_bytes"]["delta"] == 100
+
+
+def test_get_memory_profile_diff_uses_iteration_window(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    kernels = [(1_000_000_000, 2_000_000_000, 0, 7, 1, 1, 2)]
+    nvtx = [("step", 1, 500_000_000, 2_500_000_000)]
+    runtime = [(1, 1, 900_000_000, 1_000_000_000)]
+    _make_profile_with_memory_usage(
+        str(before),
+        events=[
+            (100_000_000, 0, 1000, 0),
+            (1_000_000_000, 0, 500, 0),
+            (3_000_000_000, 0, 9999, 0),
+        ],
+        kernels=kernels,
+        nvtx=nvtx,
+        runtime=runtime,
+    )
+    _make_profile_with_memory_usage(
+        str(after),
+        events=[
+            (100_000_000, 0, 1000, 0),
+            (1_000_000_000, 0, 700, 0),
+            (3_000_000_000, 0, 9999, 0),
+        ],
+        kernels=kernels,
+        nvtx=nvtx,
+        runtime=runtime,
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="step")
+        out = get_memory_profile_diff(ctx, iteration_index=0, target_gpu=0)
+
+    assert "error" not in out
+    assert out["trim_before_ns"] == [1_000_000_000, 2_000_000_000]
+    assert out["trim_after_ns"] == [1_000_000_000, 2_000_000_000]
+    assert out["before"]["baseline_vram_bytes"] == 1000
+    assert out["before"]["peak_vram_bytes"] == 1500
+    assert out["after"]["peak_vram_bytes"] == 1700
+    assert out["delta"]["peak_vram_bytes"]["delta"] == 200
+
+
+def test_get_memory_profile_diff_not_available_when_table_missing(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff_tools import DiffContext, get_memory_profile_diff
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile_with_memory_usage(str(before), events=[(0, 0, 100, 0)])
+    _make_profile_with_memory_usage(
+        str(after),
+        events=[],
+        include_memory_table=False,
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        ctx = DiffContext(before=b, after=a, trim=None, marker="sample_0")
+        out = get_memory_profile_diff(ctx)
+
+    assert out["error"] == "not available"
+    assert out["tables_present"] == {"before": True, "after": False}
+    assert "bytes" in out["available_columns"]["before"]
+    assert out["available_columns"]["after"] == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fills in the stubbed `get_memory_profile_diff` agent tool, completing the diff alongside the launch-config diff (#161). Reports peak VRAM, alloc/free counts + bytes, and net allocation delta, before vs after.

- **Running-balance peak** via a window function over `CUDA_GPU_MEMORY_USAGE_EVENTS`, including memory still live from **before the trim window** (baseline) — so the peak reflects true in-window VRAM, not just the end balance.
- `target_gpu=None` aggregates all devices (matches #163); a specific GPU filters by `deviceId`. Reuses the iteration/trim windowing (`_resolve_diff_windows`, factored out of the launch-config path).
- Structured `not available` returns (table missing in either profile, missing required columns, or `target_gpu` without `deviceId`).
- Conservative explanation, incl. the "memory unchanged → doesn't explain the regression" exclusion.

## Note for reviewers
Assumes the Nsight convention `memoryOperationType` **0 = alloc / 1 = free** and column names `start` / `bytes` / `memoryOperationType`. Unknown op types are counted separately (`unknown_event_count`) rather than guessed. Like #161 this is schema-gated + synthetic-tested — a sanity check on a **real memory-profiled capture** would be appreciated (no column-name-variant fallback yet, so a differently-named schema would degrade to "not available").

## Test plan
- [x] 4 tests: peak/counts/net-delta + baseline + out-of-window exclusion; all-GPU vs per-GPU aggregation; iteration window; table-missing
- [x] `pytest tests/` → 988 passed (SQLite + DuckDB paths both exercised)
- [x] `ruff check src/ tests/` clean