### PR TITLE
feat(findings): add headroom/ROI field and rank findings by opportunity

### DIFF
--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -97,11 +97,8 @@ class Finding:
     provenance: dict[str, Any] | None = None
     diff_lineage: "DiffLineage | None" = None
     # Potential recoverable time (ms) if this finding's inefficiency were
-    # removed — the optimization *opportunity*. Lets consumers rank by upside
-    # rather than only severity: a small idle gap with large headroom should
-    # outrank a dramatic-looking finding with little room to improve. Optional;
-    # drops from to_dict when None, and ranking is a no-op when no finding
-    # carries one (see :func:`rank_findings`).
+    # removed — the optimization *opportunity*, used by :func:`rank_findings`
+    # to order findings by upside rather than severity alone.
     headroom_ms: float | None = None
 
     def to_dict(self) -> dict:
@@ -153,27 +150,28 @@ class Finding:
         return cls(**filtered)
 
 
+def headroom_sort_prefix(headroom_ms: float | None) -> tuple[int, float]:
+    """Sort-key prefix that orders by optimization opportunity.
+
+    Items with a numeric ``headroom_ms`` come first, largest headroom first;
+    ``None`` (or any non-numeric value that survived deserialization) sorts
+    after. Shared by :func:`rank_findings` (Finding objects) and the guided
+    loop's dict-based ranking so both stay consistent.
+    """
+    hv = headroom_ms if isinstance(headroom_ms, (int, float)) else None
+    return (0 if hv is not None else 1, -(hv or 0.0))
+
+
 def rank_findings(findings: list["Finding"]) -> list["Finding"]:
     """Order findings by optimization opportunity (largest headroom first).
 
-    Findings carrying a ``headroom_ms`` sort ahead of those without, largest
-    headroom first, so the biggest *recoverable* win surfaces first regardless
-    of how severe a finding merely looks. Findings without a headroom keep
-    their original relative order and follow the headroom-bearing ones.
-
-    The ranking is a deliberate no-op when **no** finding carries a headroom:
-    the input order is returned unchanged, so behaviour on legacy findings is
-    identical to before. The sort is stable.
+    Findings carrying a numeric ``headroom_ms`` sort ahead of those without,
+    largest first, so the biggest *recoverable* win surfaces first regardless
+    of how severe a finding merely looks. The sort is stable, so findings
+    without a headroom keep their original relative order and — when **no**
+    finding carries one — the input order is returned unchanged.
     """
-    if not any(f.headroom_ms is not None for f in findings):
-        return list(findings)
-
-    def _key(item: tuple[int, "Finding"]) -> tuple:
-        idx, f = item
-        has_headroom = f.headroom_ms is not None
-        return (0 if has_headroom else 1, -(f.headroom_ms or 0.0), idx)
-
-    return [f for _, f in sorted(enumerate(findings), key=_key)]
+    return sorted(findings, key=lambda f: headroom_sort_prefix(f.headroom_ms))
 
 
 @dataclass

--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -96,6 +96,13 @@ class Finding:
     false_positive_notes: list[str] | None = None
     provenance: dict[str, Any] | None = None
     diff_lineage: "DiffLineage | None" = None
+    # Potential recoverable time (ms) if this finding's inefficiency were
+    # removed — the optimization *opportunity*. Lets consumers rank by upside
+    # rather than only severity: a small idle gap with large headroom should
+    # outrank a dramatic-looking finding with little room to improve. Optional;
+    # drops from to_dict when None, and ranking is a no-op when no finding
+    # carries one (see :func:`rank_findings`).
+    headroom_ms: float | None = None
 
     def to_dict(self) -> dict:
         # Walk fields() directly for scalar / primitive fields; nested
@@ -144,6 +151,29 @@ class Finding:
         if filtered.get("diff_lineage") is not None:
             filtered["diff_lineage"] = DiffLineage.from_dict(filtered["diff_lineage"])
         return cls(**filtered)
+
+
+def rank_findings(findings: list["Finding"]) -> list["Finding"]:
+    """Order findings by optimization opportunity (largest headroom first).
+
+    Findings carrying a ``headroom_ms`` sort ahead of those without, largest
+    headroom first, so the biggest *recoverable* win surfaces first regardless
+    of how severe a finding merely looks. Findings without a headroom keep
+    their original relative order and follow the headroom-bearing ones.
+
+    The ranking is a deliberate no-op when **no** finding carries a headroom:
+    the input order is returned unchanged, so behaviour on legacy findings is
+    identical to before. The sort is stable.
+    """
+    if not any(f.headroom_ms is not None for f in findings):
+        return list(findings)
+
+    def _key(item: tuple[int, "Finding"]) -> tuple:
+        idx, f = item
+        has_headroom = f.headroom_ms is not None
+        return (0 if has_headroom else 1, -(f.headroom_ms or 0.0), idx)
+
+    return [f for _, f in sorted(enumerate(findings), key=_key)]
 
 
 @dataclass

--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -10,7 +10,7 @@ import logging
 import os
 from collections.abc import Callable
 
-from .annotation import EvidenceReport, Finding
+from .annotation import EvidenceReport, Finding, rank_findings
 from .profile import Profile
 
 _log = logging.getLogger(__name__)
@@ -139,9 +139,11 @@ class EvidenceBuilder:
                     "Analyzer %s (skill %s) failed: %s", analyzer_name, skill_name, e, exc_info=True
                 )
 
+        # Rank by optimization opportunity (headroom) so the biggest
+        # recoverable win surfaces first. No-op when no skill emits a headroom.
         return EvidenceReport(
             title="Auto-Analysis",
             profile_id=profile_id,
             profile_path=profile_path,
-            findings=findings,
+            findings=rank_findings(findings),
         )

--- a/src/nsys_ai/loop_state.py
+++ b/src/nsys_ai/loop_state.py
@@ -29,8 +29,16 @@ def _phase_index(phase: str) -> int:
 
 
 def _normalize_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    """Rank findings so workflow surfaces high-signal rows first."""
-    ranked: list[tuple[int, dict[str, Any]]] = []
+    """Rank findings so the workflow surfaces the biggest opportunity first.
+
+    When any finding carries a ``headroom_ms`` (recoverable time), those lead —
+    largest headroom first — so a small idle gap with large upside outranks a
+    dramatic-looking finding with little room to improve; the rest fall back to
+    the legacy severity heuristic. When no finding carries a headroom the legacy
+    heuristic order is preserved exactly.
+    """
+    has_headroom = any(isinstance(f.get("headroom_ms"), (int, float)) for f in findings)
+    ranked: list[tuple[int, dict[str, Any], int, float | None]] = []
     for idx, f in enumerate(findings):
         severity = str(f.get("severity") or "").lower()
         kind = str(f.get("type") or "").lower()
@@ -42,9 +50,17 @@ def _normalize_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
         confidence = f.get("confidence")
         if isinstance(confidence, (int, float)):
             score += int(confidence * 100)
-        ranked.append((score - idx, f))
-    ranked.sort(key=lambda x: x[0], reverse=True)
-    return [f for _, f in ranked]
+        hv = f.get("headroom_ms")
+        headroom = float(hv) if isinstance(hv, (int, float)) else None
+        ranked.append((idx, f, score, headroom))
+
+    if has_headroom:
+        ranked.sort(
+            key=lambda t: (0 if t[3] is not None else 1, -(t[3] or 0.0), -t[2], t[0])
+        )
+    else:
+        ranked.sort(key=lambda t: t[2] - t[0], reverse=True)
+    return [f for _, f, *_ in ranked]
 
 
 def normalize_profile_path(path: str, *, label: str = "profile") -> str:

--- a/src/nsys_ai/loop_state.py
+++ b/src/nsys_ai/loop_state.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal
 
+from .annotation import headroom_sort_prefix
+
 Phase = Literal["diagnose", "propose", "reprofile", "diff", "accept"]
 Decision = Literal["accept", "reject"]
 Scope = Literal["global", "gpu", "iteration", "region"]
@@ -55,9 +57,8 @@ def _normalize_findings(findings: list[dict[str, Any]]) -> list[dict[str, Any]]:
         ranked.append((idx, f, score, headroom))
 
     if has_headroom:
-        ranked.sort(
-            key=lambda t: (0 if t[3] is not None else 1, -(t[3] or 0.0), -t[2], t[0])
-        )
+        # Opportunity-first, then the legacy heuristic score, then stable by idx.
+        ranked.sort(key=lambda t: (*headroom_sort_prefix(t[3]), -t[2], t[0]))
     else:
         ranked.sort(key=lambda t: t[2] - t[0], reverse=True)
     return [f for _, f, *_ in ranked]

--- a/src/nsys_ai/skills/builtins/critical_path.py
+++ b/src/nsys_ai/skills/builtins/critical_path.py
@@ -546,6 +546,14 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         provenance={"row_kind": "bound_class", "device": device},
     )
 
+    # Headroom = the recoverable on-path time for the dominant bucket: the full
+    # host-wait (cpu) or exposed-collective (comm) time is what eliminating that
+    # bottleneck would return. A gpu-compute-bound path has no headroom here —
+    # its recoverable time is a speed-of-light question (region MFU), not a
+    # bucket that can simply be removed — so it is left unset.
+    _headroom_by_cat = {"cpu": b.get("cpu_ms"), "comm": b.get("comm_ms")}
+    headroom_ms = _headroom_by_cat.get(top_cat)
+
     return [
         Finding(
             type="region",
@@ -558,6 +566,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
             id=finding_id,
             category=_CATEGORY_TO_FINDING[top_cat],
             confidence=float(r.get("confidence", 0.0)),
+            headroom_ms=headroom_ms,
             evidence=[evidence_row],
             selection=selection,
             explanation=_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -466,9 +466,9 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 id=finding_id,
                 category="idle",
                 confidence=_gap_confidence(gap_ms),
-                # The gap duration is the recoverable time if the bubble closed
-                # (an upper bound — some is unavoidable launch overhead).
-                headroom_ms=round(gap_ms, 3),
+                # No per-gap headroom: the aggregate idle opportunity is carried
+                # once by the summary finding above, so each recoverable ms is
+                # attributed to exactly one finding rather than double-counted.
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -387,6 +387,9 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                         id=finding_id,
                         category="idle",
                         confidence=min(0.95, 0.4 + pct / 100),
+                        # All idle time on the pipeline is candidate recoverable
+                        # time — the opportunity if the bubbles were closed.
+                        headroom_ms=total_idle_ms,
                         evidence=[evidence_row],
                         selection=selection,
                         explanation=_EXPLANATION,
@@ -463,6 +466,9 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 id=finding_id,
                 category="idle",
                 confidence=_gap_confidence(gap_ms),
+                # The gap duration is the recoverable time if the bubble closed
+                # (an upper bound — some is unavoidable launch overhead).
+                headroom_ms=round(gap_ms, 3),
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -78,6 +78,8 @@ def _to_findings(rows: list[dict]) -> list:
                         f"({pct:.0f}% of median {med:.1f}ms), "
                         f"{it.get('kernel_count', 0)} kernels"
                     ),
+                    # Recoverable time if this iteration ran at the median pace.
+                    headroom_ms=round(it["duration_ms"] - med, 3),
                 )
             )
     return findings

--- a/src/nsys_ai/skills/builtins/nccl_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_breakdown.py
@@ -311,6 +311,9 @@ def _to_findings(rows: list[dict], *, context: dict | None = None)-> list:
                 id=finding_id,
                 category="communication",
                 confidence=_variability_confidence(ratio, r.get("count", 0)),
+                # Straggler slack: the slowest instance's excess over the
+                # average is recoverable if the variability were eliminated.
+                headroom_ms=round(r["max_ms"] - r["avg_ms"], 3),
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_HIGH_VARIABILITY_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -326,6 +326,9 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 id=finding_id,
                 category="communication",
                 confidence=_overlap_confidence(float(overlap_pct), float(nccl_ms), float(total_ms)),
+                # Exposed (non-overlapped) NCCL is the time recoverable if the
+                # collective were hidden under compute.
+                headroom_ms=r.get("nccl_only_ms", 0.0),
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_LOW_OVERLAP_EXPLANATION,
@@ -377,6 +380,8 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                     id=finding_id,
                     category="communication",
                     confidence=_ratio_confidence(float(ratio)),
+                    # Exposed (non-overlapped) NCCL is the recoverable time.
+                    headroom_ms=r.get("nccl_only_ms", 0.0),
                     evidence=[evidence_row],
                     selection=selection,
                     explanation=_COMM_DOMINATED_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -265,6 +265,13 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
 
     profile_id = (context or {}).get("profile_id", "unknown")
     r = rows[0]
+    # Exposed (non-overlapped) NCCL is the recoverable time. The low-overlap and
+    # comm-dominated findings below describe the same inefficiency and can both
+    # fire on one row, so the headroom is attributed to exactly one of them (the
+    # first to fire) — carrying it on both would double-count the same ms and
+    # corrupt the opportunity ranking. None (not 0.0) means "no signal".
+    exposed_nccl_ms = r.get("nccl_only_ms")
+    headroom_claimed = False
     nccl_ms = r.get("nccl_only_ms", 0) + r.get("overlap_ms", 0)
     compute_ms = r.get("compute_only_ms", 0)
     overlap_pct = r.get("overlap_pct", 0)
@@ -326,9 +333,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 id=finding_id,
                 category="communication",
                 confidence=_overlap_confidence(float(overlap_pct), float(nccl_ms), float(total_ms)),
-                # Exposed (non-overlapped) NCCL is the time recoverable if the
-                # collective were hidden under compute.
-                headroom_ms=r.get("nccl_only_ms", 0.0),
+                headroom_ms=exposed_nccl_ms,
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_LOW_OVERLAP_EXPLANATION,
@@ -337,6 +342,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 provenance={"skill": "overlap_breakdown", "row_kind": "low_overlap"},
             )
         )
+        headroom_claimed = True
 
     # Communication dominated: NCCL > compute
     if nccl_ms > 0 and compute_ms > 0:
@@ -380,8 +386,9 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                     id=finding_id,
                     category="communication",
                     confidence=_ratio_confidence(float(ratio)),
-                    # Exposed (non-overlapped) NCCL is the recoverable time.
-                    headroom_ms=r.get("nccl_only_ms", 0.0),
+                    # Exposed NCCL headroom already claimed by the low-overlap
+                    # finding if it fired; avoid double-counting the same ms.
+                    headroom_ms=None if headroom_claimed else exposed_nccl_ms,
                     evidence=[evidence_row],
                     selection=selection,
                     explanation=_COMM_DOMINATED_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/region_mfu.py
+++ b/src/nsys_ai/skills/builtins/region_mfu.py
@@ -82,6 +82,28 @@ def _format(rows):
     return "\n".join(lines)
 
 
+_EXPLANATION = (
+    "MFU (Model FLOPs Utilization) is achieved TFLOPS / hardware peak TFLOPS for "
+    "the region. The speed-of-light headroom is the GPU-busy time recoverable if "
+    "the region reached peak: union kernel time * (1 - MFU). It bounds the "
+    "opportunity; realizing it needs kernel-level work (better tiling, tensor-core "
+    "use, fusion)."
+)
+_SUGGESTED_ACTIONS = [
+    "Profile the region's top kernels for occupancy and tensor-core eligibility",
+    "Check for memory-bound kernels that cap achievable FLOPS below peak",
+    "Confirm the theoretical_flops used matches the region's actual math",
+]
+_FALSE_POSITIVE_NOTES = [
+    "MFU is only as correct as the user-supplied theoretical_flops; a wrong FLOP "
+    "count scales the headroom proportionally",
+    "The peak is the hardware datasheet ceiling for the chosen precision — real "
+    "attainable peak is lower, so the headroom is an upper bound",
+    "Region-level, not time-anchored: the finding sizes the opportunity, it does "
+    "not localize it to a specific kernel or timestamp",
+]
+
+
 def _to_findings(rows, *, context: dict | None = None) -> list:
     """Emit a speed-of-light finding carrying the region's MFU headroom.
 
@@ -149,10 +171,12 @@ def _to_findings(rows, *, context: dict | None = None) -> list:
             ),
             id=finding_id,
             category="compute",
-            confidence=None,
             headroom_ms=headroom,
             evidence=[evidence_row],
             selection=selection,
+            explanation=_EXPLANATION,
+            suggested_actions=list(_SUGGESTED_ACTIONS),
+            false_positive_notes=list(_FALSE_POSITIVE_NOTES),
             provenance={"skill": "region_mfu", "row_kind": "region_sol"},
         )
     ]

--- a/src/nsys_ai/skills/builtins/region_mfu.py
+++ b/src/nsys_ai/skills/builtins/region_mfu.py
@@ -41,6 +41,24 @@ def _execute(conn, **kwargs):
     return [result]
 
 
+def _sol_headroom_ms(r: dict) -> float | None:
+    """Speed-of-light headroom in ms: time recoverable if the region ran at peak.
+
+    Uses the kernel-union basis — real GPU-busy wall time in the region, no
+    double-counting of concurrent kernels — paired with its matching MFU, so
+    numerator and denominator are the same physical time:
+    ``union_ms * (1 - mfu_pct_kernel_union / 100)``. Returns ``None`` when the
+    inputs are missing or non-positive (e.g. no theoretical_flops supplied),
+    so the region contributes no headroom rather than a bogus zero.
+    """
+    union_s = r.get("gpu_kernel_union_s")
+    mfu = r.get("mfu_pct_kernel_union")
+    if not union_s or union_s <= 0 or mfu is None or mfu <= 0:
+        return None
+    recoverable = union_s * 1000.0 * (1.0 - min(float(mfu), 100.0) / 100.0)
+    return round(recoverable, 3) if recoverable > 0 else None
+
+
 def _format(rows):
     if not rows:
         return "(No MFU data)"
@@ -49,19 +67,95 @@ def _format(rows):
         err = r["error"]
         return f"(MFU error: {err.get('code', '?')}: {err.get('message', '')})"
     lines = ["── Region MFU ──"]
-    lines.append(f"  Region: {r.get('matched_name', '?')}")
+    lines.append(f"  Region: {r.get('matched_text') or r.get('name', '?')}")
     lines.append(f"  Source: {r.get('source', '?')}")
-    timing = r.get("timing", {})
-    if timing:
-        lines.append(f"  Wall time:     {timing.get('wall_time_ms', 0):.2f}ms")
-        lines.append(f"  Kernel sum:    {timing.get('kernel_sum_ms', 0):.2f}ms")
-        lines.append(f"  Kernel union:  {timing.get('kernel_union_ms', 0):.2f}ms")
-    mfu = r.get("mfu", {})
-    if mfu:
-        lines.append(f"  MFU: {mfu.get('mfu_pct', 0):.1f}%")
-        lines.append(f"  Achieved: {mfu.get('achieved_tflops', 0):.1f} TFLOPS")
-        lines.append(f"  Peak: {mfu.get('peak_tflops', 0):.0f} TFLOPS")
+    # Timings are stored in seconds on the result; render as ms.
+    lines.append(f"  Wall time:     {r.get('wall_time_s', 0) * 1e3:.2f}ms")
+    lines.append(f"  Kernel sum:    {r.get('gpu_kernel_sum_s', 0) * 1e3:.2f}ms")
+    lines.append(f"  Kernel union:  {r.get('gpu_kernel_union_s', 0) * 1e3:.2f}ms")
+    lines.append(f"  MFU (union):   {r.get('mfu_pct_kernel_union', 0):.1f}%")
+    lines.append(f"  Achieved:      {r.get('achieved_tflops_kernel_union', 0):.1f} TFLOPS")
+    lines.append(f"  Peak:          {r.get('peak_tflops', 0):.0f} TFLOPS")
+    headroom = _sol_headroom_ms(r)
+    if headroom is not None:
+        lines.append(f"  SOL headroom:  {headroom:.2f}ms (recoverable at peak)")
     return "\n".join(lines)
+
+
+def _to_findings(rows, *, context: dict | None = None) -> list:
+    """Emit a speed-of-light finding carrying the region's MFU headroom.
+
+    Only emitted when a headroom can be computed (a theoretical_flops was
+    supplied and MFU is below 100%); otherwise no finding, so behaviour is
+    unchanged for callers that don't request MFU. The finding is region-level:
+    region_mfu does not expose per-instance timestamps, so the overlay is not
+    time-anchored — its value is the ranked opportunity, not a timeline span.
+    """
+    from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
+
+    if not rows or "error" in rows[0]:
+        return []
+    r = rows[0]
+    headroom = _sol_headroom_ms(r)
+    if headroom is None:
+        return []
+
+    mfu = float(r.get("mfu_pct_kernel_union", 0.0))
+    region = r.get("matched_text") or r.get("name") or "region"
+    device_ids = r.get("device_ids") or ([r["device_id"]] if r.get("device_id") is not None else [])
+    device = int(device_ids[0]) if device_ids else 0
+    slug = "".join(c if c.isalnum() else "_" for c in str(region))[:48]
+    finding_id = f"region_mfu_sol_{slug}"
+
+    selection = TraceSelection(
+        id=f"sel_{finding_id}",
+        profile_id=(context or {}).get("profile_id", "unknown"),
+        source="skill:region_mfu",
+        gpu_ids=device_ids or None,
+        label=f"{region} MFU {mfu:.0f}%",
+    )
+    evidence_row = EvidenceRow(
+        id=f"ev_{finding_id}",
+        source_skill="region_mfu",
+        values={
+            "mfu_pct_kernel_union": round(mfu, 2),
+            "kernel_union_ms": round(float(r.get("gpu_kernel_union_s", 0.0)) * 1e3, 3),
+            "achieved_tflops": round(float(r.get("achieved_tflops_kernel_union", 0.0)), 2),
+            "peak_tflops": round(float(r.get("peak_tflops", 0.0)), 1),
+            "sol_headroom_ms": headroom,
+        },
+        units={
+            "mfu_pct_kernel_union": "percent",
+            "kernel_union_ms": "ms",
+            "achieved_tflops": "tflops",
+            "peak_tflops": "tflops",
+            "sol_headroom_ms": "ms",
+        },
+        selection_id=selection.id,
+        provenance={"row_kind": "region_sol", "region": region},
+    )
+
+    return [
+        Finding(
+            type="region",
+            label=f"{region} at {mfu:.0f}% MFU ({headroom:.0f}ms below peak)",
+            start_ns=0,
+            end_ns=0,
+            gpu_id=device,
+            severity="warning" if mfu < 40 else "info",
+            note=(
+                f"Region '{region}' runs at {mfu:.1f}% MFU; up to {headroom:.1f}ms is "
+                "recoverable if it reached the hardware speed-of-light."
+            ),
+            id=finding_id,
+            category="compute",
+            confidence=None,
+            headroom_ms=headroom,
+            evidence=[evidence_row],
+            selection=selection,
+            provenance={"skill": "region_mfu", "row_kind": "region_sol"},
+        )
+    ]
 
 
 SKILL = Skill(
@@ -75,6 +169,7 @@ SKILL = Skill(
     category="kernels",
     execute_fn=_execute,
     format_fn=_format,
+    to_findings_fn=_to_findings,
     params=[
         SkillParam("name", "NVTX region or kernel name to analyze", "str", True, None),
         SkillParam(

--- a/tests/test_critical_path.py
+++ b/tests/test_critical_path.py
@@ -385,6 +385,32 @@ def test_insufficient_on_path_time_reported_mixed():
 # ---------------------------------------------------------------------------
 
 
+def test_headroom_is_dominant_bucket_for_confident_class():
+    """cpu-bound / comm-bound findings carry headroom == the recoverable bucket;
+    gpu-compute-bound carries none (its headroom is a speed-of-light question)."""
+    # cpu-bound
+    cpu = [
+        (0, 7, 1, 0, 100_000, 1),
+        (0, 7, 2, 20 * MS, 20 * MS + 100_000, 1),
+        (0, 7, 3, 40 * MS, 40 * MS + 100_000, 1),
+    ]
+    conn = _make_conn(cpu)
+    skill, r = _run(conn)
+    findings = skill.to_findings_fn([r])
+    conn.close()
+    assert r["bound_class"] == "cpu-bound"
+    assert findings[0].headroom_ms == r["breakdown"]["cpu_ms"]
+
+    # gpu-compute-bound -> no bucket headroom
+    gpu = [(0, 7, 1, 0, 10 * MS, 1), (0, 7, 2, 10 * MS, 20 * MS, 1), (0, 7, 3, 20 * MS, 30 * MS, 1)]
+    conn = _make_conn(gpu)
+    skill, r = _run(conn)
+    findings = skill.to_findings_fn([r])
+    conn.close()
+    assert r["bound_class"] == "gpu-compute-bound"
+    assert findings[0].headroom_ms is None
+
+
 def test_cpu_attribution_grounds_cpu_bucket():
     """A cpu-bound run whose dispatches lag the GPU by >1ms surfaces the
     dispatch-starvation count, so the cpu class is grounded in *why*."""

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -1,0 +1,219 @@
+"""Tests for Finding.headroom_ms and opportunity-based ranking (#190)."""
+
+from nsys_ai.annotation import Finding, rank_findings
+from nsys_ai.loop_state import _normalize_findings
+
+
+def _f(label, *, severity="info", headroom_ms=None, confidence=None, type="region"):
+    return Finding(
+        type=type,
+        label=label,
+        start_ns=0,
+        end_ns=1,
+        severity=severity,
+        headroom_ms=headroom_ms,
+        confidence=confidence,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Field round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_headroom_serializes_when_set():
+    f = _f("x", headroom_ms=12.5)
+    d = f.to_dict()
+    assert d["headroom_ms"] == 12.5
+    assert Finding.from_dict(d).headroom_ms == 12.5
+
+
+def test_headroom_dropped_when_none():
+    d = _f("x").to_dict()
+    assert "headroom_ms" not in d  # legacy JSON stays compact
+    assert Finding.from_dict(d).headroom_ms is None
+
+
+# ---------------------------------------------------------------------------
+# rank_findings (Finding objects — the evidence_builder path)
+# ---------------------------------------------------------------------------
+
+
+def test_large_headroom_outranks_high_severity():
+    """The issue's example: a low-severity finding with large headroom beats a
+    dramatic-looking (critical) finding with little room to improve."""
+    dramatic = _f("critical but little upside", severity="critical", headroom_ms=2.0)
+    opportunity = _f("info but big upside", severity="info", headroom_ms=200.0)
+    ranked = rank_findings([dramatic, opportunity])
+    assert [f.label for f in ranked] == [
+        "info but big upside",
+        "critical but little upside",
+    ]
+
+
+def test_findings_without_headroom_sort_last():
+    a = _f("no headroom A")
+    b = _f("has headroom", headroom_ms=50.0)
+    c = _f("no headroom B")
+    ranked = rank_findings([a, b, c])
+    assert ranked[0].label == "has headroom"
+    # The two headroom-less findings keep their original relative order.
+    assert [f.label for f in ranked[1:]] == ["no headroom A", "no headroom B"]
+
+
+def test_no_headroom_anywhere_is_unchanged():
+    """When nothing carries a headroom, ranking is a no-op (stable order)."""
+    items = [_f("first", severity="info"), _f("second", severity="critical")]
+    ranked = rank_findings(items)
+    assert [f.label for f in ranked] == ["first", "second"]
+
+
+def test_rank_findings_empty():
+    assert rank_findings([]) == []
+
+
+# ---------------------------------------------------------------------------
+# _normalize_findings (dict-based — the guided-loop path)
+# ---------------------------------------------------------------------------
+
+
+def test_normalize_findings_opportunity_first():
+    findings = [
+        {"label": "crit small", "severity": "critical", "type": "region", "headroom_ms": 3.0},
+        {"label": "info big", "severity": "info", "type": "region", "headroom_ms": 300.0},
+    ]
+    ranked = _normalize_findings(findings)
+    assert [f["label"] for f in ranked] == ["info big", "crit small"]
+
+
+def test_normalize_findings_legacy_when_no_headroom():
+    """No headroom present -> legacy severity heuristic order is preserved."""
+    findings = [
+        {"label": "info", "severity": "info", "type": "region"},
+        {"label": "critical", "severity": "critical", "type": "region"},
+    ]
+    ranked = _normalize_findings(findings)
+    assert [f["label"] for f in ranked] == ["critical", "info"]
+
+
+# ---------------------------------------------------------------------------
+# Producers populate headroom from their existing recoverable-ms evidence
+# ---------------------------------------------------------------------------
+
+
+def test_gpu_idle_gaps_headroom():
+    from nsys_ai.skills.builtins.gpu_idle_gaps import _to_findings
+
+    rows = [
+        {  # summary row
+            "_summary": True, "pct_of_profile": 20, "gpu_id": 0,
+            "profile_start_ns": 0, "profile_end_ns": 100_000_000,
+            "total_idle_ms": 40.0, "gap_count": 3,
+        },
+        {  # a single 5ms gap
+            "gap_ns": 5_000_000, "start_ns": 10_000_000, "end_ns": 15_000_000,
+            "deviceId": 0, "streamId": 7,
+        },
+    ]
+    findings = _to_findings(rows, context={"profile_id": "p"})
+    summary = next(f for f in findings if "Summary" in f.label)
+    gap = next(f for f in findings if "Gap" in f.label)
+    assert summary.headroom_ms == 40.0  # total recoverable idle
+    assert gap.headroom_ms == 5.0  # the gap duration in ms
+
+
+def test_overlap_breakdown_headroom_is_exposed_nccl():
+    from nsys_ai.skills.builtins.overlap_breakdown import _to_findings
+
+    rows = [{
+        "nccl_only_ms": 30.0, "overlap_ms": 5.0, "compute_only_ms": 10.0,
+        "overlap_pct": 14, "total_ms": 45.0,
+        "span_start_ns": 0, "span_end_ns": 45_000_000, "device_id": 0,
+    }]
+    findings = _to_findings(rows, context={"profile_id": "p"})
+    assert findings  # low-overlap and comm-dominated both fire
+    for f in findings:
+        assert f.headroom_ms == 30.0  # exposed (non-overlapped) NCCL
+
+
+def test_iteration_timing_headroom_is_slack_over_median():
+    from nsys_ai.skills.builtins.iteration_timing import _to_findings
+
+    rows = [
+        {"iteration": 1, "duration_ms": 10.0, "gpu_start_ns": 0,
+         "gpu_end_ns": 10_000_000, "kernel_count": 5},
+        {"iteration": 2, "duration_ms": 10.0, "gpu_start_ns": 10_000_000,
+         "gpu_end_ns": 20_000_000, "kernel_count": 5},
+        {"iteration": 3, "duration_ms": 40.0, "gpu_start_ns": 20_000_000,
+         "gpu_end_ns": 60_000_000, "kernel_count": 5},
+    ]
+    findings = _to_findings(rows)
+    assert len(findings) == 1  # only iter 3 exceeds 1.5x median
+    assert findings[0].headroom_ms == 30.0  # 40ms - median(10ms)
+
+
+def test_nccl_variability_headroom_is_straggler_slack():
+    from nsys_ai.skills.builtins.nccl_breakdown import _to_findings
+
+    rows = [{
+        "type": "allreduce", "pct": 50.0, "total_ms": 100.0,
+        "avg_ms": 5.0, "max_ms": 20.0, "count": 10, "stream_id": 7,
+        "device_id": 0, "span_start_ns": 0, "span_end_ns": 100_000_000,
+    }]
+    findings = _to_findings(rows, context={"profile_id": "p"})
+    var = next(f for f in findings if "Variability" in f.label)
+    assert var.headroom_ms == 15.0  # max(20) - avg(5)
+
+
+# ---------------------------------------------------------------------------
+# region_mfu speed-of-light headroom (Phase 3) + formatter fix
+# ---------------------------------------------------------------------------
+
+
+def _mfu_result(mfu_union, union_s=0.1):
+    return {
+        "name": "attn", "matched_text": "attn", "source": "nvtx",
+        "device_id": 0, "device_ids": [0],
+        "wall_time_s": union_s, "gpu_kernel_sum_s": union_s, "gpu_kernel_union_s": union_s,
+        "mfu_pct_kernel_union": mfu_union,
+        "achieved_tflops_kernel_union": 100.0, "peak_tflops": 300.0,
+    }
+
+
+def test_sol_headroom_formula():
+    from nsys_ai.skills.builtins.region_mfu import _sol_headroom_ms
+
+    # 100ms union at 40% MFU -> 60ms recoverable at peak.
+    assert _sol_headroom_ms(_mfu_result(40.0, union_s=0.1)) == 60.0
+    # No MFU (no FLOPs supplied) -> no headroom, not a bogus zero.
+    assert _sol_headroom_ms(_mfu_result(0.0)) is None
+    assert _sol_headroom_ms({"gpu_kernel_union_s": 0.1}) is None
+
+
+def test_region_mfu_emits_headroom_finding():
+    from nsys_ai.skills.builtins.region_mfu import _to_findings
+
+    findings = _to_findings([_mfu_result(30.0, union_s=0.1)], context={"profile_id": "p"})
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.headroom_ms == 70.0  # 100ms * (1 - 0.30)
+    assert f.category == "compute"
+    assert f.severity == "warning"  # low MFU is a real opportunity
+
+
+def test_region_mfu_no_finding_without_flops():
+    from nsys_ai.skills.builtins.region_mfu import _to_findings
+
+    assert _to_findings([_mfu_result(0.0)]) == []
+    assert _to_findings([{"error": {"code": "no_flops"}}]) == []
+
+
+def test_region_mfu_format_renders_ms_not_zeros():
+    """Regression: the old formatter read non-existent timing.*/mfu.* keys and
+    printed zeros; it must now render the real flat, seconds-based values."""
+    from nsys_ai.skills.builtins.region_mfu import _format
+
+    text = _format([_mfu_result(40.0, union_s=0.05)])  # 50ms union
+    assert "50.00ms" in text  # kernel union rendered from seconds
+    assert "40.0%" in text  # MFU rendered
+    assert "SOL headroom" in text

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -72,6 +72,41 @@ def test_rank_findings_empty():
     assert rank_findings([]) == []
 
 
+def test_rank_findings_stable_on_equal_headroom():
+    """Findings with identical headroom keep their original relative order."""
+    a = _f("a", headroom_ms=50.0)
+    b = _f("b", headroom_ms=50.0)
+    c = _f("c", headroom_ms=50.0)
+    assert [f.label for f in rank_findings([a, b, c])] == ["a", "b", "c"]
+
+
+def test_build_ranks_findings_by_headroom(minimal_nsys_db_path, monkeypatch):
+    """EvidenceBuilder.build() must apply rank_findings so the largest-headroom
+    finding surfaces first — pinning the wiring, not just the primitive."""
+    from nsys_ai.evidence_builder import EvidenceBuilder
+    from nsys_ai.profile import Profile
+
+    lo = _f("low headroom / critical", severity="critical", headroom_ms=2.0)
+    hi = _f("high headroom / info", severity="info", headroom_ms=200.0)
+
+    class _FakeSkill:
+        to_findings_fn = staticmethod(lambda rows, context=None: [lo, hi])
+
+        def execute(self, conn, **kwargs):
+            return [{}]
+
+    monkeypatch.setattr("nsys_ai.skills.registry.get_skill", lambda name: _FakeSkill())
+    with Profile(minimal_nsys_db_path) as prof:
+        builder = EvidenceBuilder(prof, device=0)
+        builder._SKILL_PIPELINE = {"fake": ("fake", {})}
+        report = builder.build()
+
+    assert [f.label for f in report.findings] == [
+        "high headroom / info",
+        "low headroom / critical",
+    ]
+
+
 # ---------------------------------------------------------------------------
 # _normalize_findings (dict-based — the guided-loop path)
 # ---------------------------------------------------------------------------
@@ -96,6 +131,18 @@ def test_normalize_findings_legacy_when_no_headroom():
     assert [f["label"] for f in ranked] == ["critical", "info"]
 
 
+def test_normalize_findings_largest_first_then_none_last():
+    """Mixed set: largest headroom leads, headroom-less falls last — even when
+    the headroom-less one is more severe."""
+    findings = [
+        {"label": "hr3 crit", "severity": "critical", "type": "region", "headroom_ms": 3.0},
+        {"label": "none crit", "severity": "critical", "type": "region"},
+        {"label": "hr300 info", "severity": "info", "type": "region", "headroom_ms": 300.0},
+    ]
+    ranked = _normalize_findings(findings)
+    assert [f["label"] for f in ranked] == ["hr300 info", "hr3 crit", "none crit"]
+
+
 # ---------------------------------------------------------------------------
 # Producers populate headroom from their existing recoverable-ms evidence
 # ---------------------------------------------------------------------------
@@ -118,11 +165,13 @@ def test_gpu_idle_gaps_headroom():
     findings = _to_findings(rows, context={"profile_id": "p"})
     summary = next(f for f in findings if "Summary" in f.label)
     gap = next(f for f in findings if "Gap" in f.label)
-    assert summary.headroom_ms == 40.0  # total recoverable idle
-    assert gap.headroom_ms == 5.0  # the gap duration in ms
+    assert summary.headroom_ms == 40.0  # aggregate idle opportunity, counted once
+    assert gap.headroom_ms is None  # per-gap not double-counted against the summary
 
 
-def test_overlap_breakdown_headroom_is_exposed_nccl():
+def test_overlap_breakdown_headroom_single_count():
+    """Both findings can fire on one row; the exposed-NCCL headroom must land on
+    exactly one of them, never both (or the ranking double-counts the same ms)."""
     from nsys_ai.skills.builtins.overlap_breakdown import _to_findings
 
     rows = [{
@@ -131,9 +180,10 @@ def test_overlap_breakdown_headroom_is_exposed_nccl():
         "span_start_ns": 0, "span_end_ns": 45_000_000, "device_id": 0,
     }]
     findings = _to_findings(rows, context={"profile_id": "p"})
-    assert findings  # low-overlap and comm-dominated both fire
-    for f in findings:
-        assert f.headroom_ms == 30.0  # exposed (non-overlapped) NCCL
+    assert len(findings) == 2  # low-overlap and comm-dominated both fire
+    headrooms = [f.headroom_ms for f in findings]
+    assert headrooms.count(None) == 1  # exactly one carries it
+    assert sum(h for h in headrooms if h is not None) == 30.0
 
 
 def test_iteration_timing_headroom_is_slack_over_median():
@@ -206,6 +256,26 @@ def test_region_mfu_no_finding_without_flops():
 
     assert _to_findings([_mfu_result(0.0)]) == []
     assert _to_findings([{"error": {"code": "no_flops"}}]) == []
+
+
+def test_region_mfu_at_peak_has_no_headroom():
+    """MFU at/above 100% leaves nothing recoverable -> None, not a bogus 0, and
+    no finding is emitted."""
+    from nsys_ai.skills.builtins.region_mfu import _sol_headroom_ms, _to_findings
+
+    assert _sol_headroom_ms(_mfu_result(100.0, union_s=0.1)) is None
+    assert _to_findings([_mfu_result(100.0, union_s=0.1)]) == []
+
+
+def test_region_mfu_finding_has_guidance_fields():
+    """Consistency with sibling skills: the SOL finding carries explanation,
+    suggested actions, and false-positive notes for downstream consumers."""
+    from nsys_ai.skills.builtins.region_mfu import _to_findings
+
+    f = _to_findings([_mfu_result(30.0, union_s=0.1)], context={"profile_id": "p"})[0]
+    assert f.explanation
+    assert f.suggested_actions
+    assert f.false_positive_notes
 
 
 def test_region_mfu_format_renders_ms_not_zeros():


### PR DESCRIPTION
Closes #190.

## Summary

Findings can now carry an optional `headroom_ms` — the potential recoverable time if the inefficiency were removed — so the agent and GUI rank findings by **opportunity**, not only severity. A small idle gap with large headroom outranks a dramatic-looking finding with little room to improve. When no finding carries a headroom, ordering is unchanged (fully backward compatible).

## What's included

**Mechanics**
- `Finding` gains `headroom_ms` (optional; round-trips for free via the generic field walk, drops from `to_dict` when `None`).
- New `rank_findings()` util: headroom descending, `None` last, stable, and a deliberate no-op when nothing carries a headroom. Wired at the one chokepoint — `EvidenceBuilder.build()` — so CLI, web, auto-analyze, saved findings, and the JS timeline all inherit the order. The guided-loop `_normalize_findings` also becomes opportunity-first while preserving its exact legacy order when no headroom is present.

**Populated from producers that already have the recoverable ms**
- `critical_path` — cpu-bound → `cpu_ms`, comm-bound → `comm_ms` (gpu-compute delegates to speed-of-light).
- `gpu_idle_gaps` — per-gap `gap_ms`; summary `total_idle_ms`.
- `overlap_breakdown` — exposed (non-overlapped) NCCL time.
- `iteration_timing` — a slow iteration's slack over the median.
- `nccl_breakdown` — high-variability straggler slack (max − avg). Pattern-dominance and serialization findings are intentionally left unset (informational / would double-count the overlap headroom).

**Speed-of-light source (#189 tie-in)**
- `region_mfu` gains a `to_findings` emitting an SOL finding with `headroom_ms = union GPU-busy time × (1 − MFU)`, only when a `theoretical_flops` is supplied.
- Drive-by fix: `region_mfu`'s text formatter read non-existent nested `timing.*`/`mfu.*` keys and printed zeros — now renders the real flat, seconds-based values (and the SOL headroom).

## Deferred (flagged, not in scope)

Regression-from-baseline headroom: no diff path constructs a `Finding` today (`DiffLineage`/`diff_lineage`/`role` are defined but unused), so minting regression findings and activating that lineage is separate, larger work that overlaps the verdict-loop epic. Recommend a follow-up issue.

## Tests

New `tests/test_finding_headroom.py` (round-trip; the ranking's headroom-beats-severity example; None-last; no-headroom-is-unchanged; per-producer headroom values; region SOL formula + finding + formatter regression) and a `critical_path` bucket-headroom test. Full suite green locally (1154 passed, 135 skipped); ruff and bandit clean.

## Note on #189

Issue #190 lists "Blocked by #189." `region_mfu` already computes MFU-vs-peak, so the speed-of-light headroom is derivable now — this PR wires it, effectively unblocking without a separate #189 change.