### PR TITLE
fix(cli): run_skill 'name' param collides with skills that have a 'name' param

### DIFF
--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -292,9 +292,9 @@ class Agent:
 
         return "\n".join(sections)
 
-    def run_skill(self, name: str, **kwargs) -> str:
+    def run_skill(self, skill_name: str, **kwargs) -> str:
         """Run a specific skill by name."""
-        return run_skill(name, self.conn, **kwargs)
+        return run_skill(skill_name, self.conn, **kwargs)
 
     def _try_llm_triage(self, question: str, triage_results: list[dict]) -> list[str]:
         """Use LLM to select the next set of skills based on the triage findings."""

--- a/src/nsys_ai/skills/__init__.py
+++ b/src/nsys_ai/skills/__init__.py
@@ -8,7 +8,7 @@ standalone (no LLM required) and serve as the agent's toolbox.
 Public API:
     list_skills()          → list of all registered skill names
     get_skill(name)        → Skill object by name
-    run_skill(name, conn)  → execute a skill against a SQLite connection
+    run_skill(skill_name, conn)  → execute a skill against a SQLite connection
 """
 
 from .registry import get_skill, list_skills, run_skill

--- a/src/nsys_ai/skills/registry.py
+++ b/src/nsys_ai/skills/registry.py
@@ -67,13 +67,18 @@ def all_skills() -> list[Skill]:
     return sorted(_SKILLS.values(), key=lambda s: s.name)
 
 
-def run_skill(name: str, conn: sqlite3.Connection, **kwargs) -> str:
-    """Look up and run a skill, returning formatted text."""
-    skill = get_skill(name)
+def run_skill(skill_name: str, conn: sqlite3.Connection, **kwargs) -> str:
+    """Look up and run a skill, returning formatted text.
+
+    The first parameter is ``skill_name`` (not ``name``) so it never collides
+    with a skill that exposes its own ``name`` parameter (e.g. ``region_mfu``),
+    which would otherwise raise "got multiple values for argument 'name'".
+    """
+    skill = get_skill(skill_name)
     if not skill:
         available = list_skills()
         raise SkillNotFoundError(
-            f"Unknown skill '{name}'. Available: {', '.join(available)}",
+            f"Unknown skill '{skill_name}'. Available: {', '.join(available)}",
             available=available,
         )
     return skill.run(conn, **kwargs)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1019,3 +1019,22 @@ def test_tensor_core_usage_duckdb():
     assert "ampere_fp16_fallback" in text
     assert "ampere_sgemm_128x128" in text
     assert "⚠️" in text
+
+
+def test_run_skill_name_param_does_not_collide(minimal_nsys_conn):
+    """Regression (#225): a skill exposing its own ``name`` parameter must run
+    through ``run_skill`` without a "got multiple values for argument 'name'"
+    TypeError. Before the fix the skill-name positional collided with the
+    skill's ``name`` kwarg (e.g. region_mfu)."""
+    from nsys_ai.skills.registry import run_skill
+
+    result = run_skill(
+        "region_mfu",
+        minimal_nsys_conn,
+        name="nonexistent_region",
+        source="kernel",
+        theoretical_flops=1e12,
+        peak_tflops=100.0,
+    )
+    # Returns formatted text (an error string is fine) — the point is no raise.
+    assert isinstance(result, str)


### PR DESCRIPTION
Closes #225.

## Problem

`nsys-ai skill run region_mfu <profile> --format text -p name=... ` crashed with:

```
TypeError: run_skill() got multiple values for argument 'name'
```

`run_skill(name, conn, **kwargs)` took the *skill* name as its first positional, but a skill's own `name` parameter (region_mfu's region name) arrives in `**kwargs`, so `name` was bound twice. The `--format json` path was unaffected (it calls `skill.execute` directly), so this only hit `--format text` for any skill exposing a `name` param.

## Fix

Rename the first parameter to `skill_name` in `registry.run_skill` and `AgentBackend.run_skill`. All callers pass it positionally, so this is a safe rename; a `name` skill param now flows through `**kwargs` cleanly.

## Verification

- New regression test runs a `name`-param skill through `run_skill` and asserts no raise.
- The previously-crashing CLI command now returns proper output (verified on a real profile):
```
── Region MFU ──
  Region: vectorized_elementwise_kernel
  Kernel union:  12142.77ms
  MFU (union):   0.2%
  SOL headroom:  12122.13ms (recoverable at peak)
```

Found while e2e-testing #223. Ruff clean; targeted suite (skills/agent/cli) green.