### PR TITLE
feat(diff): add communication/NCCL and idle summary axes (closes #186, #187)

### DIFF
--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -665,6 +665,12 @@ def build_communication_summary(
             )
         )
 
+    # Omit the axis entirely when there is nothing to show — no moving entries
+    # and no exposed communication on either side. Keeps compute-only diffs from
+    # rendering an empty "Total 0 -> 0" section, and makes the None-guards in the
+    # renderers live rather than dead code.
+    if not entries and before_ms == 0 and after_ms == 0:
+        return None
     entries.sort(key=lambda e: abs(e.delta_ms), reverse=True)
     return DiffAxisSummary(
         axis="communication",
@@ -825,6 +831,11 @@ def build_idle_summary(
             )
         )
 
+    # Omit the axis when there is no idle to report (no moving gaps and no
+    # wall-clock idle on either side), so the section disappears instead of
+    # rendering an empty "Total 0 -> 0".
+    if not entries and before_ms == 0 and after_ms == 0:
+        return None
     entries.sort(key=lambda e: abs(e.delta_ms), reverse=True)
     return DiffAxisSummary(
         axis="idle",

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, field, replace
 
 from .annotation import TraceSelection
 from .fingerprint import get_profile_id
-from .overlap import launch_overhead_ms, overlap_analysis
+from .overlap import classify_kernel, launch_overhead_ms, overlap_analysis
 from .profile import Profile
 
 _log = logging.getLogger(__name__)
@@ -67,6 +67,32 @@ class CategoryDelta:
 
 
 @dataclass(frozen=True)
+class DiffAxisEntry:
+    key: str
+    label: str
+    before_ms: float
+    after_ms: float
+    delta_ms: float
+    delta_pct: float | None
+    before_count: int
+    after_count: int
+    classification: str
+    selection: TraceSelection | None = None
+    metadata: dict = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class DiffAxisSummary:
+    axis: str
+    title: str
+    before_ms: float
+    after_ms: float
+    delta_ms: float
+    delta_pct: float | None
+    entries: list[DiffAxisEntry] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
 class KernelDiff:
     key: str
     name: str
@@ -114,6 +140,8 @@ class ProfileDiffSummary:
     verdict: str = "neutral"
     comparability_confidence: float = 1.0
     category_attribution: list[CategoryDelta] = field(default_factory=list)
+    communication_summary: DiffAxisSummary | None = None
+    idle_summary: DiffAxisSummary | None = None
     step_time_delta_ms: float | None = None
     step_time_delta_pct: float | None = None
     diff_id: str = ""
@@ -479,6 +507,336 @@ def _diff_selection(
     )
 
 
+def _round_ms(ns: int | float) -> float:
+    return round(float(ns) / 1e6, 3)
+
+
+def _delta_pct(before_ms: float, after_ms: float) -> float | None:
+    return round((after_ms - before_ms) / before_ms * 100.0, 2) if before_ms > 0 else None
+
+
+def _category_delta(category_attribution: list[CategoryDelta], category: str) -> CategoryDelta | None:
+    return next((c for c in category_attribution if c.category == category), None)
+
+
+def _axis_selection(
+    *,
+    axis: str,
+    key: str,
+    profile_id: str,
+    diff_id: str,
+    bounds: tuple[int, int] | None,
+    gpu_ids: list[int] | None,
+    label: str,
+    before_ns: int,
+    after_ns: int,
+) -> TraceSelection:
+    selection_key = json.dumps(
+        {
+            "axis": axis,
+            "key": key,
+            "diff_id": diff_id,
+            "before_ns": before_ns,
+            "after_ns": after_ns,
+            "profile_id": profile_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    key_hash = hashlib.sha256(selection_key).hexdigest()[:12]
+    return TraceSelection(
+        id=f"sel_diff_{axis}_{key_hash}",
+        profile_id=profile_id,
+        source=f"diff:{axis}_summary",
+        start_ns=bounds[0] if bounds else None,
+        end_ns=bounds[1] if bounds else None,
+        gpu_ids=gpu_ids,
+        label=label,
+    )
+
+
+def _aggregate_collectives(
+    prof: Profile,
+    gpu: int | None,
+    trim: tuple[int, int] | None,
+) -> dict[str, dict]:
+    if not prof.schema.kernel_table:
+        return {}
+    try:
+        kernels = prof.kernels(gpu, trim)
+    except Exception:
+        _log.debug("NCCL collective aggregation failed", exc_info=True)
+        return {}
+
+    out: dict[str, dict] = {}
+    for k in kernels:
+        name = str(k.get("name") or "")
+        demangled = str(k.get("demangled") or "")
+        ctype = classify_kernel(f"{name} {demangled}")
+        if not ctype.startswith("nccl_"):
+            continue
+        start = _safe_int(k.get("start"))
+        end = _safe_int(k.get("end"))
+        if end <= start:
+            continue
+        key = ctype.replace("nccl_", "")
+        dur = end - start
+        row = out.setdefault(
+            key,
+            {
+                "total_ns": 0,
+                "count": 0,
+                "max_ns": -1,
+                "bounds": None,
+                "device_id": None,
+            },
+        )
+        row["total_ns"] += dur
+        row["count"] += 1
+        if dur > row["max_ns"]:
+            row["max_ns"] = dur
+            row["bounds"] = (start, end)
+            device_id = k.get("deviceId")
+            row["device_id"] = int(device_id) if device_id is not None else None
+    return out
+
+
+def build_communication_summary(
+    before_prof: Profile,
+    after_prof: Profile,
+    before: ProfileSummary,
+    after: ProfileSummary,
+    category_attribution: list[CategoryDelta],
+    diff_id: str,
+    *,
+    gpu: int | None,
+    trim_before: tuple[int, int] | None,
+    trim_after: tuple[int, int] | None,
+    limit: int,
+) -> DiffAxisSummary | None:
+    b_aggs = _aggregate_collectives(before_prof, gpu, trim_before)
+    a_aggs = _aggregate_collectives(after_prof, gpu, trim_after)
+    cat = _category_delta(category_attribution, "communication")
+
+    before_ms = cat.before_ms if cat else _round_ms(sum(v["total_ns"] for v in b_aggs.values()))
+    after_ms = cat.after_ms if cat else _round_ms(sum(v["total_ns"] for v in a_aggs.values()))
+
+    entries: list[DiffAxisEntry] = []
+    for key in sorted(set(b_aggs) | set(a_aggs)):
+        b = b_aggs.get(key, {})
+        a = a_aggs.get(key, {})
+        before_ns = int(b.get("total_ns", 0) or 0)
+        after_ns = int(a.get("total_ns", 0) or 0)
+        delta_ns = after_ns - before_ns
+        if delta_ns == 0:
+            continue
+        entry_before_ms = _round_ms(before_ns)
+        entry_after_ms = _round_ms(after_ns)
+        side = a if delta_ns >= 0 and a else b
+        side_profile = after if side is a else before
+        side_name = "after" if side is a else "before"
+        device_id = side.get("device_id")
+        gpu_ids = [int(device_id)] if device_id is not None else ([gpu] if gpu is not None else None)
+        label = f"NCCL {key} {_round_ms(delta_ns):+.3f}ms"
+        selection = _axis_selection(
+            axis="communication",
+            key=key,
+            profile_id=side_profile.profile_id,
+            diff_id=diff_id,
+            bounds=side.get("bounds"),
+            gpu_ids=gpu_ids,
+            label=label,
+            before_ns=before_ns,
+            after_ns=after_ns,
+        )
+        entries.append(
+            DiffAxisEntry(
+                key=key,
+                label=f"NCCL {key}",
+                before_ms=entry_before_ms,
+                after_ms=entry_after_ms,
+                delta_ms=round(entry_after_ms - entry_before_ms, 3),
+                delta_pct=_delta_pct(entry_before_ms, entry_after_ms),
+                before_count=int(b.get("count", 0) or 0),
+                after_count=int(a.get("count", 0) or 0),
+                classification=_classify_delta(delta_ns, before_ns, after_ns),
+                selection=selection,
+                metadata={"selection_side": side_name},
+            )
+        )
+
+    entries.sort(key=lambda e: abs(e.delta_ms), reverse=True)
+    return DiffAxisSummary(
+        axis="communication",
+        title="Communication/NCCL Summary",
+        before_ms=round(before_ms, 3),
+        after_ms=round(after_ms, 3),
+        delta_ms=round(after_ms - before_ms, 3),
+        delta_pct=_delta_pct(before_ms, after_ms),
+        entries=entries[: max(0, int(limit))],
+    )
+
+
+def _kernel_label(k: dict) -> str:
+    return str(k.get("demangled") or k.get("name") or "")
+
+
+def _collect_idle_gaps(
+    prof: Profile,
+    gpu: int | None,
+    trim: tuple[int, int] | None,
+) -> dict[str, dict]:
+    if not prof.schema.kernel_table:
+        return {}
+    try:
+        kernels = sorted(
+            prof.kernels(gpu, trim),
+            key=lambda k: (
+                _safe_int(k.get("deviceId")),
+                _safe_int(k.get("streamId")),
+                _safe_int(k.get("start")),
+                _safe_int(k.get("end")),
+            ),
+        )
+    except Exception:
+        _log.debug("idle gap collection failed", exc_info=True)
+        return {}
+
+    out: dict[str, dict] = {}
+    ordinals: dict[str, int] = {}
+    prev_by_stream: dict[tuple[int, int], dict] = {}
+    for k in kernels:
+        device_id = _safe_int(k.get("deviceId"))
+        stream_id = _safe_int(k.get("streamId"))
+        start = _safe_int(k.get("start"))
+        end = _safe_int(k.get("end"))
+        stream_key = (device_id, stream_id)
+        prev = prev_by_stream.get(stream_key)
+        if prev is not None:
+            prev_end = _safe_int(prev.get("end"))
+            if start > prev_end:
+                before_kernel = _kernel_label(prev)
+                after_kernel = _kernel_label(k)
+                base_key = json.dumps(
+                    {
+                        "device_id": device_id,
+                        "stream_id": stream_id,
+                        "before_kernel": before_kernel,
+                        "after_kernel": after_kernel,
+                    },
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+                ordinal = ordinals.get(base_key, 0)
+                ordinals[base_key] = ordinal + 1
+                key = f"{base_key}:{ordinal}"
+                gap_ns = start - prev_end
+                out[key] = {
+                    "gap_ns": gap_ns,
+                    "count": 1,
+                    "bounds": (prev_end, start),
+                    "device_id": device_id,
+                    "stream_id": stream_id,
+                    "before_kernel": before_kernel,
+                    "after_kernel": after_kernel,
+                    "ordinal": ordinal,
+                }
+        if prev is None or end >= _safe_int(prev.get("end")):
+            prev_by_stream[stream_key] = k
+    return out
+
+
+def build_idle_summary(
+    before_prof: Profile,
+    after_prof: Profile,
+    before: ProfileSummary,
+    after: ProfileSummary,
+    category_attribution: list[CategoryDelta],
+    diff_id: str,
+    *,
+    gpu: int | None,
+    trim_before: tuple[int, int] | None,
+    trim_after: tuple[int, int] | None,
+    limit: int,
+) -> DiffAxisSummary | None:
+    b_gaps = _collect_idle_gaps(before_prof, gpu, trim_before)
+    a_gaps = _collect_idle_gaps(after_prof, gpu, trim_after)
+    cat = _category_delta(category_attribution, "idle")
+
+    before_ms = cat.before_ms if cat else _round_ms(sum(v["gap_ns"] for v in b_gaps.values()))
+    after_ms = cat.after_ms if cat else _round_ms(sum(v["gap_ns"] for v in a_gaps.values()))
+
+    entries: list[DiffAxisEntry] = []
+    for key in sorted(set(b_gaps) | set(a_gaps)):
+        b = b_gaps.get(key, {})
+        a = a_gaps.get(key, {})
+        before_ns = int(b.get("gap_ns", 0) or 0)
+        after_ns = int(a.get("gap_ns", 0) or 0)
+        delta_ns = after_ns - before_ns
+        if delta_ns == 0:
+            continue
+        entry_before_ms = _round_ms(before_ns)
+        entry_after_ms = _round_ms(after_ns)
+        side = a if delta_ns >= 0 and a else b
+        side_profile = after if side is a else before
+        side_name = "after" if side is a else "before"
+        device_id = side.get("device_id")
+        gpu_ids = [int(device_id)] if device_id is not None else ([gpu] if gpu is not None else None)
+        stream_id = side.get("stream_id")
+        label = f"Idle gap {_round_ms(delta_ns):+.3f}ms"
+        selection = _axis_selection(
+            axis="idle",
+            key=key,
+            profile_id=side_profile.profile_id,
+            diff_id=diff_id,
+            bounds=side.get("bounds"),
+            gpu_ids=gpu_ids,
+            label=label,
+            before_ns=before_ns,
+            after_ns=after_ns,
+        )
+        before_kernel = str(side.get("before_kernel") or "")
+        after_kernel = str(side.get("after_kernel") or "")
+        if delta_ns > 0:
+            classification = "new" if before_ns <= 0 else "grown"
+        elif delta_ns < 0:
+            classification = "removed" if after_ns <= 0 else "shrunk"
+        else:
+            classification = "neutral"
+        entries.append(
+            DiffAxisEntry(
+                key=key,
+                label=f"GPU {device_id} stream {stream_id}: {before_kernel} -> {after_kernel}",
+                before_ms=entry_before_ms,
+                after_ms=entry_after_ms,
+                delta_ms=round(entry_after_ms - entry_before_ms, 3),
+                delta_pct=_delta_pct(entry_before_ms, entry_after_ms),
+                before_count=int(b.get("count", 0) or 0),
+                after_count=int(a.get("count", 0) or 0),
+                classification=classification,
+                selection=selection,
+                metadata={
+                    "device_id": device_id,
+                    "stream_id": stream_id,
+                    "before_kernel": before_kernel,
+                    "after_kernel": after_kernel,
+                    "selection_side": side_name,
+                },
+            )
+        )
+
+    entries.sort(key=lambda e: abs(e.delta_ms), reverse=True)
+    return DiffAxisSummary(
+        axis="idle",
+        title="Idle Gap Summary",
+        before_ms=round(before_ms, 3),
+        after_ms=round(after_ms, 3),
+        delta_ms=round(after_ms - before_ms, 3),
+        delta_pct=_delta_pct(before_ms, after_ms),
+        entries=entries[: max(0, int(limit))],
+    )
+
+
 def diff_profiles(
     before_prof: Profile,
     after_prof: Profile,
@@ -648,6 +1006,30 @@ def diff_profiles(
     verdict = compute_verdict(
         step_time_delta_pct, comparability_confidence, regression_pct=regression_pct
     )
+    communication_summary = build_communication_summary(
+        before_prof,
+        after_prof,
+        before,
+        after,
+        category_attribution,
+        diff_id,
+        gpu=gpu,
+        trim_before=t_before,
+        trim_after=t_after,
+        limit=limit,
+    )
+    idle_summary = build_idle_summary(
+        before_prof,
+        after_prof,
+        before,
+        after,
+        category_attribution,
+        diff_id,
+        gpu=gpu,
+        trim_before=t_before,
+        trim_after=t_after,
+        limit=limit,
+    )
     return ProfileDiffSummary(
         before=before,
         after=after,
@@ -662,6 +1044,8 @@ def diff_profiles(
         verdict=verdict,
         comparability_confidence=comparability_confidence,
         category_attribution=category_attribution,
+        communication_summary=communication_summary,
+        idle_summary=idle_summary,
         step_time_delta_ms=step_time_delta_ms,
         step_time_delta_pct=step_time_delta_pct,
         diff_id=diff_id,

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -42,6 +42,7 @@ def _axis_summary_to_dict(axis):
     return {
         "axis": axis.axis,
         "title": axis.title,
+        "total_basis": _axis_total_basis(axis.axis),
         "before_ms": axis.before_ms,
         "after_ms": axis.after_ms,
         "delta_ms": axis.delta_ms,
@@ -68,6 +69,20 @@ def _axis_summary_to_dict(axis):
 def _fmt_ms_delta(ms: float) -> str:
     sign = "+" if ms > 0 else ""
     return f"{sign}{ms:.3f}ms"
+
+
+# The axis total and the per-entry values measure different things: the total is
+# the HTA category (exposed communication / wall-clock idle), while entries are
+# raw per-item amounts that can exceed it when work overlaps. Label them so the
+# difference doesn't read as a bug.
+def _axis_total_basis(axis_name: str) -> str:
+    return {"communication": "exposed comm", "idle": "wall-clock idle"}.get(axis_name, "total")
+
+
+_AXIS_ENTRY_FOOTNOTE = (
+    "per-item values are raw component time and can exceed the total above when "
+    "compute, communication, and idle overlap"
+)
 
 
 def format_diff_terminal(
@@ -122,7 +137,8 @@ def format_diff_terminal(
         lines.append(axis.title)
         lines.append("─" * 60)
         lines.append(
-            f"Total: {axis.before_ms:.3f}ms → {axis.after_ms:.3f}ms  (Δ {_fmt_ms_delta(axis.delta_ms)})"
+            f"Total ({_axis_total_basis(axis.axis)}): "
+            f"{axis.before_ms:.3f}ms → {axis.after_ms:.3f}ms  (Δ {_fmt_ms_delta(axis.delta_ms)})"
         )
         if axis.entries:
             lines.append(f"{'Δ':>11}  | {'Before':>9} | {'After':>9} | Item")
@@ -131,6 +147,7 @@ def format_diff_terminal(
                 lines.append(
                     f"{_fmt_ms_delta(e.delta_ms):>11}  | {e.before_ms:>9.3f} | {e.after_ms:>9.3f} | {e.label}"
                 )
+            lines.append(f"({_AXIS_ENTRY_FOOTNOTE})")
         else:
             lines.append("(no changed entries)")
         lines.append("")
@@ -316,7 +333,8 @@ def format_diff_markdown(
         md.append(f"### {axis.title}")
         md.append("")
         md.append(
-            f"- **Total**: `{axis.before_ms:.3f}ms` → `{axis.after_ms:.3f}ms` (Δ `{_fmt_ms_delta(axis.delta_ms)}`)"
+            f"- **Total ({_axis_total_basis(axis.axis)})**: `{axis.before_ms:.3f}ms` → "
+            f"`{axis.after_ms:.3f}ms` (Δ `{_fmt_ms_delta(axis.delta_ms)}`)"
         )
         md.append("")
         if not axis.entries:
@@ -329,6 +347,8 @@ def format_diff_markdown(
             md.append(
                 f"| `{_fmt_ms_delta(e.delta_ms)}` | `{e.label}` | `{e.before_ms:.3f}ms` | `{e.after_ms:.3f}ms` | `{e.classification}` |"
             )
+        md.append("")
+        md.append(f"_{_AXIS_ENTRY_FOOTNOTE}._")
         md.append("")
 
     add_axis_table(data.communication_summary)
@@ -433,7 +453,8 @@ def format_diff_markdown_multi(
         md.append(f"### {axis.title}")
         md.append("")
         md.append(
-            f"- **Total**: `{axis.before_ms:.3f}ms` → `{axis.after_ms:.3f}ms` (Δ `{_fmt_ms_delta(axis.delta_ms)}`)"
+            f"- **Total ({_axis_total_basis(axis.axis)})**: `{axis.before_ms:.3f}ms` → "
+            f"`{axis.after_ms:.3f}ms` (Δ `{_fmt_ms_delta(axis.delta_ms)}`)"
         )
         md.append("")
         if not axis.entries:
@@ -446,6 +467,8 @@ def format_diff_markdown_multi(
             md.append(
                 f"| `{_fmt_ms_delta(e.delta_ms)}` | `{e.label}` | `{e.before_ms:.3f}ms` | `{e.after_ms:.3f}ms` | `{e.classification}` |"
             )
+        md.append("")
+        md.append(f"_{_AXIS_ENTRY_FOOTNOTE}._")
         md.append("")
 
     add_global_axis(g.communication_summary)

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -36,6 +36,40 @@ def _fmt_pct(x: float) -> str:
     return f"{x * 100:.2f}%"
 
 
+def _axis_summary_to_dict(axis):
+    if axis is None:
+        return None
+    return {
+        "axis": axis.axis,
+        "title": axis.title,
+        "before_ms": axis.before_ms,
+        "after_ms": axis.after_ms,
+        "delta_ms": axis.delta_ms,
+        "delta_pct": axis.delta_pct,
+        "entries": [
+            {
+                "key": e.key,
+                "label": e.label,
+                "before_ms": e.before_ms,
+                "after_ms": e.after_ms,
+                "delta_ms": e.delta_ms,
+                "delta_pct": e.delta_pct,
+                "before_count": e.before_count,
+                "after_count": e.after_count,
+                "classification": e.classification,
+                "selection": e.selection.to_dict() if e.selection else None,
+                "metadata": dict(e.metadata),
+            }
+            for e in axis.entries
+        ],
+    }
+
+
+def _fmt_ms_delta(ms: float) -> str:
+    sign = "+" if ms > 0 else ""
+    return f"{sign}{ms:.3f}ms"
+
+
 def format_diff_terminal(
     data: ProfileDiffSummary,
     narrative: DiffNarrative | None = None,
@@ -81,6 +115,28 @@ def format_diff_terminal(
                 f"- {'overlap_pct':<15} {b['overlap_pct']:>8.1f}% → {a['overlap_pct']:>8.1f}%  (Δ {sign}{d}%)"
             )
     lines.append("")
+
+    def add_axis_section(axis):
+        if axis is None:
+            return
+        lines.append(axis.title)
+        lines.append("─" * 60)
+        lines.append(
+            f"Total: {axis.before_ms:.3f}ms → {axis.after_ms:.3f}ms  (Δ {_fmt_ms_delta(axis.delta_ms)})"
+        )
+        if axis.entries:
+            lines.append(f"{'Δ':>11}  | {'Before':>9} | {'After':>9} | Item")
+            lines.append(f"{'-' * 11}--+-{'-' * 9}-+-{'-' * 9}-+-{'-' * 30}")
+            for e in axis.entries:
+                lines.append(
+                    f"{_fmt_ms_delta(e.delta_ms):>11}  | {e.before_ms:>9.3f} | {e.after_ms:>9.3f} | {e.label}"
+                )
+        else:
+            lines.append("(no changed entries)")
+        lines.append("")
+
+    add_axis_section(data.communication_summary)
+    add_axis_section(data.idle_summary)
 
     def add_kernel_section(title: str, rows):
         lines.append(title)
@@ -254,6 +310,30 @@ def format_diff_markdown(
             )
     md.append("")
 
+    def add_axis_table(axis):
+        if axis is None:
+            return
+        md.append(f"### {axis.title}")
+        md.append("")
+        md.append(
+            f"- **Total**: `{axis.before_ms:.3f}ms` → `{axis.after_ms:.3f}ms` (Δ `{_fmt_ms_delta(axis.delta_ms)}`)"
+        )
+        md.append("")
+        if not axis.entries:
+            md.append("_no changed entries_")
+            md.append("")
+            return
+        md.append("| Δ | item | before | after | class |")
+        md.append("|---:|---|---:|---:|---|")
+        for e in axis.entries:
+            md.append(
+                f"| `{_fmt_ms_delta(e.delta_ms)}` | `{e.label}` | `{e.before_ms:.3f}ms` | `{e.after_ms:.3f}ms` | `{e.classification}` |"
+            )
+        md.append("")
+
+    add_axis_table(data.communication_summary)
+    add_axis_table(data.idle_summary)
+
     def add_table(title: str, rows, is_regression: bool):
         md.append(f"### {title}")
         md.append("")
@@ -346,6 +426,30 @@ def format_diff_markdown_multi(
                 f"  - `overlap_pct`: `{b['overlap_pct']}%` → `{a['overlap_pct']}%` (Δ `{sign}{d}%`)"
             )
     md.append("")
+
+    def add_global_axis(axis):
+        if axis is None:
+            return
+        md.append(f"### {axis.title}")
+        md.append("")
+        md.append(
+            f"- **Total**: `{axis.before_ms:.3f}ms` → `{axis.after_ms:.3f}ms` (Δ `{_fmt_ms_delta(axis.delta_ms)}`)"
+        )
+        md.append("")
+        if not axis.entries:
+            md.append("_no changed entries_")
+            md.append("")
+            return
+        md.append("| Δ | item | before | after | class |")
+        md.append("|---:|---|---:|---:|---|")
+        for e in axis.entries:
+            md.append(
+                f"| `{_fmt_ms_delta(e.delta_ms)}` | `{e.label}` | `{e.before_ms:.3f}ms` | `{e.after_ms:.3f}ms` | `{e.classification}` |"
+            )
+        md.append("")
+
+    add_global_axis(g.communication_summary)
+    add_global_axis(g.idle_summary)
 
     # 2) Per-GPU breakdown table
     if per_gpu:
@@ -466,6 +570,8 @@ def to_diff_json(data: ProfileDiffSummary) -> str:
             }
             for c in data.category_attribution
         ],
+        "communication_summary": _axis_summary_to_dict(data.communication_summary),
+        "idle_summary": _axis_summary_to_dict(data.idle_summary),
         "before": {
             "path": data.before.path,
             "profile_id": data.before.profile_id,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -63,6 +63,30 @@ def _make_profile(path: str, *, kernels: list[tuple], nvtx: list[tuple] | None =
     conn.close()
 
 
+def _make_named_profile(path: str, *, kernels: list[tuple], strings: dict[int, str]):
+    """
+    Create a minimal profile with caller-supplied StringIds.
+
+    kernels entries: (start_ns, end_ns, deviceId, streamId, correlationId, shortNameId, demangledId)
+    """
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE StringIds(id INT PRIMARY KEY, value TEXT)")
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL("
+        "start INT, [end] INT, deviceId INT, streamId INT, correlationId INT, "
+        "shortName INT, demangledName INT)"
+    )
+    conn.execute("CREATE TABLE NVTX_EVENTS(text TEXT, globalTid INT, start INT, [end] INT)")
+    conn.executemany("INSERT INTO StringIds(id, value) VALUES(?,?)", list(strings.items()))
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL(start, [end], deviceId, streamId, correlationId, shortName, demangledName) "
+        "VALUES(?,?,?,?,?,?,?)",
+        kernels,
+    )
+    conn.commit()
+    conn.close()
+
+
 def _make_profile_with_launch_config(
     path: str,
     *,
@@ -2244,6 +2268,95 @@ def test_v01_diff_json_envelope_and_verdict(tmp_path):
     assert isinstance(cats, list)
     seen = {c["category"] for c in cats}
     assert seen == {"compute", "communication", "launch_overhead", "idle"}
+
+
+def test_diff_json_includes_communication_and_idle_summary_axes(tmp_path):
+    """Diff JSON exposes drillable communication and idle summary axes."""
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    ms = 1_000_000
+    strings = {
+        1: "compute_A",
+        2: "compute_A_dem",
+        3: "compute_B",
+        4: "compute_B_dem",
+        5: "ncclAllReduceKernel",
+        6: "ncclAllReduceKernel_dem",
+        7: "ncclAllGatherKernel",
+        8: "ncclAllGatherKernel_dem",
+    }
+    _make_named_profile(
+        str(before),
+        strings=strings,
+        kernels=[
+            (0, 10 * ms, 0, 7, 1, 1, 2),
+            (12 * ms, 17 * ms, 0, 17, 2, 5, 6),
+            (18 * ms, 20 * ms, 0, 17, 3, 7, 8),
+            (30 * ms, 40 * ms, 0, 7, 4, 3, 4),
+        ],
+    )
+    _make_named_profile(
+        str(after),
+        strings=strings,
+        kernels=[
+            (0, 10 * ms, 0, 7, 1, 1, 2),
+            (12 * ms, 20 * ms, 0, 17, 2, 5, 6),
+            (21 * ms, 22 * ms, 0, 17, 3, 7, 8),
+            (45 * ms, 55 * ms, 0, 7, 4, 3, 4),
+        ],
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--gpu",
+            "0",
+            "--format",
+            "json",
+            "--limit",
+            "5",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+
+    comm = payload["communication_summary"]
+    assert comm["axis"] == "communication"
+    assert comm["before_ms"] == 7.0
+    assert comm["after_ms"] == 9.0
+    assert comm["delta_ms"] == 2.0
+    comm_entries = {entry["key"]: entry for entry in comm["entries"]}
+    assert comm_entries["allreduce"]["delta_ms"] == 3.0
+    assert comm_entries["allreduce"]["classification"] == "regression"
+    assert comm_entries["allreduce"]["selection"]["source"] == "diff:communication_summary"
+    assert comm_entries["allreduce"]["selection"]["profile_id"] == payload["after"]["profile_id"]
+    assert comm_entries["allreduce"]["selection"]["start_ns"] == 12 * ms
+    assert comm_entries["allreduce"]["selection"]["end_ns"] == 20 * ms
+    assert comm_entries["allreduce"]["selection"]["gpu_ids"] == [0]
+    assert comm_entries["allgather"]["delta_ms"] == -1.0
+
+    idle = payload["idle_summary"]
+    assert idle["axis"] == "idle"
+    assert idle["before_ms"] == 13.0
+    assert idle["after_ms"] == 26.0
+    assert idle["delta_ms"] == 13.0
+    assert len(idle["entries"]) == 1
+    gap = idle["entries"][0]
+    assert gap["delta_ms"] == 15.0
+    assert gap["classification"] == "grown"
+    assert gap["metadata"]["device_id"] == 0
+    assert gap["metadata"]["stream_id"] == 7
+    assert gap["selection"]["source"] == "diff:idle_summary"
+    assert gap["selection"]["profile_id"] == payload["after"]["profile_id"]
+    assert gap["selection"]["start_ns"] == 10 * ms
+    assert gap["selection"]["end_ns"] == 45 * ms
+    assert gap["selection"]["gpu_ids"] == [0]
 
 
 def test_v01_confidence_separates_schema_and_gpu_mismatch():

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2328,6 +2328,7 @@ def test_diff_json_includes_communication_and_idle_summary_axes(tmp_path):
 
     comm = payload["communication_summary"]
     assert comm["axis"] == "communication"
+    assert comm["total_basis"] == "exposed comm"
     assert comm["before_ms"] == 7.0
     assert comm["after_ms"] == 9.0
     assert comm["delta_ms"] == 2.0
@@ -2343,6 +2344,7 @@ def test_diff_json_includes_communication_and_idle_summary_axes(tmp_path):
 
     idle = payload["idle_summary"]
     assert idle["axis"] == "idle"
+    assert idle["total_basis"] == "wall-clock idle"
     assert idle["before_ms"] == 13.0
     assert idle["after_ms"] == 26.0
     assert idle["delta_ms"] == 13.0
@@ -2357,6 +2359,38 @@ def test_diff_json_includes_communication_and_idle_summary_axes(tmp_path):
     assert gap["selection"]["start_ns"] == 10 * ms
     assert gap["selection"]["end_ns"] == 45 * ms
     assert gap["selection"]["gpu_ids"] == [0]
+
+
+def test_diff_compute_only_omits_empty_summary_axes(tmp_path):
+    """A compute-only diff must not render empty communication/idle axis sections."""
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    ms = 1_000_000
+    # One compute kernel each: no NCCL, no inter-kernel gaps -> both axes empty.
+    _make_profile(str(before), kernels=[(0, 10 * ms, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 13 * ms, 0, 7, 1, 1, 2)])
+
+    js = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", str(before), str(after),
+         "--gpu", "0", "--format", "json"],
+        capture_output=True,
+        text=True,
+    )
+    assert js.returncode == 0, js.stderr
+    payload = json.loads(js.stdout)
+    # Omitted (null), not an empty "Total 0 -> 0" object.
+    assert payload["communication_summary"] is None
+    assert payload["idle_summary"] is None
+
+    term = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", str(before), str(after),
+         "--gpu", "0", "--no-ai"],
+        capture_output=True,
+        text=True,
+    )
+    assert term.returncode == 0, term.stderr
+    assert "Communication/NCCL Summary" not in term.stdout
+    assert "Idle Gap Summary" not in term.stdout
 
 
 def test_v01_confidence_separates_schema_and_gpu_mismatch():


### PR DESCRIPTION
## Summary
Two dedicated, drillable summary axes on the diff (issues #186 + #187), each with a before/after total, the largest-moving entries, and a `TraceSelection` per entry pointing at the relevant time window.

- **Communication axis (#186)** — NCCL kernels grouped by collective type (allreduce, allgather, …), per-collective before/after/delta sorted by |Δ|, selection anchored to the slowest instance of the moving side.
- **Idle axis (#187)** — inter-kernel gaps grouped per (device, stream, neighbour kernels), grown/shrunk/new/removed classification, selection on the gap window.
- Shared `DiffAxisEntry`/`DiffAxisSummary`; rendered in JSON, terminal, markdown, and the multi-GPU markdown. Additive `ProfileDiffSummary` fields — the existing envelope is unchanged.

##  Note for reviewers — axis total vs entries
The axis `before/after` come from `category_attribution` (**exposed** comm, `nccl_only_ms` per HTA; **wall-clock** idle), while entries are **raw per-item** amounts (a collective's full kernel time incl. the overlapped part; per-stream gaps that can overlap across streams). They reconcile only when there's no compute/comm overlap — on overlapped profiles the entries can sum to more than the axis total. Happy to switch entries to exposed accounting if you'd prefer.

## Test plan
- [x] End-to-end JSON test (NCCL allreduce/allgather + an idle gap): per-entry deltas, classifications, selections (source/profile_id/bounds/gpu_ids), axis totals
- [x] `pytest tests/` → 1065 passed; ruff clean; JSON structure-unchanged test passes