### PR TITLE
feat(loop): persist diff accept/reject decisions across web and TUI surfaces

### DIFF
--- a/src/nsys_ai/diff_decision.py
+++ b/src/nsys_ai/diff_decision.py
@@ -4,6 +4,7 @@ diff_decision.py - Persist auditable user decisions for profile diffs.
 
 from __future__ import annotations
 
+import copy
 import json
 import os
 import subprocess  # nosec B404
@@ -39,15 +40,21 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
-def build_diff_decision_record(
-    summary: ProfileDiffSummary,
+def build_diff_decision_record_from_diff_dict(
+    diff_dict: dict,
     *,
     decision: str,
     reason: str,
     decider: str | None = None,
     decided_at: str | None = None,
 ) -> tuple[dict, list[str]]:
-    """Build the byte-stable diff.json payload and return advisory warnings."""
+    """Build the byte-stable diff.json payload from a ``to_diff_dict`` mapping.
+
+    Shared by the CLI (which renders the mapping from a fresh ``ProfileDiffSummary``)
+    and the web guided loop (which already holds the diff payload in loop state), so
+    both surfaces emit byte-identical decision records for the same diff. The input
+    mapping is copied, never mutated.
+    """
     normalized_decision = decision.strip().lower()
     if normalized_decision not in {"accepted", "rejected"}:
         raise ValueError("decision must be 'accepted' or 'rejected'")
@@ -56,17 +63,20 @@ def build_diff_decision_record(
     if not normalized_reason:
         raise ValueError("--reason is required with --accept/--reject")
 
-    if not summary.before.profile_id or not summary.after.profile_id:
+    before_id = (diff_dict.get("before") or {}).get("profile_id")
+    after_id = (diff_dict.get("after") or {}).get("profile_id")
+    if not before_id or not after_id:
         raise ValueError("cannot write diff decision without before and after profile_id")
 
-    payload = to_diff_dict(summary)
+    payload = copy.deepcopy(diff_dict)
     warnings = list(payload.get("warnings") or [])
     advisory_warnings: list[str] = []
 
-    if summary.comparability_confidence < MIN_COMPARABILITY_CONFIDENCE:
+    confidence = payload.get("comparability_confidence")
+    if isinstance(confidence, (int, float)) and confidence < MIN_COMPARABILITY_CONFIDENCE:
         warning = (
             "comparability_confidence "
-            f"{summary.comparability_confidence:.3f} is below "
+            f"{confidence:.3f} is below "
             f"{MIN_COMPARABILITY_CONFIDENCE:.3f}; stamping verdict as inconclusive"
         )
         if warning not in warnings:
@@ -82,6 +92,35 @@ def build_diff_decision_record(
         "decided_at": decided_at or _utc_now_iso(),
     }
     return payload, advisory_warnings
+
+
+def build_diff_decision_record(
+    summary: ProfileDiffSummary,
+    *,
+    decision: str,
+    reason: str,
+    decider: str | None = None,
+    decided_at: str | None = None,
+) -> tuple[dict, list[str]]:
+    """Build the byte-stable diff.json payload and return advisory warnings."""
+    return build_diff_decision_record_from_diff_dict(
+        to_diff_dict(summary),
+        decision=decision,
+        reason=reason,
+        decider=decider,
+        decided_at=decided_at,
+    )
+
+
+def _write_decision_payload(payload: dict, path: str | os.PathLike[str]) -> Path:
+    """Serialize a decision payload deterministically and write it to ``path``."""
+    out_path = Path(path)
+    if out_path.parent != Path("."):
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    with open(out_path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(text)
+    return out_path
 
 
 def write_diff_decision_json(
@@ -101,10 +140,24 @@ def write_diff_decision_json(
         decider=decider,
         decided_at=decided_at,
     )
-    out_path = Path(path)
-    if out_path.parent != Path("."):
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
-    with open(out_path, "w", encoding="utf-8", newline="\n") as f:
-        f.write(text)
-    return out_path, payload, warnings
+    return _write_decision_payload(payload, path), payload, warnings
+
+
+def write_diff_decision_json_from_diff_dict(
+    diff_dict: dict,
+    *,
+    decision: str,
+    reason: str,
+    path: str | os.PathLike[str] = "diff.json",
+    decider: str | None = None,
+    decided_at: str | None = None,
+) -> tuple[Path, dict, list[str]]:
+    """Write a decision record from a stored diff payload (see the dict builder)."""
+    payload, warnings = build_diff_decision_record_from_diff_dict(
+        diff_dict,
+        decision=decision,
+        reason=reason,
+        decider=decider,
+        decided_at=decided_at,
+    )
+    return _write_decision_payload(payload, path), payload, warnings

--- a/src/nsys_ai/loop_state.py
+++ b/src/nsys_ai/loop_state.py
@@ -7,6 +7,7 @@ diagnose -> propose -> reprofile -> diff -> accept.
 from __future__ import annotations
 
 import json
+import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -161,6 +162,8 @@ class DiffLoopState:
     expected_impact: str = ""
     decision: Decision | None = None
     decision_reason: str = ""
+    decision_path: str = ""
+    decision_warnings: list[str] = field(default_factory=list)
     diagnose_ran: bool = False
     diagnose_findings_count: int = 0
     top_findings: list[dict[str, Any]] = field(default_factory=list)
@@ -182,6 +185,8 @@ class DiffLoopState:
             "expected_impact": self.expected_impact,
             "decision": self.decision,
             "decision_reason": self.decision_reason,
+            "decision_path": self.decision_path,
+            "decision_warnings": self.decision_warnings,
             "diagnose_ran": self.diagnose_ran,
             "diagnose_findings_count": self.diagnose_findings_count,
             "top_findings": self.top_findings,
@@ -202,6 +207,8 @@ class DiffLoopState:
             expected_impact=str(payload.get("expected_impact") or ""),
             decision=payload.get("decision"),
             decision_reason=str(payload.get("decision_reason") or ""),
+            decision_path=str(payload.get("decision_path") or ""),
+            decision_warnings=list(payload.get("decision_warnings") or []),
             diagnose_ran=bool(payload.get("diagnose_ran")),
             diagnose_findings_count=int(payload.get("diagnose_findings_count") or 0),
             top_findings=list(payload.get("top_findings") or []),
@@ -320,10 +327,48 @@ class DiffLoopState:
         self.last_error = ""
         return payload
 
-    def set_decision(self, decision: Decision, reason: str = "") -> None:
+    def set_decision(
+        self,
+        decision: Decision,
+        reason: str = "",
+        *,
+        decision_dir: str | os.PathLike[str] | None = None,
+        decider: str | None = None,
+        decided_at: str | None = None,
+    ) -> tuple[dict[str, Any], list[str]]:
+        """Record an accept/reject decision and persist the shared diff.json record.
+
+        The record is written with the same encoder the CLI uses, so a decision
+        made in the web loop is byte-identical to ``diff --accept/--reject --reason``
+        for the same diff. Returns the written payload and any advisory warnings.
+        """
         if decision not in ("accept", "reject"):
             raise ValueError("decision must be 'accept' or 'reject'")
+        if self.diff_summary is None:
+            raise ValueError("run diff before recording a decision")
+        normalized_reason = (reason or "").strip()
+        if not normalized_reason:
+            raise ValueError("a decision reason is required")
+
+        from .diff_decision import write_diff_decision_json_from_diff_dict
+
+        status = "accepted" if decision == "accept" else "rejected"
+        out_path = Path(decision_dir) / "diff.json" if decision_dir else Path("diff.json")
+        written_path, payload, warnings = write_diff_decision_json_from_diff_dict(
+            self.diff_summary,
+            decision=status,
+            reason=normalized_reason,
+            path=out_path,
+            decider=decider,
+            decided_at=decided_at,
+        )
         self.decision = decision
-        self.decision_reason = (reason or "").strip()
+        self.decision_reason = normalized_reason
+        self.decision_path = str(written_path)
+        self.decision_warnings = list(warnings)
+        # Reflect verdict stamping (e.g. low-comparability -> inconclusive) so the
+        # surfaced state agrees with the persisted record.
+        self.verdict = str(payload.get("verdict") or self.verdict)
         self.phase = "accept"
         self.last_error = ""
+        return payload, warnings

--- a/src/nsys_ai/templates/timeline.css
+++ b/src/nsys_ai/templates/timeline.css
@@ -1408,6 +1408,38 @@
             gap: 8px;
         }
 
+        .loop-decide .ldecide-reason-label {
+            display: block;
+            font-size: 11px;
+            opacity: 0.75;
+            margin: 4px 0 4px;
+        }
+
+        .loop-decide .ldecide-reason {
+            width: 100%;
+            box-sizing: border-box;
+            resize: vertical;
+            margin-bottom: 8px;
+            font: inherit;
+            font-size: 12px;
+            color: inherit;
+            background: rgba(255, 255, 255, 0.04);
+            border: 1px solid rgba(255, 255, 255, 0.15);
+            border-radius: 4px;
+            padding: 6px 8px;
+        }
+
+        .loop-decide .ldecide-path {
+            margin-top: 8px;
+            font-size: 11px;
+            opacity: 0.8;
+            word-break: break-all;
+        }
+
+        .loop-decide .ldecide-path.hidden {
+            display: none;
+        }
+
         .laccept {
             border-color: rgba(63, 185, 80, 0.5) !important;
             color: #aff5b4 !important;

--- a/src/nsys_ai/templates/timeline.html
+++ b/src/nsys_ai/templates/timeline.html
@@ -178,10 +178,13 @@
                 </section>
                 <section class="loop-section loop-card loop-decide" id="loopDecideSection">
                     <div class="loop-section-title">Final decision</div>
+                    <label class="ldecide-reason-label" for="loopDecisionReason">Reason (required, recorded in diff.json)</label>
+                    <textarea id="loopDecisionReason" class="ldecide-reason" rows="2" placeholder="Why accept or reject this change?"></textarea>
                     <div class="ldecide-row">
                         <button type="button" class="laction laccept" id="loopBtnAccept" onclick="loopSetDecision('accept')">Accept change</button>
                         <button type="button" class="laction lreject" id="loopBtnReject" onclick="loopSetDecision('reject')">Reject</button>
                     </div>
+                    <div class="ldecide-path hidden" id="loopDecisionPath"></div>
                 </section>
             </div>
         </div>

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -3565,6 +3565,16 @@ function loopRenderState() {
         decEl.textContent = LOOP_STATE.decision || 'pending';
         decEl.className = `lstat-v ${loopTone(LOOP_STATE.decision)}`;
     }
+    const reasonEl = document.getElementById('loopDecisionReason');
+    if (reasonEl && LOOP_STATE.decision_reason && !reasonEl.value.trim()) {
+        reasonEl.value = LOOP_STATE.decision_reason;
+    }
+    const decPathEl = document.getElementById('loopDecisionPath');
+    if (decPathEl) {
+        const path = LOOP_STATE.decision_path;
+        decPathEl.textContent = path ? `Decision recorded to ${path}` : '';
+        decPathEl.classList.toggle('hidden', !path);
+    }
     const hasDiff = Boolean(LOOP_STATE.diff_summary);
     const stepTimeAvailable = hasDiff && step.before_ms != null && step.after_ms != null;
     const confidenceEl = document.getElementById('lstConfidence');
@@ -3739,11 +3749,22 @@ async function loopSetDecision(decision) {
         loopSetError('Run diff before accepting or rejecting.');
         return;
     }
+    const reasonEl = document.getElementById('loopDecisionReason');
+    const reason = (reasonEl?.value || '').trim();
+    if (!reason) {
+        loopSetError('A reason is required before accepting or rejecting.');
+        if (reasonEl) reasonEl.focus();
+        return;
+    }
     try {
         loopSetError('');
         loopSetBusy(true);
-        await loopPost('/api/loop/decision', { decision, reason: '' });
-        showToast(decision === 'accept' ? 'Change accepted' : 'Change rejected');
+        const data = await loopPost('/api/loop/decision', { decision, reason });
+        const path = (data && data.decision_path) || (LOOP_STATE && LOOP_STATE.decision_path);
+        showToast(
+            (decision === 'accept' ? 'Change accepted' : 'Change rejected') +
+            (path ? ` — written to ${path}` : '')
+        );
     } catch (err) { showToast(loopErrorMessage('Decision failed', err)); }
     finally { loopSetBusy(false); }
 }

--- a/src/nsys_ai/timeline/app.py
+++ b/src/nsys_ai/timeline/app.py
@@ -48,6 +48,8 @@ Layout:
 
 from __future__ import annotations
 
+import os
+
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -836,15 +838,48 @@ class NsysTimelineApp(App):
             self.notify(f"Loop diff failed: {e}", severity="warning", timeout=4)
 
     def action_loop_accept(self) -> None:
-        self._loop_state.set_decision("accept", reason="accepted in timeline TUI")
-        self.analysis_phase = self._loop_state.phase
-        self._update_title()
-        self.notify("Loop decision: accept", timeout=2)
+        self._record_loop_decision("accept", "accepted in timeline TUI")
 
     def set_loop_decision(self, decision: str, reason: str = "") -> None:
-        self._loop_state.set_decision(decision, reason=reason)
+        self._record_loop_decision(decision, reason)
+
+    def _loop_decision_dir(self) -> str:
+        """Directory the shared diff.json decision record is written to.
+
+        The record lands next to the candidate ('after') profile so it is
+        discoverable alongside the run it describes rather than dropped into
+        the process CWD.
+        """
+        after = self._loop_state.after_path
+        directory = os.path.dirname(after) if after else ""
+        return directory or "."
+
+    def _record_loop_decision(self, decision: str, reason: str) -> None:
+        """Persist a loop accept/reject decision, guarding TUI-side edge cases.
+
+        set_decision requires a completed diff and a non-empty reason and
+        writes diff.json as a side effect, so guard both and surface any
+        failure through a notification instead of crashing the app.
+        """
+        if self._loop_state.diff_summary is None:
+            self.notify(
+                "Run loop diff before recording a decision", severity="warning", timeout=4
+            )
+            return
+        reason = (reason or "").strip() or f"{decision}ed in timeline TUI"
+        try:
+            _payload, warnings = self._loop_state.set_decision(
+                decision, reason=reason, decision_dir=self._loop_decision_dir()
+            )
+        except Exception as e:
+            self.notify(f"Loop decision failed: {e}", severity="warning", timeout=4)
+            return
         self.analysis_phase = self._loop_state.phase
         self._update_title()
+        msg = f"Loop decision: {decision} -> {self._loop_state.decision_path}"
+        if warnings:
+            msg += f" ({'; '.join(warnings)})"
+        self.notify(msg, timeout=3)
 
 
 # ---------------------------------------------------------------------------

--- a/src/nsys_ai/tree/app.py
+++ b/src/nsys_ai/tree/app.py
@@ -22,6 +22,8 @@ Layout:
 
 from __future__ import annotations
 
+import os
+
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
@@ -702,15 +704,48 @@ class NsysTreeApp(App):
             self.notify(f"Loop diff failed: {e}", severity="warning", timeout=4)
 
     def action_loop_accept(self) -> None:
-        self._loop_state.set_decision("accept", reason="accepted in tree TUI")
-        self.analysis_phase = self._loop_state.phase
-        self._update_title()
-        self.notify("Loop decision: accept", timeout=2)
+        self._record_loop_decision("accept", "accepted in tree TUI")
 
     def set_loop_decision(self, decision: str, reason: str = "") -> None:
-        self._loop_state.set_decision(decision, reason=reason)
+        self._record_loop_decision(decision, reason)
+
+    def _loop_decision_dir(self) -> str:
+        """Directory the shared diff.json decision record is written to.
+
+        The record lands next to the candidate ('after') profile so it is
+        discoverable alongside the run it describes rather than dropped into
+        the process CWD.
+        """
+        after = self._loop_state.after_path
+        directory = os.path.dirname(after) if after else ""
+        return directory or "."
+
+    def _record_loop_decision(self, decision: str, reason: str) -> None:
+        """Persist a loop accept/reject decision, guarding TUI-side edge cases.
+
+        set_decision requires a completed diff and a non-empty reason and
+        writes diff.json as a side effect, so guard both and surface any
+        failure through a notification instead of crashing the app.
+        """
+        if self._loop_state.diff_summary is None:
+            self.notify(
+                "Run loop diff before recording a decision", severity="warning", timeout=4
+            )
+            return
+        reason = (reason or "").strip() or f"{decision}ed in tree TUI"
+        try:
+            _payload, warnings = self._loop_state.set_decision(
+                decision, reason=reason, decision_dir=self._loop_decision_dir()
+            )
+        except Exception as e:
+            self.notify(f"Loop decision failed: {e}", severity="warning", timeout=4)
+            return
         self.analysis_phase = self._loop_state.phase
         self._update_title()
+        msg = f"Loop decision: {decision} -> {self._loop_state.decision_path}"
+        if warnings:
+            msg += f" ({'; '.join(warnings)})"
+        self.notify(msg, timeout=3)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1077,6 +1077,47 @@ def test_diff_decision_requires_profile_ids(tmp_path):
         raise AssertionError("expected missing profile_id to be refused")
 
 
+def test_diff_decision_dict_path_matches_summary_path(tmp_path):
+    """The web loop (dict) writer must be byte-identical to the CLI (summary) writer."""
+    import json as _json
+
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.diff_decision import (
+        write_diff_decision_json,
+        write_diff_decision_json_from_diff_dict,
+    )
+    from nsys_ai.diff_render import to_diff_json
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        summary = diff_profiles(b, a, gpu=0)
+
+    # The web loop stores the diff payload as JSON (to_diff_json) and reloads it.
+    stored_dict = _json.loads(to_diff_json(summary))
+
+    kwargs = dict(
+        decision="accepted",
+        reason="candidate is faster",
+        decider="tester@example.com",
+        decided_at="2026-06-18T00:00:00Z",
+    )
+    cli_path, _, _ = write_diff_decision_json(
+        summary, path=tmp_path / "cli.json", **kwargs
+    )
+    gui_path, _, _ = write_diff_decision_json_from_diff_dict(
+        stored_dict, path=tmp_path / "gui.json", **kwargs
+    )
+
+    assert cli_path.read_bytes() == gui_path.read_bytes()
+    # The stored dict must not be mutated by the writer.
+    assert "decision" not in stored_dict
+
+
 def test_compute_verdict_custom_regression_pct():
     from nsys_ai.diff import compute_verdict
 

--- a/tests/test_loop_api.py
+++ b/tests/test_loop_api.py
@@ -1,4 +1,142 @@
+import http.client
+import json
+import threading
+from contextlib import contextmanager
 from pathlib import Path
+
+from nsys_ai import web
+from nsys_ai.diff_decision import write_diff_decision_json_from_diff_dict
+from nsys_ai.loop_state import DiffLoopState
+
+
+def _diff_summary(confidence: float = 0.9) -> dict:
+    """Minimal to_diff_dict-shaped payload sufficient to record a decision."""
+    return {
+        "verdict": "neutral",
+        "comparability_confidence": confidence,
+        "warnings": [],
+        "before": {"path": "/tmp/before.sqlite", "profile_id": "before-id"},
+        "after": {"path": "/tmp/after.sqlite", "profile_id": "after-id"},
+    }
+
+
+@contextmanager
+def _running_loop_server(loop_state):
+    """Start a real _ViewerHandler HTTP server bound to an ephemeral port."""
+    handler = web._ViewerHandler
+    saved_state, saved_prof = handler._loop_state, handler.prof
+    handler._loop_state, handler.prof = loop_state, None
+    server = web._ThreadedHTTPServer(("127.0.0.1", 0), handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield port
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+        handler._loop_state, handler.prof = saved_state, saved_prof
+
+
+def _post(port, path, payload):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request("POST", path, body=json.dumps(payload), headers={"Content-Type": "application/json"})
+    resp = conn.getresponse()
+    status, body = resp.status, resp.read()
+    conn.close()
+    return status, json.loads(body) if body else {}
+
+
+def _get(port, path):
+    conn = http.client.HTTPConnection("127.0.0.1", port, timeout=5)
+    conn.request("GET", path)
+    resp = conn.getresponse()
+    status, body = resp.status, resp.read()
+    conn.close()
+    return status, json.loads(body) if body else {}
+
+
+def test_web_decision_writes_diff_json_and_matches_cli(tmp_path, monkeypatch):
+    # The web writer targets Path("diff.json") in the process CWD (same as the CLI).
+    monkeypatch.chdir(tmp_path)
+    state = DiffLoopState()
+    state.diff_summary = _diff_summary()
+
+    with _running_loop_server(state) as port:
+        status, data = _post(port, "/api/loop/decision", {"decision": "accept", "reason": "faster on H100"})
+
+    assert status == 200
+    assert data["decision"] == "accept"
+    assert data["decision_reason"] == "faster on H100"
+    assert data["decision_path"], "decision_path should be surfaced back to the client"
+
+    written = tmp_path / "diff.json"
+    assert written.exists()
+    web_record = json.loads(written.read_text(encoding="utf-8"))
+    assert web_record["decision"]["status"] == "accepted"
+    assert web_record["decision"]["reason"] == "faster on H100"
+
+    # Byte-shape parity with the CLI encoder for the same diff payload: everything
+    # except the volatile identity/timestamp must be identical.
+    write_diff_decision_json_from_diff_dict(
+        _diff_summary(),
+        decision="accepted",
+        reason="faster on H100",
+        path=tmp_path / "cli.json",
+        decider="fixed@example",
+        decided_at="2026-01-01T00:00:00Z",
+    )
+    cli_record = json.loads((tmp_path / "cli.json").read_text(encoding="utf-8"))
+    web_record["decision"]["decider"] = "fixed@example"
+    web_record["decision"]["decided_at"] = "2026-01-01T00:00:00Z"
+    assert json.dumps(web_record, sort_keys=True) == json.dumps(cli_record, sort_keys=True)
+
+
+def test_web_decision_survives_reload(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state = DiffLoopState()
+    state.diff_summary = _diff_summary()
+
+    with _running_loop_server(state) as port:
+        _post(port, "/api/loop/decision", {"decision": "reject", "reason": "regressed"})
+        # Simulate a page reload: re-fetch loop state from the server.
+        status, reloaded = _get(port, "/api/loop/state")
+
+    assert status == 200
+    assert reloaded["decision"] == "reject"
+    assert reloaded["decision_reason"] == "regressed"
+    assert reloaded["decision_path"].endswith("diff.json")
+    # The record is on disk independent of server memory, and rehydrates cleanly.
+    assert (tmp_path / "diff.json").exists()
+    restored = DiffLoopState.from_dict(reloaded)
+    assert restored.decision == "reject"
+    assert restored.decision_path.endswith("diff.json")
+
+
+def test_web_decision_requires_reason(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state = DiffLoopState()
+    state.diff_summary = _diff_summary()
+
+    with _running_loop_server(state) as port:
+        status, data = _post(port, "/api/loop/decision", {"decision": "accept", "reason": "   "})
+
+    assert status == 400
+    assert "reason" in data.get("error", "").lower()
+    assert not (tmp_path / "diff.json").exists()
+
+
+def test_web_decision_requires_diff_first(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    state = DiffLoopState()  # no diff run yet
+
+    with _running_loop_server(state) as port:
+        status, data = _post(port, "/api/loop/decision", {"decision": "accept", "reason": "looks good"})
+
+    assert status == 400
+    assert "diff" in data.get("error", "").lower()
+    assert not (tmp_path / "diff.json").exists()
 
 
 def test_web_loop_endpoints_are_registered():

--- a/tests/test_loop_state.py
+++ b/tests/test_loop_state.py
@@ -1,7 +1,10 @@
+import json
 import os
 import shutil
 import time
 from pathlib import Path
+
+import pytest
 
 from nsys_ai import profile as _profile
 from nsys_ai.loop_state import (
@@ -13,7 +16,18 @@ from nsys_ai.loop_state import (
 )
 
 
-def test_loop_state_phase_and_proposal():
+def _comparable_diff_summary(confidence: float = 0.9) -> dict:
+    """Minimal diff payload (to_diff_dict shape) sufficient to record a decision."""
+    return {
+        "verdict": "neutral",
+        "comparability_confidence": confidence,
+        "warnings": [],
+        "before": {"path": "/tmp/before.sqlite", "profile_id": "before-id"},
+        "after": {"path": "/tmp/after.sqlite", "profile_id": "after-id"},
+    }
+
+
+def test_loop_state_phase_and_proposal(tmp_path):
     state = DiffLoopState(before_path="/tmp/before.sqlite")
     assert state.phase == "diagnose"
 
@@ -25,10 +39,54 @@ def test_loop_state_phase_and_proposal():
     assert state.expected_impact == "Lower step time"
     assert state.phase == "propose"
 
-    state.set_decision("accept", reason="speedup confirmed")
+    state.diff_summary = _comparable_diff_summary()
+    state.set_decision("accept", reason="speedup confirmed", decision_dir=tmp_path)
     assert state.phase == "accept"
     assert state.decision == "accept"
     assert state.decision_reason == "speedup confirmed"
+
+    written = tmp_path / "diff.json"
+    assert state.decision_path == str(written)
+    assert written.exists()
+    record = json.loads(written.read_text(encoding="utf-8"))
+    assert record["decision"]["status"] == "accepted"
+    assert record["decision"]["reason"] == "speedup confirmed"
+
+
+def test_set_decision_requires_reason_and_diff(tmp_path):
+    state = DiffLoopState()
+    # No diff run yet.
+    with pytest.raises(ValueError, match="run diff"):
+        state.set_decision("accept", reason="looks good", decision_dir=tmp_path)
+
+    state.diff_summary = _comparable_diff_summary()
+    with pytest.raises(ValueError, match="reason is required"):
+        state.set_decision("accept", reason="   ", decision_dir=tmp_path)
+    assert not (tmp_path / "diff.json").exists()
+    assert state.decision is None
+
+
+def test_set_decision_low_comparability_stamps_inconclusive(tmp_path):
+    state = DiffLoopState()
+    state.diff_summary = _comparable_diff_summary(confidence=0.3)
+    payload, warnings = state.set_decision(
+        "reject", reason="mismatched workloads", decision_dir=tmp_path
+    )
+    assert payload["verdict"] == "inconclusive"
+    assert state.verdict == "inconclusive"
+    assert any("stamping verdict as inconclusive" in w for w in warnings)
+    assert state.decision_warnings == warnings
+
+
+def test_set_decision_survives_state_roundtrip(tmp_path):
+    state = DiffLoopState()
+    state.diff_summary = _comparable_diff_summary()
+    state.set_decision("accept", reason="faster", decision_dir=tmp_path)
+
+    restored = DiffLoopState.from_dict(state.to_dict())
+    assert restored.decision == "accept"
+    assert restored.decision_reason == "faster"
+    assert restored.decision_path == str(tmp_path / "diff.json")
 
 
 def test_detect_h100_replay_preset_picks_newest_complete_snapshot(monkeypatch, tmp_path):

--- a/tests/test_tui_timeline_app.py
+++ b/tests/test_tui_timeline_app.py
@@ -154,3 +154,62 @@ async def test_zoom_to_time_range_api(timeline_app):
         timeline_app.zoom_to_time_range(0.01, 0.05)  # 10ms–50ms
         await pilot.pause()
         assert timeline_app.cursor_ns == 10_000_000  # start_s * 1e9
+
+
+# ---------------------------------------------------------------------------
+# Loop accept/reject decision recording
+# ---------------------------------------------------------------------------
+
+
+def _comparable_diff_summary(confidence: float = 0.9) -> dict:
+    """Minimal diff payload (to_diff_dict shape) sufficient to record a decision."""
+    return {
+        "verdict": "neutral",
+        "comparability_confidence": confidence,
+        "warnings": [],
+        "before": {"path": "/tmp/before.sqlite", "profile_id": "before-id"},
+        "after": {"path": "/tmp/after.sqlite", "profile_id": "after-id"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_loop_accept_before_diff_warns_without_crashing(timeline_app, tmp_path, monkeypatch):
+    """Pressing accept before a diff has run notifies instead of crashing or writing."""
+    monkeypatch.chdir(tmp_path)
+    async with timeline_app.run_test(size=(120, 40)) as pilot:
+        notes: list[tuple] = []
+        timeline_app.notify = lambda *a, **k: notes.append((a, k))  # type: ignore[method-assign]
+        timeline_app.action_loop_accept()
+        await pilot.pause()
+        assert timeline_app.is_running
+        assert timeline_app._loop_state.decision is None
+        assert not (tmp_path / "diff.json").exists()
+        assert notes and any("diff" in str(a).lower() for a, _ in notes)
+
+
+@pytest.mark.asyncio
+async def test_loop_accept_after_diff_writes_next_to_candidate(timeline_app, tmp_path):
+    """Accept after a diff persists diff.json next to the candidate profile."""
+    async with timeline_app.run_test(size=(120, 40)) as pilot:
+        timeline_app._loop_state.after_path = str(tmp_path / "after.sqlite")
+        timeline_app._loop_state.diff_summary = _comparable_diff_summary()
+        timeline_app.action_loop_accept()
+        await pilot.pause()
+        assert timeline_app._loop_state.decision == "accept"
+        written = tmp_path / "diff.json"
+        assert written.exists()
+        assert timeline_app._loop_state.decision_path == str(written)
+
+
+@pytest.mark.asyncio
+async def test_loop_set_decision_empty_reason_uses_fallback(timeline_app, tmp_path):
+    """An agent set_decision action with the default empty reason does not crash."""
+    async with timeline_app.run_test(size=(120, 40)) as pilot:
+        timeline_app._loop_state.after_path = str(tmp_path / "after.sqlite")
+        timeline_app._loop_state.diff_summary = _comparable_diff_summary()
+        timeline_app.set_loop_decision("reject", "")
+        await pilot.pause()
+        assert timeline_app.is_running
+        assert timeline_app._loop_state.decision == "reject"
+        assert timeline_app._loop_state.decision_reason.strip()
+        assert (tmp_path / "diff.json").exists()

--- a/tests/test_tui_tree_app.py
+++ b/tests/test_tui_tree_app.py
@@ -244,3 +244,62 @@ async def test_toggle_chat_panel(tree_app):
         await pilot.press("escape")  # close via ChatPanel escape binding
         await pilot.pause()
         assert "-active" not in cp.classes
+
+
+# ---------------------------------------------------------------------------
+# Loop accept/reject decision recording
+# ---------------------------------------------------------------------------
+
+
+def _comparable_diff_summary(confidence: float = 0.9) -> dict:
+    """Minimal diff payload (to_diff_dict shape) sufficient to record a decision."""
+    return {
+        "verdict": "neutral",
+        "comparability_confidence": confidence,
+        "warnings": [],
+        "before": {"path": "/tmp/before.sqlite", "profile_id": "before-id"},
+        "after": {"path": "/tmp/after.sqlite", "profile_id": "after-id"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_loop_accept_before_diff_warns_without_crashing(tree_app, tmp_path, monkeypatch):
+    """Pressing accept before a diff has run notifies instead of crashing or writing."""
+    monkeypatch.chdir(tmp_path)
+    async with tree_app.run_test(size=(120, 40)) as pilot:
+        notes: list[tuple] = []
+        tree_app.notify = lambda *a, **k: notes.append((a, k))  # type: ignore[method-assign]
+        tree_app.action_loop_accept()
+        await pilot.pause()
+        assert tree_app.is_running
+        assert tree_app._loop_state.decision is None
+        assert not (tmp_path / "diff.json").exists()
+        assert notes and any("diff" in str(a).lower() for a, _ in notes)
+
+
+@pytest.mark.asyncio
+async def test_loop_accept_after_diff_writes_next_to_candidate(tree_app, tmp_path):
+    """Accept after a diff persists diff.json next to the candidate profile."""
+    async with tree_app.run_test(size=(120, 40)) as pilot:
+        tree_app._loop_state.after_path = str(tmp_path / "after.sqlite")
+        tree_app._loop_state.diff_summary = _comparable_diff_summary()
+        tree_app.action_loop_accept()
+        await pilot.pause()
+        assert tree_app._loop_state.decision == "accept"
+        written = tmp_path / "diff.json"
+        assert written.exists()
+        assert tree_app._loop_state.decision_path == str(written)
+
+
+@pytest.mark.asyncio
+async def test_loop_set_decision_empty_reason_uses_fallback(tree_app, tmp_path):
+    """An agent set_decision action with the default empty reason does not crash."""
+    async with tree_app.run_test(size=(120, 40)) as pilot:
+        tree_app._loop_state.after_path = str(tmp_path / "after.sqlite")
+        tree_app._loop_state.diff_summary = _comparable_diff_summary()
+        tree_app.set_loop_decision("reject", "")
+        await pilot.pause()
+        assert tree_app.is_running
+        assert tree_app._loop_state.decision == "reject"
+        assert tree_app._loop_state.decision_reason.strip()
+        assert (tmp_path / "diff.json").exists()


### PR DESCRIPTION
## Summary

Routes the guided-optimization loop's accept/reject decision through the same on-disk writer the CLI uses (from #213), so a verdict reached in the timeline web loop is persisted as a `diff.json` that is byte-identical to `diff --accept/--reject --reason` for the same diff, and survives a page reload instead of living only in server session state.

## Changes

- **`diff_decision.py`** — factor the record builder to operate on a `to_diff_dict` mapping (`build_diff_decision_record_from_diff_dict`); `build_diff_decision_record` now delegates through it, and `write_diff_decision_json_from_diff_dict` + a shared `_write_decision_payload` are added. Because both the CLI (fresh `ProfileDiffSummary` → `to_diff_dict`) and the web loop (which already holds that same mapping in loop state) feed the identical dict into one encoder, the two surfaces emit byte-identical records by construction. Input mapping is deep-copied, never mutated. CLI signatures are unchanged.
- **`loop_state.py`** — `DiffLoopState.set_decision` now persists via the shared writer (maps `accept`→`accepted`, `reject`→`rejected`), guards that a diff has been run and that the reason is non-empty (`raise ValueError`), records `decision_path` / `decision_warnings`, reflects verdict stamping (e.g. low-comparability → inconclusive), and returns the payload + advisory warnings. The new fields round-trip through `to_dict` / `from_dict` so a decision survives a reload.
- **Web frontend (`templates/timeline.html`/`.js`/`.css`)** — add a required reason field to the Final decision section, block submit until a reason is entered, and surface the written path back to the user. `web.py`'s `_handle_loop_decision` already routes through `set_decision`, so it needed no change.
- **Tree/timeline TUI (`tree/app.py`, `timeline/app.py`)** — the tightened `set_decision` contract is shared with the TUIs, so their accept/reject callers are hardened: skip with a notification when no diff has run, fall back to a descriptive reason for agent-issued empty-reason actions, surface failures via `notify` instead of crashing a Textual action, and write the record next to the candidate profile.

## Testing

- **New real-HTTP end-to-end tests (`tests/test_loop_api.py`)** — start an actual `_ViewerHandler` server on an ephemeral port and drive `/api/loop/decision` over HTTP: assert the decision record is written to disk, is byte-shape identical to the CLI encoder (modulo `decider` / `decided_at`), survives a reload via `/api/loop/state`, and that an empty reason or a missing diff is refused with `400` and writes no file.
- **New `loop_state` tests** — persist path, reason/diff guards, low-comparability inconclusive stamp, and state round-trip; plus a `diff_decision` dict-path parity test and TUI guard tests for both apps.
- Full suite: **1087 passed, 146 skipped**. `ruff check src/ tests/` clean; `bandit -r src/` clean. Live web run confirmed an accept persists across a reload and both guardrails return `400`.

## Notes

- Non-blocking: the web path writes `diff.json` to the server CWD (matching the CLI), while the TUI writes next to the candidate profile — these could be unified later if a single location is preferred.
- The writer remains the plain truncating write introduced in #213 (no atomic `os.replace`); left unchanged and out of scope here.

Closes #178.
