### PR TITLE
docs(changelog): record current work in Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,53 +9,65 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
-- `nccl_compile_context_breakdown` skill — classifies NCCL kernels by their
-  **leaf** NVTX label into eager / inductor_captured / temporal_only buckets.
-  Decides whether a collective perf fix lives in user code (stream wrap,
-  `async_op=True`) or in `torch._inductor.config` (functional collectives,
-  `reorder_for_compute_comm_overlap`).
-- `nsys-ai diff --format json` emits a v0.1 envelope (`schema_version`,
-  `producer`, `producer_version`, `diff_id`) plus top-level `verdict`,
-  `comparability_confidence`, step-time `category_attribution` (HTA
-  convention: `overlap_ms` counts as compute, `nccl_only_ms` is exposed
-  comm), and content-derived `profile_id` on each side (PR #130).
-- `nccl_payload_breakdown` skill — decodes NVTX typed-payload `binaryData`
-  to extract real NCCL message sizes, peer ranks, and communicator IDs
-  (PR #128).
+- Before/after drill-down in the diff agent: compare a kernel's launch
+  configuration (grid/block/registers/shared memory) and memory profile (peak
+  VRAM and allocation/free deltas), and locate each top kernel regression to a
+  specific GPU, stream, and time window.
+- `nsys-ai diff --exit-on-regression` exits non-zero on a likely-regression
+  verdict, so a diff can gate CI.
+- `nsys-ai diff --format json` emits a versioned envelope: a top-level
+  `verdict`, a `comparability_confidence` score, step-time `category_attribution`
+  (compute / communication / idle), and a content-derived `profile_id` per side.
+- Structured v0.1 findings — category, severity, confidence, and a located time
+  window where possible — for `overlap_breakdown`, `nccl_breakdown`,
+  `top_kernels`, `profile_health_manifest`, and `kernel_instances`, so the agent
+  and GUI consume them without per-skill parsing.
+- New analysis skills: `code_attribution_candidates` maps a selected time window
+  back to likely source/config regions; `nccl_compile_context_breakdown`
+  classifies NCCL kernels as eager vs. compiled to point at the right fix; and
+  `nccl_payload_breakdown` decodes NVTX payloads into NCCL message sizes, peer
+  ranks, and communicator IDs.
+- A labeled-profile evaluation harness under `tests/eval/` (expected and
+  forbidden findings) to keep skill outputs honest as they change.
 
 ### Changed
 
-- `nvtx_kernel_map` docstring now documents temporal-containment semantics:
-  `nvtx_text` is the **leaf** NVTX label (innermost open scope at kernel
-  launch), and `nvtx_path` containment is temporal, not lexical.
-  Classifying by ancestor-path substring (e.g. `LIKE '%Torch-Compiled%'`)
-  can pick up kernels whose enclosing scope merely happened to still be
-  open — not kernels that the enclosing tool actually traced.
+- Diff aggregates across all GPUs by default. With no device specified it now
+  sums every device (kernels, overlap, memory copies, and stream counts)
+  instead of silently scoping to GPU 0, matching the documented `--gpu` default.
+- CUTracer is pinned to a reproducible upstream revision
+  (`facebookexperimental`, `v0.2.1`).
+- `nvtx_kernel_map` documents temporal-containment semantics: `nvtx_text` is the
+  leaf NVTX label, and ancestor-path containment is temporal, not lexical, so
+  matching on a path substring can pick up kernels whose enclosing scope merely
+  happened to still be open.
 
 ### Fixed
 
-- `fingerprint.distributed` falls back to `COUNT(DISTINCT deviceId) > 1`
-  so multi-GPU single-node profiles report `distributed=True`;
-  `overlap_breakdown` surfaces `present_devices` and warns when the caller
-  did not pass `-p device=N` on a multi-device profile (PR #127).
-- Parquet cache builds are `flock`-serialized to prevent concurrent crashes
-  when two `nsys-ai` invocations target the same cache directory (PR #122).
+- A missing profile path fails immediately with `ProfileNotFoundError` and a
+  non-zero exit, instead of creating an empty database and cache directory and
+  then reporting a misleading schema error.
+- The bare `nsys-ai <profile>` shortcut again opens the web timeline.
+- `profile_health_manifest` profiler-overhead reporting no longer emits
+  impossible values, scopes overhead to the analyzed window, and uses
+  wall-clock NCCL time for the communication-dominance trigger.
+- Multi-GPU single-node profiles are detected as distributed; overlap analysis
+  reports which devices are present and warns when no device is specified.
+- Parquet cache builds are serialized so concurrent runs against the same cache
+  no longer crash.
 
 ### Performance
 
-- `overlap_analysis` SQL sweep-line — 3.2× speedup on the analysis call
-  (PR #125).
-- NVTX layer breakdown 43s → 1.4s via `nvtx_high` parquet + `ORDER BY`
-  (PR #123).
-- `profile_health_manifest` auto-trims long profiles to a representative
-  window (PR #124).
+- SQL sweep-line overlap analysis (about 3x faster on the analysis call), NVTX
+  layer breakdown reduced from ~43s to ~1.4s, and automatic trimming of long
+  profiles to a representative window.
 
 ### Docs
 
-- Evidence schema reference brought up to v0.1: new optional fields,
-  envelope keys, supporting types, enriched example (PR #119).
-- `docs/agent_skills/.../perf_budget.md` §9 rewritten for NVTX-heavy
-  profiles (PR #126).
+- Guide for running CUTracer on Modal, plus a real `--trace-size-limit-mb` flag
+  and a loud warning when SASS resolution fails.
+- Evidence-schema reference updated to v0.1, and the performance-budget guidance
+  rewritten for NVTX-heavy profiles.
 
 ## [0.2.3] — 2026-05-12 and earlier
 


### PR DESCRIPTION
## Summary

The `[Unreleased]` section of `CHANGELOG.md` had fallen behind `main`. This brings it up to date with what shipped since it was last touched.

## What is recorded

- **Diff** — launch-config and memory-profile drill-down tools, `TraceSelection` on top regressions, `--exit-on-regression` CI gate, the `--format json` envelope, and the all-GPU-by-default change.
- **Skills** — structured v0.1 findings for the core skills; new `code_attribution_candidates`, `nccl_compile_context_breakdown`, and `nccl_payload_breakdown`; the `tests/eval/` harness.
- **Fixed** — `ProfileNotFoundError` for missing paths, bare-profile shortcut, and the health-manifest overhead fixes.
- **Docs / Performance** — CUTracer Modal guide and the existing perf work.

## Style

Entries follow the [Keep a Changelog](https://keepachangelog.com) sections already used in the file and are written for readers — they describe the user-facing change and keep the concrete flags/skill names, rather than enumerating pull requests. Documentation only; no code changes.