### PR TITLE
chore: correct stale module/dependency claims in contributor docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,9 +11,8 @@ nsys-ai/
 ├── src/nsys_ai/          # Main Python package
 │   ├── __main__.py        # CLI entry point (argparse-based)
 │   ├── profile.py         # SQLite profile loader
-│   ├── tui.py             # Tree TUI (curses)
-│   ├── tui_timeline.py    # Timeline TUI (curses)
-│   ├── tree.py            # NVTX tree data model
+│   ├── tree/              # Tree TUI (Textual) + NVTX tree model
+│   ├── timeline/          # Timeline TUI (Textual)
 │   ├── search.py          # Kernel/NVTX search
 │   ├── overlap.py         # Compute/NCCL overlap analysis
 │   ├── summary.py         # Profile summary stats
@@ -25,7 +24,7 @@ nsys-ai/
 │   ├── skills/            # 🧩 Analysis skill system
 │   │   ├── base.py        # Skill dataclass + execution
 │   │   ├── registry.py    # Auto-discovery + lookup
-│   │   └── builtins/      # 29 built-in analysis skills
+│   │   └── builtins/      # 37 built-in analysis skills
 │   ├── agent/             # 🤖 AI agent
 │   │   ├── persona.py     # System prompt + identity
 │   │   └── loop.py        # Analysis loop + skill selection
@@ -204,8 +203,8 @@ Before raising a PR, verify:
 ## Key Design Decisions
 
 - **Internal module = `nsys_ai`**, external package = `nsys-ai` (historical rename)
-- **No runtime dependencies** for core TUI — only stdlib (`curses`, `sqlite3`, `json`)
-- **Optional deps**: `anthropic` for AI features (`pip install nsys-ai[ai]`), `pytest` for dev
+- **Core runtime deps**: `duckdb` + `pyarrow` (Parquet cache) and `rich` + `textual` (TUI). SQL analysis and the web server stay on the stdlib (`sqlite3`, `http.server`)
+- **Optional deps**: `litellm` (+ `anthropic`) for AI features (`pip install 'nsys-ai[agent]'`), `pytest` for dev
 - **Profiles are `.sqlite` files** exported from NVIDIA Nsight Systems (`.nsys-rep` → `.sqlite`)
 - **Two TUI modes**: tree (hierarchical NVTX browser) and timeline (horizontal kernel view)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,16 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Project Is
 
-nsys-ai is an AI-powered terminal UI for analyzing NVIDIA Nsight Systems GPU profiles (`.sqlite` files). It provides curses-based TUI viewers, HTML export, a skill-based analysis system, and an LLM agent for automated GPU performance diagnosis.
+nsys-ai is an AI-powered terminal UI for analyzing NVIDIA Nsight Systems GPU profiles (`.sqlite` files). It provides Textual-based TUI viewers, a local web timeline, HTML export, a skill-based analysis system, and an LLM agent for automated GPU performance diagnosis.
 
-**Naming:** The PyPI package is `nsys-ai`, but the internal Python module is `nsys_ai` (historical). Both `nsys-ai` and `nsys-ai` CLI commands work.
+**Naming:** The PyPI package is `nsys-ai`, but the internal Python module is `nsys_ai` (historical). Both `nsys-ai` and `nsys-tui` CLI commands work.
 
 ## Build & Development Commands
 
 ```bash
 # Install (pick one tier)
 pip install -e '.[dev]'      # Core + pytest (for development)
-pip install -e '.[agent]'    # Core + anthropic SDK (for agent work)
+pip install -e '.[agent]'    # Core + anthropic + litellm (for agent work)
 pip install -e '.[all]'      # Everything
 
 # Test
@@ -26,7 +26,7 @@ python -m nsys_ai --help
 nsys-ai <command> <profile.sqlite>
 ```
 
-Core has **zero runtime dependencies** — only Python stdlib (sqlite3, curses, json). The `anthropic` package is only needed for `[agent]` extras.
+Core runtime dependencies are `duckdb` + `pyarrow` (Parquet cache acceleration) and `rich` + `textual` (TUI). SQL profile analysis and the web server stay on the stdlib (`sqlite3`, `http.server`), so a profile can still be read and analyzed without the cache. AI features (`ask`/`chat`/`agent`) add `litellm` (and `anthropic`) via the `[agent]` / `[chat]` extras.
 
 ## Testing
 
@@ -39,7 +39,7 @@ Core has **zero runtime dependencies** — only Python stdlib (sqlite3, curses, 
 
 ### Entry Point
 
-`src/nsys_ai/__main__.py` — argparse CLI with ~20 subcommands. Two entry points registered in pyproject.toml: `nsys-ai` and `nsys-ai`, both point to `nsys_ai.__main__:main`.
+`src/nsys_ai/__main__.py` delegates to `nsys_ai.cli.app:main`; the argparse CLI is built in `cli/parsers.py` (~30 subcommands) and dispatched to `cli/handlers.py`. Two entry points registered in pyproject.toml: `nsys-ai` and `nsys-tui`, both point to `nsys_ai.__main__:main`.
 
 ### Core Data Model
 
@@ -48,13 +48,13 @@ Profiles are `.sqlite` files from NVIDIA Nsight Systems. Key tables: `CUPTI_ACTI
 ### Key Modules
 
 - `profile.py` — SQLite profile loader, `Profile`/`ProfileMeta`/`GpuInfo` classes
-- `tui.py` (44KB) — Interactive tree TUI (curses), NVTX hierarchy browser
-- `tui_timeline.py` (43KB) — Perfetto-style horizontal timeline TUI (curses)
-- `tree.py` — NVTX tree data model and formatting
-- `overlap.py` — Compute/NCCL overlap analysis
+- `tree/` — Textual NVTX tree TUI (`run_tui`) plus the NVTX tree data model and formatters (`build_nvtx_tree`, `format_text`/`format_markdown`)
+- `timeline/` — Textual Perfetto-style horizontal timeline TUI (`run_timeline`)
+- `overlap.py` — Compute/NCCL overlap analysis (and `launch_overhead_ms`)
 - `export.py` / `export_flat.py` — HTML viewer and CSV/JSON export
 - `viewer.py` — Perfetto JSON trace export
 - `web.py` — Local HTTP server (stdlib `http.server` + custom `_ThreadPoolMixIn`; no Flask/Jinja2)
+- `diff.py` / `diff_tools.py` / `diff_render.py` / `diff_web.py` — before/after profile comparison + verdict
 
 ### Skill System (`src/nsys_ai/skills/`)
 

--- a/agent/agent-design.md
+++ b/agent/agent-design.md
@@ -117,13 +117,13 @@ Per-project context, session history, and active hypotheses — accumulated duri
 
 | Module | Responsibility | Touch carefully? |
 |--------|---------------|-----------------|
-| `__main__.py` | CLI arg parsing, subcommand dispatch | ⚠️ Central — affects all commands |
+| `__main__.py` → `cli/` | CLI arg parsing (`cli/parsers.py`), subcommand dispatch (`cli/handlers.py`) | ⚠️ Central — affects all commands |
 | `profile.py` | SQLite loading, GPU/kernel queries | ⚠️ Core data layer |
-| `tui.py` | Interactive tree TUI (curses) | ⚠️ Complex curses state machine |
-| `tui_timeline.py` | Timeline TUI (curses) | ⚠️ Most complex module (~43K) |
+| `tree/` | Interactive tree TUI (Textual) | ⚠️ Textual app package |
+| `timeline/` | Timeline TUI (Textual) | ⚠️ Most complex TUI |
 | `summary.py` | Kernel statistics | ✅ Self-contained |
 | `overlap.py` | Overlap analysis | ✅ Self-contained |
-| `tree.py` | Text tree rendering | ✅ Self-contained |
+| `tree/` (logic) | Text tree rendering | ✅ Self-contained |
 | `search.py` | Name search | ✅ Self-contained |
 | `export.py` | Perfetto export | ✅ Self-contained |
 | `export_flat.py` | CSV/JSON export | ✅ Self-contained |


### PR DESCRIPTION
## What

`CLAUDE.md` and `AGENTS.md` had drifted several refactors behind the code and were actively misleading new contributors / coding agents. This corrects them.

## Fixes

- **Drop the "zero runtime dependencies / only stdlib" claim** — it's false. Core now requires `duckdb` + `pyarrow` (Parquet cache) and `rich` + `textual` (TUI); only SQL analysis and the web server stay stdlib-only. AI features add `litellm` (+ `anthropic`) via `[agent]`/`[chat]`.
- **Curses → Textual**: the old `tui.py` / `tui_timeline.py` / `tree.py` were refactored into the `tree/` and `timeline/` Textual packages. Module lists and the "curses-based" wording updated in `CLAUDE.md`, `AGENTS.md`, and `agent/agent-design.md`.
- **Small factual fixes**: duplicated CLI/entry-point name (`nsys-ai` and `nsys-ai` → `nsys-ai` and `nsys-tui`), subcommand count (~20 → ~30), builtin skill count (29 → 37), and a note that `__main__` delegates to `cli/`.

No code changes — docs only. `python -m nsys_ai --help` and core imports verified.

(A stale, **untracked** `src/nsys_tui/` directory skeleton — empty, no imports — was also removed locally; it carried no tracked files so it isn't part of this diff.)
