### PR TITLE
feat(diff): anchor TraceSelection time bounds to the slowest after-instance

### DIFF
--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -381,11 +381,74 @@ def _classify_delta(delta_ns: int, before_ns: int, after_ns: int) -> str:
     return "neutral"
 
 
+def _slowest_instances(
+    prof: Profile,
+    keys: list[str],
+    gpu: int | None,
+    trim: tuple[int, int] | None,
+) -> dict[str, tuple[int, int]]:
+    """Map kernel key -> (start_ns, end_ns) of its slowest single instance.
+
+    Scoped to the same device/window as the diff. Anchoring the slowest
+    instance keeps the selection tight; a kernel's full MIN..MAX invocation
+    envelope typically spans most of the timeline for steady-state kernels.
+    Best effort: kernels with no instances here (e.g. removed ones, which only
+    exist in the before profile) simply get no time bounds.
+    """
+    if not keys or not prof.schema.kernel_table:
+        return {}
+    placeholders = ",".join("?" for _ in keys)
+    # Key matches build_profile_summary: demangled name if non-empty, else short.
+    key_expr = "COALESCE(NULLIF(d.value, ''), s.value)"
+    sql = f"""
+        WITH ranked AS (
+            SELECT
+                {key_expr} AS key,
+                k.start AS start_ns,
+                k.[end] AS end_ns,
+                ROW_NUMBER() OVER (
+                    PARTITION BY {key_expr}
+                    ORDER BY (k.[end] - k.start) DESC, k.start ASC
+                ) AS rn
+            FROM {prof.schema.kernel_table} k
+            JOIN StringIds s ON k.shortName = s.id
+            JOIN StringIds d ON k.demangledName = d.id
+            WHERE (d.value IN ({placeholders}) OR s.value IN ({placeholders}))
+    """
+    params: list = list(keys) + list(keys)
+    if gpu is not None:
+        sql += " AND k.deviceId = ?"
+        params.append(gpu)
+    if trim:
+        sql += " AND k.start >= ? AND k.[end] <= ?"
+        params += list(trim)
+    sql += """
+        )
+        SELECT key, start_ns, end_ns FROM ranked WHERE rn = 1
+    """
+    try:
+        rows = prof._duckdb_query(sql, params)
+    except Exception:
+        # Schema variations must not break the diff; selections degrade to
+        # name+GPU anchors without time bounds.
+        _log.debug("slowest-instance lookup failed", exc_info=True)
+        return {}
+    out: dict[str, tuple[int, int]] = {}
+    for r in rows:
+        key = str(r.get("key") or "")
+        start_ns = r.get("start_ns")
+        end_ns = r.get("end_ns")
+        if key and start_ns is not None and end_ns is not None:
+            out[key] = (int(start_ns), int(end_ns))
+    return out
+
+
 def _diff_selection(
     kd: KernelDiff,
     profile_id: str,
     gpu: int | None,
     diff_id: str,
+    bounds: tuple[int, int] | None = None,
 ) -> TraceSelection:
     selection_key = json.dumps(
         {
@@ -405,6 +468,8 @@ def _diff_selection(
         id=f"sel_diff_{key_hash}",
         profile_id=profile_id,
         source="diff",
+        start_ns=bounds[0] if bounds else None,
+        end_ns=bounds[1] if bounds else None,
         gpu_ids=[gpu] if gpu is not None else None,
         label=f"{kd.name} {delta_ms:+.2f}ms",
     )
@@ -525,12 +590,24 @@ def diff_profiles(
     )
     limited_regressions = regressions[: max(0, int(limit))]
     limited_improvements = improvements[: max(0, int(limit))]
+    bound_keys = sorted({k.key for k in limited_regressions + limited_improvements})
+    instance_bounds = _slowest_instances(after_prof, bound_keys, gpu, t_after)
     limited_regressions = [
-        replace(k, selection=_diff_selection(k, after.profile_id, gpu, diff_id))
+        replace(
+            k,
+            selection=_diff_selection(
+                k, after.profile_id, gpu, diff_id, bounds=instance_bounds.get(k.key)
+            ),
+        )
         for k in limited_regressions
     ]
     limited_improvements = [
-        replace(k, selection=_diff_selection(k, after.profile_id, gpu, diff_id))
+        replace(
+            k,
+            selection=_diff_selection(
+                k, after.profile_id, gpu, diff_id, bounds=instance_bounds.get(k.key)
+            ),
+        )
         for k in limited_improvements
     ]
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -425,6 +425,112 @@ def test_diff_node_wide_selection_omits_gpu_ids(tmp_path):
     assert "gpu_ids" not in selection.to_dict()
 
 
+def test_diff_selection_anchors_slowest_after_instance(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    # kA twice in after: 10ms and 30ms. Bounds must be the slowest instance,
+    # not the MIN..MAX envelope (0..50ms).
+    _make_profile(
+        str(after),
+        kernels=[
+            (0, 10_000_000, 0, 7, 1, 1, 2),
+            (20_000_000, 50_000_000, 0, 7, 2, 1, 2),
+        ],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        diff = diff_profiles(b, a, gpu=0, limit=10)
+
+    selection = diff.top_regressions[0].selection
+    assert selection is not None
+    assert selection.start_ns == 20_000_000
+    assert selection.end_ns == 50_000_000
+    sel_dict = selection.to_dict()
+    assert sel_dict["start_ns"] == 20_000_000
+    assert sel_dict["end_ns"] == 50_000_000
+
+
+def test_diff_selection_bounds_respect_trim_window(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    # The slowest kA instance (200..260ms) sits outside the trim window and
+    # must not be chosen as the anchor.
+    _make_profile(
+        str(after),
+        kernels=[
+            (0, 30_000_000, 0, 7, 1, 1, 2),
+            (200_000_000, 260_000_000, 0, 7, 2, 1, 2),
+        ],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        diff = diff_profiles(b, a, gpu=0, trim=(0, 100_000_000), limit=10)
+
+    selection = diff.top_regressions[0].selection
+    assert selection is not None
+    assert selection.start_ns == 0
+    assert selection.end_ns == 30_000_000
+
+
+def test_diff_selection_removed_kernel_has_no_time_bounds(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    # kB exists only in before -> "removed" improvement; it has no instances in
+    # the after profile, so its selection stays a name+GPU anchor.
+    _make_profile(
+        str(before),
+        kernels=[
+            (0, 10_000_000, 0, 7, 1, 1, 2),
+            (10_000_000, 15_000_000, 0, 7, 2, 3, 4),
+        ],
+    )
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        diff = diff_profiles(b, a, gpu=0, limit=10)
+
+    removed = [k for k in diff.top_improvements if k.classification == "removed"]
+    assert removed, "expected kB to be a removed improvement"
+    selection = removed[0].selection
+    assert selection is not None
+    assert selection.start_ns is None
+    assert "start_ns" not in selection.to_dict()
+    # The regressed kernel still gets bounds from its after instance.
+    reg_sel = diff.top_regressions[0].selection
+    assert reg_sel.start_ns == 0
+    assert reg_sel.end_ns == 30_000_000
+
+
+def test_diff_selection_time_bounds_serialize_to_json(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.diff_render import to_diff_json
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 30_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        diff = diff_profiles(b, a, gpu=0, limit=10)
+
+    payload = json.loads(to_diff_json(diff))
+    selection = payload["top_regressions"][0]["selection"]
+    assert selection["start_ns"] == 0
+    assert selection["end_ns"] == 30_000_000
+
+
 def test_diff_without_top_regressions_has_empty_selection_lists(tmp_path):
     from nsys_ai import profile as profile_mod
     from nsys_ai.diff import diff_profiles


### PR DESCRIPTION
## Summary
Follow-up to #159: top-K selections had name+GPU anchors but no time bounds — a UI could filter by kernel but not zoom anywhere.

- Each top-K selection now carries `start_ns`/`end_ns` of the kernel's **slowest single instance** in the after profile, scoped to the diff's device + trim/iteration window. One instance, not the MIN..MAX invocation envelope — a steady-state kernel's envelope spans most of the timeline (the over-localization issue from #153).
- One window-function query for all top-K keys (DuckDB + SQLite fallback). Best effort: removed kernels / lookup failures keep the existing name+GPU anchor. Selection ids/labels unchanged; the JSON envelope picks up the new fields with no diff_render change.

## Test plan
- [x] 4 new tests: slowest-instance anchoring, trim-window scoping, removed kernel stays bounds-free, JSON serialization
- [x] 8 existing selection tests unchanged; `pytest` → 1035 passed; ruff clean