### PR TITLE
feat(doctor): add environment and profile-health diagnostics command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- `nsys-ai doctor` diagnoses the environment (Python, nsys CLI, Parquet cache,
+  AI provider, CUTracer toolchain including the nvdisasm/framework CUDA match)
+  and, when given a profile, its health (duration, GPUs, GPU model, NVTX and
+  NCCL presence, profiler overhead). It stays a fast triage — single-digit
+  seconds even on multi-gigabyte, multi-GPU profiles — and defers the slow NCCL
+  eager/inductor call-mode split to `--deep`. Text and `--format json` output, a
+  `--strict` flag, and a non-zero exit on failures so it can gate CI. The same
+  report is reusable in-process by the web GUI and TUI, and the analysis skill
+  uses it as a preflight.
 - Before/after drill-down in the diff agent: compare a kernel's launch
   configuration (grid/block/registers/shared memory) and memory profile (peak
   VRAM and allocation/free deltas), and locate each top kernel regression to a

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -1,0 +1,109 @@
+# nsys-ai doctor
+
+`nsys-ai doctor` checks whether your environment is ready to analyze profiles
+and, when you give it a profile, whether that profile has enough data for a
+useful diagnosis. Run it first when something is not working, or attach its
+JSON output to a bug report.
+
+```bash
+nsys-ai doctor                      # environment checks only
+nsys-ai doctor profile.sqlite       # environment + profile health
+nsys-ai doctor profile.nsys-rep     # same; reports if conversion is possible
+nsys-ai doctor profile.sqlite --format json
+```
+
+## What it checks
+
+Doctor covers the **analysis** side — reading and analyzing a profile, and the
+optional features layered on top. It does not check whether a host can *capture*
+a profile; for that, use NVIDIA's own `nsys status -e`.
+
+**System** — Python version, nsys-ai version, platform string.
+
+**Profile support**
+
+- SQLite analysis (always available; stdlib).
+- `.nsys-rep` conversion — needs the `nsys` CLI on `PATH`. Missing it is only a
+  warning: `.sqlite` profiles still work, but `.nsys-rep` files cannot be
+  converted.
+- Parquet cache — `duckdb` + `pyarrow`, which accelerate large profiles.
+
+**Optional features**
+
+- GUI / chat TUI — the `textual` package.
+- AI provider — `litellm` plus a configured API key (`ANTHROPIC_API_KEY`,
+  `OPENAI_API_KEY`, or `GEMINI_API_KEY`; `NSYS_AI_MODEL` to pick a model). Doctor
+  reports separately whether `litellm` is installed and whether a key is set, so
+  you know which half is missing.
+- CUTracer — reported in two parts, following the "installed vs compatible"
+  split:
+  - **CUTracer**: the `cutracer` package and a built `cutracer.so`.
+  - **nvdisasm ↔ framework CUDA**: the CUDA major version of `nvdisasm` must
+    match the framework's CUDA build. A mismatch silently drops a hot kernel's
+    SASS during CUTracer runs (see [cutracer-modal.md](cutracer-modal.md)). This
+    check is best-effort: it is skipped when `nvdisasm` is absent or the
+    framework CUDA version cannot be determined (install `torch` on the host, or
+    run on the training host, to enable it).
+
+**Profile health** (only when a profile is given)
+
+- Duration, GPU count (`COUNT(DISTINCT deviceId)`), GPU model (from CUPTI
+  `TARGET_INFO`; "unknown" blocks MFU), and whether the run is multi-GPU.
+- NVTX events — absence is a warning, since layer attribution and code tracing
+  depend on annotations.
+- NCCL events (a fast presence count). The eager / inductor-captured /
+  temporal-only call-mode split — which decides whether a fix belongs in user
+  code or in `torch._inductor.config` — is a slow check (it joins the NVTX map),
+  so it runs only under `--deep`.
+- Profiler overhead — a warning above 10% and a failure above 20%, since high
+  overhead distorts timings. An impossible figure (over 100%) is reported as
+  unreliable rather than as a failure.
+- RunSpec presence — reported as not-yet-available until profile capture records
+  a RunSpec.
+
+## Status meanings
+
+| Token  | Meaning |
+| ------ | ------- |
+| `OK`   | Working / present |
+| `WARN` | Usable, but degraded or distorted results likely |
+| `FAIL` | Blocking — analysis cannot proceed or the data is unsound |
+| `----` | Optional feature not configured |
+| `SKIP` | Check could not run (not enough information) |
+
+Hints for `WARN`, `FAIL`, and not-configured checks are shown by default. Pass
+`-v` / `--verbose` to also show hints for skipped checks.
+
+## Exit codes
+
+- `0` — no failures (warnings do not change the exit code).
+- `1` — at least one `FAIL` check.
+
+Use `--strict` to also exit non-zero on warnings, which is useful in CI.
+
+## Fast by default
+
+Doctor is meant to be a fast triage, so it avoids expensive analysis. The NCCL
+call-mode split joins the NVTX map and can take minutes on an NVTX-heavy
+profile; it runs only when you pass `--deep`. The default run stays in the
+single-digit-seconds range even on multi-gigabyte, multi-GPU profiles.
+
+## JSON output
+
+`--format json` prints a versioned envelope with a `summary` count. It is the
+canonical thing to attach to a bug report, since it captures versions, platform,
+and profile health in one place.
+
+```json
+{
+  "schema_version": "0.1",
+  "producer": "nsys-ai",
+  "producer_version": "0.2.3",
+  "profile_path": "profile.sqlite",
+  "profile_id": "nsys1:sha256:...",
+  "sections": [
+    {"name": "System", "checks": [{"name": "Python", "status": "ok", "detail": "3.12.3", "hint": null}]}
+  ],
+  "summary": {"ok": 12, "warn": 1, "fail": 0, "not_configured": 2, "skipped": 0}
+}
+```

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -102,7 +102,7 @@ and profile health in one place.
   "profile_path": "profile.sqlite",
   "profile_id": "nsys1:sha256:...",
   "sections": [
-    {"name": "System", "checks": [{"name": "Python", "status": "ok", "detail": "3.12.3", "hint": null}]}
+    {"name": "System", "checks": [{"name": "Python", "status": "ok", "detail": "3.12.3", "hint": null, "sub": false}]}
   ],
   "summary": {"ok": 12, "warn": 1, "fail": 0, "not_configured": 2, "skipped": 0}
 }

--- a/skills/analyze/SKILL.md
+++ b/skills/analyze/SKILL.md
@@ -29,6 +29,21 @@ nsys-ai --help   # exit 0 = ready
 
 If not installed: `pip install "nsys-ai[agent]"`.
 
+**Triage with `doctor` when you have a profile path.** Before analyzing, run:
+
+```bash
+nsys-ai doctor <profile> --format json
+```
+
+Parse it to steer the analysis (do NOT surface the raw JSON to the user):
+
+- `profiler overhead` FAIL (> 20%) → caveat every timing claim; the profile is distorted.
+- `NVTX events` WARN (none) → skip layer/region attribution; lean on kernel-level skills.
+- `GPU model` WARN (unknown) → do not attempt MFU.
+- `AI provider` not configured → you are the LLM; proceed, but skill outputs are the evidence.
+- `.nsys-rep conversion` FAIL (no `nsys`) on a `.nsys-rep` input → tell the user to install Nsight Systems.
+- A `FAIL` in `Profile health` (cannot open) → stop and report the path/file problem.
+
 **File format**: `.sqlite` used directly; `.nsys-rep` is auto-converted silently by
 `nsys-ai` (see PRINCIPLES.md §4.2). **Do not ask the user to convert.**
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -380,6 +380,35 @@ def _cmd_info(args, _profile):
             )
 
 
+def _cmd_doctor(args, _profile):
+    """Diagnose the environment and (optionally) a profile's health.
+
+    Exit code follows the brew/npm consensus: warnings are exit 0, failures
+    are non-zero. ``--strict`` promotes warnings to failures for CI use.
+    """
+    import json as _json
+
+    from nsys_ai.doctor import format_doctor_text, run_doctor
+
+    profile_path = getattr(args, "profile", None)
+    report = run_doctor(
+        profile_path,
+        device=getattr(args, "gpu", None),
+        deep=getattr(args, "deep", False),
+    )
+
+    fmt = getattr(args, "format", "text") or "text"
+    if fmt == "json":
+        print(_json.dumps(report.to_dict(), indent=2))
+    else:
+        print(format_doctor_text(report, verbose=getattr(args, "verbose", False)))
+
+    if report.has_failures():
+        sys.exit(1)
+    if getattr(args, "strict", False) and report.has_warnings():
+        sys.exit(1)
+
+
 def _cmd_analyze(args, _profile):
     fmt = getattr(args, "format", "text") or "text"
     if fmt == "json":

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -393,7 +393,6 @@ def _cmd_doctor(args, _profile):
     profile_path = getattr(args, "profile", None)
     report = run_doctor(
         profile_path,
-        device=getattr(args, "gpu", None),
         deep=getattr(args, "deep", False),
     )
 

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -20,6 +20,7 @@ from .handlers import (
     _cmd_cutracer,
     _cmd_diff,
     _cmd_diff_web,
+    _cmd_doctor,
     _cmd_evidence,
     _cmd_export,
     _cmd_export_csv,
@@ -55,6 +56,39 @@ def _register_info_parser(sub):
     p = sub.add_parser("info", help="Show profile metadata and GPU info")
     p.add_argument("profile", help="Path to profile (.sqlite or .nsys-rep)")
     p.set_defaults(handler=_cmd_info)
+    return p
+
+
+def _register_doctor_parser(sub):
+    """Register the ``doctor`` subcommand on *sub*."""
+    p = sub.add_parser(
+        "doctor",
+        help="Diagnose the environment and a profile's health",
+    )
+    p.add_argument(
+        "profile",
+        nargs="?",
+        default=None,
+        help="Optional profile (.sqlite or .nsys-rep) for a health summary",
+    )
+    p.add_argument(
+        "--gpu", type=int, default=None, help="GPU device ID for the health summary"
+    )
+    p.add_argument(
+        "--format", choices=["text", "json"], default="text", help="Output format"
+    )
+    p.add_argument(
+        "-v", "--verbose", action="store_true", help="Show hints for skipped checks too"
+    )
+    p.add_argument(
+        "--strict", action="store_true", help="Exit non-zero on warnings (for CI)"
+    )
+    p.add_argument(
+        "--deep",
+        action="store_true",
+        help="Run slow checks too (e.g. NCCL eager/inductor split); off by default",
+    )
+    p.set_defaults(handler=_cmd_doctor)
     return p
 
 
@@ -226,7 +260,7 @@ def _build_parser():
         dest="command",
         metavar=(
             "{open,web,timeline-web,chat,ask,agent-guide,"
-            "info,skill,evidence,report,diff,diff-web,export,help}"
+            "info,doctor,skill,evidence,report,diff,diff-web,export,help}"
         ),
     )
 
@@ -583,6 +617,7 @@ def _build_parser():
 
     # Agent-facing commands (promoted from legacy so --help exposes them)
     _register_info_parser(sub)
+    _register_doctor_parser(sub)
     _register_skill_parser(sub, include_management=False)
     _register_evidence_parser(sub)
     _register_root_cause_parser(sub)
@@ -595,6 +630,7 @@ def _build_parser():
 def _register_legacy_commands(sub):
     """Register legacy commands on the provided subparser collection."""
     _register_info_parser(sub)
+    _register_doctor_parser(sub)
 
     p = sub.add_parser(
         "analyze",

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -72,9 +72,6 @@ def _register_doctor_parser(sub):
         help="Optional profile (.sqlite or .nsys-rep) for a health summary",
     )
     p.add_argument(
-        "--gpu", type=int, default=None, help="GPU device ID for the health summary"
-    )
-    p.add_argument(
         "--format", choices=["text", "json"], default="text", help="Output format"
     )
     p.add_argument(

--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -1,0 +1,705 @@
+"""doctor.py — environment and profile-health diagnostics for nsys-ai.
+
+``run_doctor()`` returns a structured :class:`DoctorReport` that every surface
+consumes the same way:
+
+* CLI       — ``format_doctor_text(report)`` for humans, ``report.to_dict()`` for ``--format json``.
+* Web GUI   — a ``/api/doctor`` route serves ``report.to_dict()``.
+* TUI       — a health badge / panel reads the same report.
+* Claude    — the ``nsys-ai`` skill runs ``nsys-ai doctor --format json`` as a preflight.
+
+All detection logic lives here, never in the CLI handler, so ``web.py`` and the
+TUI can ``import nsys_ai.doctor`` and call ``run_doctor(...)`` in-process without
+shelling out.
+
+Scope: this checks the *analysis* environment (can we read and analyze this
+profile, are optional features configured) and the *quality* of a profile (is
+there enough data for a useful diagnosis). It does NOT check whether the host
+can capture a profile — for that, run ``nsys status -e`` (NVIDIA's own
+profiling-environment check).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import platform
+import shutil
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+SCHEMA_VERSION = "0.1"
+
+# Profiler-overhead thresholds (percent of profile span).
+_OVERHEAD_WARN_PCT = 10.0
+_OVERHEAD_FAIL_PCT = 20.0
+
+CheckStatus = Literal["ok", "warn", "fail", "not_configured", "skipped"]
+
+# Fixed-width status tokens for the text renderer (ASCII — portable across
+# terminals, CI logs, and Windows; the project keeps emoji out of output).
+_STATUS_TOKEN: dict[CheckStatus, str] = {
+    "ok": "OK  ",
+    "warn": "WARN",
+    "fail": "FAIL",
+    "not_configured": "----",
+    "skipped": "SKIP",
+}
+
+# Statuses whose hint is shown by default (actionable). ``skipped`` hints are
+# only surfaced with ``--verbose``.
+_HINT_BY_DEFAULT: set[CheckStatus] = {"warn", "fail", "not_configured"}
+
+
+# ---------------------------------------------------------------------------
+# Report model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CheckResult:
+    """One diagnostic line: a named check, its status, and how to fix it.
+
+    *sub* marks a check that refines the one above it (e.g. the CUDA-match
+    detail under CUTracer); the text renderer indents it, while JSON keeps the
+    name clean so consumers can match on it directly.
+    """
+
+    name: str
+    status: CheckStatus
+    detail: str = ""
+    hint: str | None = None
+    sub: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "status": self.status,
+            "detail": self.detail,
+            "hint": self.hint,
+            "sub": self.sub,
+        }
+
+
+@dataclass
+class DoctorSection:
+    """A group of related checks (e.g. "System", "Profile health")."""
+
+    name: str
+    checks: list[CheckResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "checks": [c.to_dict() for c in self.checks]}
+
+
+@dataclass
+class DoctorReport:
+    """The full diagnostic, consumed identically by every surface."""
+
+    schema_version: str
+    producer: str
+    producer_version: str
+    profile_path: str | None
+    profile_id: str | None
+    sections: list[DoctorSection]
+
+    def all_checks(self) -> list[CheckResult]:
+        return [c for s in self.sections for c in s.checks]
+
+    def summary(self) -> dict[str, int]:
+        counts = {status: 0 for status in _STATUS_TOKEN}
+        for c in self.all_checks():
+            counts[c.status] = counts.get(c.status, 0) + 1
+        return counts
+
+    def has_failures(self) -> bool:
+        return any(c.status == "fail" for c in self.all_checks())
+
+    def has_warnings(self) -> bool:
+        return any(c.status == "warn" for c in self.all_checks())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "producer": self.producer,
+            "producer_version": self.producer_version,
+            "profile_path": self.profile_path,
+            "profile_id": self.profile_id,
+            "sections": [s.to_dict() for s in self.sections],
+            "summary": self.summary(),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Small detection helpers
+# ---------------------------------------------------------------------------
+
+
+def _have_pkg(name: str) -> bool:
+    """Return True if *name* is importable without importing it."""
+    try:
+        return importlib.util.find_spec(name) is not None
+    except (ImportError, ValueError):
+        return False
+
+
+def _producer_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("nsys-ai")
+    except Exception:  # noqa: BLE001 — version lookup is best-effort
+        return "unknown"
+
+
+def _skill_conn(prof: Any) -> Any:
+    """The connection a skill should run against (DuckDB cache if present)."""
+    return prof.db if getattr(prof, "db", None) is not None else prof.conn
+
+
+# ---------------------------------------------------------------------------
+# Environment sections (no profile required)
+# ---------------------------------------------------------------------------
+
+
+def _check_system() -> DoctorSection:
+    checks: list[CheckResult] = []
+
+    # nsys-ai requires Python >= 3.10 at install time, so a running interpreter
+    # is supported by construction; report the version for bug reports.
+    checks.append(CheckResult("Python", "ok", platform.python_version()))
+    checks.append(CheckResult("nsys-ai", "ok", _producer_version()))
+    checks.append(CheckResult("Platform", "ok", platform.platform()))
+    return DoctorSection("System", checks)
+
+
+def _check_profile_support() -> DoctorSection:
+    checks: list[CheckResult] = []
+
+    # SQLite analysis is always available (stdlib).
+    checks.append(CheckResult("SQLite analysis", "ok", "stdlib sqlite3"))
+
+    # .nsys-rep conversion needs the nsys CLI on PATH.
+    nsys = shutil.which("nsys")
+    if nsys:
+        checks.append(CheckResult(".nsys-rep conversion", "ok", nsys))
+    else:
+        checks.append(
+            CheckResult(
+                ".nsys-rep conversion",
+                "warn",
+                "nsys CLI not found on PATH",
+                hint=(
+                    "Install NVIDIA Nsight Systems to analyze .nsys-rep files directly. "
+                    ".sqlite profiles work without it."
+                ),
+            )
+        )
+
+    # Parquet cache acceleration needs duckdb + pyarrow.
+    missing = [p for p in ("duckdb", "pyarrow") if not _have_pkg(p)]
+    if not missing:
+        checks.append(CheckResult("Parquet cache", "ok", "duckdb + pyarrow"))
+    else:
+        checks.append(
+            CheckResult(
+                "Parquet cache",
+                "warn",
+                f"missing: {', '.join(missing)}",
+                hint="pip install nsys-ai  (duckdb + pyarrow accelerate large profiles)",
+            )
+        )
+
+    return DoctorSection("Profile support", checks)
+
+
+def _check_ai_provider() -> CheckResult:
+    if not _have_pkg("litellm"):
+        return CheckResult(
+            "AI provider (litellm)",
+            "not_configured",
+            "litellm not installed",
+            hint="pip install 'nsys-ai[agent]' to enable ask/chat/agent features.",
+        )
+    try:
+        from nsys_ai.chat_config import get_available_models
+
+        models = get_available_models()
+    except Exception as exc:  # noqa: BLE001 — never let a config probe crash doctor
+        return CheckResult(
+            "AI provider (litellm)", "warn", f"model probe failed: {exc}"
+        )
+
+    if models:
+        labels = ", ".join(m["label"] for m in models[:3])
+        more = f" (+{len(models) - 3} more)" if len(models) > 3 else ""
+        return CheckResult(
+            "AI provider (litellm)", "ok", f"{len(models)} model(s): {labels}{more}"
+        )
+    return CheckResult(
+        "AI provider (litellm)",
+        "not_configured",
+        "litellm OK; no API key set",
+        hint=(
+            "Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY "
+            "(and optionally NSYS_AI_MODEL)."
+        ),
+    )
+
+
+def _check_cutracer() -> list[CheckResult]:
+    """CUTracer split into 'installed' and 'CUDA-compatible' (ds_report style)."""
+    checks: list[CheckResult] = []
+
+    # 1. Installed: package + prebuilt .so.
+    try:
+        from nsys_ai.cutracer.installer import _find_cutracer_so_path
+
+        so_path = _find_cutracer_so_path()
+    except Exception:  # noqa: BLE001
+        so_path = None
+    pkg = _have_pkg("cutracer")
+
+    if pkg and so_path:
+        checks.append(CheckResult("CUTracer", "ok", so_path))
+    else:
+        missing = []
+        if not pkg:
+            missing.append("cutracer package")
+        if not so_path:
+            missing.append("cutracer.so")
+        checks.append(
+            CheckResult(
+                "CUTracer",
+                "not_configured",
+                f"missing: {', '.join(missing)}",
+                hint="nsys-ai cutracer install  (requires CUDA toolkit + g++)",
+            )
+        )
+
+    # 2. Compatible: nvdisasm CUDA major must match the framework's CUDA build.
+    #    A mismatch silently drops the hot kernel's SASS — see docs/cutracer-modal.md.
+    #    Only relevant (and only worth importing torch for) when CUTracer is
+    #    present; skip it entirely otherwise.
+    if pkg or so_path:
+        checks.append(_check_cuda_toolchain_match())
+    return checks
+
+
+def _framework_cuda() -> str | None:
+    """Best-effort CUDA version the local ML framework was built against."""
+    try:
+        import torch  # type: ignore[import]
+
+        if getattr(torch, "version", None) and torch.version.cuda:
+            return str(torch.version.cuda)
+    except Exception:  # noqa: BLE001 — torch is optional on an analysis host
+        pass
+    try:
+        from nsys_ai.cutracer.installer import detect_cuda_version
+
+        ver = detect_cuda_version()
+        if ver:
+            return f"{ver[0]}.{ver[1]}"
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def _check_cuda_toolchain_match() -> CheckResult:
+    name = "nvdisasm <-> framework CUDA"
+    if not shutil.which("nvdisasm"):
+        return CheckResult(
+            name,
+            "skipped",
+            "nvdisasm not found",
+            hint="nvdisasm (CUDA toolkit) is needed only for CUTracer SASS resolution.",
+            sub=True,
+        )
+    try:
+        from nsys_ai.cutracer.installer import _run_version_cmd
+
+        nvd = _run_version_cmd(["nvdisasm", "--version"], r"release (\d+\.\d+)")
+    except Exception:  # noqa: BLE001
+        nvd = None
+    fw = _framework_cuda()
+
+    if not nvd or nvd == "?":
+        return CheckResult(
+            name, "skipped", "could not read nvdisasm CUDA version", sub=True
+        )
+    if not fw:
+        return CheckResult(
+            name,
+            "skipped",
+            f"nvdisasm {nvd}; framework CUDA unknown",
+            hint="Install torch on this host (or run on the training host) to compare.",
+            sub=True,
+        )
+
+    nvd_major = nvd.split(".")[0]
+    fw_major = fw.split(".")[0]
+    if nvd_major == fw_major:
+        return CheckResult(name, "ok", f"{nvd} <-> {fw}", sub=True)
+    return CheckResult(
+        name,
+        "warn",
+        f"{nvd} <-> {fw} (CUDA major mismatch)",
+        hint=(
+            "nvdisasm older than the framework CUDA silently drops a kernel's SASS. "
+            "Match the CUDA toolkit to your framework — see docs/cutracer-modal.md."
+        ),
+        sub=True,
+    )
+
+
+def _check_optional_features() -> DoctorSection:
+    checks: list[CheckResult] = []
+
+    if _have_pkg("textual"):
+        checks.append(CheckResult("GUI / chat TUI (textual)", "ok", "textual"))
+    else:
+        checks.append(
+            CheckResult(
+                "GUI / chat TUI (textual)",
+                "not_configured",
+                "textual not installed",
+                hint="pip install 'nsys-ai[chat]' for the chat TUI.",
+            )
+        )
+
+    checks.append(_check_ai_provider())
+    checks.extend(_check_cutracer())
+    return DoctorSection("Optional features", checks)
+
+
+# ---------------------------------------------------------------------------
+# Profile health section (requires an opened profile)
+# ---------------------------------------------------------------------------
+
+
+def _safe_profile_id(prof: Any, fallback_path: str | None) -> str | None:
+    try:
+        from nsys_ai.fingerprint import get_profile_id
+
+        return get_profile_id(getattr(prof, "conn", None), fallback_path=fallback_path)
+    except Exception:  # noqa: BLE001 — identity is informational, never fatal
+        return None
+
+
+def _nccl_kernel_count(prof: Any) -> int | None:
+    """Count NCCL kernels by name — a cheap presence probe (no NVTX IEJoin).
+
+    Returns the count, or None if the kernel table / StringIds is unavailable.
+    """
+    kt = getattr(getattr(prof, "schema", None), "kernel_table", None)
+    if not kt:
+        return None
+    try:
+        cur = prof.adapter.execute(
+            f"SELECT COUNT(*) FROM {kt} k "  # noqa: S608 — kt is a validated table name
+            "JOIN StringIds s ON k.shortName = s.id "
+            "WHERE lower(s.value) LIKE '%nccl%'",
+            [],
+        )
+        row = cur.fetchone()
+        return int(row[0]) if row else 0
+    except Exception:  # noqa: BLE001 — presence probe is best-effort
+        return None
+
+
+def _nccl_call_modes(prof: Any, device: int) -> str | None:
+    """eager / inductor-captured / temporal-only split via the breakdown skill.
+
+    Runs ``nccl_compile_context_breakdown``, which joins ``nvtx_kernel_map`` and
+    can take minutes on an NVTX-heavy profile — so doctor only calls this under
+    ``--deep``, never on the default fast path.
+    """
+    try:
+        from nsys_ai.skills.registry import get_skill
+
+        skill = get_skill("nccl_compile_context_breakdown")
+        if skill is None:
+            return None
+        rows = skill.execute(_skill_conn(prof), device=device)
+    except Exception:  # noqa: BLE001
+        return None
+
+    buckets = {r["bucket"]: r for r in rows if "bucket" in r}
+    if not buckets:
+        return None
+    return (
+        f"eager {buckets.get('eager', {}).get('pct', 0):.0f}% / "
+        f"inductor {buckets.get('inductor_captured', {}).get('pct', 0):.0f}% / "
+        f"temporal {buckets.get('temporal_only', {}).get('pct', 0):.0f}%"
+    )
+
+
+def _profiler_overhead_pct(prof: Any, span_ns: int) -> float | None:
+    """Profiler overhead as a percent of the full profile span, or None."""
+    if span_ns <= 0:
+        return None
+    try:
+        from nsys_ai.skills.base import compute_profiler_overhead_ns
+
+        overhead_ns = compute_profiler_overhead_ns(_skill_conn(prof))
+    except Exception:  # noqa: BLE001
+        return None
+    return overhead_ns / span_ns * 100.0
+
+
+def _gpu_model_check(meta: Any, devices: list[int]) -> CheckResult:
+    names = {
+        (meta.gpu_info[d].name or "").strip()
+        for d in devices
+        if d in meta.gpu_info
+    }
+    named = sorted(n for n in names if n and n.lower() != "unknown")
+    if named:
+        return CheckResult("GPU model", "ok", ", ".join(named))
+    return CheckResult(
+        "GPU model",
+        "warn",
+        "unknown",
+        hint="GPU model missing from CUPTI TARGET_INFO; MFU / efficiency cannot be computed.",
+    )
+
+
+def _overhead_check(pct: float | None) -> CheckResult:
+    if pct is None:
+        return CheckResult(
+            "Profiler overhead", "skipped", "no profiler-overhead table in profile"
+        )
+    if pct > 100.0:
+        # Physically impossible — a degenerate/very short profile, not a real
+        # overhead problem (cf. silencing impossible profile-overhead findings).
+        return CheckResult(
+            "Profiler overhead",
+            "skipped",
+            f"{pct:.0f}% (unreliable; profile too short to measure)",
+        )
+    if pct > _OVERHEAD_FAIL_PCT:
+        return CheckResult(
+            "Profiler overhead",
+            "fail",
+            f"{pct:.1f}%",
+            hint=(
+                f"Overhead > {_OVERHEAD_FAIL_PCT:.0f}% badly distorts timings; "
+                "re-profile with fewer trace domains or a capture range."
+            ),
+        )
+    if pct > _OVERHEAD_WARN_PCT:
+        return CheckResult(
+            "Profiler overhead",
+            "warn",
+            f"{pct:.1f}%",
+            hint=f"Overhead > {_OVERHEAD_WARN_PCT:.0f}% may skew kernel timings.",
+        )
+    return CheckResult("Profiler overhead", "ok", f"{pct:.1f}%")
+
+
+def _check_profile_health(prof: Any, device: int | None, *, deep: bool = False) -> DoctorSection:
+    checks: list[CheckResult] = []
+    meta = prof.meta
+    devices = list(meta.devices or [])
+    dev = device if device is not None else (devices[0] if devices else 0)
+    span_ns = (meta.time_range[1] - meta.time_range[0]) if meta.time_range else 0
+
+    checks.append(CheckResult("Duration", "ok", f"{span_ns / 1e9:.1f}s"))
+    # GPUs — COUNT(DISTINCT deviceId), not the fingerprint heuristic.
+    checks.append(CheckResult("GPUs", "ok", str(len(devices))))
+    checks.append(_gpu_model_check(meta, devices))
+
+    nccl_count = _nccl_kernel_count(prof)
+    has_nccl = bool(nccl_count and nccl_count > 0)
+
+    # Multi-GPU: device count is authoritative; NCCL on a single device hints
+    # at a per-rank profile from a larger distributed run.
+    if len(devices) > 1:
+        checks.append(CheckResult("Multi-GPU run", "ok", f"yes ({len(devices)} GPUs)"))
+    elif has_nccl:
+        checks.append(
+            CheckResult("Multi-GPU run", "ok", "single device; NCCL present (per-rank profile?)")
+        )
+    else:
+        checks.append(CheckResult("Multi-GPU run", "ok", "no (single GPU)"))
+
+    # NVTX presence (coverage percentage is a future enhancement).
+    if meta.nvtx_count and meta.nvtx_count > 0:
+        checks.append(CheckResult("NVTX events", "ok", f"{meta.nvtx_count} events"))
+    else:
+        checks.append(
+            CheckResult(
+                "NVTX events",
+                "warn",
+                "none",
+                hint=(
+                    "No NVTX annotations — layer/region attribution and code "
+                    "tracing will be weak. Annotate with torch.cuda.nvtx or nvtx.annotate."
+                ),
+            )
+        )
+
+    if nccl_count is None:
+        checks.append(CheckResult("NCCL events", "skipped", "could not probe NCCL kernels"))
+    elif has_nccl:
+        checks.append(CheckResult("NCCL events", "ok", f"{nccl_count} kernels"))
+        # The eager/inductor/temporal split joins the NVTX map and can take
+        # minutes on an NVTX-heavy profile, so keep it off the fast path.
+        if deep:
+            modes = _nccl_call_modes(prof, dev)
+            if modes:
+                checks.append(CheckResult("NCCL by call mode", "ok", modes, sub=True))
+            else:
+                checks.append(
+                    CheckResult("NCCL by call mode", "skipped", "classification unavailable", sub=True)
+                )
+        else:
+            checks.append(
+                CheckResult(
+                    "NCCL by call mode",
+                    "skipped",
+                    "deep check (use --deep)",
+                    hint="--deep classifies NCCL as eager vs inductor-captured; slow on NVTX-heavy profiles.",
+                    sub=True,
+                )
+            )
+    else:
+        checks.append(CheckResult("NCCL events", "ok", "none"))
+
+    checks.append(_overhead_check(_profiler_overhead_pct(prof, span_ns)))
+
+    # RunSpec presence (forward-compatible; recording lands with `profile --runspec`).
+    checks.append(
+        CheckResult(
+            "RunSpec attached",
+            "not_configured",
+            "no",
+            hint="RunSpec recording (nsys-ai profile --runspec) is not yet available.",
+        )
+    )
+
+    return DoctorSection("Profile health", checks)
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def run_doctor(
+    profile_path: str | None = None,
+    *,
+    profile: Any = None,
+    device: int | None = None,
+    include_env: bool = True,
+    include_health: bool = True,
+    deep: bool = False,
+) -> DoctorReport:
+    """Build a :class:`DoctorReport`.
+
+    *profile_path* — open this profile for the health section.
+    *profile* — an already-open ``Profile`` (used by in-process surfaces like
+      the web GUI / TUI); takes precedence over *profile_path*.
+    *include_env* / *include_health* — toggle the environment and profile-health
+      sections so a surface can request only what it needs.
+    *deep* — also run slow checks (e.g. the NCCL eager/inductor call-mode split,
+      which joins the NVTX map). Off by default to keep doctor a fast triage.
+    """
+    sections: list[DoctorSection] = []
+    if include_env:
+        sections.append(_check_system())
+        sections.append(_check_profile_support())
+        sections.append(_check_optional_features())
+
+    profile_id: str | None = None
+    if include_health and (profile is not None or profile_path):
+        prof = profile
+        own = False
+        try:
+            if prof is None:
+                from nsys_ai import profile as _profile_mod
+
+                prof = _profile_mod.open(profile_path)
+                own = True
+        except Exception as exc:  # noqa: BLE001 — a bad path/file is a real finding
+            sections.append(
+                DoctorSection(
+                    "Profile health",
+                    [
+                        CheckResult(
+                            "Open profile",
+                            "fail",
+                            str(exc),
+                            hint="Check the path and that the file is a valid Nsight profile.",
+                        )
+                    ],
+                )
+            )
+            prof = None
+        if prof is not None:
+            try:
+                profile_id = _safe_profile_id(prof, profile_path)
+                # _check_profile_health is internally best-effort; each enrichment
+                # degrades to a skipped check rather than raising.
+                sections.append(_check_profile_health(prof, device, deep=deep))
+            finally:
+                if own:
+                    try:
+                        prof.close()
+                    except Exception:  # noqa: BLE001
+                        pass
+
+    return DoctorReport(
+        schema_version=SCHEMA_VERSION,
+        producer="nsys-ai",
+        producer_version=_producer_version(),
+        profile_path=profile_path,
+        profile_id=profile_id,
+        sections=sections,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Text renderer (CLI)
+# ---------------------------------------------------------------------------
+
+
+def format_doctor_text(report: DoctorReport, *, verbose: bool = False) -> str:
+    """Render a report as aligned, human-readable text."""
+    lines: list[str] = []
+    if report.profile_path:
+        lines.append(f"Profile: {report.profile_path}")
+        if report.profile_id:
+            lines.append(f"  id: {report.profile_id}")
+        lines.append("")
+
+    # Column width for check names across the whole report (sub-checks indent
+    # by two spaces, so account for that when sizing the column).
+    _sub_indent = 2
+    width = max(
+        (len(c.name) + (_sub_indent if c.sub else 0) for c in report.all_checks()),
+        default=0,
+    )
+
+    for section in report.sections:
+        lines.append(section.name)
+        for c in section.checks:
+            token = _STATUS_TOKEN.get(c.status, c.status)
+            detail = f"  {c.detail}" if c.detail else ""
+            label = ("  " if c.sub else "") + c.name
+            lines.append(f"  {label.ljust(width)}  [{token}]{detail}")
+            show_hint = c.hint and (c.status in _HINT_BY_DEFAULT or verbose)
+            if show_hint:
+                lines.append(f"  {' ' * width}     -> {c.hint}")
+        lines.append("")
+
+    s = report.summary()
+    lines.append(
+        "Summary: "
+        f"{s.get('ok', 0)} ok, {s.get('warn', 0)} warning, {s.get('fail', 0)} failed, "
+        f"{s.get('not_configured', 0)} not configured, {s.get('skipped', 0)} skipped"
+    )
+    if report.profile_path is None:
+        lines.append("Pass a profile (nsys-ai doctor profile.sqlite) for a health summary.")
+    lines.append("Capture-side checks (can this host profile?): run  nsys status -e")
+    return "\n".join(lines)

--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -1,16 +1,18 @@
 """doctor.py — environment and profile-health diagnostics for nsys-ai.
 
-``run_doctor()`` returns a structured :class:`DoctorReport` that every surface
-consumes the same way:
+``run_doctor()`` returns a structured :class:`DoctorReport` with a stable
+``to_dict()`` contract, so any surface can render it the same way. Live
+consumers today:
 
-* CLI       — ``format_doctor_text(report)`` for humans, ``report.to_dict()`` for ``--format json``.
-* Web GUI   — a ``/api/doctor`` route serves ``report.to_dict()``.
-* TUI       — a health badge / panel reads the same report.
-* Claude    — the ``nsys-ai`` skill runs ``nsys-ai doctor --format json`` as a preflight.
+* CLI    — ``format_doctor_text(report)`` for humans, ``report.to_dict()`` for
+  ``--format json``.
+* Claude — the ``nsys-ai`` analysis skill runs ``nsys-ai doctor --format json``
+  as a preflight and steers on the result (see ``skills/analyze/SKILL.md``).
 
-All detection logic lives here, never in the CLI handler, so ``web.py`` and the
-TUI can ``import nsys_ai.doctor`` and call ``run_doctor(...)`` in-process without
-shelling out.
+All detection logic lives here rather than in the CLI handler, so an in-process
+surface — a future ``web.py`` ``/api/doctor`` route, or a TUI health panel — can
+``import nsys_ai.doctor`` and call ``run_doctor(...)`` directly, without shelling
+out or duplicating the checks.
 
 Scope: this checks the *analysis* environment (can we read and analyze this
 profile, are optional features configured) and the *quality* of a profile (is
@@ -407,12 +409,13 @@ def _nccl_kernel_count(prof: Any) -> int | None:
         return None
 
 
-def _nccl_call_modes(prof: Any, device: int) -> str | None:
+def _nccl_call_modes(prof: Any) -> str | None:
     """eager / inductor-captured / temporal-only split via the breakdown skill.
 
     Runs ``nccl_compile_context_breakdown``, which joins ``nvtx_kernel_map`` and
     can take minutes on an NVTX-heavy profile — so doctor only calls this under
-    ``--deep``, never on the default fast path.
+    ``--deep``, never on the default fast path. The split is profile-wide (the
+    skill classifies every NCCL kernel by its leaf NVTX scope, not per device).
     """
     try:
         from nsys_ai.skills.registry import get_skill
@@ -420,7 +423,11 @@ def _nccl_call_modes(prof: Any, device: int) -> str | None:
         skill = get_skill("nccl_compile_context_breakdown")
         if skill is None:
             return None
-        rows = skill.execute(_skill_conn(prof), device=device)
+        # Pass the source .sqlite path so NVTX attribution works even when the
+        # skill runs against the DuckDB/Parquet cache connection.
+        rows = skill.execute(
+            _skill_conn(prof), _sqlite_path=getattr(prof, "path", None)
+        )
     except Exception:  # noqa: BLE001
         return None
 
@@ -497,11 +504,10 @@ def _overhead_check(pct: float | None) -> CheckResult:
     return CheckResult("Profiler overhead", "ok", f"{pct:.1f}%")
 
 
-def _check_profile_health(prof: Any, device: int | None, *, deep: bool = False) -> DoctorSection:
+def _check_profile_health(prof: Any, *, deep: bool = False) -> DoctorSection:
     checks: list[CheckResult] = []
     meta = prof.meta
     devices = list(meta.devices or [])
-    dev = device if device is not None else (devices[0] if devices else 0)
     span_ns = (meta.time_range[1] - meta.time_range[0]) if meta.time_range else 0
 
     checks.append(CheckResult("Duration", "ok", f"{span_ns / 1e9:.1f}s"))
@@ -546,7 +552,7 @@ def _check_profile_health(prof: Any, device: int | None, *, deep: bool = False) 
         # The eager/inductor/temporal split joins the NVTX map and can take
         # minutes on an NVTX-heavy profile, so keep it off the fast path.
         if deep:
-            modes = _nccl_call_modes(prof, dev)
+            modes = _nccl_call_modes(prof)
             if modes:
                 checks.append(CheckResult("NCCL by call mode", "ok", modes, sub=True))
             else:
@@ -590,7 +596,6 @@ def run_doctor(
     profile_path: str | None = None,
     *,
     profile: Any = None,
-    device: int | None = None,
     include_env: bool = True,
     include_health: bool = True,
     deep: bool = False,
@@ -604,6 +609,10 @@ def run_doctor(
       sections so a surface can request only what it needs.
     *deep* — also run slow checks (e.g. the NCCL eager/inductor call-mode split,
       which joins the NVTX map). Off by default to keep doctor a fast triage.
+
+    The health section is profile-wide (duration, GPU count/model, NVTX/NCCL
+    presence, overhead all aggregate across devices), so there is no per-device
+    scoping knob.
     """
     sections: list[DoctorSection] = []
     if include_env:
@@ -641,7 +650,7 @@ def run_doctor(
                 profile_id = _safe_profile_id(prof, profile_path)
                 # _check_profile_health is internally best-effort; each enrichment
                 # degrades to a skipped check rather than raising.
-                sections.append(_check_profile_health(prof, device, deep=deep))
+                sections.append(_check_profile_health(prof, deep=deep))
             finally:
                 if own:
                     try:

--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -441,9 +441,24 @@ def _nccl_call_modes(prof: Any) -> str | None:
     )
 
 
+def _has_overhead_table(prof: Any) -> bool:
+    """True if the profile carries the table compute_profiler_overhead_ns reads.
+
+    Nsight names it ``PROFILER_OVERHEAD`` in SQLite and ``profiler_overhead`` in
+    the Parquet/DuckDB cache; match either case-insensitively.
+    """
+    tables = getattr(getattr(prof, "schema", None), "tables", None) or []
+    return any(t.lower() == "profiler_overhead" for t in tables)
+
+
 def _profiler_overhead_pct(prof: Any, span_ns: int) -> float | None:
-    """Profiler overhead as a percent of the full profile span, or None."""
-    if span_ns <= 0:
+    """Profiler overhead as a percent of the full profile span.
+
+    Returns None when overhead cannot be measured (degenerate span, no
+    overhead table, or a probe error) — distinct from a measured 0%, so the
+    caller can report "skipped" rather than a falsely reassuring "ok 0.0%".
+    """
+    if span_ns <= 0 or not _has_overhead_table(prof):
         return None
     try:
         from nsys_ai.skills.base import compute_profiler_overhead_ns
@@ -474,7 +489,7 @@ def _gpu_model_check(meta: Any, devices: list[int]) -> CheckResult:
 def _overhead_check(pct: float | None) -> CheckResult:
     if pct is None:
         return CheckResult(
-            "Profiler overhead", "skipped", "no profiler-overhead table in profile"
+            "Profiler overhead", "skipped", "no profiler-overhead data in profile"
         )
     if pct > 100.0:
         # Physically impossible — a degenerate/very short profile, not a real

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -284,22 +284,33 @@ class Profile:
 
         kernel_table = self.schema.kernel_table
 
-        devices = [
-            r[0]
-            for r in self.adapter.execute(
-                f"SELECT DISTINCT deviceId FROM {kernel_table} ORDER BY deviceId"
-            ).fetchall()
-        ]
-
+        # Single pass over the kernel table for devices, per-device streams,
+        # time range, total kernel count, and per-device kernel counts. These
+        # were five separate full scans; in direct-SQLite mode (large profiles)
+        # each scan is seconds, so collapsing them noticeably speeds up open.
+        # ORDER BY preserves the previous device/stream ordering exactly.
+        devices: list[int] = []
         streams: dict[int, list[int]] = {}
-        for r in self.adapter.execute(
-            f"SELECT DISTINCT deviceId, streamId FROM {kernel_table} ORDER BY deviceId, streamId"
+        kcounts: dict[int, int] = {}
+        kernel_count = 0
+        min_start = None
+        max_end = None
+        for dev, stream, mn, mx, cnt in self.adapter.execute(
+            f"SELECT deviceId, streamId, MIN(start), MAX([end]), COUNT(*) "
+            f"FROM {kernel_table} GROUP BY deviceId, streamId ORDER BY deviceId, streamId"
         ).fetchall():
-            streams.setdefault(r[0], []).append(r[1])
+            if dev not in streams:
+                streams[dev] = []
+                kcounts[dev] = 0
+                devices.append(dev)
+            streams[dev].append(stream)
+            kcounts[dev] += cnt
+            kernel_count += cnt
+            if mn is not None:
+                min_start = mn if min_start is None else min(min_start, mn)
+            if mx is not None:
+                max_end = mx if max_end is None else max(max_end, mx)
 
-        tr = self.adapter.execute(f"SELECT MIN(start), MAX([end]) FROM {kernel_table}").fetchone()
-
-        kc = self.adapter.execute(f"SELECT COUNT(*) FROM {kernel_table}").fetchone()[0]
         nc = (
             self.adapter.execute("SELECT COUNT(*) FROM NVTX_EVENTS").fetchone()[0]
             if "NVTX_EVENTS" in tables
@@ -309,24 +320,18 @@ class Profile:
         return ProfileMeta(
             devices=devices,
             streams=streams,
-            time_range=(tr[0] or 0, tr[1] or 0),
-            kernel_count=kc,
+            time_range=(min_start or 0, max_end or 0),
+            kernel_count=kernel_count,
             nvtx_count=nc,
             tables=tables,
-            gpu_info=self._gpu_info(devices, streams, tables),
+            gpu_info=self._gpu_info(devices, streams, tables, kcounts),
         )
 
-    def _gpu_info(self, devices, streams, tables) -> dict[int, GpuInfo]:
-        """Query hardware metadata per GPU."""
+    def _gpu_info(self, devices, streams, tables, kcounts) -> dict[int, GpuInfo]:
+        """Build per-GPU metadata. Per-device kernel counts come from the
+        single scan in :meth:`_discover`; only hardware metadata is queried here."""
         info: dict[int, GpuInfo] = {}
-
-        # Kernel counts per device
-        kcounts = {}
         query_conn = self.db if self.db is not None else self.conn
-        for r in query_conn.execute(
-            f"SELECT deviceId, COUNT(*) FROM {self.schema.kernel_table} GROUP BY deviceId"
-        ).fetchall():
-            kcounts[r[0]] = r[1]
 
         # Hardware info from TARGET_INFO_GPU + TARGET_INFO_CUDA_DEVICE
         hw = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -170,6 +170,50 @@ def test_agent_guide():
     assert "Available Skills" in result.stdout
 
 
+def test_doctor_no_profile():
+    """doctor without a profile reports environment checks and exits 0."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "doctor"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "System" in result.stdout
+    assert "Optional features" in result.stdout
+    assert "Summary:" in result.stdout
+
+
+def test_doctor_json():
+    """doctor --format json emits a versioned, parseable envelope."""
+    import json
+
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "doctor", "--format", "json"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "0.1"
+    assert payload["producer"] == "nsys-ai"
+    assert [s["name"] for s in payload["sections"]] == [
+        "System",
+        "Profile support",
+        "Optional features",
+    ]
+    assert "summary" in payload
+
+
+def test_doctor_with_profile(minimal_nsys_db_path):
+    """doctor on a profile adds a health section."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "doctor", minimal_nsys_db_path],
+        capture_output=True,
+        text=True,
+    )
+    # May exit 1 if the synthetic profile trips a FAIL check; output is what matters.
+    assert "Profile health" in result.stdout
+    assert "Duration" in result.stdout
+
+
 def test_skill_info():
     """skill info subcommand should return a JSON schema."""
     import json

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,6 +214,18 @@ def test_doctor_with_profile(minimal_nsys_db_path):
     assert "Duration" in result.stdout
 
 
+def test_doctor_missing_profile_exits_nonzero(tmp_path):
+    """A missing profile is a FAIL, so doctor exits non-zero (can gate CI)."""
+    missing = str(tmp_path / "nope.sqlite")
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "doctor", missing],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "FAIL" in result.stdout
+
+
 def test_skill_info():
     """skill info subcommand should return a JSON schema."""
     import json

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import pytest
+
 from nsys_ai.doctor import (
     DoctorReport,
+    _overhead_check,
     format_doctor_text,
     run_doctor,
 )
@@ -103,3 +106,24 @@ def test_missing_profile_is_reported_as_failure(tmp_path):
 def test_health_only_mode_has_no_env(minimal_nsys_db_path):
     report = run_doctor(minimal_nsys_db_path, include_env=False)
     assert [s.name for s in report.sections] == ["Profile health"]
+
+
+# ---------------------------------------------------------------------------
+# Profiler-overhead thresholds (pure function)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "pct, expected",
+    [
+        (None, "skipped"),  # no overhead table
+        (5.0, "ok"),  # below warn
+        (10.0, "ok"),  # exactly at warn boundary (strictly-greater triggers)
+        (15.0, "warn"),  # warn band
+        (20.0, "warn"),  # exactly at fail boundary (strictly-greater triggers)
+        (25.0, "fail"),  # fail band
+        (150.0, "skipped"),  # physically impossible -> unreliable, not a failure
+    ],
+)
+def test_overhead_check_thresholds(pct, expected):
+    assert _overhead_check(pct).status == expected

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,105 @@
+"""Unit tests for the `doctor` diagnostics (nsys_ai.doctor)."""
+
+from __future__ import annotations
+
+from nsys_ai.doctor import (
+    DoctorReport,
+    format_doctor_text,
+    run_doctor,
+)
+
+
+def _section(report: DoctorReport, name: str):
+    return next((s for s in report.sections if s.name == name), None)
+
+
+def _check(report: DoctorReport, name: str):
+    return next((c for c in report.all_checks() if c.name == name), None)
+
+
+# ---------------------------------------------------------------------------
+# Environment-only mode (no profile)
+# ---------------------------------------------------------------------------
+
+
+def test_env_only_report_shape():
+    report = run_doctor()
+    assert report.schema_version == "0.1"
+    assert report.producer == "nsys-ai"
+    assert report.profile_path is None
+    assert report.profile_id is None
+    names = [s.name for s in report.sections]
+    assert names == ["System", "Profile support", "Optional features"]
+
+
+def test_env_checks_present():
+    report = run_doctor()
+    assert _check(report, "Python") is not None
+    assert _check(report, "SQLite analysis").status == "ok"
+    # AI provider + CUTracer are always reported (configured or not).
+    assert _check(report, "AI provider (litellm)") is not None
+    assert _check(report, "CUTracer") is not None
+
+
+def test_to_dict_roundtrip_and_summary():
+    report = run_doctor()
+    d = report.to_dict()
+    assert d["schema_version"] == "0.1"
+    assert "summary" in d
+    total = sum(d["summary"].values())
+    assert total == len(report.all_checks())
+    # Each check serializes name/status/detail/hint/sub.
+    first = d["sections"][0]["checks"][0]
+    assert {"name", "status", "detail", "hint", "sub"} <= set(first)
+
+
+def test_check_names_are_clean_for_machine_consumers():
+    # Nesting is carried by the `sub` flag, never by leading/trailing spaces in
+    # the name — so the web GUI / plugin can match names directly.
+    for c in run_doctor().all_checks():
+        assert c.name == c.name.strip()
+        assert isinstance(c.sub, bool)
+
+
+def test_text_render_includes_capture_hint():
+    text = format_doctor_text(run_doctor())
+    assert "Summary:" in text
+    # Points users at nsys for capture-side checks (we only cover analysis).
+    assert "nsys status -e" in text
+
+
+def test_include_env_false_skips_environment():
+    report = run_doctor(include_env=False, include_health=False)
+    assert report.sections == []
+
+
+# ---------------------------------------------------------------------------
+# Profile-health mode
+# ---------------------------------------------------------------------------
+
+
+def test_health_section_on_minimal_profile(minimal_nsys_db_path):
+    report = run_doctor(minimal_nsys_db_path)
+    health = _section(report, "Profile health")
+    assert health is not None
+    assert report.profile_path == minimal_nsys_db_path
+    # profile_id is content-derived when Nsight metadata is reachable.
+    assert report.profile_id is None or report.profile_id.startswith("nsys1:")
+    by_name = {c.name: c for c in health.checks}
+    assert "Duration" in by_name
+    assert "GPUs" in by_name
+    assert "RunSpec attached" in by_name
+
+
+def test_missing_profile_is_reported_as_failure(tmp_path):
+    missing = str(tmp_path / "does_not_exist.sqlite")
+    report = run_doctor(missing)
+    assert report.has_failures()
+    health = _section(report, "Profile health")
+    assert health is not None
+    assert any(c.status == "fail" for c in health.checks)
+
+
+def test_health_only_mode_has_no_env(minimal_nsys_db_path):
+    report = run_doctor(minimal_nsys_db_path, include_env=False)
+    assert [s.name for s in report.sections] == ["Profile health"]

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -2,11 +2,16 @@
 
 from __future__ import annotations
 
+import sqlite3
+import types
+
 import pytest
 
 from nsys_ai.doctor import (
     DoctorReport,
+    _has_overhead_table,
     _overhead_check,
+    _profiler_overhead_pct,
     format_doctor_text,
     run_doctor,
 )
@@ -127,3 +132,36 @@ def test_health_only_mode_has_no_env(minimal_nsys_db_path):
 )
 def test_overhead_check_thresholds(pct, expected):
     assert _overhead_check(pct).status == expected
+
+
+def test_has_overhead_table_matches_either_case():
+    # SQLite (PROFILER_OVERHEAD) and the DuckDB cache (profiler_overhead) both count.
+    for name in ("PROFILER_OVERHEAD", "profiler_overhead"):
+        prof = types.SimpleNamespace(schema=types.SimpleNamespace(tables=[name]))
+        assert _has_overhead_table(prof) is True
+    prof = types.SimpleNamespace(schema=types.SimpleNamespace(tables=["NVTX_EVENTS"]))
+    assert _has_overhead_table(prof) is False
+
+
+def test_overhead_pct_is_none_without_table():
+    """An absent overhead table is unmeasurable, not a measured 0%."""
+    prof = types.SimpleNamespace(schema=types.SimpleNamespace(tables=["NVTX_EVENTS"]))
+    assert _profiler_overhead_pct(prof, span_ns=1_000_000) is None
+
+
+def test_overhead_skipped_when_profile_has_no_overhead_table(minimal_nsys_db_path):
+    """The minimal profile has no overhead table -> skipped, not a false 'ok 0.0%'."""
+    # Guard the premise: the fixture genuinely lacks the table.
+    with sqlite3.connect(minimal_nsys_db_path) as conn:
+        names = {
+            r[0].lower()
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    assert "profiler_overhead" not in names
+
+    report = run_doctor(minimal_nsys_db_path, include_env=False)
+    overhead = _check(report, "Profiler overhead")
+    assert overhead is not None
+    assert overhead.status == "skipped"


### PR DESCRIPTION
## What

`nsys-ai doctor` — fast triage for "why is analysis failing / unreliable?", as one actionable report.

```
nsys-ai doctor                    # environment only
nsys-ai doctor profile.sqlite     # + profile health   (--format json, --strict, --deep)
```

- **Environment**: Python/nsys-ai/platform, `.nsys-rep` conversion (nsys CLI), Parquet cache deps, GUI (textual), AI provider (litellm + API key), CUTracer (installed-vs-CUDA-compatible, incl. the nvdisasm ↔ framework-CUDA match that catches the silent-SASS-drop class).
- **Profile health**: duration, GPU count + model (warns "unknown" -> no MFU), multi-GPU, NVTX/NCCL presence, profiler overhead (warn >10%, fail >20%).

## Design

- Logic in a surface-agnostic `doctor.py` returning a `DoctorReport`; CLI / web / TUI / the analysis-skill preflight all consume the same `to_dict()`.
- Text + `--format json`; `--strict` makes warnings fail; non-zero exit on failures (CI gate). Exit semantics follow the brew/npm consensus (warn = 0, fail != 0).

## Fast by default

The slow NCCL eager/inductor split (joins the NVTX map) is gated behind `--deep`. Real profiles:

| Profile | Size / GPUs / NVTX | Default |
|---|---|---|
| sp1 | 130 MB / 1 / 0.67M | 1.6 s |
| sp2 | 571 MB / 2 / 1.7M | 5.4 s |
| perf | 3.7 GB / 4 / 15.9M | ~20 s |

Time is dominated by `profile.open()`, not doctor's probes. The second commit, `perf(profile)`, collapses `_discover`'s five kernel-table scans into one `GROUP BY` pass (meta discovery ~3.8s -> ~0.8s on the 3.7 GB profile; behavior identical, full suite unchanged).

## Notes

- Deferred: web `/api/doctor` route and TUI badge (just consume `to_dict()`); RunSpec presence reported as not-yet-available.
- Open-path perf follow-ups (separate PR, not done here): direct mode eagerly creates views for all ~47 attached tables (~8s of DuckDB sqlite-scanner type inference) — lazy creation would cut most; and a complete, version-matched Parquet cache is rejected purely on mtime, forcing slow direct mode or a rebuild — a content-derived (`profile_id`) validity check would avoid that.

## Tests

`tests/test_doctor.py` + 3 `tests/test_cli.py` smoke tests. Full suite: 1025 passed, 135 skipped; ruff + bandit clean.