### PR TITLE
feat(baseline): add local baseline snapshot store and diff --against resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ data/nsys-hero/
 examples/*/output/
 snapshot_report.html
 uv.lock
+
+# Local baseline snapshot store (nsys-ai baseline tag)
+.nsys-ai-baselines/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- `nsys-ai baseline` keeps a local store of named profile snapshots (`tag`,
+  `list`, `show`) so `diff --against baseline:<name>` resolves a stable name to a
+  known snapshot instead of a fragile path. The store lives in
+  `.nsys-ai-baselines/` and can be relocated with `NSYS_AI_BASELINE_ROOT` for
+  cross-job CI use.
 - `nsys-ai doctor` diagnoses the environment (Python, nsys CLI, Parquet cache,
   AI provider, CUTracer toolchain including the nvdisasm/framework CUDA match)
   and, when given a profile, its health (duration, GPUs, GPU model, NVTX and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Profiles are `.sqlite` files from NVIDIA Nsight Systems. Key tables: `CUPTI_ACTI
 - `viewer.py` — Perfetto JSON trace export
 - `web.py` — Local HTTP server (stdlib `http.server` + custom `_ThreadPoolMixIn`; no Flask/Jinja2)
 - `diff.py` / `diff_tools.py` / `diff_render.py` / `diff_web.py` — before/after profile comparison + verdict
+- `baseline.py` — local baseline snapshot store (tag/list/show + `diff --against` resolution)
 
 ### Skill System (`src/nsys_ai/skills/`)
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,43 @@ across every device.
 | `--exit-on-regression` | — | Exit 1 when the verdict is `regression_likely` |
 | `--gate PCT` | 5.0 | Regression threshold (%) for the verdict; implies `--exit-on-regression` |
 
+## Baselines
+
+A diff needs something to compare against. Passing a raw file path is fragile in
+CI: the path drifts between jobs and the file may not survive to the next run.
+The `baseline` command keeps a local store of named snapshots so a stable name,
+not a path, resolves the comparison.
+
+```bash
+# Tag a known-good run under a name (copies the resolved .sqlite into the store)
+nsys-ai baseline tag main run.sqlite --reason "green main @ abc123"
+
+# List and inspect what has been tagged
+nsys-ai baseline list
+nsys-ai baseline show main
+
+# Compare a candidate against a tagged baseline by name
+nsys-ai diff --against baseline:main candidate.sqlite
+```
+
+`tag` resolves the profile (including a `.nsys-rep` sidecar), copies the
+self-contained `.sqlite` into the store, and records a deterministic `meta.json`
+(content-derived `profile_id`, source path, reason, tagger, timestamp). The
+snapshot stays valid even if the original file moves.
+
+The store lives in `.nsys-ai-baselines/` under the current directory. Set
+`NSYS_AI_BASELINE_ROOT` to point tag and resolve at a shared location so a job
+that tags and a later job that diffs find the same store regardless of CWD:
+
+```bash
+export NSYS_AI_BASELINE_ROOT="$CI_CACHE/nsys-baselines"
+nsys-ai baseline tag main run.sqlite --reason "green main" \
+  && nsys-ai diff --against baseline:main candidate.sqlite
+```
+
+The `baseline:<name>` reference is accepted anywhere a baseline profile path is,
+via `--against` or as the `before` positional.
+
 ## Commands
 
 | Command | Description |
@@ -218,6 +255,7 @@ across every device.
 | `report` | Generate a performance report |
 | `diff` | Before/after profile comparison |
 | `diff-web` | Side-by-side comparison web viewer |
+| `baseline` | Manage named baseline snapshots (`tag`, `list`, `show`) |
 | `chat` | AI chat TUI for a profile |
 | `ask` | One-shot AI question about a profile |
 | `agent` | Agent auto-analysis (`analyze`, `ask`) |

--- a/src/nsys_ai/baseline.py
+++ b/src/nsys_ai/baseline.py
@@ -35,6 +35,9 @@ from .fingerprint import get_profile_id
 DEFAULT_ROOT = ".nsys-ai-baselines"
 """Directory (relative to CWD) that holds the local baseline store."""
 
+_ROOT_ENV_VAR = "NSYS_AI_BASELINE_ROOT"
+"""Environment variable that relocates the store when no explicit root is given."""
+
 _REF_PREFIX = "baseline:"
 
 # Names become directory names, so keep them to a safe identifier alphabet and
@@ -46,7 +49,48 @@ META_FILENAME = "meta.json"
 
 
 def _store_root(root: str | os.PathLike[str] | None) -> Path:
-    return Path(root) if root is not None else Path(DEFAULT_ROOT)
+    # An explicit root always wins (tests and callers pass it directly). When
+    # unset, honour NSYS_AI_BASELINE_ROOT so a CI job can point tag and
+    # ``diff --against baseline:X`` at one shared store regardless of CWD.
+    if root is not None:
+        return Path(root)
+    env_root = os.environ.get(_ROOT_ENV_VAR)
+    if env_root and env_root.strip():
+        return Path(env_root)
+    return Path(DEFAULT_ROOT)
+
+
+def _reject_symlink(path: Path, label: str) -> None:
+    """Refuse to write *through* a symlink, so a planted link cannot redirect
+    the write to a target outside the store."""
+    if path.is_symlink():
+        raise ValueError(f"refusing to write {label} through a symlink: {path}")
+
+
+def _is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _write_no_follow(path: Path, text: str) -> None:
+    """Write *text* to *path* without following a pre-existing symlink."""
+    _reject_symlink(path, path.name)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    fd = os.open(path, flags, 0o644)
+    with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+        f.write(text)
+
+
+def _copy_no_follow(src: str | os.PathLike[str], dst: Path) -> None:
+    """Copy *src* to *dst* byte-for-byte without following a symlink at *dst*."""
+    _reject_symlink(dst, "baseline snapshot")
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW
+    fd = os.open(dst, flags, 0o644)
+    with os.fdopen(fd, "wb") as out, open(src, "rb") as source:
+        shutil.copyfileobj(source, out)
 
 
 def _validate_name(name: str) -> str:
@@ -102,12 +146,23 @@ def tag_baseline(
     root_path = _store_root(root)
     entry_dir = root_path / clean_name
 
-    with _profile.open(os.fspath(profile_path)) as prof:
+    # Refuse a symlinked entry directory and enforce that the entry stays inside
+    # the store, so a planted symlink cannot make writes escape the root.
+    _reject_symlink(entry_dir, "baseline entry directory")
+    if not _is_within(entry_dir.resolve(), root_path.resolve()):
+        raise ValueError(
+            f"baseline entry directory escapes the store root: {entry_dir}"
+        )
+
+    # ``direct`` cache mode reads the profile in place; only prof.conn/prof.path
+    # are needed here, so avoid building a Parquet cache next to the user's
+    # source profile (surprising, and can fail if that directory is read-only).
+    with _profile.open(os.fspath(profile_path), cache_mode="direct") as prof:
         profile_id = get_profile_id(prof.conn, fallback_path=prof.path)
         source_path = os.path.abspath(prof.path)
 
         entry_dir.mkdir(parents=True, exist_ok=True)
-        shutil.copy2(source_path, entry_dir / SNAPSHOT_FILENAME)
+        _copy_no_follow(source_path, entry_dir / SNAPSHOT_FILENAME)
 
     meta = {
         "name": clean_name,
@@ -126,13 +181,18 @@ def tag_baseline(
 
 def _write_meta(path: str | os.PathLike[str], meta: dict) -> None:
     text = json.dumps(meta, indent=2, sort_keys=True) + "\n"
-    with open(path, "w", encoding="utf-8", newline="\n") as f:
-        f.write(text)
+    _write_no_follow(Path(path), text)
 
 
 def _read_meta(entry_dir: Path) -> dict:
     with open(entry_dir / META_FILENAME, encoding="utf-8") as f:
-        return json.load(f)
+        data = json.load(f)
+    # A non-object meta.json (``[]``, ``"x"``, ``123``) parses fine but breaks
+    # every ``meta.get(...)`` caller; treat it as corrupt so list_baselines
+    # skips it and show_baseline surfaces a clean error instead of crashing.
+    if not isinstance(data, dict):
+        raise ValueError("meta.json is not a JSON object")
+    return data
 
 
 def list_baselines(root: str | os.PathLike[str] | None = None) -> list[dict]:

--- a/src/nsys_ai/baseline.py
+++ b/src/nsys_ai/baseline.py
@@ -1,0 +1,188 @@
+"""
+baseline.py - Local store of named profile snapshots.
+
+A persisted diff verdict is a record; a *reproducible* verdict needs a named
+snapshot to compare against. This module keeps a local, CI-friendly store of
+tagged ``.sqlite`` profiles so a CI invocation like
+``diff --against baseline:main`` resolves a stable name to a known snapshot
+instead of a fragile file path.
+
+Layout (relative to the current working directory by default)::
+
+    .nsys-ai-baselines/
+        <name>/
+            snapshot.sqlite   # self-contained copy of the resolved profile
+            meta.json         # deterministic identity + provenance record
+
+``meta.json`` carries ``runspec: null`` as a forward-compatible placeholder.
+RunSpec recording (issue #25) does not exist yet and is only needed for later
+"compatible setup" checks, not for resolving a baseline snapshot, so it is
+deliberately deferred here rather than implemented.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+
+from . import profile as _profile
+from .diff_decision import _utc_now_iso, resolve_decider_identity
+from .fingerprint import get_profile_id
+
+DEFAULT_ROOT = ".nsys-ai-baselines"
+"""Directory (relative to CWD) that holds the local baseline store."""
+
+_REF_PREFIX = "baseline:"
+
+# Names become directory names, so keep them to a safe identifier alphabet and
+# reject the current/parent directory tokens to avoid any path traversal.
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+SNAPSHOT_FILENAME = "snapshot.sqlite"
+META_FILENAME = "meta.json"
+
+
+def _store_root(root: str | os.PathLike[str] | None) -> Path:
+    return Path(root) if root is not None else Path(DEFAULT_ROOT)
+
+
+def _validate_name(name: str) -> str:
+    if not isinstance(name, str):
+        raise ValueError("baseline name must be a string")
+    cleaned = name.strip()
+    if not cleaned:
+        raise ValueError("baseline name must not be empty")
+    if cleaned in (".", ".."):
+        raise ValueError(f"invalid baseline name: {name!r}")
+    if not _NAME_RE.match(cleaned):
+        raise ValueError(
+            "baseline name may only contain letters, digits, '.', '_' and '-' "
+            f"and must start alphanumerically: {name!r}"
+        )
+    return cleaned
+
+
+def parse_baseline_ref(s: str | None) -> str | None:
+    """Return the ``<name>`` from a ``baseline:<name>`` token, else None.
+
+    Only the ``baseline:`` prefix form is recognised as a baseline reference;
+    any other string (a file path, a bare name) returns None so callers can
+    treat it as an ordinary profile path.
+    """
+    if not isinstance(s, str):
+        return None
+    if not s.startswith(_REF_PREFIX):
+        return None
+    name = s[len(_REF_PREFIX) :].strip()
+    return name or None
+
+
+def tag_baseline(
+    name: str,
+    profile_path: str | os.PathLike[str],
+    reason: str,
+    root: str | os.PathLike[str] | None = None,
+) -> dict:
+    """Record a tagged snapshot of *profile_path* under *name*.
+
+    Opens the profile through the existing loader (resolving ``.nsys-rep`` to
+    its ``.sqlite`` sidecar), copies that resolved ``.sqlite`` into the store so
+    the baseline stays valid even if the original file moves, and writes a
+    deterministic ``meta.json``. Returns the metadata mapping.
+    """
+    clean_name = _validate_name(name)
+
+    clean_reason = reason.strip() if isinstance(reason, str) else ""
+    if not clean_reason:
+        raise ValueError("a non-empty --reason is required to tag a baseline")
+
+    root_path = _store_root(root)
+    entry_dir = root_path / clean_name
+
+    with _profile.open(os.fspath(profile_path)) as prof:
+        profile_id = get_profile_id(prof.conn, fallback_path=prof.path)
+        source_path = os.path.abspath(prof.path)
+
+        entry_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, entry_dir / SNAPSHOT_FILENAME)
+
+    meta = {
+        "name": clean_name,
+        "profile_id": profile_id,
+        "source_path": source_path,
+        "reason": clean_reason,
+        "tagged_at": _utc_now_iso(),
+        "tagger": resolve_decider_identity(),
+        # Forward-compatible placeholder; a future RunSpec recording (#25) can
+        # populate this without changing the on-disk layout.
+        "runspec": None,
+    }
+    _write_meta(entry_dir / META_FILENAME, meta)
+    return meta
+
+
+def _write_meta(path: str | os.PathLike[str], meta: dict) -> None:
+    text = json.dumps(meta, indent=2, sort_keys=True) + "\n"
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(text)
+
+
+def _read_meta(entry_dir: Path) -> dict:
+    with open(entry_dir / META_FILENAME, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def list_baselines(root: str | os.PathLike[str] | None = None) -> list[dict]:
+    """Return metadata for every tagged baseline, sorted by name."""
+    root_path = _store_root(root)
+    if not root_path.is_dir():
+        return []
+    entries: list[dict] = []
+    for child in sorted(root_path.iterdir(), key=lambda p: p.name):
+        if not child.is_dir():
+            continue
+        if not (child / META_FILENAME).is_file():
+            continue
+        try:
+            entries.append(_read_meta(child))
+        except (OSError, ValueError):
+            # Skip corrupt entries rather than failing the whole listing.
+            continue
+    return entries
+
+
+def show_baseline(name: str, root: str | os.PathLike[str] | None = None) -> dict:
+    """Return the metadata for a single tagged baseline.
+
+    Raises ValueError if no baseline with *name* exists.
+    """
+    clean_name = _validate_name(name)
+    entry_dir = _store_root(root) / clean_name
+    if not (entry_dir / META_FILENAME).is_file():
+        raise ValueError(f"unknown baseline: {clean_name!r}")
+    return _read_meta(entry_dir)
+
+
+def resolve_baseline_ref(
+    ref: str, root: str | os.PathLike[str] | None = None
+) -> str:
+    """Resolve a ``baseline:<name>`` reference (or bare name) to a snapshot path.
+
+    Returns the filesystem path of the stored ``.sqlite`` snapshot, ready to
+    hand to the profile loader. Raises ValueError if the name is unknown.
+    """
+    name = parse_baseline_ref(ref)
+    if name is None:
+        name = ref
+    clean_name = _validate_name(name)
+    entry_dir = _store_root(root) / clean_name
+    snapshot = entry_dir / SNAPSHOT_FILENAME
+    if not snapshot.is_file():
+        raise ValueError(
+            f"unknown baseline: {clean_name!r} "
+            f"(no snapshot at {snapshot}); tag one with 'nsys-ai baseline tag'"
+        )
+    return str(snapshot)

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -515,6 +515,80 @@ def _cmd_report(args, _profile):
     _cmd_analyze(args, _profile)
 
 
+def _resolve_diff_before(args):
+    """Fill and resolve the diff ``before`` side, including baseline refs.
+
+    ``--against`` (when given) supplies the before side; otherwise the ``before``
+    positional is used. Any ``baseline:<name>`` token on either side is resolved
+    to the stored snapshot path so the rest of ``_cmd_diff`` sees an ordinary
+    profile path.
+    """
+    from nsys_ai.baseline import parse_baseline_ref, resolve_baseline_ref
+
+    against = getattr(args, "against", None)
+    if against:
+        if getattr(args, "before", None):
+            print(
+                "Error: pass the baseline via --against or as the 'before' "
+                "positional, not both",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        args.before = against
+
+    if not getattr(args, "before", None):
+        print(
+            "Error: a 'before' profile is required (positional path or --against)",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    for attr in ("before", "after"):
+        ref = getattr(args, attr, None)
+        if parse_baseline_ref(ref) is None:
+            continue
+        try:
+            setattr(args, attr, resolve_baseline_ref(ref))
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(2)
+
+
+def _cmd_baseline_tag(args, _profile):
+    from nsys_ai.baseline import tag_baseline
+
+    try:
+        meta = tag_baseline(args.name, args.profile, args.reason)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    print(f"Tagged baseline {meta['name']!r} ({meta['profile_id']})")
+
+
+def _cmd_baseline_list(args, _profile):
+    from nsys_ai.baseline import list_baselines
+
+    entries = list_baselines()
+    if not entries:
+        print("No baselines tagged yet.")
+        return
+    for meta in entries:
+        print(f"{meta.get('name')}\t{meta.get('profile_id')}\t{meta.get('tagged_at')}")
+
+
+def _cmd_baseline_show(args, _profile):
+    import json as _json
+
+    from nsys_ai.baseline import show_baseline
+
+    try:
+        meta = show_baseline(args.name)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+    print(_json.dumps(meta, indent=2, sort_keys=True))
+
+
 def _cmd_diff(args, _profile):
     from nsys_ai.diff import STEP_TIME_REGRESSION_PCT, diff_profiles
     from nsys_ai.diff_decision import write_diff_decision_json
@@ -526,6 +600,8 @@ def _cmd_diff(args, _profile):
         to_diff_json,
     )
     from nsys_ai.diff_tools import DiffContext, get_iteration_boundaries
+
+    _resolve_diff_before(args)
 
     no_ai = getattr(args, "no_ai", False)
     gate_summary = None

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -17,6 +17,9 @@ from .handlers import (
     _cmd_agent_guide,
     _cmd_analyze,
     _cmd_ask,
+    _cmd_baseline_list,
+    _cmd_baseline_show,
+    _cmd_baseline_tag,
     _cmd_chat,
     _cmd_cutracer,
     _cmd_diff,
@@ -372,8 +375,21 @@ def _build_parser():
     p.set_defaults(handler=_cmd_report)
 
     p = sub.add_parser("diff", help="Compare two profiles (before/after)")
-    p.add_argument("before", help="Path to baseline profile (.sqlite or .nsys-rep)")
+    p.add_argument(
+        "before",
+        nargs="?",
+        default=None,
+        help="Path to baseline profile (.sqlite or .nsys-rep), or a "
+        "'baseline:<name>' reference. Optional when --against is given.",
+    )
     p.add_argument("after", help="Path to candidate profile (.sqlite or .nsys-rep)")
+    p.add_argument(
+        "--against",
+        default=None,
+        metavar="REF",
+        help="Baseline to diff against, supplying the before side "
+        "(e.g. 'baseline:<name>' or a profile path)",
+    )
     p.add_argument("--gpu", type=int, default=None, help="GPU device ID (default: all GPUs)")
     p.add_argument(
         "--trim",
@@ -464,6 +480,22 @@ def _build_parser():
     p.add_argument("--port", type=int, default=8145, help="HTTP port (default: 8145)")
     p.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
     p.set_defaults(handler=_cmd_diff_web)
+
+    p = sub.add_parser("baseline", help="Manage named baseline snapshots")
+    bl_sub = p.add_subparsers(dest="baseline_action", required=True)
+
+    sp = bl_sub.add_parser("tag", help="Record a tagged baseline snapshot")
+    sp.add_argument("name", help="Baseline name (e.g. 'main')")
+    sp.add_argument("profile", help="Path to profile (.sqlite or .nsys-rep)")
+    sp.add_argument("--reason", required=True, help="Why this snapshot is a baseline")
+    sp.set_defaults(handler=_cmd_baseline_tag)
+
+    sp = bl_sub.add_parser("list", help="List tagged baselines")
+    sp.set_defaults(handler=_cmd_baseline_list)
+
+    sp = bl_sub.add_parser("show", help="Show one tagged baseline")
+    sp.add_argument("name", help="Baseline name to inspect")
+    sp.set_defaults(handler=_cmd_baseline_show)
 
     p = sub.add_parser("export", help="Export Perfetto JSON traces")
     _add_gpu_trim(p, gpu_required=False)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -145,3 +145,86 @@ def test_retag_overwrites(tmp_path, profile_a):
     meta = baseline.tag_baseline("v1", str(profile_a), "second", root=root)
     assert meta["reason"] == "second"
     assert baseline.show_baseline("v1", root=root)["reason"] == "second"
+
+
+def test_tag_refuses_symlinked_snapshot_destination(tmp_path, profile_a):
+    root = tmp_path / "store"
+    entry_dir = root / "v1"
+    entry_dir.mkdir(parents=True)
+
+    victim = tmp_path / "victim.txt"
+    victim.write_text("do-not-touch", encoding="utf-8")
+
+    # Plant a symlink where the snapshot would be written.
+    link = entry_dir / baseline.SNAPSHOT_FILENAME
+    link.symlink_to(victim)
+
+    with pytest.raises(ValueError):
+        baseline.tag_baseline("v1", str(profile_a), "reason", root=root)
+
+    # The victim's contents must be untouched, and the link not followed.
+    assert victim.read_text(encoding="utf-8") == "do-not-touch"
+
+
+def test_tag_refuses_symlinked_entry_dir(tmp_path, profile_a):
+    root = tmp_path / "store"
+    root.mkdir(parents=True)
+
+    victim_dir = tmp_path / "outside"
+    victim_dir.mkdir()
+
+    # Plant a symlinked entry directory pointing outside the store.
+    (root / "v1").symlink_to(victim_dir, target_is_directory=True)
+
+    with pytest.raises(ValueError):
+        baseline.tag_baseline("v1", str(profile_a), "reason", root=root)
+
+    # Nothing should have been written into the escape target.
+    assert not (victim_dir / baseline.SNAPSHOT_FILENAME).exists()
+    assert not (victim_dir / baseline.META_FILENAME).exists()
+
+
+def test_list_skips_non_dict_meta(tmp_path, profile_a):
+    root = tmp_path / "store"
+    baseline.tag_baseline("good", str(profile_a), "ok", root=root)
+    baseline.tag_baseline("bad", str(profile_a), "ok", root=root)
+
+    # Corrupt one entry's meta.json into a non-object JSON value.
+    (root / "bad" / baseline.META_FILENAME).write_text("[]\n", encoding="utf-8")
+
+    names = [m["name"] for m in baseline.list_baselines(root=root)]
+    assert names == ["good"]
+
+
+def test_show_non_dict_meta_raises(tmp_path, profile_a):
+    root = tmp_path / "store"
+    baseline.tag_baseline("bad", str(profile_a), "ok", root=root)
+    (root / "bad" / baseline.META_FILENAME).write_text('"x"\n', encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        baseline.show_baseline("bad", root=root)
+
+
+def test_env_root_used_when_no_explicit_root(tmp_path, profile_a, monkeypatch):
+    env_root = tmp_path / "env_store"
+    monkeypatch.setenv("NSYS_AI_BASELINE_ROOT", str(env_root))
+
+    # No root= passed: tag/list/resolve should read from the env-configured root.
+    baseline.tag_baseline("v1", str(profile_a), "reason")
+    assert (env_root / "v1" / baseline.SNAPSHOT_FILENAME).is_file()
+    assert [m["name"] for m in baseline.list_baselines()] == ["v1"]
+
+    resolved = baseline.resolve_baseline_ref("baseline:v1")
+    assert resolved.startswith(str(env_root))
+
+
+def test_explicit_root_overrides_env_root(tmp_path, profile_a, monkeypatch):
+    env_root = tmp_path / "env_store"
+    monkeypatch.setenv("NSYS_AI_BASELINE_ROOT", str(env_root))
+
+    explicit = tmp_path / "explicit_store"
+    baseline.tag_baseline("v1", str(profile_a), "reason", root=explicit)
+
+    # The explicit root wins; the env root stays empty.
+    assert (explicit / "v1" / baseline.SNAPSHOT_FILENAME).is_file()
+    assert not env_root.exists()

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,147 @@
+"""Tests for the local baseline snapshot store (nsys_ai.baseline)."""
+
+import json
+import sqlite3
+
+import pytest
+
+from nsys_ai import baseline
+
+
+def _make_profile(path, *, kernels):
+    """Create a minimal Nsight-like SQLite export sufficient for Profile()."""
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE StringIds(id INT PRIMARY KEY, value TEXT)")
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL("
+        "start INT, [end] INT, deviceId INT, streamId INT, correlationId INT, "
+        "shortName INT, demangledName INT)"
+    )
+    conn.execute("CREATE TABLE NVTX_EVENTS(text TEXT, globalTid INT, start INT, [end] INT)")
+    conn.executemany(
+        "INSERT INTO StringIds(id, value) VALUES(?,?)",
+        [(1, "kA"), (2, "kA_dem")],
+    )
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL(start, [end], deviceId, streamId, "
+        "correlationId, shortName, demangledName) VALUES(?,?,?,?,?,?,?)",
+        kernels,
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def profile_a(tmp_path):
+    p = tmp_path / "before.sqlite"
+    _make_profile(p, kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    return p
+
+
+def test_parse_baseline_ref():
+    assert baseline.parse_baseline_ref("baseline:main") == "main"
+    assert baseline.parse_baseline_ref("baseline:  v1  ") == "v1"
+    assert baseline.parse_baseline_ref("some/path.sqlite") is None
+    assert baseline.parse_baseline_ref("baseline:") is None
+    assert baseline.parse_baseline_ref(None) is None
+
+
+def test_tag_round_trip(tmp_path, profile_a):
+    root = tmp_path / "store"
+    meta = baseline.tag_baseline("v1", str(profile_a), "known good", root=root)
+
+    # meta shape
+    assert meta["name"] == "v1"
+    assert meta["profile_id"].startswith("nsys1:")
+    assert meta["reason"] == "known good"
+    assert meta["runspec"] is None
+    assert meta["tagger"]
+    assert meta["tagged_at"].endswith("Z")
+    assert meta["source_path"].endswith("before.sqlite")
+
+    entry = root / "v1"
+    snapshot = entry / baseline.SNAPSHOT_FILENAME
+    meta_file = entry / baseline.META_FILENAME
+    assert snapshot.is_file()
+    assert meta_file.is_file()
+
+    # snapshot is a real copy of the source profile
+    assert snapshot.read_bytes() == profile_a.read_bytes()
+
+    # meta.json is deterministic: sorted keys, indent 2, trailing newline
+    text = meta_file.read_text(encoding="utf-8")
+    assert text.endswith("\n")
+    on_disk = json.loads(text)
+    assert on_disk == meta
+    assert text == json.dumps(meta, indent=2, sort_keys=True) + "\n"
+
+
+def test_tag_records_profile_id_matching_get_profile_id(tmp_path, profile_a):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.fingerprint import get_profile_id
+
+    with profile_mod.open(str(profile_a)) as prof:
+        expected = get_profile_id(prof.conn, fallback_path=prof.path)
+
+    root = tmp_path / "store"
+    meta = baseline.tag_baseline("v1", str(profile_a), "reason", root=root)
+    assert meta["profile_id"] == expected
+
+
+def test_tag_blank_reason_refused(tmp_path, profile_a):
+    root = tmp_path / "store"
+    with pytest.raises(ValueError):
+        baseline.tag_baseline("v1", str(profile_a), "   ", root=root)
+    with pytest.raises(ValueError):
+        baseline.tag_baseline("v1", str(profile_a), "", root=root)
+
+
+def test_tag_invalid_name_refused(tmp_path, profile_a):
+    root = tmp_path / "store"
+    for bad in ["", "  ", "..", ".", "a/b", "../evil", "foo\\bar"]:
+        with pytest.raises(ValueError):
+            baseline.tag_baseline(bad, str(profile_a), "reason", root=root)
+
+
+def test_list_and_show(tmp_path, profile_a):
+    root = tmp_path / "store"
+    assert baseline.list_baselines(root=root) == []
+
+    baseline.tag_baseline("v1", str(profile_a), "first", root=root)
+    baseline.tag_baseline("v2", str(profile_a), "second", root=root)
+
+    names = [m["name"] for m in baseline.list_baselines(root=root)]
+    assert names == ["v1", "v2"]
+
+    shown = baseline.show_baseline("v1", root=root)
+    assert shown["reason"] == "first"
+
+
+def test_show_unknown_raises(tmp_path):
+    root = tmp_path / "store"
+    with pytest.raises(ValueError):
+        baseline.show_baseline("nope", root=root)
+
+
+def test_resolve_baseline_ref(tmp_path, profile_a):
+    root = tmp_path / "store"
+    baseline.tag_baseline("v1", str(profile_a), "reason", root=root)
+
+    # both the prefixed ref and the bare name resolve to the snapshot
+    resolved = baseline.resolve_baseline_ref("baseline:v1", root=root)
+    assert resolved.endswith(baseline.SNAPSHOT_FILENAME)
+    assert baseline.resolve_baseline_ref("v1", root=root) == resolved
+
+
+def test_resolve_unknown_ref_raises(tmp_path):
+    root = tmp_path / "store"
+    with pytest.raises(ValueError):
+        baseline.resolve_baseline_ref("baseline:missing", root=root)
+
+
+def test_retag_overwrites(tmp_path, profile_a):
+    root = tmp_path / "store"
+    baseline.tag_baseline("v1", str(profile_a), "first", root=root)
+    meta = baseline.tag_baseline("v1", str(profile_a), "second", root=root)
+    assert meta["reason"] == "second"
+    assert baseline.show_baseline("v1", root=root)["reason"] == "second"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -342,3 +342,164 @@ def test_skill_run_duckdb_cache(tmp_path):
     assert cache_dir.exists(), f"Cache directory {cache_dir} was not created"
     parquet_files = list(cache_dir.glob("*.parquet"))
     assert len(parquet_files) >= 1, "No .parquet files found in cache directory"
+
+
+def _write_min_profile(path, *, dur_ns):
+    """Minimal Nsight-like SQLite export sufficient for the diff pipeline."""
+    import sqlite3
+
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE StringIds(id INT PRIMARY KEY, value TEXT)")
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL("
+        "start INT, [end] INT, deviceId INT, streamId INT, correlationId INT, "
+        "shortName INT, demangledName INT)"
+    )
+    conn.execute("CREATE TABLE NVTX_EVENTS(text TEXT, globalTid INT, start INT, [end] INT)")
+    conn.executemany(
+        "INSERT INTO StringIds(id, value) VALUES(?,?)",
+        [(1, "kA"), (2, "kA_dem")],
+    )
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL(start, [end], deviceId, streamId, "
+        "correlationId, shortName, demangledName) VALUES(?,?,?,?,?,?,?)",
+        (0, dur_ns, 0, 7, 1, 1, 2),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_baseline_subcommand_help():
+    """baseline subcommand should expose tag/list/show."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "baseline", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    for word in ("tag", "list", "show"):
+        assert word in result.stdout
+
+
+def test_baseline_tag_list_show_roundtrip(tmp_path):
+    """tag records a snapshot + meta.json; list/show read it back."""
+    import json
+
+    prof = tmp_path / "before.sqlite"
+    _write_min_profile(prof, dur_ns=10_000_000)
+
+    tag = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "baseline", "tag", "v1", str(prof),
+         "--reason", "known good"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert tag.returncode == 0, f"stderr: {tag.stderr}\nstdout: {tag.stdout}"
+
+    entry = tmp_path / ".nsys-ai-baselines" / "v1"
+    assert (entry / "snapshot.sqlite").is_file()
+    meta = json.loads((entry / "meta.json").read_text(encoding="utf-8"))
+    assert meta["name"] == "v1"
+    assert meta["reason"] == "known good"
+    assert meta["runspec"] is None
+    assert meta["profile_id"].startswith("nsys1:")
+    assert meta["tagger"]
+    assert meta["tagged_at"].endswith("Z")
+
+    listed = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "baseline", "list"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert listed.returncode == 0
+    assert "v1" in listed.stdout
+
+    shown = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "baseline", "show", "v1"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert shown.returncode == 0
+    assert json.loads(shown.stdout)["name"] == "v1"
+
+
+def test_baseline_tag_blank_reason_rejected(tmp_path):
+    prof = tmp_path / "before.sqlite"
+    _write_min_profile(prof, dur_ns=10_000_000)
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "baseline", "tag", "v1", str(prof),
+         "--reason", "   "],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "reason" in result.stderr.lower()
+
+
+def test_baseline_show_unknown_rejected(tmp_path):
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "baseline", "show", "nope"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "unknown baseline" in result.stderr.lower()
+
+
+def test_diff_against_baseline_ref(tmp_path):
+    """diff --against baseline:<name> resolves the tag and produces diff output."""
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _write_min_profile(before, dur_ns=10_000_000)
+    _write_min_profile(after, dur_ns=30_000_000)
+
+    tag = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "baseline", "tag", "v1", str(before),
+         "--reason", "known good"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert tag.returncode == 0, f"stderr: {tag.stderr}"
+
+    # --against form
+    diff1 = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", "--against", "baseline:v1",
+         str(after), "--format", "markdown", "--no-ai"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert diff1.returncode == 0, f"stderr: {diff1.stderr}\nstdout: {diff1.stdout}"
+    assert "not found" not in diff1.stderr.lower()
+    assert diff1.stdout.strip()
+
+    # positional token form
+    diff2 = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", "baseline:v1", str(after),
+         "--format", "markdown", "--no-ai"],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert diff2.returncode == 0, f"stderr: {diff2.stderr}\nstdout: {diff2.stdout}"
+    assert diff2.stdout.strip()
+
+
+def test_diff_against_unknown_baseline_errors(tmp_path):
+    after = tmp_path / "after.sqlite"
+    _write_min_profile(after, dur_ns=30_000_000)
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", "--against", "baseline:missing",
+         str(after)],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 2
+    assert "unknown baseline" in result.stderr.lower()


### PR DESCRIPTION
## Summary

Adds a local, CI-friendly baseline snapshot store plus a `baseline` subcommand (`tag` / `list` / `show`) and `diff --against baseline:<name>` resolution. A "known good" run can be captured once and compared against later without re-supplying (or losing) the original file path — `diff --against baseline:main` resolves a stable name to a stored snapshot instead of a fragile path.

## Changes

- **New module `src/nsys_ai/baseline.py`** — `tag_baseline` / `list_baselines` / `show_baseline` / `resolve_baseline_ref` / `parse_baseline_ref`. Each tag is stored under `.nsys-ai-baselines/<name>/` as a self-contained `snapshot.sqlite` (a copy of the resolved profile, so the baseline survives the original file moving) plus a deterministic `meta.json` (`json.dumps(indent=2, sort_keys=True)` + trailing newline).
- **`meta.json` fields** — `name`, `profile_id` (via `fingerprint.get_profile_id`), `source_path`, `reason`, `tagged_at` (UTC ISO-8601), `tagger` (reuses `diff_decision.resolve_decider_identity`), and `runspec: null`.
- **`diff` resolution** — the `diff` subparser gains `--against REF` and the `before` positional becomes optional (`nargs="?"`); `_resolve_diff_before` fills the before side from `--against` or the positional and resolves any `baseline:<name>` token on either side to the stored snapshot before the profiles are opened. Existing `diff <before> <after>` usage is unchanged.
- Name validation rejects empty / `.` / `..` / path-separator names to avoid traversal; all guards use `raise ValueError` (no `assert`). `.nsys-ai-baselines/` added to `.gitignore`.

## RunSpec deferral

The issue notes this is "blocked by #25 (RunSpec recording), since a tag stores the RunSpec snapshot." RunSpec recording does not exist yet, and it is only needed for later "compatible setup" checks — not for resolving a baseline snapshot. So `runspec` is stored as a forward-compatible `null` placeholder (documented in the module docstring); a future #25 can populate it without changing the on-disk layout. All Done criteria are met without it.

## Testing

- **`tests/test_baseline.py`** (store module) — tag round-trip (profile_id recorded, snapshot copied byte-identical, meta.json shape), list/show, `resolve_baseline_ref`, unknown-name error, blank-reason refusal, and path-traversal name rejection (`a/b`, `../evil`, `.`, `..`).
- **`tests/test_cli.py`** (subprocess smoke) — `baseline --help`, tag/list/show round-trip, blank-reason exit 2, unknown-show exit 2, and a real end-to-end `diff --against baseline:v1 <after>` plus the positional `diff baseline:v1 <after>` form resolving and producing diff output, and unknown-baseline exit 2.
- Full targeted run: **122 passed** (`test_baseline.py` + `test_cli.py` + `test_diff.py`); `ruff check src/ tests/` clean; `bandit -r src/` clean (no new findings). Verified live that `diff --against baseline:v1` resolves to the stored snapshot and that no `.nsys-ai-baselines/` is left in the repo (tests confine the store to a tmp root).

Closes #180.
