### PR TITLE
fix(web): show AI chat configuration errors

### DIFF
--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -880,6 +880,15 @@ def chat_completion_stream(body_bytes: bytes):
 
     model, _ = _get_model_and_key(payload.get("model"))
     if not model:
+        yield _sse_event(
+            "text",
+            {
+                "chunk": (
+                    "LLM not configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, "
+                    "or GEMINI_API_KEY before starting nsys-ai."
+                )
+            },
+        )
         yield _sse_event("done", {"error": "LLM not configured"})
         return
 

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -2564,6 +2564,9 @@ async function sendChat() {
                         if (payload.content) {
                             fullContent = payload.content;
                             aiDiv.innerHTML = formatChatContent(fullContent);
+                        } else if (payload.error && !fullContent) {
+                            fullContent = 'Error: ' + payload.error;
+                            aiDiv.innerHTML = formatChatContent(fullContent);
                         }
                         streamDone = true;
                     } else if (currentEvent === 'action') {

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -638,6 +638,18 @@ def test_chat_completion_stream_no_db_agent(monkeypatch):
     assert b"event: done" in raw
 
 
+def test_chat_completion_stream_no_model_reports_configuration_error(monkeypatch):
+    """Streaming chat should emit visible text when no model/API key is configured."""
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: (None, None))
+    body = json.dumps({"messages": [{"role": "user", "content": "hi"}], "stream": True}).encode()
+
+    raw = b"".join(chat_mod.chat_completion_stream(body)).decode("utf-8")
+
+    assert "event: text" in raw
+    assert "LLM not configured" in raw
+    assert "event: done" in raw
+
+
 def test_stream_agent_loop_skill_names_injected(monkeypatch, tmp_path):
     """skill_names causes SESSION SKILL CONTEXT to appear in the system prompt sent to LLM."""
     import nsys_ai.prompt_loader as pl


### PR DESCRIPTION
## Summary

- Fixes web timeline AI chat showing an empty assistant bubble when no LLM/API key is configured.
- Makes streaming chat configuration failures visible to the user instead of silently completing.
- Adds regression coverage for the no-model streaming response path.

## Changes

- `src/nsys_ai/chat.py`
  - Emits a visible SSE `text` event when no configured model/API key is available.
  - Keeps the existing final `done` event with `{"error": "LLM not configured"}`.

- `src/nsys_ai/templates/timeline.js`
  - Renders `done.error` as a fallback if the stream completes before any assistant text is received.

- `tests/test_chat.py`
  - Adds coverage that streaming chat emits visible text and a `done` event when no model is configured.

## Backward compatibility

Yes. This only improves error visibility for an existing failure path and preserves the existing streaming event protocol.

## Test plan

- [x] Tests added or updated for the new behavior
- [ ] `python -m nsys_ai --help` — CLI loads without error
- [ ] `pytest tests/ -v --tb=short` passes locally
- [ ] `ruff check src/ tests/` clean
- [ ] Manually exercised the changed CLI / GUI path (if applicable)

Validated:
- `PYTHONPATH=src conda run -n llm_sys_py311 python -m pytest tests/test_chat.py::test_chat_completion_stream_no_model_reports_configuration_error tests/test_chat.py::test_chat_completion_stream_no_db_agent -v --tb=short` — `2 passed`

## Out of scope

- Does not add anonymous/free LLM support.
- Does not change model/API key discovery.
- Does not change successful chat streaming behavior.