### PR TITLE
agent: add evidence-first ask answers with verify command

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,9 @@ catalog.
 
 The agent is a CUDA performance expert that runs the skills and cites the
 evidence — kernel names, durations, timestamps — behind each diagnosis rather
-than guessing.
+than guessing. Targeted `ask` answers use a fixed evidence-first shape:
+summary, primary diagnosis, cited evidence, confidence, recommended action,
+and a final runnable verification command.
 
 ```bash
 nsys-ai agent analyze profile.sqlite
@@ -290,8 +292,8 @@ Install the dependencies with the `agent` extra:
 pip install 'nsys-ai[agent]'
 ```
 
-If no key is set, the agent still runs the deterministic skills and prints their
-results; it just skips the natural-language synthesis.
+If no key is set, the agent still runs deterministic skills and returns the
+same evidence-first answer shape; it just skips the natural-language synthesis.
 
 ## Claude Code plugin
 

--- a/README.md
+++ b/README.md
@@ -292,8 +292,10 @@ Install the dependencies with the `agent` extra:
 pip install 'nsys-ai[agent]'
 ```
 
-If no key is set, the agent still runs deterministic skills and returns the
-same evidence-first answer shape; it just skips the natural-language synthesis.
+With a key, targeted `ask` uses the model to select deep-dive skills and synthesize
+the Summary; the remaining evidence-first sections and verification command are
+built deterministically from skill output. If no key is set, the agent returns the
+same answer shape with a deterministic Summary.
 
 ## Claude Code plugin
 

--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -8,6 +8,7 @@ extra installed, can delegate to an LLM for natural language analysis.
 """
 
 import logging
+import shlex
 import sqlite3
 
 from ..exceptions import NsysAiError, ProfileNotFoundError
@@ -233,7 +234,6 @@ class Agent:
             model, api_key = None, None
         has_llm = bool(model and api_key)
 
-        sections = [f"Question: {question}\n"]
         evidence = {}
 
         # Stage 1: Triage (Unconditional root_cause_matcher)
@@ -243,12 +243,8 @@ class Agent:
             if skill:
                 rows = skill.execute(self.conn, **self._trim_kwargs)
                 evidence[triage_skill] = rows
-                sections.append("── Phase 1: Triage (Root Cause Matcher) ──")
-                sections.append(skill.format_rows(rows))
-                sections.append("")
         except Exception as e:
             log.debug("Triage skill '%s' failed: %s", triage_skill, e, exc_info=True)
-            sections.append(f"({triage_skill}: skipped — {e})\n")
 
         # Select Deep Dive Skills
         if has_llm:
@@ -260,7 +256,6 @@ class Agent:
                 selected = self._select_skills(question)
             if not selected:
                 selected = ["top_kernels", "gpu_idle_gaps"]
-            sections.append(f"── Phase 2: AI Triage selected skills: {', '.join(selected)} ──\n")
         else:
             selected = self._select_skills(question)
             if not selected:
@@ -276,21 +271,21 @@ class Agent:
                     continue
                 rows = skill.execute(self.conn, **self._trim_kwargs)
                 evidence[skill_name] = rows
-                text = skill.format_rows(rows)
-                sections.append(text)
-                sections.append("")
             except Exception as e:
                 log.debug("Skill '%s' failed: %s", skill_name, e, exc_info=True)
-                sections.append(f"({skill_name}: skipped — {e})\n")
 
         # Try LLM synthesis with combined structured evidence
+        llm_answer = None
         if has_llm:
             llm_answer = self._try_llm_synthesis(question, evidence)
-            if llm_answer:
-                sections.append("── Phase 3: AI Final Analysis ──")
-                sections.append(llm_answer)
 
-        return "\n".join(sections)
+        answer = self._format_evidence_first_answer(
+            question,
+            evidence,
+            selected_skills=[triage_skill, *selected],
+            llm_answer=llm_answer,
+        )
+        return answer
 
     def run_skill(self, name: str, **kwargs) -> str:
         """Run a specific skill by name."""
@@ -353,6 +348,226 @@ class Agent:
             if keyword in q_lower:
                 selected.update(skill_names)
         return sorted(selected)
+
+    def _format_evidence_first_answer(
+        self,
+        question: str,
+        evidence: dict[str, list[dict]],
+        selected_skills: list[str],
+        llm_answer: str | None = None,
+    ) -> str:
+        """Build the fixed answer shape required by issue #205."""
+        selected_skills = list(dict.fromkeys(skill for skill in selected_skills if skill))
+        diagnosis_row = self._first_actionable_row(evidence.get("root_cause_matcher", []))
+        diagnosis = self._primary_diagnosis(question, evidence, diagnosis_row)
+        evidence_lines = self._evidence_lines(evidence)
+        confidence = self._confidence_label(evidence, diagnosis_row)
+        action = self._recommended_action(diagnosis_row)
+        verify_skill = self._choose_verify_skill(evidence, selected_skills)
+        verify_command = self._verify_command(verify_skill)
+
+        if llm_answer:
+            summary = (
+                "Ran targeted skills and generated a grounded answer from their structured "
+                "outputs; model synthesis was available, but the final answer is constrained "
+                "to the evidence-first template."
+            )
+        else:
+            ran = ", ".join(skill for skill in selected_skills if skill)
+            if ran:
+                summary = (
+                    f"Ran {ran} against the profile and summarized the strongest supported "
+                    "signal in a verification-friendly format."
+                )
+            else:
+                summary = (
+                    "No skill returned usable evidence, so the answer is limited to a "
+                    "verification fallback."
+                )
+
+        lines = [
+            "## Summary",
+            summary,
+            "",
+            "## Primary Diagnosis",
+            diagnosis,
+            "",
+            "## Evidence",
+        ]
+        if evidence_lines:
+            lines.extend(evidence_lines)
+        else:
+            lines.append(
+                "- source_skill=none; metric=none; window=full profile; "
+                "scope=profile; evidence=no skill returned usable rows"
+            )
+        lines.extend(
+            [
+                "",
+                "## Confidence",
+                confidence,
+                "",
+                "## Recommended Action",
+                action,
+                "",
+                "## Verify",
+            ]
+        )
+        if verify_command:
+            lines.append(f"`{verify_command}`")
+        else:
+            lines.append(
+                "Could not build a runnable verification command because no skill "
+                "produced evidence. Inspect available skills with:"
+            )
+            lines.append("`nsys-ai skill list`")
+        return "\n".join(lines)
+
+    def _first_actionable_row(self, rows: list[dict]) -> dict | None:
+        for row in rows:
+            pattern = str(row.get("pattern", ""))
+            if pattern and pattern != "No Known Anti-Patterns Detected":
+                return row
+        return None
+
+    def _primary_diagnosis(
+        self,
+        question: str,
+        evidence: dict[str, list[dict]],
+        diagnosis_row: dict | None,
+    ) -> str:
+        if diagnosis_row:
+            pattern = diagnosis_row.get("pattern") or diagnosis_row.get("label")
+            if pattern:
+                return str(pattern)
+        for skill_name, rows in evidence.items():
+            if rows:
+                row = rows[0]
+                label = row.get("label") or row.get("name") or row.get("kernel_name")
+                if label:
+                    return f"{label} ({skill_name})"
+        return f"No specific diagnosis could be grounded for: {question}"
+
+    def _recommended_action(self, diagnosis_row: dict | None) -> str:
+        if diagnosis_row:
+            rec = diagnosis_row.get("recommendation") or diagnosis_row.get("action")
+            if rec:
+                return str(rec)
+        return (
+            "Re-run the verify command, inspect the cited metrics and window, then collect "
+            "a narrower profile with NVTX ranges if the evidence is too broad."
+        )
+
+    def _confidence_label(self, evidence: dict[str, list[dict]], diagnosis_row: dict | None) -> str:
+        row_count = sum(len(rows) for rows in evidence.values())
+        if diagnosis_row and row_count:
+            return "0.75 (medium-high): at least one root-cause matcher finding is backed by skill output."
+        if row_count:
+            return "0.60 (medium): skill output exists, but no root-cause matcher finding dominated."
+        return "0.20 (low): no skill returned usable evidence."
+
+    def _evidence_lines(self, evidence: dict[str, list[dict]]) -> list[str]:
+        lines: list[str] = []
+        for skill_name, rows in evidence.items():
+            for row in rows[:2]:
+                if not isinstance(row, dict):
+                    continue
+                if row.get("_summary") and len(rows) > 1:
+                    continue
+                metric = self._metric_fragment(row)
+                window = self._window_fragment(row)
+                scope = self._scope_fragment(row)
+                evidence_text = str(row.get("evidence") or row.get("note") or "").strip()
+                suffix = f"; evidence={evidence_text}" if evidence_text else ""
+                lines.append(
+                    f"- source_skill={skill_name}; metric={metric}; "
+                    f"window={window}; scope={scope}{suffix}"
+                )
+                if len(lines) >= 5:
+                    return lines
+        return lines
+
+    def _metric_fragment(self, row: dict) -> str:
+        priority = (
+            "pattern",
+            "label",
+            "name",
+            "kernel_name",
+            "severity",
+            "total_ms",
+            "duration_ms",
+            "gap_ms",
+            "gap_ns",
+            "idle_pct",
+            "total_idle_ms",
+            "overlap_pct",
+            "nccl_only_ms",
+            "compute_only_ms",
+            "count",
+        )
+        parts = []
+        for key in priority:
+            if key in row and row[key] not in (None, ""):
+                parts.append(f"{key}={self._compact_value(row[key])}")
+            if len(parts) >= 3:
+                break
+        return ", ".join(parts) if parts else "row_present=true"
+
+    def _compact_value(self, value) -> str:
+        text = str(value)
+        return text if len(text) <= 120 else text[:117] + "..."
+
+    def _window_fragment(self, row: dict) -> str:
+        start = row.get("start_ns", row.get("gpu_start_ns"))
+        end = row.get("end_ns", row.get("gpu_end_ns"))
+        if start is not None and end is not None:
+            return f"{start}-{end}ns"
+        if row.get("start_ms") is not None and row.get("end_ms") is not None:
+            return f"{row['start_ms']}-{row['end_ms']}ms"
+        trim_start = self._trim_kwargs.get("trim_start_ns")
+        trim_end = self._trim_kwargs.get("trim_end_ns")
+        if trim_start is not None and trim_end is not None:
+            return f"{trim_start}-{trim_end}ns"
+        return "full profile"
+
+    def _scope_fragment(self, row: dict) -> str:
+        parts = []
+        for key in ("gpu_id", "device_id", "device", "rank", "stream_id", "communicator_hex"):
+            if key in row and row[key] not in (None, ""):
+                parts.append(f"{key}={row[key]}")
+        return ", ".join(parts) if parts else "profile"
+
+    def _choose_verify_skill(
+        self,
+        evidence: dict[str, list[dict]],
+        selected_skills: list[str],
+    ) -> str | None:
+        for skill_name in selected_skills:
+            rows = evidence.get(skill_name)
+            if rows:
+                return skill_name
+        for skill_name, rows in evidence.items():
+            if rows:
+                return skill_name
+        return None
+
+    def _verify_command(self, skill_name: str | None) -> str | None:
+        if not skill_name:
+            return None
+        cmd = [
+            "nsys-ai",
+            "skill",
+            "run",
+            skill_name,
+            self.profile_path,
+            "--format",
+            "json",
+        ]
+        trim_start = self._trim_kwargs.get("trim_start_ns")
+        trim_end = self._trim_kwargs.get("trim_end_ns")
+        if trim_start is not None and trim_end is not None:
+            cmd.extend(["--trim", f"{trim_start / 1e9:g}", f"{trim_end / 1e9:g}"])
+        return " ".join(shlex.quote(str(part)) for part in cmd)
 
     def _try_llm_synthesis(self, question: str, evidence: dict[str, list[dict]]) -> str | None:
         """Try to use an LLM to synthesize an answer from structured evidence.

--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -222,7 +222,9 @@ class Agent:
         Uses a two-stage process:
         1. Triage: Runs root_cause_matcher to gather baseline signals.
         2. Deep Dive: Uses an LLM to select targeted skills based on the triage signals,
-           executes them, and synthesizes a final response. If no LLM, falls back to keywords.
+           executes them, and synthesizes the Summary. If no LLM, falls back to keywords
+           and a deterministic Summary. The remaining answer sections are always built
+           deterministically from skill evidence.
         """
         # Use shared chat configuration to determine if an LLM is available
         try:
@@ -274,16 +276,17 @@ class Agent:
             except Exception as e:
                 log.debug("Skill '%s' failed: %s", skill_name, e, exc_info=True)
 
-        # Try LLM synthesis with combined structured evidence
-        llm_answer = None
+        # Ask the LLM for the summary that will be placed into the deterministic
+        # evidence-first answer shape below.
+        llm_summary = None
         if has_llm:
-            llm_answer = self._try_llm_synthesis(question, evidence)
+            llm_summary = self._try_llm_synthesis(question, evidence, summary_only=True)
 
         answer = self._format_evidence_first_answer(
             question,
             evidence,
             selected_skills=[triage_skill, *selected],
-            llm_answer=llm_answer,
+            llm_summary=llm_summary,
         )
         return answer
 
@@ -354,7 +357,7 @@ class Agent:
         question: str,
         evidence: dict[str, list[dict]],
         selected_skills: list[str],
-        llm_answer: str | None = None,
+        llm_summary: str | None = None,
     ) -> str:
         """Build the fixed answer shape required by issue #205."""
         selected_skills = list(dict.fromkeys(skill for skill in selected_skills if skill))
@@ -366,24 +369,7 @@ class Agent:
         verify_skill = self._choose_verify_skill(evidence, selected_skills)
         verify_command = self._verify_command(verify_skill)
 
-        if llm_answer:
-            summary = (
-                "Ran targeted skills and generated a grounded answer from their structured "
-                "outputs; model synthesis was available, but the final answer is constrained "
-                "to the evidence-first template."
-            )
-        else:
-            ran = ", ".join(skill for skill in selected_skills if skill)
-            if ran:
-                summary = (
-                    f"Ran {ran} against the profile and summarized the strongest supported "
-                    "signal in a verification-friendly format."
-                )
-            else:
-                summary = (
-                    "No skill returned usable evidence, so the answer is limited to a "
-                    "verification fallback."
-                )
+        summary = self._answer_summary(selected_skills, llm_summary)
 
         lines = [
             "## Summary",
@@ -423,6 +409,39 @@ class Agent:
             lines.append("`nsys-ai skill list`")
         return "\n".join(lines)
 
+    def _answer_summary(
+        self,
+        selected_skills: list[str],
+        llm_summary: str | None,
+    ) -> str:
+        """Return model synthesis when available, otherwise a deterministic summary."""
+        if llm_summary:
+            lines = [line.strip() for line in str(llm_summary).strip().splitlines()]
+            if lines and lines[0].lower().lstrip("#").strip() == "summary":
+                lines = lines[1:]
+
+            summary_lines = []
+            for line in lines:
+                if line.startswith("#"):
+                    break
+                if line:
+                    summary_lines.append(line)
+
+            summary = " ".join(summary_lines)
+            if summary and not summary.startswith("(LLM synthesis failed:"):
+                return summary
+
+        ran = ", ".join(skill for skill in selected_skills if skill)
+        if ran:
+            return (
+                f"Ran {ran} against the profile and summarized the strongest supported "
+                "signal in a verification-friendly format."
+            )
+        return (
+            "No skill returned usable evidence, so the answer is limited to a "
+            "verification fallback."
+        )
+
     def _first_actionable_row(self, rows: list[dict]) -> dict | None:
         for row in rows:
             pattern = str(row.get("pattern", ""))
@@ -461,7 +480,25 @@ class Agent:
     def _confidence_label(self, evidence: dict[str, list[dict]], diagnosis_row: dict | None) -> str:
         row_count = sum(len(rows) for rows in evidence.values())
         if diagnosis_row and row_count:
-            return "0.75 (medium-high): at least one root-cause matcher finding is backed by skill output."
+            severity = str(diagnosis_row.get("severity", "")).strip().lower()
+            confidence_by_severity = {
+                "critical": (
+                    "0.90 (high): a critical root-cause matcher finding is backed by skill output."
+                ),
+                "warning": (
+                    "0.75 (medium-high): a warning root-cause matcher finding is backed by "
+                    "skill output."
+                ),
+                "info": (
+                    "0.55 (medium): an informational root-cause matcher finding is backed by "
+                    "skill output."
+                ),
+            }
+            return confidence_by_severity.get(
+                severity,
+                "0.65 (medium): a root-cause matcher finding is backed by skill output, "
+                "but its severity is unknown.",
+            )
         if row_count:
             return "0.60 (medium): skill output exists, but no root-cause matcher finding dominated."
         return "0.20 (low): no skill returned usable evidence."
@@ -569,12 +606,20 @@ class Agent:
             cmd.extend(["--trim", f"{trim_start / 1e9:g}", f"{trim_end / 1e9:g}"])
         return " ".join(shlex.quote(str(part)) for part in cmd)
 
-    def _try_llm_synthesis(self, question: str, evidence: dict[str, list[dict]]) -> str | None:
+    def _try_llm_synthesis(
+        self,
+        question: str,
+        evidence: dict[str, list[dict]],
+        *,
+        summary_only: bool = False,
+    ) -> str | None:
         """Try to use an LLM to synthesize an answer from structured evidence.
 
         Args:
             question: The question to answer.
             evidence: Dict mapping skill names to their JSON-serializable results.
+            summary_only: Return one concise summary paragraph for ``ask()``'s
+                deterministic answer formatter.
 
         Returns None if no LLM available.
         """
@@ -604,10 +649,22 @@ class Agent:
                 return "You are an expert GPU profiling assistant."
 
         evidence_json = json.dumps(evidence, indent=2, default=str)
+        response_instruction = ""
+        max_tokens = 2048
+        if summary_only:
+            response_instruction = (
+                "\n\nReturn only one concise executive-summary paragraph grounded in the "
+                "provided evidence. Do not include a heading or any other answer sections; "
+                "the caller will add the diagnosis, evidence, confidence, action, and verify "
+                "sections deterministically."
+            )
+            max_tokens = 256
+
         user_msg = (
             f"Profile analysis data (structured JSON):\n"
             f"```json\n{evidence_json}\n```\n\n"
             f"Based on this data, answer the following question:\n{question}"
+            f"{response_instruction}"
         )
 
         # Try litellm first (supports Gemini, OpenAI, Anthropic, etc.)
@@ -632,7 +689,7 @@ class Agent:
                         {"role": "system", "content": system},
                         {"role": "user", "content": user_msg},
                     ],
-                    max_tokens=2048,
+                    max_tokens=max_tokens,
                 )
                 return resp.choices[0].message.content
         except ImportError:
@@ -657,7 +714,7 @@ class Agent:
             client = anthropic.Anthropic(api_key=api_key)
             message = client.messages.create(
                 model="claude-sonnet-4-20250514",
-                max_tokens=2048,
+                max_tokens=max_tokens,
                 system=system,
                 messages=[{"role": "user", "content": user_msg}],
             )

--- a/src/nsys_ai/agent/persona.md
+++ b/src/nsys_ai/agent/persona.md
@@ -98,16 +98,22 @@ You have internalized the Book of Root Causes — common GPU performance problem
 
 # Output Format
 
-Structure your analysis as:
+Every final answer must use this evidence-first shape:
 
 ## Summary
 One-paragraph executive summary.
 
-## Evidence
-Table of key findings with specific numbers.
-
-## Diagnosis
+## Primary Diagnosis
 Root cause identification with confidence level.
 
-## Recommendations
-Prioritized action items, each with expected impact.
+## Evidence
+Bullets or a compact table. Each line must name the source skill, the metric/value, and the time window, GPU, rank, stream, or profile scope that locates the evidence.
+
+## Confidence
+Numeric or low/medium/high confidence with the reason.
+
+## Recommended Action
+Prioritized action with expected impact.
+
+## Verify
+End with a runnable command that verifies the diagnosis, usually `nsys-ai skill run <skill> <profile.sqlite> --format json`. If you cannot build a runnable command, say why and emit the relevant help command instead, such as `nsys-ai skill list`.

--- a/src/nsys_ai/agent/persona.md
+++ b/src/nsys_ai/agent/persona.md
@@ -98,7 +98,11 @@ You have internalized the Book of Root Causes — common GPU performance problem
 
 # Output Format
 
-Every final answer must use this evidence-first shape:
+For targeted `agent ask` synthesis, return the concise evidence-grounded Summary
+paragraph requested by the caller. The deterministic formatter adds the remaining
+sections and runnable verification command from the skill output.
+
+For full analysis synthesis, use this evidence-first shape:
 
 ## Summary
 One-paragraph executive summary.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -70,3 +70,44 @@ def test_agent_run_skill(minimal_nsys_db_path):
         assert isinstance(result, str)
     finally:
         agent.close()
+
+
+def test_agent_ask_uses_evidence_first_template(minimal_nsys_db_path, monkeypatch):
+    """Targeted answers should be grounded and end with a runnable verify command."""
+    from nsys_ai.agent.loop import Agent
+
+    monkeypatch.setattr("nsys_ai.chat_config._get_model_and_key", lambda: (None, None))
+
+    agent = Agent(minimal_nsys_db_path)
+    try:
+        answer = agent.ask("why is this slow?")
+    finally:
+        agent.close()
+
+    assert answer.startswith("## Summary")
+    for heading in (
+        "## Primary Diagnosis",
+        "## Evidence",
+        "## Confidence",
+        "## Recommended Action",
+        "## Verify",
+    ):
+        assert heading in answer
+    assert "source_skill=" in answer
+    assert "window=" in answer
+    assert "`nsys-ai skill run" in answer
+    assert answer.strip().splitlines()[-1].startswith("`nsys-ai skill run")
+
+
+def test_agent_verify_fallback_when_no_skill_evidence(minimal_nsys_db_path):
+    from nsys_ai.agent.loop import Agent
+
+    agent = Agent(minimal_nsys_db_path)
+    try:
+        answer = agent._format_evidence_first_answer("what happened?", {}, [])
+    finally:
+        agent.close()
+
+    assert "Could not build a runnable verification command" in answer
+    assert "`nsys-ai skill list`" in answer
+    assert answer.strip().splitlines()[-1] == "`nsys-ai skill list`"

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -99,6 +99,66 @@ def test_agent_ask_uses_evidence_first_template(minimal_nsys_db_path, monkeypatc
     assert answer.strip().splitlines()[-1].startswith("`nsys-ai skill run")
 
 
+def test_agent_ask_includes_llm_synthesis(minimal_nsys_db_path, monkeypatch):
+    """A paid synthesis result should be used as the answer Summary."""
+    from nsys_ai.agent.loop import Agent
+
+    monkeypatch.setattr(
+        "nsys_ai.chat_config._get_model_and_key",
+        lambda: ("test-model", "test-key"),
+    )
+    monkeypatch.setattr(
+        Agent,
+        "_try_llm_triage",
+        lambda self, question, evidence: ["top_kernels"],
+    )
+    synthesis_call = {}
+
+    def fake_synthesis(self, question, evidence, *, summary_only=False):
+        synthesis_call["question"] = question
+        synthesis_call["evidence"] = evidence
+        synthesis_call["summary_only"] = summary_only
+        return "The model synthesized this grounded performance summary."
+
+    monkeypatch.setattr(Agent, "_try_llm_synthesis", fake_synthesis)
+
+    agent = Agent(minimal_nsys_db_path)
+    try:
+        answer = agent.ask("why is this slow?")
+    finally:
+        agent.close()
+
+    assert answer.startswith(
+        "## Summary\nThe model synthesized this grounded performance summary."
+    )
+    assert synthesis_call["question"] == "why is this slow?"
+    assert synthesis_call["evidence"]
+    assert synthesis_call["summary_only"] is True
+    assert answer.strip().splitlines()[-1].startswith("`nsys-ai skill run")
+
+
+def test_agent_confidence_reflects_root_cause_severity(minimal_nsys_db_path):
+    """Critical, warning, and info findings should not report the same confidence."""
+    from nsys_ai.agent.loop import Agent
+
+    agent = Agent(minimal_nsys_db_path)
+    try:
+        confidence = {}
+        for severity in ("critical", "warning", "info"):
+            row = {"pattern": "Test finding", "severity": severity}
+            confidence[severity] = agent._confidence_label(
+                {"root_cause_matcher": [row]},
+                row,
+            )
+    finally:
+        agent.close()
+
+    assert confidence["critical"].startswith("0.90 (high)")
+    assert confidence["warning"].startswith("0.75 (medium-high)")
+    assert confidence["info"].startswith("0.55 (medium)")
+    assert len(set(confidence.values())) == 3
+
+
 def test_agent_verify_fallback_when_no_skill_evidence(minimal_nsys_db_path):
     from nsys_ai.agent.loop import Agent
 


### PR DESCRIPTION
Closes #205.

## Summary
- Make `nsys-ai agent ask` return a fixed evidence-first answer shape: Summary, Primary Diagnosis, Evidence, Confidence, Recommended Action, Verify.
- Ground each evidence line with `source_skill`, metric/value, time window, and scope such as GPU/rank/stream when available, falling back to profile scope.
- Ensure the answer ends with a runnable verification command, or with `nsys-ai skill list` when no evidence-backed command can be built.
- Update the agent persona and README to document the answer contract.

## Verification
- `uv run pytest -q`
- `uv run pytest tests/test_agent.py -q`
- `uv run ruff check src/nsys_ai/agent/loop.py tests/test_agent.py`
- `git diff --check`
- Dogfooded: `uv run python -m nsys_ai agent ask tests/fixtures/mock.sqlite "why is this slow?"`