### PR TITLE
fix(skills): correct iteration-noise, same-stream, and top-kernel naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,16 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   reports which devices are present and warns when no device is specified.
 - Parquet cache builds are serialized so concurrent runs against the same cache
   no longer crash.
+- Iteration timing separates real training iterations from sub-iteration NVTX
+  noise: a loose marker that matched hundreds of short op ranges used to
+  contaminate the median so every real iteration looked thousands of percent
+  slow. `iteration_timing` and `iteration_detail` now judge variance against the
+  real iterations only.
+- `overlap_breakdown` only flags a same-stream compute/NCCL collision when a
+  meaningful fraction of both actually share a stream, instead of firing on a
+  single stray kernel.
+- `profile_health_manifest` top kernels now also carry `kernel_name` /
+  `invocations`, matching the field names the rest of the codebase uses.
 
 ### Performance
 

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -403,6 +403,32 @@ def nccl_breakdown(prof: Profile, device: int, trim: tuple[int, int] | None = No
 # ── Iteration detection ────────────────────────────────────────────
 
 
+# Rows whose GPU duration is below this fraction of the longest iteration are
+# treated as sub-iteration NVTX noise, not real training iterations. A loose
+# marker substring can match many short op-level ranges; real iterations cluster
+# near a similar, large duration, so the tiny tail drops out.
+_REAL_ITER_MIN_FRACTION = 0.1
+
+
+def _flag_real_iterations(results: list[dict]) -> list[dict]:
+    """Mark each row ``is_real_iteration`` to separate true iterations from noise.
+
+    A real training iteration has a substantial GPU duration; sub-iteration op
+    markers that a loose NVTX marker happens to match are orders of magnitude
+    shorter. Flag any row within ``_REAL_ITER_MIN_FRACTION`` of the longest as
+    real. When durations are uniform (no tiny tail) every row stays real, so a
+    clean profile is unaffected. Consumers compute medians/variance over the
+    real rows only, avoiding a median contaminated by the sub-ms tail.
+    """
+    if not results:
+        return results
+    max_dur = max((r.get("duration_ms") or 0.0) for r in results)
+    floor = max_dur * _REAL_ITER_MIN_FRACTION
+    for r in results:
+        r["is_real_iteration"] = (r.get("duration_ms") or 0.0) >= floor if max_dur > 0 else True
+    return results
+
+
 def detect_iterations(
     prof: Profile, device: int, trim: tuple[int, int] | None = None, marker: str = "sample_0"
 ) -> list[dict]:
@@ -593,7 +619,7 @@ def detect_iterations(
             }
         )
 
-    return results
+    return _flag_real_iterations(results)
 
 
 # ── Interval math helpers ──────────────────────────────────────────

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -403,36 +403,43 @@ def nccl_breakdown(prof: Profile, device: int, trim: tuple[int, int] | None = No
 # ── Iteration detection ────────────────────────────────────────────
 
 
-# Rows whose GPU duration is below this fraction of the longest iteration are
-# treated as sub-iteration NVTX noise, not real training iterations. A loose
-# marker substring can match many short op-level ranges; real iterations cluster
-# near a similar, large duration, so the tiny tail drops out.
+# Rows whose GPU compute is below this fraction of the busiest iteration are
+# treated as noise, not real training iterations. A loose marker substring can
+# match many short op-level ranges, and the heuristic fallback can emit a row
+# spanning a long idle gap with almost no work; real iterations all do a similar,
+# substantial amount of GPU compute, so both kinds of artifact drop out.
 _REAL_ITER_MIN_FRACTION = 0.1
 
 
 def _flag_real_iterations(results: list[dict]) -> list[dict]:
     """Mark each row ``is_real_iteration`` to separate true iterations from noise.
 
-    A real training iteration has a substantial GPU duration; sub-iteration op
-    markers that a loose NVTX marker happens to match are orders of magnitude
-    shorter. Flag any row within ``_REAL_ITER_MIN_FRACTION`` of the longest as
-    real. When durations are uniform (no tiny tail) every row stays real, so a
-    clean profile is unaffected. Consumers compute medians/variance over the
-    real rows only, avoiding a median contaminated by the sub-ms tail.
+    Classification is by **GPU compute** (sum of kernel durations), not wall-clock
+    span: a real training iteration does a substantial, similar amount of work,
+    whereas the two artifacts this guards against have little. Op-level ranges a
+    loose NVTX marker matches are orders of magnitude shorter; a heuristic-fallback
+    "ghost" can have a huge span (a long idle gap) but near-zero compute. Flagging
+    by a fraction of the busiest iteration's compute drops both, while a clean
+    profile (uniform compute) keeps every row. Consumers then compute their
+    median/variance over the real rows only — measured on duration (iteration
+    wall-clock time), but selected by compute.
 
-    This is a heuristic, not exact iteration detection: an extreme outlier (e.g.
-    a warmup region many times longer than a normal step) inflates the cutoff
-    and can drop a borderline-short real iteration. That is acceptable here —
-    the goal is a representative median, so losing a data point at the margin is
-    harmless, whereas the contaminated median it replaces produced findings that
-    were off by orders of magnitude.
+    This is a heuristic, not exact iteration detection: if real iterations vary in
+    compute by more than ``1/_REAL_ITER_MIN_FRACTION``×, a borderline-light one can
+    be dropped. That is acceptable — the goal is a representative median, so losing
+    a marginal data point is harmless, whereas the contaminated median it replaces
+    produced findings off by orders of magnitude. Validated to match a
+    duration-based rule on a dozen real profiles while additionally dropping a
+    real ghost iteration the duration rule kept.
     """
     if not results:
         return results
-    max_dur = max((r.get("duration_ms") or 0.0) for r in results)
-    floor = max_dur * _REAL_ITER_MIN_FRACTION
+    max_compute = max((r.get("compute_ms") or 0.0) for r in results)
+    floor = max_compute * _REAL_ITER_MIN_FRACTION
     for r in results:
-        r["is_real_iteration"] = (r.get("duration_ms") or 0.0) >= floor if max_dur > 0 else True
+        r["is_real_iteration"] = (
+            (r.get("compute_ms") or 0.0) >= floor if max_compute > 0 else True
+        )
     return results
 
 

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -419,6 +419,13 @@ def _flag_real_iterations(results: list[dict]) -> list[dict]:
     real. When durations are uniform (no tiny tail) every row stays real, so a
     clean profile is unaffected. Consumers compute medians/variance over the
     real rows only, avoiding a median contaminated by the sub-ms tail.
+
+    This is a heuristic, not exact iteration detection: an extreme outlier (e.g.
+    a warmup region many times longer than a normal step) inflates the cutoff
+    and can drop a borderline-short real iteration. That is acceptable here —
+    the goal is a representative median, so losing a data point at the margin is
+    harmless, whereas the contaminated median it replaces produced findings that
+    were off by orders of magnitude.
     """
     if not results:
         return results

--- a/src/nsys_ai/skills/builtins/iteration_detail.py
+++ b/src/nsys_ai/skills/builtins/iteration_detail.py
@@ -71,8 +71,11 @@ def _execute(conn, **kwargs):
             }
         )
 
-    # 3. Compute vs_median
-    durs = [it["duration_ms"] for it in iters]
+    # 3. Compute vs_median over real iterations only — a loose NVTX marker can
+    #    match many sub-ms op ranges whose contaminated median otherwise yields
+    #    absurd vs_median figures.
+    real = [it for it in iters if it.get("is_real_iteration", True)]
+    durs = [it["duration_ms"] for it in (real or iters)]
     median = statistics.median(durs)
     vs_median = round((target["duration_ms"] - median) / median * 100, 1) if median > 0 else 0
 

--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -33,10 +33,14 @@ def _to_findings(rows: list[dict]) -> list:
     from nsys_ai.annotation import Finding
 
     findings = []
-    if len(rows) < 3:
+    # Only judge variance over real iterations — a loose NVTX marker can match
+    # many sub-ms op ranges whose contaminated median makes every real iteration
+    # look thousands of percent slow.
+    real = [it for it in rows if it.get("is_real_iteration", True)]
+    if len(real) < 3:
         return findings
 
-    durs = [it["duration_ms"] for it in rows if "duration_ms" in it]
+    durs = [it["duration_ms"] for it in real if "duration_ms" in it]
     if not durs:
         return findings
 
@@ -44,7 +48,7 @@ def _to_findings(rows: list[dict]) -> list:
     if med <= 0:
         return findings
 
-    for it in rows:
+    for it in real:
         if it.get("duration_ms", 0) > 1.5 * med:
             pct = 100 * it["duration_ms"] / med
             # Prefer nanosecond-precision timestamps if available; fall back to seconds-based values.

--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -92,16 +92,27 @@ def _format(rows):
         if is_heuristic
         else "── Iteration Timings ──"
     )
+    # Show real iterations only — a loose NVTX marker can match hundreds of
+    # sub-iteration op ranges, and listing all of them buries the signal.
+    real = [it for it in rows if it.get("is_real_iteration", True)]
+    display = real if real else rows
+    noise_count = len(rows) - len(real)
+
     lines = [title]
-    for it in rows:
+    for it in display:
         lines.append(
             f"  iter {it['iteration']:2d}  "
             f"{it['duration_ms']:8.1f}ms  "
             f"({it['kernel_count']} kernels, {it['nccl_count']} NCCL)  "
             f"compute={it['compute_ms']:.1f}ms"
         )
-    if len(rows) > 1:
-        durs = [it["duration_ms"] for it in rows]
+    if noise_count:
+        lines.append(
+            f"  … {noise_count} sub-iteration NVTX range(s) filtered as noise "
+            f"(marker matched op-level annotations)"
+        )
+    if len(display) > 1:
+        durs = [it["duration_ms"] for it in display]
         avg = sum(durs) / len(durs)
         lines.append(f"\n  Average: {avg:.1f}ms  Min: {min(durs):.1f}ms  Max: {max(durs):.1f}ms")
     return "\n".join(lines)

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -20,6 +20,12 @@ _log = logging.getLogger(__name__)
 # if one exists on StringIds.value.
 _NCCL_LIKE = "(s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%')"
 
+# A same-stream collision is only worth flagging when a meaningful fraction of
+# BOTH compute and NCCL actually share a stream. A few stray cross-stream kernels
+# (e.g. one eager kernel on the NCCL stream) score ~0% and must not trigger the
+# diagnosis.
+_SAME_STREAM_MIN_PCT = 5.0
+
 
 def _execute(conn, **kwargs):
     from ...overlap import overlap_analysis
@@ -61,11 +67,11 @@ def _execute(conn, **kwargs):
                 params,
             )
             if same_stream:
-                result["same_stream_diagnosis"] = [str(r["streamId"]) for r in same_stream]
-                # Quantify the diagnosis: a near-clean multi-stream layout
-                # with a few stray cross-stream kernels reads identically
-                # to 100 % collision without these percentages. Trigger
-                # above is unchanged; the proportions are purely additive.
+                # Quantify the shared fraction BEFORE flagging. A near-clean
+                # multi-stream layout with a few stray cross-stream kernels
+                # reads identically to a 100% collision by stream id alone, so
+                # gate the diagnosis on a meaningful share of both kinds rather
+                # than firing on a single stray cross-stream kernel.
                 totals = prof._duckdb_query(
                     f"""
                     SELECT
@@ -77,19 +83,25 @@ def _execute(conn, **kwargs):
                     """,
                     params,
                 )
+                compute_pct = nccl_pct = 0.0
                 if totals:
                     nccl_total = totals[0]["nccl_total"] or 0
                     compute_total = totals[0]["compute_total"] or 0
                     nccl_same = sum((r["nccl_count"] or 0) for r in same_stream)
                     compute_same = sum((r["compute_count"] or 0) for r in same_stream)
                     if compute_total > 0:
-                        result["same_stream_compute_pct"] = round(
-                            100 * compute_same / compute_total, 1
-                        )
+                        compute_pct = round(100 * compute_same / compute_total, 1)
                     if nccl_total > 0:
-                        result["same_stream_nccl_pct"] = round(
-                            100 * nccl_same / nccl_total, 1
-                        )
+                        nccl_pct = round(100 * nccl_same / nccl_total, 1)
+                if (
+                    compute_pct >= _SAME_STREAM_MIN_PCT
+                    and nccl_pct >= _SAME_STREAM_MIN_PCT
+                ):
+                    result["same_stream_diagnosis"] = [
+                        str(r["streamId"]) for r in same_stream
+                    ]
+                    result["same_stream_compute_pct"] = compute_pct
+                    result["same_stream_nccl_pct"] = nccl_pct
     except DB_ERRORS:
         _log.debug("Failed to enrich stream compute/nccl overlap", exc_info=True)
 

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -403,11 +403,19 @@ def _execute(conn, **kwargs):
         name = r.get("demangled", "?")
         if len(name) > 60:
             name = name[:57] + "..."
+        total_ms = round(r.get("total_ns", 0) / 1e6, 2)
+        count = r.get("count", 0)
         top_kernels.append(
             {
                 "name": name,
-                "total_ms": round(r.get("total_ns", 0) / 1e6, 2),
-                "count": r.get("count", 0),
+                "total_ms": total_ms,
+                "count": count,
+                # Aliases matching the dominant codebase convention used by the
+                # top_kernels skill / planner / tool_dispatch (which read
+                # kernel_name / invocations, not name / count). Additive so
+                # existing manifest consumers of name / count keep working.
+                "kernel_name": name,
+                "invocations": count,
             }
         )
 

--- a/tests/test_iteration_noise.py
+++ b/tests/test_iteration_noise.py
@@ -36,6 +36,20 @@ def test_flag_real_iterations_splits_bimodal():
     assert all(r["duration_ms"] == 500.0 for r in real)
 
 
+def test_flag_real_iterations_drops_low_compute_ghost():
+    """A heuristic-fallback 'ghost' — a huge wall-clock span with almost no GPU
+    work — must NOT count as a real iteration, even though its duration is large.
+    Classification is by compute, not duration."""
+    rows = [_row(500.0, iteration=i, compute_ms=480.0) for i in range(8)]
+    # Ghost: longest duration of all, but negligible compute (a long idle gap).
+    rows.append(_row(9000.0, iteration=99, compute_ms=0.6, kernel_count=2))
+    _flag_real_iterations(rows)
+
+    ghost = next(r for r in rows if r["iteration"] == 99)
+    assert ghost["is_real_iteration"] is False, "ghost (high span, ~0 compute) must be dropped"
+    assert all(r["is_real_iteration"] for r in rows if r["iteration"] != 99)
+
+
 def test_flag_real_iterations_keeps_uniform_all_real():
     """A clean profile (no tiny tail) must keep every iteration real."""
     rows = [_row(500.0, iteration=i) for i in range(16)]

--- a/tests/test_iteration_noise.py
+++ b/tests/test_iteration_noise.py
@@ -8,7 +8,7 @@ skills compute variance over the real rows only.
 """
 
 from nsys_ai.overlap import _flag_real_iterations
-from nsys_ai.skills.builtins.iteration_timing import _to_findings
+from nsys_ai.skills.builtins.iteration_timing import _format, _to_findings
 
 
 def _row(dur_ms, **extra):
@@ -19,6 +19,7 @@ def _row(dur_ms, **extra):
         "gpu_end_ns": extra.get("gpu_end_ns", int(dur_ms * 1e6)),
         "kernel_count": extra.get("kernel_count", 1),
         "nccl_count": 0,
+        "compute_ms": extra.get("compute_ms", dur_ms),
     }
     row.update(extra)
     return row
@@ -69,6 +70,22 @@ def test_findings_ignore_noise_and_use_real_median():
     assert "median 500" in f.note, f"expected real median in note, got: {f.note!r}"
     # And no absurd thousands-of-percent figure from a contaminated median.
     assert "390" not in f.note
+
+
+def test_format_shows_real_iterations_and_filtered_count():
+    """The text view lists real iterations and reports the noise it hid, instead
+    of dumping hundreds of sub-iteration ranges."""
+    rows = [_row(500.0, iteration=i) for i in range(16)]
+    rows += [_row(0.3, iteration=100 + i) for i in range(968)]
+    _flag_real_iterations(rows)
+
+    text = _format(rows)
+    # 16 real iteration lines, not 984.
+    iter_lines = [ln for ln in text.splitlines() if ln.strip().startswith("iter ")]
+    assert len(iter_lines) == 16, f"expected 16 iter lines, got {len(iter_lines)}"
+    assert "968 sub-iteration NVTX range(s) filtered as noise" in text
+    # The average must reflect real iterations (~500ms), not the noise.
+    assert "Average: 500.0ms" in text
 
 
 def test_findings_empty_when_fewer_than_three_real():

--- a/tests/test_iteration_noise.py
+++ b/tests/test_iteration_noise.py
@@ -1,0 +1,79 @@
+"""Regression tests for iteration-noise classification.
+
+A loose NVTX marker substring can match many short op-level ranges in addition
+to the true iteration boundary. Those tiny ranges contaminated the median, so
+every real iteration looked thousands of percent slow. `_flag_real_iterations`
+separates the real iterations from the sub-ms tail, and the timing/detail
+skills compute variance over the real rows only.
+"""
+
+from nsys_ai.overlap import _flag_real_iterations
+from nsys_ai.skills.builtins.iteration_timing import _to_findings
+
+
+def _row(dur_ms, **extra):
+    row = {
+        "iteration": extra.get("iteration", 0),
+        "duration_ms": dur_ms,
+        "gpu_start_ns": extra.get("gpu_start_ns", 0),
+        "gpu_end_ns": extra.get("gpu_end_ns", int(dur_ms * 1e6)),
+        "kernel_count": extra.get("kernel_count", 1),
+        "nccl_count": 0,
+    }
+    row.update(extra)
+    return row
+
+
+def test_flag_real_iterations_splits_bimodal():
+    """16 real iterations (~500ms) + 968 sub-ms op markers → only 16 are real."""
+    rows = [_row(500.0, iteration=i) for i in range(16)]
+    rows += [_row(0.3, iteration=100 + i) for i in range(968)]
+    _flag_real_iterations(rows)
+
+    real = [r for r in rows if r["is_real_iteration"]]
+    assert len(real) == 16, f"expected 16 real iterations, got {len(real)}"
+    assert all(r["duration_ms"] == 500.0 for r in real)
+
+
+def test_flag_real_iterations_keeps_uniform_all_real():
+    """A clean profile (no tiny tail) must keep every iteration real."""
+    rows = [_row(500.0, iteration=i) for i in range(16)]
+    # Normal variance (one slow iteration) must not be misread as noise.
+    rows.append(_row(900.0, iteration=99))
+    _flag_real_iterations(rows)
+    assert all(r["is_real_iteration"] for r in rows)
+
+
+def test_flag_real_iterations_empty_and_zero_duration():
+    assert _flag_real_iterations([]) == []
+    rows = [_row(0.0), _row(0.0)]
+    _flag_real_iterations(rows)
+    assert all(r["is_real_iteration"] for r in rows)  # can't distinguish → all real
+
+
+def test_findings_ignore_noise_and_use_real_median():
+    """With 968 noise rows, the contaminated median used to flag every real
+    iteration as ~+390,000% slow. After the fix, findings come only from real
+    iterations judged against the real median."""
+    rows = [_row(500.0, iteration=i) for i in range(15)]
+    rows.append(_row(900.0, iteration=15))  # a genuinely slow real iteration
+    rows += [_row(0.3, iteration=100 + i) for i in range(968)]
+    _flag_real_iterations(rows)
+
+    findings = _to_findings(rows)
+    # Exactly one slow-iteration finding: the 900ms one (> 1.5 * median 500).
+    assert len(findings) == 1, f"expected 1 finding, got {len(findings)}: {[f.label for f in findings]}"
+    f = findings[0]
+    assert "Slow Iteration 15" in f.label
+    # The note must reference the real median (~500ms), not a sub-ms noise value.
+    assert "median 500" in f.note, f"expected real median in note, got: {f.note!r}"
+    # And no absurd thousands-of-percent figure from a contaminated median.
+    assert "390" not in f.note
+
+
+def test_findings_empty_when_fewer_than_three_real():
+    """Two real iterations buried in noise → not enough real data to judge."""
+    rows = [_row(500.0, iteration=0), _row(500.0, iteration=1)]
+    rows += [_row(0.3, iteration=100 + i) for i in range(50)]
+    _flag_real_iterations(rows)
+    assert _to_findings(rows) == []

--- a/tests/test_overlap_breakdown.py
+++ b/tests/test_overlap_breakdown.py
@@ -99,6 +99,33 @@ def test_clean_multi_stream_does_not_fire_diagnostic(minimal_nsys_conn):
     assert "same_stream_nccl_pct" not in r
 
 
+def test_stray_kernel_on_nccl_stream_does_not_fire_diagnostic(minimal_nsys_conn):
+    """A few stray compute kernels sharing the NCCL stream must NOT trigger
+    same_stream_diagnosis when they are a tiny fraction of compute.
+
+    Stream 7 keeps its 3 compute + 1 NCCL (the would-be false positive). Adding
+    100 compute kernels on a clean stream drops stream-7's compute share to
+    ~2.9% (3/103) — below the 5% threshold — so the diagnosis must stay silent.
+    """
+    c = minimal_nsys_conn.cursor()
+    for i in range(100):
+        c.execute(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES "
+            "(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (100, 0, 9, 200 + i, 20_000_000 + i * 100, 20_000_000 + i * 100 + 50,
+             1, 1, 32, 1, 1, 256, 1, 1),  # stream 9, compute (shortName=1), no NCCL
+        )
+    minimal_nsys_conn.commit()
+
+    r = SKILL.execute_fn(minimal_nsys_conn)[0]
+    assert "same_stream_diagnosis" not in r, (
+        f"stray compute on the NCCL stream (~2.9% of compute) should not fire; "
+        f"got {r.get('same_stream_diagnosis')!r}"
+    )
+    assert "same_stream_compute_pct" not in r
+    assert "same_stream_nccl_pct" not in r
+
+
 def test_present_devices_survives_empty_kernel_table():
     """If the kernel table exists but is empty, present_devices should
     either be empty or absent — not crash."""

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -55,6 +55,17 @@ class TestManifestExecute:
         m = rows[0]
         assert isinstance(m["top_kernels"], list)
 
+    def test_top_kernels_carry_dominant_convention_aliases(
+        self, minimal_nsys_conn, manifest_skill
+    ):
+        """Manifest top_kernels expose kernel_name/invocations (the convention
+        used by the top_kernels skill / planner / tool_dispatch) in addition to
+        the legacy name/count, additively."""
+        m = manifest_skill.execute(minimal_nsys_conn, device=0)[0]
+        for k in m["top_kernels"]:
+            assert k["kernel_name"] == k["name"]
+            assert k["invocations"] == k["count"]
+
     def test_nccl_summary_has_streams(self, minimal_nsys_conn, manifest_skill):
         """Our test data has NCCL kernels, so streams > 0."""
         rows = manifest_skill.execute(minimal_nsys_conn, device=0)


### PR DESCRIPTION
## What

Three skill-output **correctness** fixes surfaced while drilling a 4-GPU fastvideo profile. Each produced misleading values that were consumed by the agent and the GUI.

## Iteration noise — slow-iteration findings were garbage

The NVTX iteration marker is matched as a **substring**, so a marker such as `sample_0` also matches hundreds of short op-level NVTX ranges that merely contain that text. `detect_iterations` therefore returned a handful of real training iterations plus a long tail of sub-millisecond ranges. The median was taken over **every** returned row, so it collapsed onto the sub-ms tail, and every real iteration was then reported as thousands of percent slower than "median" — a real run showed **+390,703%**.

`detect_iterations` now tags each row with an `is_real_iteration` flag: a row is real when its GPU duration is at least **10% of the longest** detected iteration. This relative-to-maximum rule stays correct even when the noise rows are the *majority* (a median/percentile rule would not, since the noise dominates those statistics). `iteration_timing` and `iteration_detail` then compute their median / variance / vs-median over the **real** rows only. A profile with fewer than three real iterations now produces **no** slow-iteration findings instead of hundreds of spurious ones.

**Validated end-to-end on real profiles:**

| profile | before (all rows / median) | after (real iters / median) |
|---|---|---|
| inference (`perf_h100_sp1`) | 875 rows / **0.39 ms** | 2 real / **434,973 ms** |
| training (`mfu_h1002_nsys`) | 42 rows / 547 ms | 23 real / **1,677 ms** |

The 0.39 ms "median" was literally a sub-ms noise op — exactly what manufactured the absurd percentages.

## Same-stream collision — fired on a single stray kernel

`overlap_breakdown` raised its compute/NCCL same-stream collision diagnosis whenever **any** stream carried ≥1 NCCL and ≥1 compute kernel, so one stray eager kernel landing on the NCCL stream was enough to trip it. The per-stream compute/NCCL shares were already being computed for the report; the diagnosis now only fires when a **meaningful fraction (≥5%) of both** compute and NCCL actually share a stream. That suppresses the stray-kernel false positive while still catching genuine serialization.

## Top-kernel field naming — inconsistent across the codebase

The `profile_health_manifest` top-kernels list used `name` / `count`, while the `top_kernels` skill, the CUTracer planner, and the agent tool dispatcher all read `kernel_name` / `invocations`. The manifest entries now **additionally** carry `kernel_name` / `invocations` alongside the existing `name` / `count`, so every consumer can use the same field names and nothing that still reads `name` / `count` breaks.

## Tests

The real-vs-noise classifier on a bimodal distribution, suppression of slow-iteration findings under a contaminated median, the stray-kernel false-positive case, and the manifest field aliases. The full affected suite (231 tests across diff / skills / overlap / iteration / manifest), ruff, and bandit are all clean.