### PR TITLE
fix(findings): put every headroom_ms on one comparable scale

### DIFF
--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -100,6 +100,13 @@ class Finding:
     # removed — the optimization *opportunity*, used by :func:`rank_findings`
     # to order findings by upside rather than severity alone.
     headroom_ms: float | None = None
+    # What span ``headroom_ms`` covers. Ranking compares the raw magnitudes, so
+    # producers must agree on the span or the ordering is meaningless — a
+    # per-instance value loses to a capture-wide one for reasons that have
+    # nothing to do with opportunity. Every producer currently emits
+    # ``"capture_total"``; the field exists so a new one has to state its basis
+    # rather than diverge silently.
+    headroom_basis: str | None = None
 
     def to_dict(self) -> dict:
         # Walk fields() directly for scalar / primitive fields; nested

--- a/src/nsys_ai/skills/builtins/critical_path.py
+++ b/src/nsys_ai/skills/builtins/critical_path.py
@@ -567,6 +567,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
             category=_CATEGORY_TO_FINDING[top_cat],
             confidence=float(r.get("confidence", 0.0)),
             headroom_ms=headroom_ms,
+            headroom_basis="capture_total" if headroom_ms is not None else None,
             evidence=[evidence_row],
             selection=selection,
             explanation=_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -390,6 +390,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                         # All idle time on the pipeline is candidate recoverable
                         # time — the opportunity if the bubbles were closed.
                         headroom_ms=total_idle_ms,
+                        headroom_basis="capture_total",
                         evidence=[evidence_row],
                         selection=selection,
                         explanation=_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -48,40 +48,58 @@ def _to_findings(rows: list[dict]) -> list:
     if med <= 0:
         return findings
 
-    for it in real:
-        if it.get("duration_ms", 0) > 1.5 * med:
-            pct = 100 * it["duration_ms"] / med
-            # Prefer nanosecond-precision timestamps if available; fall back to seconds-based values.
-            start_ns = it.get("gpu_start_ns")
-            if start_ns is None:
-                start_ns = int(it.get("gpu_start_s", 0) * 1e9)
-            else:
-                start_ns = int(start_ns)
-            end_ns = it.get("gpu_end_ns")
-            if end_ns is None:
-                end_ns = int(it.get("gpu_end_s", 0) * 1e9)
-            else:
-                end_ns = int(end_ns)
+    slow = [it for it in real if it.get("duration_ms", 0) > 1.5 * med]
+    # The recoverable opportunity is the total slack across every slow
+    # iteration, which is a capture-scoped quantity comparable with the other
+    # headroom producers. A single iteration's slack is not: ranking it against
+    # a profile-wide idle total silently favours the aggregate. Following the
+    # gpu_idle_gaps convention, the aggregate is carried once — by the worst
+    # iteration, which is where a reader would start — and the remaining
+    # findings carry none, so no millisecond is attributed twice.
+    total_slack_ms = round(sum(it["duration_ms"] - med for it in slow), 3)
+    worst = max(slow, key=lambda it: it["duration_ms"], default=None)
 
-            findings.append(
-                Finding(
-                    type="region",
-                    label=f"Slow Iteration {it.get('iteration', '?')}",
-                    start_ns=start_ns,
-                    end_ns=end_ns,
-                    gpu_id=it.get(
-                        "device_id", 0
-                    ),  # Assuming device_id is available or defaults to 0
-                    severity="warning",
-                    note=(
-                        f"{it['duration_ms']:.1f}ms "
-                        f"({pct:.0f}% of median {med:.1f}ms), "
-                        f"{it.get('kernel_count', 0)} kernels"
-                    ),
-                    # Recoverable time if this iteration ran at the median pace.
-                    headroom_ms=round(it["duration_ms"] - med, 3),
-                )
+    for it in slow:
+        pct = 100 * it["duration_ms"] / med
+        # Prefer nanosecond-precision timestamps if available; fall back to seconds-based values.
+        start_ns = it.get("gpu_start_ns")
+        if start_ns is None:
+            start_ns = int(it.get("gpu_start_s", 0) * 1e9)
+        else:
+            start_ns = int(start_ns)
+        end_ns = it.get("gpu_end_ns")
+        if end_ns is None:
+            end_ns = int(it.get("gpu_end_s", 0) * 1e9)
+        else:
+            end_ns = int(end_ns)
+
+        carries_headroom = it is worst
+        note = (
+            f"{it['duration_ms']:.1f}ms "
+            f"({pct:.0f}% of median {med:.1f}ms), "
+            f"{it.get('kernel_count', 0)} kernels"
+        )
+        if carries_headroom and len(slow) > 1:
+            note += (
+                f". Headroom is the total slack across all {len(slow)} slow "
+                "iterations, counted once here."
             )
+
+        findings.append(
+            Finding(
+                type="region",
+                label=f"Slow Iteration {it.get('iteration', '?')}",
+                start_ns=start_ns,
+                end_ns=end_ns,
+                gpu_id=it.get(
+                    "device_id", 0
+                ),  # Assuming device_id is available or defaults to 0
+                severity="warning",
+                note=note,
+                headroom_ms=total_slack_ms if carries_headroom else None,
+                headroom_basis="capture_total" if carries_headroom else None,
+            )
+        )
     return findings
 
 

--- a/src/nsys_ai/skills/builtins/nccl_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_breakdown.py
@@ -135,6 +135,24 @@ def _serialization_confidence(nccl_capture_pct: float, captured_ms: float = 0.0)
         return 0.85
     return 0.70
 
+def _variability_headroom_ms(row: dict) -> float | None:
+    """Capture-scoped recoverable time for a high-variability collective.
+
+    If every instance ran at the fastest observed time instead of the average,
+    ``count * (avg - min)`` would be saved. An upper bound — some spread is
+    unavoidable — but it spans the whole capture, so it is comparable with the
+    other headroom producers. Returns ``None`` when the row lacks the fields to
+    compute it honestly rather than guessing a value.
+    """
+    count = row.get("count")
+    avg_ms = row.get("avg_ms")
+    min_ms = row.get("min_ms")
+    if not count or avg_ms is None or min_ms is None:
+        return None
+    recoverable = count * (float(avg_ms) - float(min_ms))
+    return round(recoverable, 3) if recoverable > 0 else None
+
+
 def _to_findings(rows: list[dict], *, context: dict | None = None)-> list:
     from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
 
@@ -311,9 +329,15 @@ def _to_findings(rows: list[dict], *, context: dict | None = None)-> list:
                 id=finding_id,
                 category="communication",
                 confidence=_variability_confidence(ratio, r.get("count", 0)),
-                # Straggler slack: the slowest instance's excess over the
-                # average is recoverable if the variability were eliminated.
-                headroom_ms=round(r["max_ms"] - r["avg_ms"], 3),
+                # Recoverable time across the whole capture if the variability
+                # were eliminated and every instance ran at the fastest observed
+                # time: count x (avg - min). An upper bound — some spread is
+                # unavoidable — but capture-scoped, so it is comparable with the
+                # other headroom producers. (The previous value, one instance's
+                # max - avg, undercounted by a factor of `count` and made a
+                # thousand slow collectives rank below a single idle gap.)
+                headroom_ms=_variability_headroom_ms(r),
+                headroom_basis="capture_total" if _variability_headroom_ms(r) else None,
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_HIGH_VARIABILITY_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/nccl_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_breakdown.py
@@ -295,6 +295,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None)-> list:
     for r in rows:
         if r["avg_ms"] > 0 and r["max_ms"] / r["avg_ms"] > _VARIABILITY_RATIO_THRESHOLD and r["pct"] >= _VARIABILITY_MIN_PCT:
             ratio = round(r["max_ms"] / r["avg_ms"], 1)
+            variability_headroom_ms = _variability_headroom_ms(r)
             finding_id = f"nccl_high_variability_{r['type']}_stream{r['stream_id']}"
             selection = TraceSelection(
                 id=f"sel_{finding_id}",
@@ -336,8 +337,8 @@ def _to_findings(rows: list[dict], *, context: dict | None = None)-> list:
                 # other headroom producers. (The previous value, one instance's
                 # max - avg, undercounted by a factor of `count` and made a
                 # thousand slow collectives rank below a single idle gap.)
-                headroom_ms=_variability_headroom_ms(r),
-                headroom_basis="capture_total" if _variability_headroom_ms(r) else None,
+                headroom_ms=variability_headroom_ms,
+                headroom_basis="capture_total" if variability_headroom_ms else None,
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_HIGH_VARIABILITY_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -334,6 +334,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 category="communication",
                 confidence=_overlap_confidence(float(overlap_pct), float(nccl_ms), float(total_ms)),
                 headroom_ms=exposed_nccl_ms,
+                headroom_basis="capture_total",
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_LOW_OVERLAP_EXPLANATION,
@@ -389,6 +390,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                     # Exposed NCCL headroom already claimed by the low-overlap
                     # finding if it fired; avoid double-counting the same ms.
                     headroom_ms=None if headroom_claimed else exposed_nccl_ms,
+                    headroom_basis=None if headroom_claimed else "capture_total",
                     evidence=[evidence_row],
                     selection=selection,
                     explanation=_COMM_DOMINATED_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/region_mfu.py
+++ b/src/nsys_ai/skills/builtins/region_mfu.py
@@ -172,6 +172,7 @@ def _to_findings(rows, *, context: dict | None = None) -> list:
             id=finding_id,
             category="compute",
             headroom_ms=headroom,
+            headroom_basis="capture_total",
             evidence=[evidence_row],
             selection=selection,
             explanation=_EXPLANATION,

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -200,9 +200,49 @@ def test_iteration_timing_headroom_is_slack_over_median():
     findings = _to_findings(rows)
     assert len(findings) == 1  # only iter 3 exceeds 1.5x median
     assert findings[0].headroom_ms == 30.0  # 40ms - median(10ms)
+    assert findings[0].headroom_basis == "capture_total"
 
 
-def test_nccl_variability_headroom_is_straggler_slack():
+def test_iteration_timing_headroom_is_aggregated_and_counted_once():
+    """With several slow iterations the headroom is the total slack across all
+    of them, carried by the worst one only — a per-iteration value would not be
+    comparable with the capture-scoped producers."""
+    from nsys_ai.skills.builtins.iteration_timing import _to_findings
+
+    rows = [
+        {"iteration": i, "duration_ms": d, "gpu_start_ns": i * 10_000_000,
+         "gpu_end_ns": i * 10_000_000 + int(d * 1e6), "kernel_count": 5}
+        for i, d in enumerate([10.0, 10.0, 10.0, 40.0, 25.0])
+    ]
+    findings = _to_findings(rows)
+    assert len(findings) == 2  # iterations of 40ms and 25ms exceed 1.5x median(10)
+    carriers = [f for f in findings if f.headroom_ms is not None]
+    assert len(carriers) == 1, "the aggregate must be attributed exactly once"
+    # (40-10) + (25-10) = 45ms total slack, on the worst iteration.
+    assert carriers[0].headroom_ms == 45.0
+    assert carriers[0].label.endswith("3")  # the 40ms iteration
+    assert carriers[0].headroom_basis == "capture_total"
+
+
+def test_nccl_variability_headroom_is_capture_scoped():
+    """The recoverable total across the whole capture, not one instance's
+    excess — otherwise 1000 slow collectives rank below a single idle gap."""
+    from nsys_ai.skills.builtins.nccl_breakdown import _to_findings
+
+    rows = [{
+        "type": "allreduce", "pct": 50.0, "total_ms": 100.0,
+        "avg_ms": 5.0, "min_ms": 2.0, "max_ms": 20.0, "count": 10, "stream_id": 7,
+        "device_id": 0, "span_start_ns": 0, "span_end_ns": 100_000_000,
+    }]
+    findings = _to_findings(rows, context={"profile_id": "p"})
+    var = next(f for f in findings if "Variability" in f.label)
+    assert var.headroom_ms == 30.0  # count(10) * (avg 5 - min 2)
+    assert var.headroom_basis == "capture_total"
+
+
+def test_nccl_variability_headroom_absent_when_fields_missing():
+    """Without min_ms the capture-scoped value cannot be computed honestly, so
+    no headroom is claimed rather than a guessed one."""
     from nsys_ai.skills.builtins.nccl_breakdown import _to_findings
 
     rows = [{
@@ -210,9 +250,11 @@ def test_nccl_variability_headroom_is_straggler_slack():
         "avg_ms": 5.0, "max_ms": 20.0, "count": 10, "stream_id": 7,
         "device_id": 0, "span_start_ns": 0, "span_end_ns": 100_000_000,
     }]
-    findings = _to_findings(rows, context={"profile_id": "p"})
-    var = next(f for f in findings if "Variability" in f.label)
-    assert var.headroom_ms == 15.0  # max(20) - avg(5)
+    var = next(
+        f for f in _to_findings(rows, context={"profile_id": "p"}) if "Variability" in f.label
+    )
+    assert var.headroom_ms is None
+    assert var.headroom_basis is None
 
 
 # ---------------------------------------------------------------------------
@@ -287,3 +329,23 @@ def test_region_mfu_format_renders_ms_not_zeros():
     assert "50.00ms" in text  # kernel union rendered from seconds
     assert "40.0%" in text  # MFU rendered
     assert "SOL headroom" in text
+
+
+def test_every_headroom_producer_declares_a_capture_scoped_basis():
+    """Cross-producer invariant (#231): ranking compares raw magnitudes, so a
+    producer that emits a different span silently distorts the ordering. Any
+    finding carrying headroom must declare its basis, and all builtins agree."""
+    import pathlib
+    import re
+
+    builtins = pathlib.Path("src/nsys_ai/skills/builtins")
+    offenders = []
+    for path in sorted(builtins.glob("*.py")):
+        src = path.read_text()
+        # Each headroom_ms assignment must be accompanied by a headroom_basis
+        # within the same Finding(...) construction.
+        n_headroom = len(re.findall(r"\bheadroom_ms=", src))
+        n_basis = len(re.findall(r"\bheadroom_basis=", src))
+        if n_headroom != n_basis:
+            offenders.append(f"{path.name}: {n_headroom} headroom_ms vs {n_basis} headroom_basis")
+    assert not offenders, "every headroom_ms must declare a basis: " + "; ".join(offenders)

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -28,6 +28,21 @@ def test_headroom_serializes_when_set():
     assert Finding.from_dict(d).headroom_ms == 12.5
 
 
+def test_headroom_basis_round_trips_with_headroom():
+    """The basis must survive serialization alongside the value it qualifies —
+    a headroom whose span is lost in transit is not comparable."""
+    f = Finding(type="region", label="x", start_ns=0, end_ns=1,
+                headroom_ms=12.5, headroom_basis="capture_total")
+    d = f.to_dict()
+    assert d["headroom_basis"] == "capture_total"
+    assert Finding.from_dict(d).headroom_basis == "capture_total"
+
+
+def test_headroom_basis_dropped_when_absent():
+    d = Finding(type="region", label="x", start_ns=0, end_ns=1).to_dict()
+    assert "headroom_basis" not in d
+
+
 def test_headroom_dropped_when_none():
     d = _f("x").to_dict()
     assert "headroom_ms" not in d  # legacy JSON stays compact


### PR DESCRIPTION
Closes #231.

## Problem

`rank_findings` orders on the raw magnitude of `headroom_ms`, but the producers did not agree on what the number spans, so the ordering could invert for reasons unrelated to opportunity.

| producer | span before |
|---|---|
| `gpu_idle_gaps`, `overlap_breakdown`, `critical_path`, `region_mfu` | capture-scoped ✓ |
| `nccl_breakdown` | **one instance's** `max - avg`, on a row aggregating `count` instances |
| `iteration_timing` | **one iteration's** slack |

Concretely: 1000 collectives each carrying slack reported `headroom_ms` for a single instance and sorted below a lone idle summary — the inversion the field exists to prevent.

## Fix

**`nccl_breakdown`** now reports `count * (avg - min)` — the capture-wide recoverable total if every instance ran at the fastest observed time. An upper bound (some spread is unavoidable), documented as such. It returns `None` when the row lacks `min_ms`/`count` rather than guessing, so a missing field cannot silently produce a wrong magnitude — and cannot raise inside a findings path either.

**`iteration_timing`** now aggregates the slack across all slow iterations and attributes it **once**, to the worst one, with the remaining findings carrying none. That is the same single-count rule `gpu_idle_gaps` already applies between its summary and per-gap findings. The note says so when more than one iteration is involved.

**New `Finding.headroom_basis`**, set to `"capture_total"` by every producer. All current values agree, so the field earns its place by forcing a *new* producer to state its span rather than diverge silently.

## Verification

Both behaviour changes are mutation-tested:

- removing a `headroom_basis` from any builtin fails the cross-producer invariant test (verified: `gpu_idle_gaps.py: 1 headroom_ms vs 0 headroom_basis`)
- the iteration test pins that with five iterations (two slow) the aggregate `45.0ms` is carried by exactly one finding, the 40ms iteration
- the nccl test pins `count(10) * (avg 5 - min 2) = 30.0`, plus a case with `min_ms` absent asserting no headroom is claimed

Full suite 1223 passed / 135 skipped; ruff clean.

## Note

This unblocks #230: `critical_path` cannot be enrolled in `_SKILL_PIPELINE` until the headroom it contributes is comparable with the producers already there, and until the overlap convention is shared (that part landed in #233).