### PR TITLE
fix: raise ProfileNotFoundError for missing profile paths

### DIFF
--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -10,7 +10,7 @@ extra installed, can delegate to an LLM for natural language analysis.
 import logging
 import sqlite3
 
-from ..exceptions import NsysAiError
+from ..exceptions import NsysAiError, ProfileNotFoundError
 from ..profile import Profile
 from ..skills.registry import get_skill, run_skill
 
@@ -118,6 +118,10 @@ class Agent:
             self._trim_kwargs["trim_end_ns"] = trim_ns[1]
         try:
             self.profile = Profile(profile_path)
+        except ProfileNotFoundError:
+            # A missing file has nothing to fall back to — fail cleanly rather
+            # than letting sqlite3.connect below create an empty stub.
+            raise
         except (NsysAiError, sqlite3.Error, ValueError) as e:
             import sqlite3 as _sqlite3
 

--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -310,9 +310,14 @@ def open_profile_readonly(path: str):
     the cache-building process performs disk writes.
     """
     from nsys_ai import parquet_cache
+    from nsys_ai.exceptions import ProfileNotFoundError
 
     try:
         return parquet_cache.open_cached_db(path)
+    except ProfileNotFoundError:
+        # A missing file can't be salvaged by the SQLite fallback; surface the
+        # clear not-found error instead of a vague "unable to open database".
+        raise
     except Exception as e:
         _log.warning("Failed to open DuckDB cache for %s, falling back to SQLite: %s", path, e)
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -48,6 +48,8 @@ from pathlib import Path
 
 import duckdb
 
+from nsys_ai.exceptions import ProfileNotFoundError
+
 # fcntl is POSIX-only. On Windows we degrade to no-locking — concurrent
 # builders may then race redundantly, but ``build_cache``'s tmp_dir +
 # atomic rename still keeps the cache consistent.
@@ -57,6 +59,12 @@ except ImportError:
     _fcntl = None  # type: ignore[assignment]
 
 log = logging.getLogger(__name__)
+
+
+def _require_profile_exists(path: str) -> None:
+    """Raise before opening so a missing path can't create an empty stub/cache."""
+    if not os.path.exists(path):
+        raise ProfileNotFoundError(f"profile not found: {path}")
 
 
 @contextlib.contextmanager
@@ -642,6 +650,7 @@ def open_cached_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
       ``string_ids``, ``gpu_info``, ``cuda_device``, ``nvtx_kernel_map``,
      ``nvtx_path_dict`` (when map uses ``path_id``).
     """
+    _require_profile_exists(sqlite_path)
     if not is_cache_valid(sqlite_path):
         build_cache(sqlite_path)
 
@@ -1381,6 +1390,7 @@ def open_direct_sqlite(sqlite_path: str) -> duckdb.DuckDBPyConnection:
       - One-off queries that only touch 1-2 tables
       - ``--no-cache`` mode for quick diagnostics
     """
+    _require_profile_exists(sqlite_path)
     db = duckdb.connect()
     _configure_duckdb_analytics_session(db)
     safe_path = str(sqlite_path).replace("'", "''")

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -26,6 +26,7 @@ from nsys_ai.exceptions import (
     ExportError,
     ExportTimeoutError,
     ExportToolMissingError,
+    ProfileNotFoundError,
     SchemaError,
 )
 
@@ -191,6 +192,11 @@ class Profile:
             raise ValueError(
                 "cache_mode is not supported with backend='parquetdir'; use cache_mode='auto'."
             )
+        # Guard before sqlite3.connect, which would otherwise create an empty
+        # stub + cache for a missing path. Covers every entry path, including
+        # direct Profile(...) construction that bypasses resolve_profile_path.
+        if not os.path.exists(path):
+            raise ProfileNotFoundError(f"profile not found: {path}")
         self.path = path
         self.backend = backend
         self._lock = threading.Lock()
@@ -719,7 +725,12 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
 
     Exports always pass `--include-blobs=true` so NVTX payload-dependent
     analysis (for example communicator-aware NCCL diagnostics) remains available.
+
+    Raises ProfileNotFoundError when *path* does not exist (e.g. a missing
+    `.nsys-rep`, before any export is attempted).
     """
+    if not os.path.exists(path):
+        raise ProfileNotFoundError(f"profile not found: {path}")
     if backend == "parquetdir":
         return _resolve_parquetdir_path(path)
     if not path.lower().endswith(".nsys-rep"):

--- a/tests/test_profile_resolve.py
+++ b/tests/test_profile_resolve.py
@@ -6,7 +6,12 @@ from pathlib import Path
 import pytest
 
 from nsys_ai import profile as profile_mod
-from nsys_ai.exceptions import ExportError, ExportTimeoutError, ExportToolMissingError
+from nsys_ai.exceptions import (
+    ExportError,
+    ExportTimeoutError,
+    ExportToolMissingError,
+    ProfileNotFoundError,
+)
 
 
 def test_resolve_non_nsys_rep_passthrough(tmp_path: Path):
@@ -15,6 +20,50 @@ def test_resolve_non_nsys_rep_passthrough(tmp_path: Path):
     path.write_bytes(b"0")
     result = profile_mod.resolve_profile_path(str(path))
     assert result == str(path)
+
+
+def test_resolve_missing_path_raises_without_side_effects(tmp_path: Path):
+    """Missing path raises ProfileNotFoundError and creates no files."""
+    missing = tmp_path / "does_not_exist.sqlite"
+    with pytest.raises(ProfileNotFoundError) as exc:
+        profile_mod.resolve_profile_path(str(missing))
+    assert "not found" in str(exc.value)
+    assert exc.value.error_code == "PROFILE_NOT_FOUND"
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_open_missing_path_raises_without_creating_files(tmp_path: Path):
+    """profile.open() on a missing path raises and leaves no stub/cache behind."""
+    missing = tmp_path / "typo.sqlite"
+    with pytest.raises(ProfileNotFoundError):
+        profile_mod.open(str(missing))
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_profile_init_missing_path_raises_without_creating_files(tmp_path: Path):
+    """Direct Profile(...) (e.g. the agent, dispatcher) also guards, not just open()."""
+    missing = tmp_path / "direct.sqlite"
+    with pytest.raises(ProfileNotFoundError):
+        profile_mod.Profile(str(missing))
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_cache_open_missing_path_raises_without_creating_files(tmp_path: Path):
+    """Cache-open helpers (used by `skill run` and the chat DB tool) also guard."""
+    from nsys_ai import parquet_cache
+
+    missing = tmp_path / "cache.sqlite"
+    with pytest.raises(ProfileNotFoundError):
+        parquet_cache.open_cached_db(str(missing))
+    with pytest.raises(ProfileNotFoundError):
+        parquet_cache.open_direct_sqlite(str(missing))
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_resolve_missing_nsys_rep_raises_not_found(tmp_path: Path):
+    """Missing .nsys-rep raises ProfileNotFoundError before the export path runs."""
+    with pytest.raises(ProfileNotFoundError):
+        profile_mod.resolve_profile_path(str(tmp_path / "missing.nsys-rep"))
 
 
 def test_resolve_parquetdir_passthrough_directory(tmp_path: Path):


### PR DESCRIPTION
Closes #165.

## Problem

Opening a non-existent profile path did not fail cleanly. `sqlite3.connect()` (and the Parquet cache build) auto-create the missing file, so a typo silently left junk on disk and produced a misleading error:

```
$ nsys-ai timeline-web does_not_exist.sqlite --no-browser
# creates: does_not_exist.sqlite (0 bytes), does_not_exist.nsys-cache/, does_not_exist.nsys-cache.build.lock
Error [SCHEMA_ERROR]: This profile does not contain GPU kernel activity ...
```

## Fix

Guard every path that opens a profile, raising the existing `ProfileNotFoundError` (`PROFILE_NOT_FOUND`, already surfaced by the CLI as a clean non-zero-exit error):

- **`Profile.__init__`** — check before `sqlite3.connect`, the choke point reached by `open()`, direct `Profile(...)`, the agent, the dispatcher, and benchmarks.
- **`resolve_profile_path`** — check at entry, so a missing `.nsys-rep` fails before any export is attempted.
- **`parquet_cache.open_cached_db` / `open_direct_sqlite`** — check before building/attaching, covering `skill run` and the chat DB tool, which bypass `Profile`.
- **agent loop** and the **chat read-only opener** — let `ProfileNotFoundError` propagate instead of falling back to a raw SQLite connection (which would re-create the stub or surface a vaguer error).

## Result

No files/dirs are created for a missing path, and every profile-opening command exits non-zero with a clear message:

```
$ nsys-ai <cmd> does_not_exist.sqlite
Error [PROFILE_NOT_FOUND]: profile not found: does_not_exist.sqlite   # exit 1, nothing written
```

Verified across `timeline-web`, `open`, `skill run`, `info`, and `agent analyze`.

## Tests

5 regression tests in `test_profile_resolve.py` (resolve, `open()`, direct `Profile()`, missing `.nsys-rep`, cache-open helpers) — each asserts the exception **and** that nothing was written to disk. Full suite: 999 passed, 135 skipped; ruff clean.