### PR TITLE
fix(skills): stream_concurrency — key streams by (deviceId, streamId)

### DIFF
--- a/src/nsys_ai/skills/builtins/stream_concurrency.py
+++ b/src/nsys_ai/skills/builtins/stream_concurrency.py
@@ -23,6 +23,7 @@ SKILL = Skill(
     sql="""\
 WITH stream_summary AS (
     SELECT
+        k.deviceId,
         k.streamId,
         COUNT(*) AS kernel_count,
         MIN(k.start) AS first_start,
@@ -33,11 +34,11 @@ WITH stream_summary AS (
     FROM {kernel_table} k
     WHERE 1=1
         {trim_clause}
-    GROUP BY k.streamId
+    GROUP BY k.deviceId, k.streamId
 ),
 global_stats AS (
     SELECT
-        COUNT(DISTINCT streamId) AS active_streams,
+        COUNT(*) AS active_streams,
         SUM(kernel_count) AS total_kernels,
         MIN(first_start) AS global_start,
         MAX(last_end) AS global_end,
@@ -45,6 +46,7 @@ global_stats AS (
     FROM stream_summary
 )
 SELECT
+    s.deviceId,
     s.streamId,
     s.kernel_count,
     s.total_gpu_ms,
@@ -59,7 +61,7 @@ SELECT
     ROUND(g.sum_gpu_ms / NULLIF((g.global_end - g.global_start) / 1e6, 0) * 100, 1)
         AS sum_util_pct
 FROM stream_summary s, global_stats g
-ORDER BY s.total_gpu_ms DESC
+ORDER BY s.total_gpu_ms DESC, s.deviceId, s.streamId
 LIMIT {limit}""",
     format_fn=lambda rows: _format(rows),
     params=[
@@ -80,12 +82,12 @@ def _format(rows):
         f"  Global span:    {r0['global_span_ms']:.2f}ms",
         f"  Sum GPU time:   {r0['sum_util_pct']:.1f}% of span (>100% = true concurrency)",
         "",
-        f"{'Stream':>7s} {'Kernels':>8s} {'GPU(ms)':>10s} {'AvgKern':>10s} {'Util%':>7s}",
-        "─" * 50,
+        f"{'GPU':>3s} {'Stream':>7s} {'Kernels':>8s} {'GPU(ms)':>10s} {'AvgKern':>10s} {'Util%':>7s}",
+        "─" * 54,
     ]
     for r in rows:
         lines.append(
-            f"s{r['streamId']:>5d} {r['kernel_count']:>8d} "
+            f"{r['deviceId']:>3d} s{r['streamId']:>5d} {r['kernel_count']:>8d} "
             f"{r['total_gpu_ms']:>10.2f} {r['avg_kernel_us']:>8.1f}µs "
             f"{r['stream_util_pct']:>6.1f}%"
         )

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -162,6 +162,47 @@ def test_skill_execute_json_serializable():
     conn.close()
 
 
+def test_stream_concurrency_keys_streams_by_device():
+    """Same numeric stream id on different GPUs must not be merged."""
+    from nsys_ai.skills.registry import get_skill
+
+    conn = sqlite3.connect(":memory:")
+    conn.executescript("""
+        CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+            deviceId INT,
+            streamId INT,
+            correlationId INT,
+            start INT,
+            [end] INT,
+            shortName INT
+        );
+        INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES
+            (0, 7,  1, 0,        43000000, 1),
+            (0, 7,  2, 57000000, 100000000, 1),
+            (1, 17, 3, 0,        43000000, 1),
+            (1, 17, 4, 57000000, 100000000, 1),
+            (2, 17, 5, 0,        43000000, 1),
+            (2, 17, 6, 57000000, 100000000, 1),
+            (3, 17, 7, 0,        43000000, 1),
+            (3, 17, 8, 57000000, 100000000, 1);
+    """)
+
+    skill = get_skill("stream_concurrency")
+    rows = skill.execute(conn, limit=10)
+
+    by_device_stream = {(row["deviceId"], row["streamId"]): row for row in rows}
+    assert set(by_device_stream) == {(0, 7), (1, 17), (2, 17), (3, 17)}
+    assert all(row["stream_util_pct"] == pytest.approx(86.0) for row in rows)
+    assert rows[0]["active_streams"] == 4
+    assert rows[0]["sum_util_pct"] == pytest.approx(344.0)
+
+    formatted = skill.format_rows(rows)
+    assert "GPU" in formatted
+    assert "Stream" in formatted
+    assert "  1 s   17" in formatted
+    conn.close()
+
+
 # ---------------------------------------------------------------------------
 # C4: Markdown skill persistence tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes #142. On multi-GPU profiles the same numeric `streamId` on different devices was merged into one row, so a single stream's util exceeded 100% (stream 17 across 3 L40S devices → 258%). Grouping by `(deviceId, streamId)` computes each stream's util against its own device's span, keeping it ≤ 100%.

- `active_streams` switches from `COUNT(DISTINCT streamId)` to `COUNT(*)` over the per-(device,stream) groups, so shared ids across devices are no longer undercounted (4× L40S now reports 4, not 2).
- Output rows + the text table gain a `GPU` column.
- **`sum_util_pct` intentionally stays node-wide** (total GPU time / wall span), so >100% still means real cross-device/stream concurrency — as the header already states. The per-stream metric was the bug, not this one.

## Test plan
- [x] New test reproduces the issue's L40S case (dev0/s7 + s17 on dev1/2/3): per-stream util is 86% (not 258%), `active_streams=4`, `sum_util_pct≈344%`
- [x] `pytest tests/` → 1065 passed; ruff clean
- [x] No consumer breakage — `stream_concurrency` is only referenced by name in `agent/loop.py` routing, not by output fields