### PR TITLE
docs(readme): refresh for current features and drop emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
 <div align="center">
 
-# 🔬 nsys-ai
+# nsys-ai
 
 **AI-powered analysis for NVIDIA Nsight Systems profiles**
 
-Navigate GPU kernel timelines, diagnose performance bottlenecks with AI, and explore NVTX hierarchies — from your browser or terminal.
+Navigate GPU kernel timelines, diff two runs, and diagnose performance
+bottlenecks with an evidence-first agent — from your browser or terminal.
 
-> **Mission:** Build an intelligent agent that truly understands GPU performance from first principles. An agent that can identify pipeline bubbles, calculate MFU, assess arithmetic intensity, and diagnose the root causes that cost millions of dollars in GPU hours — turning months of expert debugging into minutes.
+> **Mission:** Build an agent that understands GPU performance from first
+> principles — one that can identify pipeline bubbles, calculate MFU, assess
+> arithmetic intensity, and diagnose the root causes that cost millions of GPU
+> hours, turning months of expert debugging into minutes.
 
 [![CI](https://github.com/GindaChen/nsys-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/GindaChen/nsys-ai/actions)
 [![PyPI](https://img.shields.io/pypi/v/nsys-ai)](https://pypi.org/project/nsys-ai/)
@@ -17,436 +21,316 @@ Navigate GPU kernel timelines, diagnose performance bottlenecks with AI, and exp
 
 ---
 
-## ⚡ Install
+nsys-ai reads `.nsys-rep` or `.sqlite` exports from
+[NVIDIA Nsight Systems](https://developer.nvidia.com/nsight-systems) and turns
+them into something you can navigate and reason about: a web timeline, terminal
+viewers, a before/after diff that reports whether a change actually helped, and
+a set of deterministic analysis skills an LLM agent can drive. `.nsys-rep` files
+are opened directly — nsys-ai exports them to SQLite for you on first use.
+
+## Installation
 
 ```bash
 pip install nsys-ai
 ```
 
-That's it. No system dependencies, no CUDA required. Just Python 3.10+.
+No CUDA and no Nsight install are required to analyze a profile. Python 3.10+
+only. (Capturing a new `.nsys-rep`, or converting one, needs the `nsys` CLI on
+your machine; analyzing an existing `.sqlite` does not.)
 
----
+## Quick start
 
-## 🌐 Web UI First (Default)
+### 1. Capture a profile
 
-`nsys-ai` is web-first. The default command opens the timeline UI in your browser.
+For ML training, capture a few representative iterations rather than the whole
+run — it keeps the profile small and the profiler overhead low. Mark the region
+with the CUDA profiler API and trace CUDA plus NVTX:
+
+```python
+import torch
+
+for step in range(warmup):
+    train_step()
+torch.cuda.synchronize()
+torch.cuda.cudart().cudaProfilerStart()
+for step in range(3):            # profile these iterations
+    train_step()
+torch.cuda.synchronize()
+torch.cuda.cudart().cudaProfilerStop()
+```
 
 ```bash
-# Default: open web timeline UI
+nsys profile --capture-range=cudaProfilerApi --trace=cuda,nvtx \
+  -o my_training python train.py
+# -> my_training.nsys-rep
+```
+
+`--trace=cuda` is what every skill relies on (GPU kernels, memory copies, CUDA
+API). `nvtx` adds the annotation hierarchy that drives the iteration, region,
+and layer views. To use the iteration tools (`iters`, `diff --iteration`),
+annotate each step with a consistent NVTX marker — see
+[Focused Profiling](docs/08-focused-profiling.md) and
+[NVTX Annotations](docs/03-nvtx-annotations.md).
+
+No workload handy? Download an example profile:
+
+```bash
+cd examples/example-20-megatron-distca && python download_data.py
+# -> output/megatron_distca.nsys-rep
+```
+
+### 2. Open it
+
+```bash
+# Default: open the web timeline in your browser
 nsys-ai my_training.nsys-rep
 
-# Explicit command (same web UI)
-nsys-ai timeline-web my_training.nsys-rep
-```
-
-Use TUI/CLI modes when you specifically want terminal workflows.
-
----
-
-## 🎯 What It Does
-
-nsys-ai reads `.nsys-rep` or `.sqlite` profile exports from [NVIDIA Nsight Systems](https://developer.nvidia.com/nsight-systems) and gives you a **web-first workflow** plus terminal and export tools:
-
-<table>
-<tr>
-<td width="25%" align="center">
-
-### 🌐 Web Timeline
-Multi-GPU browser viewer with progressive rendering
-
-</td>
-<td width="25%" align="center">
-
-### 🖥️ Timeline TUI
-Perfetto-style horizontal timeline in your terminal
-
-</td>
-<td width="25%" align="center">
-
-### 🌲 Tree TUI
-Interactive NVTX hierarchy browser with kernel details
-
-</td>
-<td width="25%" align="center">
-
-### 📄 HTML Export
-Exportable interactive visualizations for sharing
-
-</td>
-</tr>
-<tr>
-<td>
-
-Browser-based viewer:<br>
-• Multi-GPU stacked streams<br>
-• NVTX hierarchy bars<br>
-• Pinch-to-zoom, trackpad pan<br>
-• AI chat sidebar
-
-</td>
-<td>
-
-```
-S21 ████░██████░███
-S56 ██████░░░███████
-S60 ░░░██████░░░░░██
-    |         │
-    39.1s   39.5s
-```
-
-</td>
-<td>
-
-```
-▼ Iteration (324ms)
-  ▼ forward (180ms)
-    ▼ Attention (89ms)
-      ■ flash_fwd  26ms
-      ■ flash_bwd  63ms
-```
-
-</td>
-<td>
-
-Interactive HTML exports:<br>
-• NVTX stack viewer<br>
-• SQLite schema explorer<br>
-• Perfetto JSON traces
-
-</td>
-</tr>
-</table>
-
----
-
-## 🚀 Quick Start
-
-### 1. Get a profile
-
-```bash
-# Option A: Profile your own PyTorch training
-nsys profile -o my_training python train.py
-# → produces my_training.nsys-rep  (or .sqlite via --export sqlite)
-
-# Option B: Download an example profile
-cd examples/example-20-megatron-distca
-python download_data.py
-# → downloads output/megatron_distca.nsys-rep
-```
-
-### 2. Explore it
-
-```bash
-# Start here: one command opens the web timeline in your browser
-nsys-ai my_training.nsys-rep
-
-# Or explicitly:
-nsys-ai timeline-web my_training.nsys-rep
-
-# Then use overview/summaries as needed
+# Metadata and GPU info
 nsys-ai info my_training.nsys-rep
 
 # GPU kernel summary
 nsys-ai summary my_training.nsys-rep --gpu 0
 ```
 
-> **Prefer a terminal?** nsys-ai also has full TUI support:
-> ```bash
-> nsys-ai timeline my_training.nsys-rep --gpu 0 --trim 39 42  # horizontal timeline
-> nsys-ai tui my_training.nsys-rep --gpu 0 --trim 39 42       # tree browser
-> ```
-
-### 3. Export & share
+Prefer the terminal? The TUIs work the same way:
 
 ```bash
-# Perfetto JSON (open in ui.perfetto.dev)
-nsys-ai export my_training.sqlite -o traces/
-
-# Interactive HTML viewer
-nsys-ai viewer my_training.sqlite --gpu 0 --trim 39 42 -o report.html
-
-# Flat CSV/JSON for scripting
-nsys-ai export-csv my_training.sqlite --gpu 0 --trim 39 42 -o kernels.csv
+nsys-ai timeline my_training.nsys-rep --gpu 0   # Perfetto-style horizontal timeline
+nsys-ai tui my_training.nsys-rep --gpu 0        # NVTX tree browser
 ```
 
----
-
-## 🌐 Web Timeline
-
-The web timeline is a **browser-based multi-GPU viewer** with progressive rendering — no `--trim` required. This is the **default view** when you run `nsys-ai <profile>`.
+### 3. Compare two runs
 
 ```bash
-# Just give it a profile — opens in your browser
-nsys-ai my_training.nsys-rep
+nsys-ai diff before.sqlite after.sqlite
+```
 
-# Or explicitly with GPU selection:
+## Web timeline
+
+A browser-based multi-GPU viewer with progressive rendering — no `--trim`
+required. This is the default view when you run `nsys-ai <profile>`.
+
+```bash
+nsys-ai my_training.nsys-rep                       # opens in your browser
 nsys-ai timeline-web my_training.nsys-rep --gpu 0 1 2 3
 ```
 
-### Features
-
-- **Multi-GPU stacked view** — all GPUs shown simultaneously with color-coded separators
-- **Progressive rendering** — pre-builds full NVTX tree at startup, then serves tiles instantly (~1ms per tile)
-- **NVTX hierarchy** — layered bars (L0–L5) showing annotation nesting per GPU
-- **AI chat sidebar** — press `A` to ask questions about the profile
-- **Kernel search** — press `/` to search by kernel name
-
-### Navigation
+- Multi-GPU stacked view with color-coded separators
+- Progressive rendering — pre-builds the NVTX tree at startup, then serves tiles
+  in about a millisecond each
+- NVTX hierarchy bars (L0-L5) per GPU
+- AI chat sidebar (press `a`) and kernel search (press `/`)
 
 | Input | Action |
 |:-----:|--------|
-| **Swipe left/right** | Pan through time |
-| **Swipe up/down** | Scroll through GPU streams |
-| **Pinch** | Zoom in / out |
-| `Shift+scroll` | Zoom in / out |
-| `h` `l` or `←` `→` | Pan left / right |
-| `j` `k` or `↑` `↓` | Select stream |
-| `+` `-` | Zoom in / out |
-| `f` or `0` | Fit all (full time range) |
+| Swipe / `h` `l` / arrows | Pan through time |
+| Swipe up-down / `j` `k` | Select stream |
+| Pinch / `Shift+scroll` / `+` `-` | Zoom |
+| `f` or `0` | Fit full time range |
 | `Tab` | Next kernel |
 | `/` | Search kernels |
 | `n` | Toggle NVTX |
-| `a` | AI Chat |
+| `a` | AI chat |
 | `?` | Help overlay |
 
----
+## Timeline TUI
 
-## ⌨️ Timeline TUI
-
-Prefer working in the terminal? The timeline TUI is a **Perfetto-style** horizontal viewer with per-stream kernel visualization, NVTX hierarchy bars, and a time-cursor navigation model.
-
-### Navigation
+A Perfetto-style horizontal viewer with per-stream kernels, NVTX hierarchy
+bars, and a time-cursor navigation model.
 
 | Key | Action |
 |:---:|--------|
-| `←` `→` | Pan through time |
-| `Shift+←/→` | Page pan (1/4 viewport) |
-| `↑` `↓` | Select stream |
+| arrows | Pan time / select stream |
+| `Shift+arrows` | Page pan (quarter viewport) |
 | `Tab` | Snap to next kernel |
-| `+` `-` | Zoom in / out |
-| `a` | Toggle absolute ↔ relative time |
-
-### Analysis
-
-| Key | Action |
-|:---:|--------|
+| `+` `-` | Zoom |
 | `/` | Filter kernels by name |
-| `m` | Set minimum duration threshold |
-| `d` | Toggle demangled kernel names |
-| `C` | Open config panel |
+| `m` | Minimum-duration threshold |
+| `d` | Toggle demangled names |
+| `B` | Save bookmark (with kernel + NVTX context) |
+| `C` | Config panel (stream rows, tick density, NVTX depth) |
 | `h` | Full help overlay |
 
-### Bookmarks
+## Profile diff
 
-| Key | Action |
-|:---:|--------|
-| `B` | Save bookmark (with kernel + NVTX context) |
-| `'` | Bookmark list — press 1-9 to jump |
-| `,` `.` | Cycle through bookmarks |
-| `` ` `` | Jump back to previous position |
-| `[` `]` | Set range start / end |
-
-### Config Panel (`C`)
-
-Tweak settings live with ↑/↓ to select and ←/→ to adjust:
-
-- Selected stream rows (1-6)
-- Other stream rows (1-4)
-- Time tick density (2-20)
-- NVTX depth levels (0-8)
-- Min kernel duration filter
-
----
-
-## 🤖 Claude Code plugin
-
-nsys-ai ships as a [Claude Code](https://claude.com/claude-code) plugin: one slash command
-`/nsys-ai` turns a profile into a root-cause + fix + annotated timeline. See
-[docs/claude-plugin-quickstart.md](docs/claude-plugin-quickstart.md) to install and
-[docs/claude-plugin.md](docs/claude-plugin.md) for the full 9-mode reference.
-
----
-
-## 📚 Documentation
-
-The `docs/` directory includes comprehensive guides for Nsight Systems profiling:
-
-| Guide | Topic |
-|-------|-------|
-| [CLI Reference](docs/01-cli-reference.md) | Full `nsys` command reference |
-| [SQLite Schema](docs/02-sqlite-schema.md) | Database tables & relationships |
-| [NVTX Annotations](docs/03-nvtx-annotations.md) | Adding markers to your code |
-| [CUDA Trace](docs/04-cuda-trace.md) | GPU kernel tracing |
-| [NCCL Tracing](docs/05-nccl-tracing.md) | Multi-GPU collective analysis |
-| [Python/PyTorch](docs/06-python-pytorch.md) | Profiling PyTorch workloads |
-| [Containers](docs/07-container-profiling.md) | Profiling inside Docker/Slurm |
-| [Focused Profiling](docs/08-focused-profiling.md) | Targeted profiling strategies |
-| [CUTracer Instruction Analysis](docs/cutracer-instruction-analysis.md) | Instruction-level drill-down for top kernels |
-
-### 🔍 Interactive SQLite Schema Explorer
-
-The [`docs/sqlite-explorer/`](docs/sqlite-explorer/) contains an **interactive HTML tool** for exploring the Nsight SQLite schema — tables, foreign keys, example queries, and key concepts. Open `docs/sqlite-explorer/index.html` in a browser:
-
-- Browse all Nsight SQLite tables with column types
-- See foreign key relationships visualized
-- Copy-paste ready SQL query examples
-- Cross-highlighted concept explanations
-
----
-
-## 🔀 Profile Diff
-
-Compare two profiles side-by-side — spot regressions and improvements from a single command.
+Comparing two profiles is the point of nsys-ai: it reports not just what changed
+but whether the change is a likely regression or improvement.
 
 ```bash
-# Compare before and after a code change
+# Terminal report
 nsys-ai diff before.sqlite after.sqlite
 
-# Open interactive side-by-side web comparison
+# Interactive side-by-side web comparison
 nsys-ai diff-web before.sqlite after.sqlite
 
-# Focus on a specific GPU
-nsys-ai diff before.sqlite after.sqlite --gpu 0
+# A specific device or time window
+nsys-ai diff before.sqlite after.sqlite --gpu 0 --trim 39 42
 
-# Compare a specific time window
-nsys-ai diff before.sqlite after.sqlite --trim 39 42
+# Compare one aligned iteration
+nsys-ai diff before.sqlite after.sqlite --iteration 0
 
-# Export as markdown (for GitHub issues)
+# Markdown (for a PR or issue) or JSON (for scripting)
 nsys-ai diff before.sqlite after.sqlite --format markdown -o diff.md
+nsys-ai diff before.sqlite after.sqlite --format json
 
-# JSON output for scripting
-nsys-ai diff before.sqlite after.sqlite --format json --no-ai
-
-# Fail CI when the diff verdict reports a likely regression
-nsys-ai diff before.sqlite after.sqlite --format json --exit-on-regression
+# Gate CI: exit non-zero when the verdict is a likely regression
+nsys-ai diff before.sqlite after.sqlite --exit-on-regression
 ```
 
-The report shows:
-
-- **Top regressions** — kernels that got slower (by Δ time, %, or total)
-- **Top improvements** — kernels that got faster
-- **New / removed kernels** — workload changes across runs
-- **NVTX region diff** — wall-time delta for annotated regions
-- **Overlap diff** — compute/NCCL overlap and idle gap changes
-- **Per-GPU breakdown** — when no `--gpu` is specified, shows every device
-
-Options:
+The report covers top regressions and improvements, new and removed kernels,
+NVTX region deltas, compute/NCCL overlap and idle changes, and a step-time
+category rollup (compute / communication / idle). With `--format json` it adds a
+top-level `verdict`, a `comparability_confidence` score, and a stable
+content-derived `profile_id` per side. With no `--gpu`, the diff aggregates
+across every device.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--gpu N` | all GPUs | Focus on a specific device |
-| `--trim START END` | — | Compare only this time window (seconds) |
+| `--gpu N` | all GPUs | Restrict to one device |
+| `--trim START END` | full span | Compare only this window (seconds) |
+| `--iteration N` | — | Compare one aligned iteration (needs an NVTX marker) |
 | `--format` | `terminal` | `terminal` \| `markdown` \| `json` |
-| `-o / --output` | stdout | Write output to file |
 | `--limit N` | 15 | Top regressions/improvements to show |
 | `--sort` | `delta` | `delta` \| `percent` \| `total` |
-| `--no-ai` | — | Skip AI narration (numeric diff only) |
-| `--exit-on-regression` | — | Exit with status 1 when verdict is `regression_likely` |
+| `--exit-on-regression` | — | Exit 1 when the verdict is `regression_likely` |
 
----
-
-## 🛠️ All Commands
+## Commands
 
 | Command | Description |
 |---------|-------------|
-| `info` | Profile metadata & GPU hardware |
-| `summary` | Top kernels, stream breakdown, auto-commentary |
+| `open` | Quick-open a profile in the web UI, Perfetto, or TUI |
+| `timeline-web` | Web multi-GPU timeline (progressive rendering) |
+| `timeline` | Timeline TUI |
+| `tui` | NVTX tree TUI |
+| `web` | Web viewer server |
+| `info` | Profile metadata and GPU hardware |
+| `summary` | Top kernels and stream breakdown |
+| `analyze` | Full auto-report (`--format json` emits evidence findings) |
 | `overlap` | Compute / NCCL overlap analysis |
-| `nccl` | NCCL collective breakdown by type |
+| `nccl` | NCCL collective breakdown |
 | `iters` | Auto-detect training iterations |
-| `tree` | NVTX hierarchy as text |
-| `diff` | **Before/after profile comparison (CLI)** |
-| `diff-web` | **Side-by-side comparison web viewer** |
-| `tui` | **Interactive tree TUI** |
-| `timeline` | **Interactive timeline TUI** |
-| `timeline-web` | **Web-based multi-GPU timeline** (progressive rendering) |
-| `cutracer` | **Instruction-level drill-down** (`check`, `install`, `plan`, `run`, `analyze`) |
-| `search` | Search kernels / NVTX by name |
-| `export` | Perfetto JSON traces |
-| `export-csv` | Flat CSV for spreadsheets |
-| `export-json` | Flat JSON for scripting |
-| `viewer` | Interactive HTML report |
-| `markdown` | NVTX hierarchy as markdown |
+| `tree` / `markdown` | NVTX hierarchy as text / markdown |
+| `search` | Search kernels and NVTX by name |
+| `report` | Generate a performance report |
+| `diff` | Before/after profile comparison |
+| `diff-web` | Side-by-side comparison web viewer |
+| `chat` | AI chat TUI for a profile |
+| `ask` | One-shot AI question about a profile |
+| `agent` | Agent auto-analysis (`analyze`, `ask`) |
+| `skill` | List and run analysis skills |
+| `evidence` | Build evidence findings for the timeline overlay |
+| `root-cause` | Browse and submit root-cause patterns |
+| `cutracer` | Instruction-level drill-down (`check`, `install`, `plan`, `run`, `analyze`) |
+| `export` / `export-csv` / `export-json` | Perfetto JSON, flat CSV, flat JSON |
+| `viewer` / `timeline-html` | Interactive HTML report / timeline |
+| `perfetto` | Open the trace in the Perfetto UI |
 
----
+Run `nsys-ai <command> --help` for flags.
 
-## 🧩 Skills (Analysis Building Blocks)
+## Skills
 
-nsys-ai ships with built-in analysis skills — self-contained analysis units that work without any LLM:
+Skills are self-contained analysis units that run without an LLM. nsys-ai ships
+37 of them (kernels, memory, NCCL/communicators, NVTX, MFU, idle, root-cause,
+profile health, and more).
 
 ```bash
-# List all available skills
-nsys-ai skill list
-
-# Run a specific skill
+nsys-ai skill list                                 # full catalog
 nsys-ai skill run top_kernels profile.sqlite
-nsys-ai skill run gpu_idle_gaps profile.sqlite
 nsys-ai skill run nccl_breakdown profile.sqlite
+nsys-ai skill run profile_health_manifest profile.sqlite --format json
 ```
+
+A few common ones:
 
 | Skill | What it does |
 |-------|-------------|
 | `top_kernels` | Heaviest GPU kernels by total time |
-| `memory_transfers` | H2D/D2H/D2D transfer breakdown |
-| `nvtx_kernel_map` | NVTX annotation → kernel mapping |
 | `gpu_idle_gaps` | Pipeline bubbles between kernels |
-| `nccl_breakdown` | NCCL collective operation summary |
-| `kernel_launch_overhead` | CPU→GPU dispatch latency |
-| `thread_utilization` | CPU thread bottleneck detection |
-| `schema_inspect` | Database tables and columns |
-| `module_loading` | JIT compilation & module loading stalls |
-| `gc_impact` | GC & memory allocation stalls |
-| `pipeline_bubble_metrics` | True GPU idle percentage per device |
-| `cutracer_analysis` | Correlate CUTracer instruction mix with nsys/NVTX context |
+| `memory_transfers` | H2D / D2H / D2D transfer breakdown |
+| `nccl_breakdown` | NCCL collective summary by type |
+| `nccl_communicator_analysis` | Per-communicator NCCL topology and efficiency |
+| `overlap_breakdown` | Compute / communication overlap |
+| `kernel_launch_overhead` | CPU-to-GPU dispatch latency |
+| `region_mfu` | Model FLOPs utilization for an NVTX region |
+| `profile_health_manifest` | One-shot health summary (run this first) |
 
-Skills are extensible — add your own by creating a Python file that exports a `SKILL` constant.
+Skills are extensible — add one by dropping a Python file that exports a `SKILL`
+constant. See [`skill list`](docs/agent_skills/commands/skill.md) for the full
+catalog.
 
----
+## AI analysis (optional)
 
-## 🤖 AI Agent
-
-The agent is a CUDA ML systems expert that runs skills automatically and diagnoses problems:
+The agent is a CUDA performance expert that runs the skills and cites the
+evidence — kernel names, durations, timestamps — behind each diagnosis rather
+than guessing.
 
 ```bash
-# Full auto-analysis
 nsys-ai agent analyze profile.sqlite
-
-# Ask a specific question
 nsys-ai agent ask profile.sqlite "why are there bubbles in the pipeline?"
-nsys-ai agent ask profile.sqlite "is NCCL overlapping with compute?"
+nsys-ai ask profile.sqlite "is NCCL overlapping with compute?"
+nsys-ai chat profile.sqlite                        # interactive chat TUI
 ```
 
-With `pip install nsys-ai[agent]`, the agent can use an LLM to synthesize natural language analysis from skill results.
-
----
-
-## 📦 Install Tiers
+The AI features need a provider API key. Set one of:
 
 ```bash
-pip install nsys-ai          # Core: CLI + TUI + skills (rich + textual)
-pip install nsys-ai[agent]   # + LLM-backed agent analysis (requires anthropic)
-pip install nsys-ai[cutracer] # + CUTracer instruction-level workflow
-pip install nsys-ai[all]     # Everything
+export ANTHROPIC_API_KEY=...      # or
+export OPENAI_API_KEY=...         # or
+export GEMINI_API_KEY=...
+export NSYS_AI_MODEL=...          # optional: pick a specific model
 ```
 
----
-
-## 🤖 AI Analysis (Optional)
-
-nsys-ai includes an optional AI module that can analyze your profiles:
+Install the dependencies with the `agent` extra:
 
 ```bash
-pip install nsys-ai[ai]
+pip install 'nsys-ai[agent]'
 ```
 
-- **Auto-commentary** on kernel distributions and performance patterns
-- **NVTX annotation suggestions** for un-annotated code regions
-- **Performance bottleneck detection** with actionable recommendations
-- **Framework Fingerprinting** statically identifies distributed stacks (vLLM, Megatron-LM, DeepSpeed) and cluster networking hardware (Mellanox, Broadcom) to context-align AI recommendations.
+If no key is set, the agent still runs the deterministic skills and prints their
+results; it just skips the natural-language synthesis.
 
----
+## Claude Code plugin
 
-## 🧑‍💻 Development
+nsys-ai ships as a [Claude Code](https://claude.com/claude-code) plugin: the
+`/nsys-ai` slash command turns a profile into a root cause, a proposed fix, and
+an annotated timeline. See
+[docs/claude-plugin-quickstart.md](docs/claude-plugin-quickstart.md) to install
+and [docs/claude-plugin.md](docs/claude-plugin.md) for the full reference.
+
+## Documentation
+
+The `docs/` directory mirrors the relevant NVIDIA Nsight Systems reference
+(capture, schema, NVTX, CUDA/NCCL trace) plus nsys-ai project guides:
+
+| Guide | Topic |
+|-------|-------|
+| [NVIDIA nsys CLI](docs/01-cli-reference.md) | The upstream `nsys` profiler CLI (capture-time) |
+| [SQLite schema](docs/02-sqlite-schema.md) | Nsight export tables and queries |
+| [NVTX annotations](docs/03-nvtx-annotations.md) | Annotating your code (and iteration markers) |
+| [CUDA trace](docs/04-cuda-trace.md) | GPU kernel and memory tracing |
+| [NCCL tracing](docs/05-nccl-tracing.md) | Multi-GPU collective analysis |
+| [Python / PyTorch](docs/06-python-pytorch.md) | Profiling PyTorch workloads |
+| [Containers](docs/07-container-profiling.md) | Profiling inside Docker / Slurm |
+| [Focused profiling](docs/08-focused-profiling.md) | Capturing representative iterations |
+| [CUTracer](docs/cutracer-instruction-analysis.md) | Instruction-level drill-down for top kernels |
+
+The [`docs/sqlite-explorer/`](docs/sqlite-explorer/) directory holds an
+interactive HTML explorer for the Nsight SQLite schema — open
+`docs/sqlite-explorer/index.html` in a browser.
+
+## Install tiers
+
+```bash
+pip install nsys-ai              # core: CLI, TUIs, skills, web/diff viewers
+pip install 'nsys-ai[agent]'     # + LLM-backed agent (anthropic + litellm)
+pip install 'nsys-ai[chat]'      # + chat TUI
+pip install 'nsys-ai[cutracer]'  # + CUTracer instruction-level workflow
+pip install 'nsys-ai[all]'       # everything
+```
+
+The `ai` extra is kept as an alias of `agent` for backward compatibility.
+
+## Development
 
 ```bash
 git clone https://github.com/GindaChen/nsys-ai.git
@@ -455,9 +339,7 @@ pip install -e '.[dev]'
 pytest tests/ -v
 ```
 
----
-
-## 📄 License
+## License
 
 MIT — see [LICENSE](LICENSE).
 


### PR DESCRIPTION
## Summary

The README had fallen behind the tool and was heavy on decorative emoji. This refreshes the content and cleans up the styling.

## Content

- **Capture guidance** now shows the recommended focused-profiling command (`--capture-range=cudaProfilerApi --trace=cuda,nvtx`) with a short PyTorch snippet, and notes the NVTX iteration marker that `iters` / `diff --iteration` depend on — the previous bare `nsys profile -o my_training python train.py` produces a profile with no NVTX and full-run overhead.
- Notes that `.nsys-rep` files open directly (auto-exported to SQLite).
- **Command table** completed — `open`, `web`, `chat`, `ask`, `agent`, `report`, `evidence`, `root-cause`, `perfetto`, `analyze`, and others were missing.
- **Skills** section states the real count (37) and points at `skill list` instead of a hand-maintained subset that had drifted.
- **AI setup** — consolidates the two overlapping AI sections into one and documents the provider API key (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` / `NSYS_AI_MODEL`), which was undocumented; standardizes the install extra on `agent` (with `ai` noted as an alias) and adds `chat`.
- Marks `docs/01-cli-reference.md` as the upstream `nsys` CLI (it documents the NVIDIA profiler, not nsys-ai).

## Style

- Removes decorative emoji from headings and tables.
- Drops the ASCII feature-showcase block (its sub-headings were the emoji-heavy part); happy to restore a de-emoji'd version if you'd prefer to keep it.

Documentation only; no code changes. All `docs/` links verified to resolve.