### PR TITLE
feat(diff): add launch_overhead step-time attribution bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   verdict, so a diff can gate CI.
 - `nsys-ai diff --format json` emits a versioned envelope: a top-level
   `verdict`, a `comparability_confidence` score, step-time `category_attribution`
-  (compute / communication / idle), and a content-derived `profile_id` per side.
+  (compute / communication / launch overhead / idle), and a content-derived
+  `profile_id` per side. Launch overhead is the exposed kernel-dispatch latency
+  — the GPU-idle time spent waiting on a launch call — carved out of idle, so
+  the buckets still sum to step time and the verdict is unchanged.
 - Structured v0.1 findings — category, severity, confidence, and a located time
   window where possible — for `overlap_breakdown`, `nccl_breakdown`,
   `top_kernels`, `profile_health_manifest`, and `kernel_instances`, so the agent

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field, replace
 
 from .annotation import TraceSelection
 from .fingerprint import get_profile_id
-from .overlap import overlap_analysis
+from .overlap import launch_overhead_ms, overlap_analysis
 from .profile import Profile
 
 _log = logging.getLogger(__name__)
@@ -179,6 +179,9 @@ def build_profile_summary(
 
     if gpu is not None:
         overlap = overlap_analysis(prof, gpu, trim=trim)
+        # Exposed launch overhead — a subset of idle, carved out in attribution.
+        if "error" not in overlap:
+            overlap["launch_overhead_ms"] = launch_overhead_ms(prof, gpu, trim=trim)
     else:
         # Node-wide aggregation: sum up individual GPU overlap stats.
         overlap = {
@@ -186,6 +189,7 @@ def build_profile_summary(
             "nccl_only_ms": 0.0,
             "overlap_ms": 0.0,
             "idle_ms": 0.0,
+            "launch_overhead_ms": 0.0,
             "total_ms": 0.0,
             "overlap_pct": 0.0,
             "compute_kernels": 0,
@@ -202,6 +206,7 @@ def build_profile_summary(
                 overlap["total_ms"] += dev_stats.get("total_ms", 0.0)
                 overlap["compute_kernels"] += dev_stats.get("compute_kernels", 0)
                 overlap["nccl_kernels"] += dev_stats.get("nccl_kernels", 0)
+                overlap["launch_overhead_ms"] += launch_overhead_ms(prof, dev, trim=trim)
 
         # Round logic to avoid float drift, and set a clean combined overlap pct
         # Node-wide idle logic is tricky because overlap might not overlap across GPUs perfectly,
@@ -210,7 +215,14 @@ def build_profile_summary(
             c_nccl = overlap["nccl_only_ms"] + overlap["overlap_ms"]
             overlap["overlap_pct"] = round(100 * overlap["overlap_ms"] / c_nccl, 1)
 
-        for k in ("compute_only_ms", "nccl_only_ms", "overlap_ms", "idle_ms", "total_ms"):
+        for k in (
+            "compute_only_ms",
+            "nccl_only_ms",
+            "overlap_ms",
+            "idle_ms",
+            "launch_overhead_ms",
+            "total_ms",
+        ):
             overlap[k] = round(overlap[k], 2)
 
     pid = get_profile_id(prof.conn, fallback_path=prof.path)
@@ -296,6 +308,14 @@ def compute_category_attribution(
     # like a real "compute=0, comm=0, idle=0" measurement.
     if before.overlap.get("error") or after.overlap.get("error"):
         return []
+    # launch_overhead is the exposed dispatch latency carved OUT of idle (it is
+    # a strict subset; see overlap.launch_overhead_ms). Cap it at idle so the
+    # residual idle stays >= 0 and the four buckets still sum to total — keeping
+    # step_time (and therefore the verdict) identical to the 3-bucket result.
+    b_idle = _ms(before.overlap, "idle_ms")
+    a_idle = _ms(after.overlap, "idle_ms")
+    b_launch = min(_ms(before.overlap, "launch_overhead_ms"), b_idle)
+    a_launch = min(_ms(after.overlap, "launch_overhead_ms"), a_idle)
     buckets: list[tuple[str, float, float]] = [
         (
             "compute",
@@ -308,9 +328,14 @@ def compute_category_attribution(
             _ms(after.overlap, "nccl_only_ms"),
         ),
         (
+            "launch_overhead",
+            b_launch,
+            a_launch,
+        ),
+        (
             "idle",
-            _ms(before.overlap, "idle_ms"),
-            _ms(after.overlap, "idle_ms"),
+            b_idle - b_launch,
+            a_idle - a_launch,
         ),
     ]
     return [

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -101,7 +101,11 @@ def launch_overhead_ms(
     if not runtime_table:
         return 0.0
 
-    where = ["k.correlationId IS NOT NULL"]
+    # All kernels define the GPU-busy boundary (so idle gaps are correct); the
+    # LEFT JOIN below — not a WHERE filter — gates which kernels have a launch
+    # window to attribute. Seeding with 1=1 keeps the SQL valid when no device/
+    # trim is given.
+    where = ["1=1"]
     params: list = []
     if device is not None:
         where.append("k.deviceId = ?")

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -68,6 +68,79 @@ def overlap_analysis(prof: Profile, device: int, trim: tuple[int, int] | None = 
     return _overlap_analysis_python(prof, device, trim)
 
 
+def launch_overhead_ms(
+    prof: Profile, device: int | None, trim: tuple[int, int] | None = None
+) -> float:
+    """Exposed CUDA kernel-launch overhead on a device, in milliseconds.
+
+    This is the slice of GPU-idle time during which the CPU was still inside a
+    kernel-launch API call — the dispatch latency the GPU actually *waited on*.
+    It is deliberately not the full ``kernel_start - api_start`` gap, which is
+    mostly hidden by pipelined launches and would double-count compute (the
+    cartesian-overhead trap). Being a strict subset of ``overlap_analysis``'s
+    ``idle_ms``, it is meant to be *carved out* of idle in the step-time
+    attribution so the four buckets still sum to total.
+
+    Definition: walk kernels on the device by start time, tracking
+    ``prev_end`` = the latest end of any earlier kernel (the GPU-busy
+    boundary). The idle gap before kernel K is ``(prev_end, K.start)``; the part
+    of K's launch window ``(api_start, api_end)`` that falls inside that gap is
+    exposed launch overhead. Per-kernel gaps are disjoint, so nothing is counted
+    twice. Returns 0.0 when the kernel or runtime table is unavailable.
+    """
+    kernel_table = prof.schema.kernel_table
+    if not kernel_table:
+        return 0.0
+    tables = prof.schema.tables
+    runtime_table: str | None = "CUPTI_ACTIVITY_KIND_RUNTIME"
+    if runtime_table not in tables:
+        runtime_table = next(
+            (t for t in sorted(tables) if t.startswith("CUPTI_ACTIVITY_KIND_RUNTIME")),
+            None,
+        )
+    if not runtime_table:
+        return 0.0
+
+    where = ["k.correlationId IS NOT NULL"]
+    params: list = []
+    if device is not None:
+        where.append("k.deviceId = ?")
+        params.append(device)
+    if trim:
+        where.append("k.start >= ? AND k.[end] <= ?")
+        params.extend(trim)
+    where_sql = " AND ".join(where)
+
+    sql = f"""
+        SELECT k.start AS ks, k.[end] AS ke, r.start AS rs, r.[end] AS re
+        FROM {kernel_table} k
+        LEFT JOIN {runtime_table} r ON k.correlationId = r.correlationId
+        WHERE {where_sql}
+        ORDER BY k.start
+    """  # noqa: S608 — table names are validated schema identifiers, values are bound
+    try:
+        rows = prof.adapter.execute(sql, params).fetchall()
+    except Exception:  # noqa: BLE001 — launch overhead is best-effort enrichment
+        log.debug("launch_overhead_ms query failed", exc_info=True)
+        return 0.0
+
+    launch_ns = 0
+    prev_end: int | None = None
+    for row in rows:
+        ks, ke, rs, re = row[0], row[1], row[2], row[3]
+        if ks is None or ke is None:
+            continue
+        if prev_end is not None and rs is not None and re is not None and ks > prev_end:
+            # exposed = | (prev_end, ks) ∩ (rs, re) |
+            lo = prev_end if prev_end > rs else rs
+            hi = ks if ks < re else re
+            if hi > lo:
+                launch_ns += hi - lo
+        if prev_end is None or ke > prev_end:
+            prev_end = ke
+    return round(launch_ns / 1e6, 2)
+
+
 def _has_duckdb(prof: Profile) -> bool:
     from .connection import DuckDBAdapter, wrap_connection
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1898,6 +1898,64 @@ def test_launch_overhead_ms_without_runtime_table_is_zero():
     assert launch_overhead_ms(_Prof(), device=0) == 0.0
 
 
+def test_launch_overhead_through_real_profile_stack(tmp_path):
+    """End-to-end: launch overhead flows through Profile (incl. DuckDB cache) and
+    into the carved attribution bucket — guards against the best-effort
+    try/except silently returning 0 on a backend the unit test doesn't exercise.
+    """
+    import sqlite3
+
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import build_profile_summary, compute_category_attribution
+    from nsys_ai.overlap import launch_overhead_ms
+
+    db = tmp_path / "ctrl.sqlite"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        """
+        CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+        CREATE TABLE TARGET_INFO_GPU (id INTEGER PRIMARY KEY, name TEXT,
+          busLocation TEXT DEFAULT '', totalMemory INTEGER DEFAULT 0,
+          smCount INTEGER DEFAULT 0, chipName TEXT DEFAULT '', memoryBandwidth INTEGER DEFAULT 0);
+        CREATE TABLE TARGET_INFO_CUDA_DEVICE (gpuId INTEGER, cudaId INTEGER,
+          pid INTEGER DEFAULT 0, uuid TEXT DEFAULT '', numMultiprocessors INTEGER DEFAULT 0);
+        CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+          globalPid INTEGER DEFAULT 0, deviceId INTEGER DEFAULT 0, streamId INTEGER DEFAULT 0,
+          correlationId INTEGER DEFAULT 0, start INTEGER, end INTEGER, shortName INTEGER,
+          demangledName INTEGER DEFAULT 0, gridX INTEGER DEFAULT 1, gridY INTEGER DEFAULT 1,
+          gridZ INTEGER DEFAULT 1, blockX INTEGER DEFAULT 1, blockY INTEGER DEFAULT 1, blockZ INTEGER DEFAULT 1);
+        CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (globalTid INTEGER DEFAULT 0,
+          correlationId INTEGER, start INTEGER, end INTEGER, nameId INTEGER DEFAULT 0);
+        INSERT INTO StringIds VALUES (1, 'kernel_A');
+        INSERT INTO TARGET_INFO_GPU VALUES (0, 'NVIDIA Test GPU', '', 0, 108, 'Chip', 0);
+        INSERT INTO TARGET_INFO_CUDA_DEVICE VALUES (0, 0, 100, '', 108);
+        INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL
+          (deviceId, streamId, correlationId, start, end, shortName) VALUES
+          (0, 7, 1, 1000000, 2000000, 1),
+          (0, 7, 2, 5000000, 6000000, 1),
+          (0, 7, 3, 10000000, 11000000, 1),
+          (0, 7, 4, 12000000, 13000000, 1);
+        INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME (correlationId, start, end) VALUES
+          (1, 900000, 1000000), (2, 4000000, 4500000),
+          (3, 8500000, 10200000), (4, 10500000, 10900000);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    prof = profile_mod.open(str(db))
+    try:
+        # Same scenario as the unit test: 0.5 + 1.5 ms exposed.
+        assert launch_overhead_ms(prof, 0) == 2.0
+        summary = build_profile_summary(prof, 0, trim=None)
+        assert summary.overlap["launch_overhead_ms"] == 2.0
+        # Carved out of idle in attribution, and present as its own bucket.
+        cats = {c.category: c for c in compute_category_attribution(summary, summary)}
+        assert cats["launch_overhead"].before_ms == 2.0
+    finally:
+        prof.close()
+
+
 def test_v01_compute_verdict_thresholds():
     """compute_verdict applies ±5% threshold + confidence ≥ 0.5 gate."""
     from nsys_ai.diff import compute_verdict

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1699,7 +1699,9 @@ def test_diff_cli_json_structure_unchanged(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def _make_overlap_dict(compute_only_ms, nccl_only_ms, overlap_ms, idle_ms):
+def _make_overlap_dict(
+    compute_only_ms, nccl_only_ms, overlap_ms, idle_ms, launch_overhead_ms=0.0
+):
     """Helper to build a fake overlap dict matching overlap_analysis output."""
     total = compute_only_ms + nccl_only_ms + overlap_ms + idle_ms
     return {
@@ -1707,6 +1709,7 @@ def _make_overlap_dict(compute_only_ms, nccl_only_ms, overlap_ms, idle_ms):
         "nccl_only_ms": nccl_only_ms,
         "overlap_ms": overlap_ms,
         "idle_ms": idle_ms,
+        "launch_overhead_ms": launch_overhead_ms,
         "total_ms": total,
         "overlap_pct": 0.0,
         "compute_kernels": 1,
@@ -1746,10 +1749,153 @@ def test_v01_category_attribution_hta_convention():
     assert cats["compute"].delta_ms == 25.0
     assert cats["communication"].before_ms == 20.0  # exposed_comm = nccl_only
     assert cats["communication"].after_ms == 25.0
+    # No launch_overhead in these fixtures, so idle is unchanged and the
+    # launch bucket is zero.
     assert cats["idle"].before_ms == 5.0
     assert cats["idle"].after_ms == 10.0
-    # launch_overhead is intentionally absent in v0.1 (PR-B will add it).
-    assert "launch_overhead" not in cats
+    assert cats["launch_overhead"].before_ms == 0.0
+    assert cats["launch_overhead"].after_ms == 0.0
+
+
+def test_v01_launch_overhead_carved_from_idle():
+    """launch_overhead is carved out of idle; the four buckets sum to total."""
+    from nsys_ai.diff import ProfileSummary, compute_category_attribution
+
+    def _summary(co, nccl, ov, idle, launch):
+        return ProfileSummary(
+            path="p",
+            gpu=0,
+            schema_version=None,
+            total_gpu_ns=0,
+            kernel_rows=0,
+            kernels=[],
+            nvtx=[],
+            overlap=_make_overlap_dict(co, nccl, ov, idle, launch_overhead_ms=launch),
+        )
+
+    # before idle=20 of which 8 is launch overhead; after idle=30 of which 5 is.
+    before = _summary(100, 20, 10, 20, 8)
+    after = _summary(120, 25, 15, 30, 5)
+    cats = {c.category: c for c in compute_category_attribution(before, after)}
+
+    assert cats["launch_overhead"].before_ms == 8.0
+    assert cats["launch_overhead"].after_ms == 5.0
+    # idle is reduced by the carved launch overhead (residual idle).
+    assert cats["idle"].before_ms == 12.0  # 20 - 8
+    assert cats["idle"].after_ms == 25.0  # 30 - 5
+
+    # Sum invariant: the four buckets reproduce the original step time, so the
+    # verdict is unaffected by adding the bucket.
+    for side in ("before_ms", "after_ms"):
+        four = sum(getattr(cats[c], side) for c in cats)
+        three = (
+            getattr(cats["compute"], side)
+            + getattr(cats["communication"], side)
+            + getattr(cats["launch_overhead"], side)
+            + getattr(cats["idle"], side)
+        )
+        assert four == three  # tautology guard that all four are present
+    assert sum(getattr(cats[c], "before_ms") for c in cats) == 100 + 20 + 10 + 20
+
+
+def test_v01_launch_overhead_capped_at_idle():
+    """A launch_overhead_ms exceeding idle is capped so residual idle stays >= 0."""
+    from nsys_ai.diff import ProfileSummary, compute_category_attribution
+
+    def _summary(launch):
+        return ProfileSummary(
+            path="p",
+            gpu=0,
+            schema_version=None,
+            total_gpu_ns=0,
+            kernel_rows=0,
+            kernels=[],
+            nvtx=[],
+            overlap=_make_overlap_dict(100, 0, 0, 5, launch_overhead_ms=launch),
+        )
+
+    cats = {
+        c.category: c
+        for c in compute_category_attribution(_summary(9.0), _summary(9.0))
+    }
+    # launch capped at idle (5), residual idle clamped to 0.
+    assert cats["launch_overhead"].before_ms == 5.0
+    assert cats["idle"].before_ms == 0.0
+
+
+def test_launch_overhead_ms_counts_only_exposed_idle():
+    """launch_overhead_ms = GPU-idle time overlapping a kernel-launch API call."""
+    import sqlite3
+
+    from nsys_ai.overlap import launch_overhead_ms
+
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+            deviceId INTEGER, correlationId INTEGER, start INTEGER, end INTEGER
+        );
+        CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+            correlationId INTEGER, start INTEGER, end INTEGER
+        );
+        """
+    )
+    # All on device 0; timestamps in ns (1e6 ns = 1 ms).
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?,?,?,?)",
+        [
+            (0, 1, 1_000_000, 2_000_000),  # first kernel: no preceding idle -> 0
+            (0, 2, 5_000_000, 6_000_000),  # idle gap (2e6,5e6)
+            (0, 3, 10_000_000, 11_000_000),  # idle gap (6e6,10e6)
+            (0, 4, 12_000_000, 13_000_000),  # idle gap (11e6,12e6)
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (?,?,?)",
+        [
+            (1, 900_000, 1_000_000),  # before first kernel — not attributed
+            (2, 4_000_000, 4_500_000),  # fully inside gap -> 0.5 ms
+            (3, 8_500_000, 10_200_000),  # (8.5e6,10.2e6) ∩ (6e6,10e6) -> 1.5 ms
+            (4, 10_500_000, 10_900_000),  # ends before gap start (11e6) -> hidden, 0
+        ],
+    )
+    conn.commit()
+
+    class _Schema:
+        kernel_table = "CUPTI_ACTIVITY_KIND_KERNEL"
+        tables = ["CUPTI_ACTIVITY_KIND_KERNEL", "CUPTI_ACTIVITY_KIND_RUNTIME"]
+
+    class _Prof:
+        schema = _Schema()
+        adapter = conn
+
+    assert launch_overhead_ms(_Prof(), device=0) == 2.0  # 0.5 + 1.5
+    assert launch_overhead_ms(_Prof(), device=99) == 0.0  # no kernels on device
+
+
+def test_launch_overhead_ms_without_runtime_table_is_zero():
+    """No runtime table → launch overhead is 0.0 (best-effort enrichment)."""
+    import sqlite3
+
+    from nsys_ai.overlap import launch_overhead_ms
+
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+        "(deviceId INTEGER, correlationId INTEGER, start INTEGER, end INTEGER);"
+    )
+    conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (0, 1, 0, 1000)")
+    conn.commit()
+
+    class _Schema:
+        kernel_table = "CUPTI_ACTIVITY_KIND_KERNEL"
+        tables = ["CUPTI_ACTIVITY_KIND_KERNEL"]  # no RUNTIME table
+
+    class _Prof:
+        schema = _Schema()
+        adapter = conn
+
+    assert launch_overhead_ms(_Prof(), device=0) == 0.0
 
 
 def test_v01_compute_verdict_thresholds():
@@ -1853,11 +1999,12 @@ def test_v01_diff_json_envelope_and_verdict(tmp_path):
     assert "step_time" in payload
     assert "delta_ms" in payload["step_time"]
 
-    # category_attribution is a list of category bucket entries
+    # category_attribution is a list of category bucket entries — all four
+    # step-time buckets (launch_overhead carved from idle; see §1.6).
     cats = payload["category_attribution"]
     assert isinstance(cats, list)
     seen = {c["category"] for c in cats}
-    assert seen == {"compute", "communication", "idle"}
+    assert seen == {"compute", "communication", "launch_overhead", "idle"}
 
 
 def test_v01_confidence_separates_schema_and_gpu_mismatch():


### PR DESCRIPTION
## What

`compute_category_attribution` emitted only three of the four step-time buckets declared on `CategoryDelta.category` — `compute`, `communication`, `idle` — leaving **`launch_overhead`** unimplemented. This adds it, completing the step-time vocabulary (`Step Time = Compute + Communication + Launch/Overhead + Idle`).

## How

**`overlap.launch_overhead_ms(prof, device, trim)`** computes the *exposed* kernel-dispatch latency: the GPU-idle time during which the CPU was still inside a kernel-launch API call. It walks kernels by start time, tracks the GPU-busy boundary (`prev_end` = running max end), and for each idle gap before a kernel sums the intersection with that kernel's launch window (runtime API, joined via `correlationId`).

This is deliberately **not** the full `kernel_start - api_start` gap — that is mostly hidden by pipelined launches and would double-count compute (the cartesian-overhead trap). Exposed launch overhead is a strict subset of idle, so:

- `build_profile_summary` records `launch_overhead_ms` on the overlap dict (single-GPU and node-wide / per-device-summed paths).
- `compute_category_attribution` **carves it out of idle** (capped at idle so residual idle stays ≥ 0).

Because the launch bucket is carved from idle, **the four buckets still sum to total**, so `step_time_delta` and the **verdict are unchanged** vs the previous three-bucket result. This is purely a finer attribution, not a re-scoring.

## Tests

- `launch_overhead_ms` sweep: exposed vs hidden vs before-first-kernel launches; empty device; missing runtime table.
- Carve-from-idle + sum-invariant; idle cap when launch ≥ idle.
- Updated the attribution and JSON-envelope tests to assert all four buckets.

Full `test_diff.py` (65), `test_cli.py`/`test_skills.py` (142), and the overlap suites (37) pass; ruff + bandit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)