### PR TITLE
fix(profile): recover Nsight export metadata, which read as absent everywhere

### DIFF
--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -22,6 +22,7 @@ if typing.TYPE_CHECKING:
 
 
 from nsys_ai import parquet_cache
+from nsys_ai.connection import DB_ERRORS
 from nsys_ai.exceptions import (
     ExportError,
     ExportTimeoutError,
@@ -70,8 +71,17 @@ class NsightSchema:
 
         self.tables = list(self._adapter.get_table_names())
 
+        # Read the metadata tables once; both version fields derive from it.
+        self._meta: dict[str, str] = {}
+        for table in ("META_DATA_EXPORT", "META_DATA_CAPTURE"):
+            self._meta.update(self._read_kv_table(table))
+
         self.version: str | None = self._detect_version()
-        self.schema_version: str | None = self._detect_schema_version()
+        # The export schema version is what actually changes shape between
+        # releases — NVIDIA documents that the SQLite schema "can and will
+        # change" — so this, not the product version, is what compatibility
+        # handling should key off.
+        self.schema_version: str | None = self._meta.get("EXPORT_SCHEMA_VERSION") or None
         kt = self._detect_kernel_table()
         self.kernel_table: str | None = _validate_table_name(kt) if kt else None
 
@@ -91,13 +101,13 @@ class NsightSchema:
             try:
                 if table not in self._meta_adapter.get_table_names():
                     return {}
-            except Exception:
+            except DB_ERRORS:
                 return {}
             adapter = self._meta_adapter
 
         try:
             cols = adapter.get_table_columns(table)
-        except Exception:
+        except DB_ERRORS:
             return {}
         key_col = None
         val_col = None
@@ -124,7 +134,7 @@ class NsightSchema:
         try:
             cur = adapter.execute(f"SELECT {key_col}, {val_col} FROM {table}")  # noqa: S608
             rows = cur.fetchall()
-        except Exception:
+        except DB_ERRORS:
             return {}
         for k, v in rows:
             if k is not None and v is not None:
@@ -132,10 +142,8 @@ class NsightSchema:
         return kv
 
     def _detect_version(self) -> str | None:
-        """Try to infer Nsight Systems version from META_DATA tables."""
-        meta: dict[str, str] = {}
-        for table in ("META_DATA_EXPORT", "META_DATA_CAPTURE"):
-            meta.update(self._read_kv_table(table))
+        """Infer the Nsight Systems version from the metadata tables."""
+        meta = self._meta
 
         # The canonical key in current exports. Checked first and by exact name
         # so the product *name* ("NVIDIA Nsight Systems") can never be mistaken
@@ -155,18 +163,6 @@ class NsightSchema:
             if "Nsight Systems" in val and any(ch.isdigit() for ch in val):
                 return val
         return None
-
-    def _detect_schema_version(self) -> str | None:
-        """The export schema version, which is what actually changes shape.
-
-        NVIDIA documents that the SQLite schema "can and will change" between
-        releases, so this is the field to key any compatibility handling off —
-        the product version can move without the schema doing so.
-        """
-        meta: dict[str, str] = {}
-        for table in ("META_DATA_EXPORT", "META_DATA_CAPTURE"):
-            meta.update(self._read_kv_table(table))
-        return meta.get("EXPORT_SCHEMA_VERSION") or None
 
     # ── Table detection ────────────────────────────────────────────────
 

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -54,15 +54,24 @@ class NsightSchema:
     and exposes canonical table choices (e.g., kernel activity table).
     """
 
-    def __init__(self, conn):
+    def __init__(self, conn, meta_conn=None):
         self._conn = conn
         from .connection import wrap_connection
 
         self._adapter = wrap_connection(conn)
+        # ``META_DATA_*`` lives only in the SQLite export — the Parquet/DuckDB
+        # cache materializes the analysis tables and not the metadata ones. When
+        # the schema is built on the cache (the normal path), those lookups must
+        # fall back to the original SQLite connection or every metadata field
+        # silently reads as absent.
+        self._meta_adapter = (
+            wrap_connection(meta_conn) if meta_conn is not None and meta_conn is not conn else None
+        )
 
         self.tables = list(self._adapter.get_table_names())
 
         self.version: str | None = self._detect_version()
+        self.schema_version: str | None = self._detect_schema_version()
         kt = self._detect_kernel_table()
         self.kernel_table: str | None = _validate_table_name(kt) if kt else None
 
@@ -73,29 +82,51 @@ class NsightSchema:
         Best-effort reader for META_DATA_* style tables which may use
         slightly different column names across Nsight versions.
         """
+        adapter = self._adapter
         if table not in self.tables:
-            return {}
+            # Not in the primary connection — try the metadata source before
+            # giving up (see the note in __init__).
+            if self._meta_adapter is None:
+                return {}
+            try:
+                if table not in self._meta_adapter.get_table_names():
+                    return {}
+            except Exception:
+                return {}
+            adapter = self._meta_adapter
 
-        cols = self._adapter.get_table_columns(table)
+        try:
+            cols = adapter.get_table_columns(table)
+        except Exception:
+            return {}
         key_col = None
         val_col = None
 
-        # Common patterns seen in Nsight exports
-        for cand in ("key", "Key", "NAME", "Name"):
-            if cand in cols:
-                key_col = cand
+        # Common patterns seen in Nsight exports. Matching is case-insensitive
+        # because the real exports use lowercase ``name``/``value`` while older
+        # probes only listed ``NAME``/``Name`` — the omission silently produced
+        # an empty mapping, so every consumer of these tables (version
+        # detection, GPU clock) degraded to None on every real profile.
+        lowered = {str(c).lower(): c for c in cols}
+        for cand in ("name", "key"):
+            if cand in lowered:
+                key_col = lowered[cand]
                 break
-        for cand in ("value", "Value", "VAL", "Val"):
-            if cand in cols:
-                val_col = cand
+        for cand in ("value", "val"):
+            if cand in lowered:
+                val_col = lowered[cand]
                 break
 
         if not key_col or not val_col:
             return {}
 
         kv: dict[str, str] = {}
-        cur = self._adapter.execute(f"SELECT {key_col}, {val_col} FROM {table}")
-        for k, v in cur.fetchall():
+        try:
+            cur = adapter.execute(f"SELECT {key_col}, {val_col} FROM {table}")  # noqa: S608
+            rows = cur.fetchall()
+        except Exception:
+            return {}
+        for k, v in rows:
             if k is not None and v is not None:
                 kv[str(k)] = str(v)
         return kv
@@ -106,16 +137,36 @@ class NsightSchema:
         for table in ("META_DATA_EXPORT", "META_DATA_CAPTURE"):
             meta.update(self._read_kv_table(table))
 
+        # The canonical key in current exports. Checked first and by exact name
+        # so the product *name* ("NVIDIA Nsight Systems") can never be mistaken
+        # for the version, which the old value-substring fallback allowed.
+        for key in ("EXPORT_PRODUCT_VERSION", "PRODUCT_VERSION"):
+            if meta.get(key):
+                return meta[key]
+
         # Heuristic keys that might carry version information
         for key in meta:
             lk = key.lower()
             if "nsight systems version" in lk or "exporter version" in lk:
                 return meta[key]
-        # Fallback: sometimes the value itself contains 'Nsight Systems X.Y'
+        # Fallback: a value carrying 'Nsight Systems X.Y'. Require a digit so a
+        # bare product name is not returned as a version.
         for val in meta.values():
-            if "Nsight Systems" in val:
+            if "Nsight Systems" in val and any(ch.isdigit() for ch in val):
                 return val
         return None
+
+    def _detect_schema_version(self) -> str | None:
+        """The export schema version, which is what actually changes shape.
+
+        NVIDIA documents that the SQLite schema "can and will change" between
+        releases, so this is the field to key any compatibility handling off —
+        the product version can move without the schema doing so.
+        """
+        meta: dict[str, str] = {}
+        for table in ("META_DATA_EXPORT", "META_DATA_CAPTURE"):
+            meta.update(self._read_kv_table(table))
+        return meta.get("EXPORT_SCHEMA_VERSION") or None
 
     # ── Table detection ────────────────────────────────────────────────
 
@@ -239,7 +290,11 @@ class Profile:
         from .connection import wrap_connection
 
         self.adapter = wrap_connection(self.db if self.db is not None else self.conn)
-        self.schema = NsightSchema(self.db if self.db is not None else self.conn)
+        self.schema = NsightSchema(
+            self.db if self.db is not None else self.conn,
+            # The SQLite export is the only place META_DATA_* exists.
+            meta_conn=self.conn,
+        )
         self.meta = self._discover()
         self._nvtx_has_text_id = self.adapter.detect_nvtx_text_id()
 

--- a/tests/test_profile_metadata.py
+++ b/tests/test_profile_metadata.py
@@ -79,3 +79,60 @@ def test_metadata_falls_back_to_the_sqlite_connection():
     assert "META_DATA_EXPORT" not in s.tables  # genuinely absent from the primary conn
     assert s.version == "2026.1.1.204"  # ...but recovered from the metadata source
     assert s.schema_version == "3.24.14"
+
+
+class TestMetadataReaderDegradesCleanly:
+    """The reader's error paths only evaluate their exception tuple when an
+    error actually fires, so a missing import there passes every happy-path
+    test and raises NameError in production. These exercise each path."""
+
+    def _schema(self):
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE StringIds (id INTEGER)")
+        conn.commit()
+        return NsightSchema(conn)
+
+    def _apply(self, schema, adapter):
+        schema._meta_adapter = adapter
+        schema.tables = []
+        return schema._read_kv_table("META_DATA_EXPORT")
+
+    def test_metadata_source_table_listing_failure(self):
+        class Boom:
+            def get_table_names(self):
+                raise sqlite3.OperationalError("boom")
+
+        assert self._apply(self._schema(), Boom()) == {}
+
+    def test_column_probe_failure(self):
+        class BadCols:
+            def get_table_names(self):
+                return ["META_DATA_EXPORT"]
+
+            def get_table_columns(self, table):
+                raise sqlite3.OperationalError("no cols")
+
+        assert self._apply(self._schema(), BadCols()) == {}
+
+    def test_query_failure(self):
+        class BadExec:
+            def get_table_names(self):
+                return ["META_DATA_EXPORT"]
+
+            def get_table_columns(self, table):
+                return ["name", "value"]
+
+            def execute(self, query):
+                raise sqlite3.OperationalError("exec fail")
+
+        assert self._apply(self._schema(), BadExec()) == {}
+
+    def test_unrecognised_columns_yield_nothing(self):
+        class OddCols:
+            def get_table_names(self):
+                return ["META_DATA_EXPORT"]
+
+            def get_table_columns(self, table):
+                return ["foo", "bar"]
+
+        assert self._apply(self._schema(), OddCols()) == {}

--- a/tests/test_profile_metadata.py
+++ b/tests/test_profile_metadata.py
@@ -1,0 +1,81 @@
+"""Tests for Nsight export metadata detection (#235).
+
+`META_DATA_*` lives only in the SQLite export, and its columns are lowercase
+`name`/`value`. Both facts were missed, so every metadata field read as absent
+on every real profile.
+"""
+
+import sqlite3
+
+from nsys_ai.profile import NsightSchema
+
+
+def _meta_db(rows, table="META_DATA_EXPORT", key_col="name", val_col="value"):
+    conn = sqlite3.connect(":memory:")
+    conn.execute(f"CREATE TABLE {table} ({key_col} TEXT, {val_col} TEXT)")
+    conn.executemany(f"INSERT INTO {table} VALUES (?, ?)", rows)
+    conn.commit()
+    return conn
+
+
+_REAL_ROWS = [
+    ("EXPORT_PRODUCT_NAME", "NVIDIA Nsight Systems"),
+    ("EXPORT_PRODUCT_VERSION", "2026.1.1.204"),
+    ("EXPORT_SCHEMA_VERSION", "3.24.14"),
+]
+
+
+def test_reads_lowercase_name_column():
+    """The real exports use `name`; only NAME/Name were probed, so the reader
+    returned an empty mapping and every consumer degraded to None."""
+    s = NsightSchema(_meta_db(_REAL_ROWS))
+    kv = s._read_kv_table("META_DATA_EXPORT")
+    assert kv["EXPORT_PRODUCT_VERSION"] == "2026.1.1.204"
+
+
+def test_detects_product_version():
+    s = NsightSchema(_meta_db(_REAL_ROWS))
+    assert s.version == "2026.1.1.204"
+
+
+def test_exposes_export_schema_version():
+    """The schema version is what actually changes shape between releases, so
+    it is the field compatibility handling should key off."""
+    s = NsightSchema(_meta_db(_REAL_ROWS))
+    assert s.schema_version == "3.24.14"
+
+
+def test_product_name_is_never_mistaken_for_a_version():
+    """The old value-substring fallback would return 'NVIDIA Nsight Systems'
+    itself, since that string contains 'Nsight Systems'."""
+    s = NsightSchema(_meta_db([("EXPORT_PRODUCT_NAME", "NVIDIA Nsight Systems")]))
+    assert s.version is None
+
+
+def test_uppercase_column_names_still_work():
+    """Older exports used NAME/Value; matching is case-insensitive now."""
+    s = NsightSchema(_meta_db(_REAL_ROWS, key_col="NAME", val_col="Value"))
+    assert s.version == "2026.1.1.204"
+
+
+def test_missing_metadata_is_absent_not_fabricated():
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE StringIds (id INTEGER, value TEXT)")
+    conn.commit()
+    s = NsightSchema(conn)
+    assert s.version is None
+    assert s.schema_version is None
+
+
+def test_metadata_falls_back_to_the_sqlite_connection():
+    """The Parquet/DuckDB cache does not materialize META_DATA_*, so a schema
+    built on the cache must consult the original SQLite export or metadata is
+    invisible on the primary product path."""
+    cache_like = sqlite3.connect(":memory:")  # stands in for the cache: no META_DATA_*
+    cache_like.execute("CREATE TABLE StringIds (id INTEGER, value TEXT)")
+    cache_like.commit()
+
+    s = NsightSchema(cache_like, meta_conn=_meta_db(_REAL_ROWS))
+    assert "META_DATA_EXPORT" not in s.tables  # genuinely absent from the primary conn
+    assert s.version == "2026.1.1.204"  # ...but recovered from the metadata source
+    assert s.schema_version == "3.24.14"


### PR DESCRIPTION
Closes #235.

## Problem

`NsightSchema.version` was `None` for every real profile, and `_gpu_clock_mhz` in `diff_tools.py` was silently degraded the same way — both read through `_read_kv_table`. `nsys-ai info` printed nothing useful for the Nsight version.

Two independent causes, both needed fixing:

**1. The key-column probe missed the real column name.** It listed `("key", "Key", "NAME", "Name")`, but exports use lowercase `name`:

```
PRAGMA table_info(META_DATA_EXPORT) -> ['name', 'value']
```

The *value* candidates did include lowercase `value`, which is why the omission survived. Matching is now case-insensitive.

**2. The metadata tables are not in the cache.** `META_DATA_*` exists only in the SQLite export; the Parquet/DuckDB cache materializes the analysis tables. Since `profile.py` builds the schema on the cache whenever one exists — the normal path — the tables were simply absent:

```
DuckDBAdapter: 'META_DATA_EXPORT' in schema.tables -> False
```

So fixing the column probe alone would have fixed only the raw-SQLite path and left the product path still blind. The schema now takes a metadata connection and falls back to the SQLite export for these lookups.

## Also

- Prefers the canonical `EXPORT_PRODUCT_VERSION` key rather than relying on a heuristic that did not match it.
- Stops the value-substring fallback returning the product *name* — `EXPORT_PRODUCT_NAME` is literally `"NVIDIA Nsight Systems"`, which contains the string the fallback searched for.
- Exposes `EXPORT_SCHEMA_VERSION`. That is the field that actually changes shape between releases, so it is what compatibility handling should key off; the product version can move without it doing so.

## Verification

Through the real cache-backed path:

```
fastvideo.sqlite    version=2026.1.1.204  schema=3.24.14
megatron_distca     version=2026.1.1.204  schema=3.24.14
perf.sqlite (3.5G)  version=2026.2.1.210  schema=3.25.0
```

Note the schema version differs across those releases — concrete evidence for #237, which proposes CI coverage across export schema versions and was blocked on this working.

`_gpu_clock_mhz` still returns `None` on these profiles, and that is correct: their metadata carries no GPU-clock key (only `THREAD_STATE_SCAN_FREQ` and friends). It now fails for the honest reason rather than because it read nothing.

7 new tests covering the lowercase column, uppercase compatibility, the product-name trap, the cache fallback, and honest absence. Full suite 1232 passed / 135 skipped; ruff clean.