### PR TITLE
feat(diff): serialize DiffLineage onto diff.json (closes #179)

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -517,6 +517,7 @@ def _cmd_report(args, _profile):
 
 def _cmd_diff(args, _profile):
     from nsys_ai.diff import STEP_TIME_REGRESSION_PCT, diff_profiles
+    from nsys_ai.diff_decision import write_diff_decision_json
     from nsys_ai.diff_render import (
         format_diff_markdown,
         format_diff_markdown_multi,
@@ -530,6 +531,27 @@ def _cmd_diff(args, _profile):
     gate_summary = None
     gate_pct = getattr(args, "gate", None)
     regression_pct = gate_pct if gate_pct is not None else STEP_TIME_REGRESSION_PCT
+    decision = None
+    if getattr(args, "accept", False):
+        decision = "accepted"
+    elif getattr(args, "reject", False):
+        decision = "rejected"
+    reason = getattr(args, "reason", None)
+    if decision is not None:
+        if getattr(args, "chat", False):
+            print("Error: --accept/--reject cannot be used with --chat", file=sys.stderr)
+            sys.exit(2)
+        if not reason or not reason.strip():
+            print("Error: --reason is required with --accept/--reject", file=sys.stderr)
+            sys.exit(2)
+        if getattr(args, "output", None) and os.path.abspath(args.output) == os.path.abspath(
+            "diff.json"
+        ):
+            print(
+                "Error: --output diff.json conflicts with the decision record path",
+                file=sys.stderr,
+            )
+            sys.exit(2)
 
     def _narrative_for(summary):
         if args.format not in ("terminal", "markdown"):
@@ -660,6 +682,21 @@ def _cmd_diff(args, _profile):
                 out = to_diff_json(global_summary)
             else:
                 raise RuntimeError(f"Unknown format: {args.format}")
+
+    if decision is not None and gate_summary is not None:
+        try:
+            decision_path, _, decision_warnings = write_diff_decision_json(
+                gate_summary,
+                decision=decision,
+                reason=reason or "",
+                path="diff.json",
+            )
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(2)
+        for warning in decision_warnings:
+            print(f"Warning: {warning}", file=sys.stderr)
+        print(f"Diff decision written to {decision_path}", file=sys.stderr)
 
     if args.output:
         out_dir = os.path.dirname(args.output)

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -431,6 +431,22 @@ def _build_parser():
         help="Step-time regression threshold in percent for the verdict and CI gate "
         "(implies --exit-on-regression; default: 5.0)",
     )
+    decision = p.add_mutually_exclusive_group()
+    decision.add_argument(
+        "--accept",
+        action="store_true",
+        help="Persist an accepted user decision to diff.json (requires --reason)",
+    )
+    decision.add_argument(
+        "--reject",
+        action="store_true",
+        help="Persist a rejected user decision to diff.json (requires --reason)",
+    )
+    p.add_argument(
+        "--reason",
+        default=None,
+        help="Reason text required when using --accept or --reject",
+    )
     p.set_defaults(handler=_cmd_diff)
 
     p = sub.add_parser("diff-web", help="Serve web diff viewer for two profiles")

--- a/src/nsys_ai/diff_decision.py
+++ b/src/nsys_ai/diff_decision.py
@@ -1,0 +1,110 @@
+"""
+diff_decision.py - Persist auditable user decisions for profile diffs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess  # nosec B404
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .diff import MIN_COMPARABILITY_CONFIDENCE, ProfileDiffSummary
+from .diff_render import to_diff_dict
+
+
+def resolve_decider_identity(cwd: str | os.PathLike[str] | None = None) -> str:
+    """Resolve the decider identity from git config, falling back to USER."""
+    try:
+        result = subprocess.run(  # nosec B603 B607
+            ["git", "config", "user.email"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        result = None
+
+    if result is not None and result.returncode == 0:
+        email = result.stdout.strip()
+        if email:
+            return email
+
+    return os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def build_diff_decision_record(
+    summary: ProfileDiffSummary,
+    *,
+    decision: str,
+    reason: str,
+    decider: str | None = None,
+    decided_at: str | None = None,
+) -> tuple[dict, list[str]]:
+    """Build the byte-stable diff.json payload and return advisory warnings."""
+    normalized_decision = decision.strip().lower()
+    if normalized_decision not in {"accepted", "rejected"}:
+        raise ValueError("decision must be 'accepted' or 'rejected'")
+
+    normalized_reason = reason.strip()
+    if not normalized_reason:
+        raise ValueError("--reason is required with --accept/--reject")
+
+    if not summary.before.profile_id or not summary.after.profile_id:
+        raise ValueError("cannot write diff decision without before and after profile_id")
+
+    payload = to_diff_dict(summary)
+    warnings = list(payload.get("warnings") or [])
+    advisory_warnings: list[str] = []
+
+    if summary.comparability_confidence < MIN_COMPARABILITY_CONFIDENCE:
+        warning = (
+            "comparability_confidence "
+            f"{summary.comparability_confidence:.3f} is below "
+            f"{MIN_COMPARABILITY_CONFIDENCE:.3f}; stamping verdict as inconclusive"
+        )
+        if warning not in warnings:
+            warnings.append(warning)
+        advisory_warnings.append(warning)
+        payload["verdict"] = "inconclusive"
+
+    payload["warnings"] = warnings
+    payload["decision"] = {
+        "status": normalized_decision,
+        "reason": normalized_reason,
+        "decider": decider or resolve_decider_identity(),
+        "decided_at": decided_at or _utc_now_iso(),
+    }
+    return payload, advisory_warnings
+
+
+def write_diff_decision_json(
+    summary: ProfileDiffSummary,
+    *,
+    decision: str,
+    reason: str,
+    path: str | os.PathLike[str] = "diff.json",
+    decider: str | None = None,
+    decided_at: str | None = None,
+) -> tuple[Path, dict, list[str]]:
+    """Write a diff decision record using the shared deterministic JSON encoding."""
+    payload, warnings = build_diff_decision_record(
+        summary,
+        decision=decision,
+        reason=reason,
+        decider=decider,
+        decided_at=decided_at,
+    )
+    out_path = Path(path)
+    if out_path.parent != Path("."):
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    with open(out_path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(text)
+    return out_path, payload, warnings

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -560,9 +560,9 @@ def format_diff_markdown_multi(
     return "\n".join(md).rstrip() + "\n"
 
 
-def to_diff_json(data: ProfileDiffSummary) -> str:
+def to_diff_dict(data: ProfileDiffSummary) -> dict:
     # Keep this relatively stable; tests can snapshot it.
-    payload = {
+    return {
         "schema_version": SCHEMA_VERSION,
         "producer": PRODUCER,
         "producer_version": _producer_version(),
@@ -683,4 +683,8 @@ def to_diff_json(data: ProfileDiffSummary) -> str:
             "delta": data.overlap_delta,
         },
     }
+
+
+def to_diff_json(data: ProfileDiffSummary) -> str:
+    payload = to_diff_dict(data)
     return json.dumps(payload, indent=2, sort_keys=True) + "\n"

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 
 from .ai.diff_narrative import DiffNarrative
-from .annotation import PRODUCER, SCHEMA_VERSION, _producer_version
+from .annotation import PRODUCER, SCHEMA_VERSION, DiffLineage, _producer_version
 from .diff import ProfileDiffSummary
 
 
@@ -83,6 +83,15 @@ _AXIS_ENTRY_FOOTNOTE = (
     "per-item values are raw component time and can exceed the total above when "
     "compute, communication, and idle overlap"
 )
+
+
+def _diff_lineage_to_dict(data: ProfileDiffSummary, role: str, rank: int) -> dict:
+    return DiffLineage(
+        diff_id=data.diff_id,
+        role=role,
+        rank=rank,
+        baseline_profile_id=data.before.profile_id,
+    ).to_dict()
 
 
 def format_diff_terminal(
@@ -625,8 +634,9 @@ def to_diff_dict(data: ProfileDiffSummary) -> dict:
                 "after_share": k.after_share,
                 "delta_share": k.delta_share,
                 "selection": k.selection.to_dict() if k.selection else None,
+                "diff_lineage": _diff_lineage_to_dict(data, "regression", rank),
             }
-            for k in data.top_regressions
+            for rank, k in enumerate(data.top_regressions)
         ],
         "top_improvements": [
             {
@@ -643,8 +653,9 @@ def to_diff_dict(data: ProfileDiffSummary) -> dict:
                 "after_share": k.after_share,
                 "delta_share": k.delta_share,
                 "selection": k.selection.to_dict() if k.selection else None,
+                "diff_lineage": _diff_lineage_to_dict(data, "improvement", rank),
             }
-            for k in data.top_improvements
+            for rank, k in enumerate(data.top_improvements)
         ],
         "nvtx_regressions": [
             {

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,7 +1,9 @@
 import json
+import os
 import sqlite3
 import subprocess
 import sys
+from dataclasses import replace
 
 
 def _make_db_with_target_info(path: str, gpu_name: str = "NVIDIA A100-SXM4-80GB"):
@@ -838,12 +840,30 @@ def test_diff_cli_exit_on_regression_allows_inconclusive(tmp_path):
     assert "Diff gate failed" not in result.stderr
 
 
-def _run_diff_cli(before, after, *extra):
+def _run_diff_cli(before, after, *extra, cwd=None, env=None):
     return subprocess.run(
         [sys.executable, "-m", "nsys_ai", "diff", str(before), str(after), "--gpu", "0", *extra],
         capture_output=True,
+        cwd=cwd,
+        env=env,
         text=True,
     )
+
+
+def _decision_cli_env(tmp_path):
+    env = os.environ.copy()
+    src_path = os.path.abspath("src")
+    env["PYTHONPATH"] = (
+        src_path
+        if not env.get("PYTHONPATH")
+        else os.pathsep.join([src_path, env["PYTHONPATH"]])
+    )
+    empty_gitconfig = tmp_path / "empty.gitconfig"
+    empty_gitconfig.write_text("", encoding="utf-8")
+    env["GIT_CONFIG_NOSYSTEM"] = "1"
+    env["GIT_CONFIG_GLOBAL"] = str(empty_gitconfig)
+    env["USER"] = "fallback-user"
+    return env
 
 
 def test_diff_cli_gate_help_and_validation(tmp_path):
@@ -900,6 +920,161 @@ def test_diff_cli_gate_loosens_threshold(tmp_path):
     assert loose.returncode == 0, loose.stderr
     assert json.loads(loose.stdout)["verdict"] == "neutral"
     assert "Diff gate failed" not in loose.stderr
+
+
+def test_diff_cli_decision_help():
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--accept" in result.stdout
+    assert "--reject" in result.stdout
+    assert "--reason" in result.stdout
+
+
+def test_diff_cli_accept_writes_stable_decision_json(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--format",
+        "json",
+        "--accept",
+        "--reason",
+        "candidate is faster",
+        cwd=tmp_path,
+        env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    diff_path = tmp_path / "diff.json"
+    assert diff_path.exists()
+    record = json.loads(diff_path.read_text(encoding="utf-8"))
+    stdout_payload = json.loads(result.stdout)
+
+    assert record["diff_id"] == stdout_payload["diff_id"]
+    assert record["verdict"] == stdout_payload["verdict"]
+    assert record["comparability_confidence"] == stdout_payload["comparability_confidence"]
+    assert record["category_attribution"] == stdout_payload["category_attribution"]
+    assert record["before"]["profile_id"].startswith("nsys1:")
+    assert record["after"]["profile_id"].startswith("nsys1:")
+    assert record["decision"]["status"] == "accepted"
+    assert record["decision"]["reason"] == "candidate is faster"
+    assert record["decision"]["decider"] == "fallback-user"
+    assert record["decision"]["decided_at"].endswith("Z")
+    assert diff_path.read_text(encoding="utf-8") == json.dumps(
+        record, indent=2, sort_keys=True
+    ) + "\n"
+    assert "Diff decision written to diff.json" in result.stderr
+
+
+def test_diff_cli_reject_writes_decision_status(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 12_000_000, 0, 7, 1, 1, 2)])
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--reject",
+        "--reason",
+        "regression is too large",
+        cwd=tmp_path,
+        env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    record = json.loads((tmp_path / "diff.json").read_text(encoding="utf-8"))
+    assert record["decision"]["status"] == "rejected"
+    assert record["decision"]["reason"] == "regression is too large"
+
+
+def test_diff_cli_decision_missing_reason_is_refused(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--accept",
+        cwd=tmp_path,
+        env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 2
+    assert "--reason is required" in result.stderr
+    assert not (tmp_path / "diff.json").exists()
+
+
+def test_diff_cli_decision_low_comparability_stamps_inconclusive(tmp_path):
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(
+        str(after),
+        kernels=[
+            (0, 12_000_000, 0, 7, 1, 1, 2),
+            (12_000_000, 24_000_000, 0, 7, 2, 1, 2),
+            (24_000_000, 36_000_000, 0, 7, 3, 1, 2),
+        ],
+    )
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--format",
+        "json",
+        "--accept",
+        "--reason",
+        "ship despite mismatch",
+        cwd=tmp_path,
+        env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    record = json.loads((tmp_path / "diff.json").read_text(encoding="utf-8"))
+    assert record["decision"]["status"] == "accepted"
+    assert record["verdict"] == "inconclusive"
+    assert record["comparability_confidence"] < 0.5
+    assert any("stamping verdict as inconclusive" in w for w in record["warnings"])
+    assert "Warning: comparability_confidence" in result.stderr
+
+
+def test_diff_decision_requires_profile_ids(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.diff_decision import build_diff_decision_record
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        summary = diff_profiles(b, a, gpu=0)
+
+    missing_before_id = replace(summary, before=replace(summary.before, profile_id=""))
+    try:
+        build_diff_decision_record(
+            missing_before_id,
+            decision="accepted",
+            reason="candidate is faster",
+            decider="tester@example.com",
+            decided_at="2026-06-18T00:00:00Z",
+        )
+    except ValueError as exc:
+        assert "profile_id" in str(exc)
+    else:
+        raise AssertionError("expected missing profile_id to be refused")
 
 
 def test_compute_verdict_custom_regression_pct():

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -996,6 +996,54 @@ def test_diff_cli_reject_writes_decision_status(tmp_path):
     assert record["decision"]["reason"] == "regression is too large"
 
 
+def test_diff_cli_decision_json_carries_lineage_for_top_regressions(tmp_path):
+    from nsys_ai.annotation import DiffLineage
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(
+        str(before),
+        kernels=[
+            (0, 10_000_000, 0, 7, 1, 1, 2),
+            (10_000_000, 20_000_000, 0, 7, 2, 3, 4),
+        ],
+    )
+    _make_profile(
+        str(after),
+        kernels=[
+            (0, 20_000_000, 0, 7, 1, 1, 2),
+            (20_000_000, 35_000_000, 0, 7, 2, 3, 4),
+        ],
+    )
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--format",
+        "json",
+        "--limit",
+        "2",
+        "--accept",
+        "--reason",
+        "regressions are expected",
+        cwd=tmp_path,
+        env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    record = json.loads((tmp_path / "diff.json").read_text(encoding="utf-8"))
+    regressions = record["top_regressions"]
+    assert len(regressions) == 2
+    for rank, row in enumerate(regressions):
+        lineage = row["diff_lineage"]
+        restored = DiffLineage.from_dict(lineage)
+        assert restored.to_dict() == lineage
+        assert lineage["diff_id"] == record["diff_id"]
+        assert lineage["role"] == "regression"
+        assert lineage["rank"] == rank
+        assert lineage["baseline_profile_id"] == record["before"]["profile_id"]
+
+
 def test_diff_cli_decision_missing_reason_is_refused(tmp_path):
     before = tmp_path / "before.sqlite"
     after = tmp_path / "after.sqlite"


### PR DESCRIPTION
## Summary
Each top diff entry now names the diff it came from. `to_diff_dict` attaches a `diff_lineage` block to every `top_regressions` / `top_improvements` entry: `diff_id`, `role` (regression / improvement), 0-indexed `rank` within the top
list, and `baseline_profile_id` (the before profile). Reuses the existing `DiffLineage` dataclass; flows into both the `--format json` envelope and the `diff.json` decision record (#177).

> **Stacked on #213 (#177).** It rides the `to_diff_dict` writer that #213 introduces, so this PR currently also shows #213's commit. Best reviewed together with #213; once #213 merges, the diff collapses to just the lineage change. 

## Test plan
- [x] New test: a 2-regression diff writes `diff.json`; each top_regression carries a `diff_lineage` that round-trips via `DiffLineage.from_dict`, with correct `diff_id` / `role` / `rank` / `baseline_profile_id`
- [x] `pytest tests/` → 1074 passed; ruff clean