### PR TITLE
fix(skills): use one overlap convention for the manifest's comm-bound verdict

### DIFF
--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -597,7 +597,6 @@ def _infer_bottleneck(m: dict) -> str:
     # reported as a profile-quality signal via its own finding.
     overlap = m.get("overlap", {})
     idle = m.get("idle", {})
-    nccl = m.get("nccl", {})
 
     # Check NCCL serialization first (most impactful)
     if overlap.get("overlap_pct", 100) < _COMM_BOUND_OVERLAP_PCT and overlap.get("nccl_only_ms", 0) > 0:
@@ -615,9 +614,17 @@ def _infer_bottleneck(m: dict) -> str:
         if top_pct > _KERNEL_HOTSPOT_PCT:
             return f"Kernel hotspot: {top_k[0]['name']} ({top_pct:.0f}%)"
 
-    # Check NCCL dominance
-    if nccl.get("total_nccl_ms", 0) > overlap.get("compute_only_ms", float("inf")):
-        return "Communication-bound (NCCL > compute)"
+    # Check NCCL dominance. Compare wall-clock exposed NCCL against wall-clock
+    # compute, mirroring the comm_bound finding below exactly — the two must not
+    # disagree. The per-stream sum ``total_nccl_ms`` used here previously
+    # overcounts when NCCL runs concurrently on multiple streams, and it also
+    # counts overlapped NCCL that ``compute_only_ms`` has already excluded from
+    # compute, so overlap was penalised twice and this headline could claim
+    # "communication-bound" for a run the findings path called healthy.
+    nccl_only_ms = float(overlap.get("nccl_only_ms", 0) or 0)
+    compute_only_ms = float(overlap.get("compute_only_ms", 0) or 0)
+    if nccl_only_ms > 0 and nccl_only_ms > compute_only_ms:
+        return "Communication-bound (exposed NCCL > compute)"
 
     # Check iteration variance (spike pattern)
     nvtx = m.get("nvtx", {})

--- a/tests/test_profile_health_manifest_findings.py
+++ b/tests/test_profile_health_manifest_findings.py
@@ -511,3 +511,60 @@ class TestFormatRendering:
         )
         assert "Profiler Overhead" in clean and "⚠️" not in clean
         assert "Profiler Overhead" in noisy and "⚠️" in noisy
+
+
+class TestCommBoundConventionIsConsistent:
+    """Regression (#232): the manifest headline and its own comm_bound finding
+    used opposite overlap conventions, so the same profile could be called
+    communication-bound by one and healthy by the other."""
+
+    def _comm_manifest(self, compute_only, nccl_only, overlap_ms, total_nccl):
+        m = _healthy_manifest()
+        m["overlap"]["compute_only_ms"] = compute_only
+        m["overlap"]["nccl_only_ms"] = nccl_only
+        m["overlap"]["overlap_ms"] = overlap_ms
+        m["overlap"]["overlap_pct"] = 75  # healthy, so low_overlap does not fire
+        m["nccl"]["total_nccl_ms"] = total_nccl
+        return m
+
+    def test_heavily_overlapped_run_is_not_called_communication_bound(self):
+        """Overlapped NCCL is hidden behind compute. Counting it as comm *and*
+        excluding it from compute penalised overlap twice: this profile has
+        400ms of well-overlapped NCCL and used to be reported comm-bound."""
+        from nsys_ai.skills.builtins.profile_health_manifest import _infer_bottleneck
+
+        m = self._comm_manifest(
+            compute_only=100.0, nccl_only=0.0, overlap_ms=400.0, total_nccl=400.0
+        )
+        assert "ommunication-bound" not in _infer_bottleneck(m)
+
+    def test_genuinely_exposed_comm_is_still_reported(self):
+        """The fix must not silence a real comm-bound run."""
+        from nsys_ai.skills.builtins.profile_health_manifest import _infer_bottleneck
+
+        m = self._comm_manifest(
+            compute_only=100.0, nccl_only=500.0, overlap_ms=0.0, total_nccl=500.0
+        )
+        assert "ommunication-bound" in _infer_bottleneck(m)
+
+    def test_headline_and_finding_never_disagree(self):
+        """The two paths must agree across the overlap spectrum."""
+        from nsys_ai.skills.builtins.profile_health_manifest import _infer_bottleneck
+
+        for compute_only, nccl_only, overlap_ms in [
+            (100.0, 0.0, 400.0),    # fully hidden
+            (100.0, 50.0, 200.0),   # partly exposed, compute still dominant
+            (100.0, 500.0, 0.0),    # clearly exposed
+            (0.0, 0.0, 0.0),        # no data
+        ]:
+            m = self._comm_manifest(compute_only, nccl_only, overlap_ms, nccl_only + overlap_ms)
+            headline_comm = "ommunication-bound" in _infer_bottleneck(m)
+            finding_comm = any(
+                f.id == "profile_comm_bound"
+                and "nccl_exceeds_compute" in f.provenance.get("triggers", "")
+                for f in _to_findings([m])
+            )
+            assert headline_comm == finding_comm, (
+                f"headline={headline_comm} finding={finding_comm} for "
+                f"compute_only={compute_only} nccl_only={nccl_only} overlap={overlap_ms}"
+            )

--- a/tests/test_profile_health_manifest_findings.py
+++ b/tests/test_profile_health_manifest_findings.py
@@ -555,6 +555,7 @@ class TestCommBoundConventionIsConsistent:
             (100.0, 0.0, 400.0),    # fully hidden
             (100.0, 50.0, 200.0),   # partly exposed, compute still dominant
             (100.0, 500.0, 0.0),    # clearly exposed
+            (0.0, 500.0, 0.0),      # comm present, no compute recorded
             (0.0, 0.0, 0.0),        # no data
         ]:
             m = self._comm_manifest(compute_only, nccl_only, overlap_ms, nccl_only + overlap_ms)


### PR DESCRIPTION
Closes #232.

## Problem

`profile_health_manifest` used two opposite overlap conventions in the same file.

The headline verdict (`_infer_bottleneck`):
```python
if nccl.get("total_nccl_ms", 0) > overlap.get("compute_only_ms", float("inf")):
    return "Communication-bound (NCCL > compute)"
```

Its own comm_bound finding, a few hundred lines below:
```python
nccl_dominates_compute = nccl_only_ms > 0 and nccl_only_ms > compute_only_ms
```

The file already documents why the first is wrong, right next to the second:

> The earlier per-stream sum `total_nccl_ms` overcounts when NCCL runs concurrently on multiple streams, which makes the comparison apples-to-oranges versus the wall-clock compute denominator and produces spurious dominance findings on multi-stream NCCL workloads.

There is a second problem the comment does not mention: `compute_only_ms` already excludes overlapped time, so counting overlapped NCCL as communication penalises overlap **twice**. A run with 100ms of compute and 400ms of well-hidden NCCL — a *good* overlap result — was reported `Communication-bound` as the headline while the manifest's own finding called it healthy.

That also contradicted `critical_path` (#221), which follows the recorded HTA convention that hidden communication is off the critical path. Three surfaces, two conventions.

## Fix

The headline now mirrors the finding exactly. `overlap` already carries `nccl_only_ms`, so no new plumbing was needed — this is a one-line change plus the now-unused `nccl` binding.

## Verification

Three tests, and I mutation-tested them: restoring the old convention fails two of them, including the one that pins the contradiction directly (`headline=True finding=False` for the 400ms-overlap case).

- a heavily overlapped run is no longer called communication-bound
- a genuinely exposed comm run still is (the fix does not silence real findings)
- the headline and the finding agree across the overlap spectrum, including the no-data case

Checked on real profiles: `fastvideo.sqlite` still reports `NCCL serialization (overlap < 30%)` from the low-overlap trigger, unchanged. Full suite 1220 passed / 135 skipped; ruff clean.

## Note

This also settles the shared convention that #230 needs before `critical_path` can be enrolled in `_SKILL_PIPELINE` without its bound classes contradicting the manifest's.