### PR TITLE
feat(diff): add --gate PCT custom regression threshold for the CI gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ nsys-ai diff before.sqlite after.sqlite --format json
 
 # Gate CI: exit non-zero when the verdict is a likely regression
 nsys-ai diff before.sqlite after.sqlite --exit-on-regression
+
+# Same gate with a custom regression threshold (default 5%)
+nsys-ai diff before.sqlite after.sqlite --gate 3.0
 ```
 
 The report covers top regressions and improvements, new and removed kernels,
@@ -193,6 +196,7 @@ across every device.
 | `--limit N` | 15 | Top regressions/improvements to show |
 | `--sort` | `delta` | `delta` \| `percent` \| `total` |
 | `--exit-on-regression` | — | Exit 1 when the verdict is `regression_likely` |
+| `--gate PCT` | 5.0 | Regression threshold (%) for the verdict; implies `--exit-on-regression` |
 
 ## Commands
 

--- a/docs/agent_skills/INDEX.md
+++ b/docs/agent_skills/INDEX.md
@@ -40,6 +40,9 @@ nsys-ai diff before.sqlite after.sqlite --format json
 # Fail a CI job on a likely regression verdict
 nsys-ai diff before.sqlite after.sqlite --format json --exit-on-regression
 
+# Same gate with a custom regression threshold (default 5%)
+nsys-ai diff before.sqlite after.sqlite --format json --gate 3.0
+
 # Specific iteration (skip warmup iteration 0)
 nsys-ai diff before.sqlite after.sqlite --iteration 1 --format json
 
@@ -51,7 +54,7 @@ nsys-ai diff before.sqlite after.sqlite --chat
 ```
 
 **Output formats**: `terminal` (default), `markdown`, `json`
-**Key flags**: `--gpu N`, `--trim START END` (seconds), `--iteration N`, `--marker NAME`, `--exit-on-regression`
+**Key flags**: `--gpu N`, `--trim START END` (seconds), `--iteration N`, `--marker NAME`, `--exit-on-regression`, `--gate PCT`
 
 ### Report — Full analysis report
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -516,7 +516,7 @@ def _cmd_report(args, _profile):
 
 
 def _cmd_diff(args, _profile):
-    from nsys_ai.diff import diff_profiles
+    from nsys_ai.diff import STEP_TIME_REGRESSION_PCT, diff_profiles
     from nsys_ai.diff_render import (
         format_diff_markdown,
         format_diff_markdown_multi,
@@ -528,6 +528,8 @@ def _cmd_diff(args, _profile):
 
     no_ai = getattr(args, "no_ai", False)
     gate_summary = None
+    gate_pct = getattr(args, "gate", None)
+    regression_pct = gate_pct if gate_pct is not None else STEP_TIME_REGRESSION_PCT
 
     def _narrative_for(summary):
         if args.format not in ("terminal", "markdown"):
@@ -589,6 +591,7 @@ def _cmd_diff(args, _profile):
                 trim_after=trim_after,
                 limit=args.limit,
                 sort=args.sort,
+                regression_pct=regression_pct,
             )
             gate_summary = summary
             narrative = _narrative_for(summary)
@@ -608,6 +611,7 @@ def _cmd_diff(args, _profile):
                 trim=trim,
                 limit=args.limit,
                 sort=args.sort,
+                regression_pct=regression_pct,
             )
             gate_summary = summary
             narrative = _narrative_for(summary)
@@ -628,6 +632,7 @@ def _cmd_diff(args, _profile):
                 trim=trim,
                 limit=args.limit,
                 sort=args.sort,
+                regression_pct=regression_pct,
             )
             gate_summary = global_summary
             # For per-GPU we keep top-k small to avoid overwhelming output.
@@ -642,6 +647,7 @@ def _cmd_diff(args, _profile):
                     trim=trim,
                     limit=per_gpu_limit,
                     sort=args.sort,
+                    regression_pct=regression_pct,
                 )
 
             narrative = _narrative_for(global_summary)
@@ -665,14 +671,16 @@ def _cmd_diff(args, _profile):
     else:
         print(out, end="")
 
-    if getattr(args, "exit_on_regression", False) and gate_summary is not None:
+    gate_enabled = getattr(args, "exit_on_regression", False) or gate_pct is not None
+    if gate_enabled and gate_summary is not None:
         if gate_summary.verdict == "regression_likely":
             print(
                 "Diff gate failed: "
                 f"verdict={gate_summary.verdict} "
                 f"step_time_delta_ms={gate_summary.step_time_delta_ms:+.3f} "
                 f"step_time_delta_pct={gate_summary.step_time_delta_pct:+.2f}% "
-                f"comparability_confidence={gate_summary.comparability_confidence:.3f}.",
+                f"comparability_confidence={gate_summary.comparability_confidence:.3f} "
+                f"gate_pct={regression_pct:.2f}%.",
                 file=sys.stderr,
             )
             sys.exit(1)

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -7,6 +7,7 @@ Extracted from app.py to reduce file size and improve maintainability.
 from __future__ import annotations
 
 import argparse
+import math
 
 from nsys_ai.cutracer.installer import NVBIT_VERSION
 
@@ -53,7 +54,9 @@ from .handlers import (
 
 def _positive_pct(value: str) -> float:
     pct = float(value)
-    if pct <= 0:
+    # Reject nan/inf too: NaN compares false against everything and inf exceeds
+    # any delta, so either would make the CI gate silently never fire (fail-open).
+    if not math.isfinite(pct) or pct <= 0:
         raise argparse.ArgumentTypeError(f"must be a positive percentage, got {value}")
     return pct
 

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -51,6 +51,13 @@ from .handlers import (
 # ---------------------------------------------------------------------------
 
 
+def _positive_pct(value: str) -> float:
+    pct = float(value)
+    if pct <= 0:
+        raise argparse.ArgumentTypeError(f"must be a positive percentage, got {value}")
+    return pct
+
+
 def _register_info_parser(sub):
     """Register the ``info`` subcommand on *sub*."""
     p = sub.add_parser("info", help="Show profile metadata and GPU info")
@@ -373,6 +380,14 @@ def _build_parser():
         "--exit-on-regression",
         action="store_true",
         help="Exit with status 1 when the diff verdict is regression_likely (CI gate)",
+    )
+    p.add_argument(
+        "--gate",
+        type=_positive_pct,
+        default=None,
+        metavar="PCT",
+        help="Step-time regression threshold in percent for the verdict and CI gate "
+        "(implies --exit-on-regression; default: 5.0)",
     )
     p.set_defaults(handler=_cmd_diff)
 

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -350,12 +350,16 @@ def compute_category_attribution(
     ]
 
 
-def compute_verdict(step_time_delta_pct: float | None, confidence: float) -> str:
+def compute_verdict(
+    step_time_delta_pct: float | None,
+    confidence: float,
+    regression_pct: float = STEP_TIME_REGRESSION_PCT,
+) -> str:
     if confidence < MIN_COMPARABILITY_CONFIDENCE or step_time_delta_pct is None:
         return "inconclusive"
-    if step_time_delta_pct >= STEP_TIME_REGRESSION_PCT:
+    if step_time_delta_pct >= regression_pct:
         return "regression_likely"
-    if step_time_delta_pct <= -STEP_TIME_REGRESSION_PCT:
+    if step_time_delta_pct <= -regression_pct:
         return "improvement_likely"
     return "neutral"
 
@@ -421,6 +425,7 @@ def diff_profiles(
     limit: int = 15,
     sort: str = "delta",
     nvtx_limit: int | None = 200,
+    regression_pct: float = STEP_TIME_REGRESSION_PCT,
 ) -> ProfileDiffSummary:
     """Compare two profiles. Use trim for same window, or trim_before/trim_after for iteration diff."""
     t_before = trim_before if trim_before is not None else trim
@@ -511,18 +516,19 @@ def diff_profiles(
     improvements = [k for k in kernel_diffs if k.delta_ns < 0]
     regressions.sort(key=sort_key, reverse=True)
     improvements.sort(key=sort_key)  # most negative first
-    diff_id = _make_diff_id(
-        before.profile_id,
-        after.profile_id,
-        {
-            "gpu": gpu,
-            "trim_before": trim_before,
-            "trim_after": trim_after,
-            "limit": limit,
-            "sort": sort,
-            "nvtx_limit": nvtx_limit,
-        },
-    )
+    diff_id_params = {
+        "gpu": gpu,
+        "trim_before": trim_before,
+        "trim_after": trim_after,
+        "limit": limit,
+        "sort": sort,
+        "nvtx_limit": nvtx_limit,
+    }
+    # Only key the diff_id on the threshold when it deviates from the default,
+    # so ids of existing default-threshold diffs stay stable.
+    if regression_pct != STEP_TIME_REGRESSION_PCT:
+        diff_id_params["regression_pct"] = regression_pct
+    diff_id = _make_diff_id(before.profile_id, after.profile_id, diff_id_params)
     limited_regressions = regressions[: max(0, int(limit))]
     limited_improvements = improvements[: max(0, int(limit))]
     limited_regressions = [
@@ -562,7 +568,9 @@ def diff_profiles(
         step_time_delta_ms = round(delta, 3)
         if step_time_before_ms > 0:
             step_time_delta_pct = round(delta / step_time_before_ms * 100.0, 2)
-    verdict = compute_verdict(step_time_delta_pct, comparability_confidence)
+    verdict = compute_verdict(
+        step_time_delta_pct, comparability_confidence, regression_pct=regression_pct
+    )
     return ProfileDiffSummary(
         before=before,
         after=after,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -729,9 +729,13 @@ def test_diff_cli_gate_help_and_validation(tmp_path):
     after = tmp_path / "after.sqlite"
     _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
     _make_profile(str(after), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
-    bad = _run_diff_cli(before, after, "--gate", "-3")
-    assert bad.returncode == 2
-    assert "positive percentage" in bad.stderr
+    # Non-finite values would make the gate silently never fire (fail-open):
+    # NaN compares false against everything, inf exceeds any delta. The =form
+    # keeps argparse from reading "-inf" as an option name.
+    for invalid in ("-3", "0", "nan", "inf", "-inf"):
+        bad = _run_diff_cli(before, after, f"--gate={invalid}")
+        assert bad.returncode == 2, f"--gate {invalid} should be rejected"
+        assert "positive percentage" in bad.stderr
 
 
 def test_diff_cli_gate_tightens_threshold_and_implies_exit(tmp_path):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -708,6 +708,77 @@ def test_diff_cli_exit_on_regression_allows_inconclusive(tmp_path):
     assert "Diff gate failed" not in result.stderr
 
 
+def _run_diff_cli(before, after, *extra):
+    return subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", str(before), str(after), "--gpu", "0", *extra],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_diff_cli_gate_help_and_validation(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--gate" in result.stdout
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    bad = _run_diff_cli(before, after, "--gate", "-3")
+    assert bad.returncode == 2
+    assert "positive percentage" in bad.stderr
+
+
+def test_diff_cli_gate_tightens_threshold_and_implies_exit(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # +4% step time: passes the default 5% verdict but fails a 3% gate.
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 10_400_000, 0, 7, 1, 1, 2)])
+
+    default_gate = _run_diff_cli(before, after, "--format", "json", "--exit-on-regression")
+    assert default_gate.returncode == 0, default_gate.stderr
+    assert json.loads(default_gate.stdout)["verdict"] == "neutral"
+
+    # --gate alone implies the CI gate; the verdict reflects the custom threshold.
+    tight = _run_diff_cli(before, after, "--format", "json", "--gate", "3.0")
+    assert tight.returncode == 1
+    payload = json.loads(tight.stdout)
+    assert payload["verdict"] == "regression_likely"
+    assert "Diff gate failed" in tight.stderr
+    assert "step_time_delta_pct=+4.00%" in tight.stderr
+    assert "gate_pct=3.00%" in tight.stderr
+
+
+def test_diff_cli_gate_loosens_threshold(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # +20% fails the default gate but passes a 30% gate, and the verdict agrees.
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 12_000_000, 0, 7, 1, 1, 2)])
+
+    loose = _run_diff_cli(before, after, "--format", "json", "--gate", "30")
+    assert loose.returncode == 0, loose.stderr
+    assert json.loads(loose.stdout)["verdict"] == "neutral"
+    assert "Diff gate failed" not in loose.stderr
+
+
+def test_compute_verdict_custom_regression_pct():
+    from nsys_ai.diff import compute_verdict
+
+    assert compute_verdict(4.0, 1.0) == "neutral"
+    assert compute_verdict(4.0, 1.0, regression_pct=3.0) == "regression_likely"
+    assert compute_verdict(-4.0, 1.0, regression_pct=3.0) == "improvement_likely"
+    assert compute_verdict(20.0, 1.0, regression_pct=30.0) == "neutral"
+    # Confidence gating still wins over any threshold.
+    assert compute_verdict(50.0, 0.4, regression_pct=3.0) == "inconclusive"
+
+
 def test_diff_cli_iteration_out_of_range_exits_nonzero(tmp_path):
     before = tmp_path / "before.sqlite"
     after = tmp_path / "after.sqlite"


### PR DESCRIPTION
## Summary
Completes the Direction 3 CI-gate pair (`--gate` / `--exit-on-regression`, refs #13). #144 gates at the fixed 5% verdict threshold; `--gate 3.0` sets a custom one.

- The threshold feeds **the verdict itself** (`compute_verdict`/`diff_profiles` gain a `regression_pct` param) — JSON envelope, terminal output, and exit code always agree; no "verdict says neutral but the gate failed".
- `--gate` implies `--exit-on-regression`. Gate-failure stderr adds `gate_pct=X.XX%`.
- Must be a positive percentage (argparse error otherwise). `diff_id` keys on the threshold only when non-default, so existing ids stay stable.
- Docs: README flag table + example, agent INDEX key flags.

## Test plan
- [x] 4 new tests: help+validation; tighten (+4% passes default, fails --gate 3, verdict flips); loosen (+20% passes --gate 30); compute_verdict unit incl. confidence still gating
- [x] 4 existing --exit-on-regression tests unchanged; `pytest` → 1035 passed; ruff clean