### PR TITLE
feat(findings): enroll critical_path in the evidence pipeline as a verdict

### DIFF
--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -74,6 +74,12 @@ class EvidenceBuilder:
         "memory_anomalies": ("memory_bandwidth", {"limit": 5}),
         "h2d_spikes": ("h2d_distribution", {}),
         "nccl_breakdown": ("nccl_breakdown", {}),
+        # Profile-level bound class (cpu / gpu-compute / comm). Contributes the
+        # verdict, not a new pool of recoverable time: its cpu bucket is the
+        # same idle gpu_idle_gaps already claims and its comm bucket the same
+        # exposed NCCL overlap_breakdown claims, so it deliberately reports no
+        # headroom of its own (see critical_path._to_findings).
+        "bound_class": ("critical_path", {}),
         # Roll-up characterization of the whole profile (comm-bound,
         # sync-bound, idle-dominant, coverage gaps). Reads only the
         # already-assembled manifest dict, so its findings are

--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -74,11 +74,11 @@ class EvidenceBuilder:
         "memory_anomalies": ("memory_bandwidth", {"limit": 5}),
         "h2d_spikes": ("h2d_distribution", {}),
         "nccl_breakdown": ("nccl_breakdown", {}),
-        # Profile-level bound class (cpu / gpu-compute / comm). Contributes the
-        # verdict, not a new pool of recoverable time: its cpu bucket is the
-        # same idle gpu_idle_gaps already claims and its comm bucket the same
-        # exposed NCCL overlap_breakdown claims, so it deliberately reports no
-        # headroom of its own (see critical_path._to_findings).
+        # Profile-level bound class. Contributes the verdict only and reports
+        # no headroom by design (the reasoning lives in
+        # critical_path._to_findings). It therefore ranks below every
+        # headroom-bearing finding — read the verdict from the finding itself,
+        # not from its position.
         "bound_class": ("critical_path", {}),
         # Roll-up characterization of the whole profile (comm-bound,
         # sync-bound, idle-dominant, coverage gaps). Reads only the

--- a/src/nsys_ai/skills/builtins/critical_path.py
+++ b/src/nsys_ai/skills/builtins/critical_path.py
@@ -546,20 +546,13 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
         provenance={"row_kind": "bound_class", "device": device},
     )
 
-    # Headroom = the recoverable on-path time for the dominant bucket: the full
-    # host-wait (cpu) or exposed-collective (comm) time is what eliminating that
-    # bottleneck would return. A gpu-compute-bound path has no headroom here —
-    # its recoverable time is a speed-of-light question (region MFU), not a
-    # bucket that can simply be removed — so it is left unset.
-    # This skill reports no headroom by design. Its contribution is the
-    # *verdict* — which resource bounds the run — not a new pool of recoverable
-    # time: the cpu bucket is the same GPU-idle gpu_idle_gaps already claims and
-    # the comm bucket the same exposed NCCL overlap_breakdown claims. Measured on
-    # a real 82.5s profile those two idle figures were 79.0s and 78.5s, so
-    # claiming both would report ~157s recoverable out of 82.5s. Those skills
-    # keep the claim because they can also localize it to specific gaps and
-    # streams; the bucket sizes stay on the evidence row, so only the double
-    # count is lost.
+    # No headroom, by design. This skill's contribution is the *verdict* —
+    # which resource bounds the run — not a new pool of recoverable time: the
+    # cpu bucket is the same GPU-idle that gpu_idle_gaps already claims, and the
+    # comm bucket the same exposed NCCL that overlap_breakdown claims. Those
+    # skills keep the claim because they can also localize it to specific gaps
+    # and streams. The bucket sizes stay on the evidence row below, so the
+    # measurement is still reported — only the double count is dropped.
     return [
         Finding(
             type="region",

--- a/src/nsys_ai/skills/builtins/critical_path.py
+++ b/src/nsys_ai/skills/builtins/critical_path.py
@@ -551,8 +551,16 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     # bottleneck would return. A gpu-compute-bound path has no headroom here —
     # its recoverable time is a speed-of-light question (region MFU), not a
     # bucket that can simply be removed — so it is left unset.
-    _headroom_by_cat = {"cpu": b.get("cpu_ms"), "comm": b.get("comm_ms")}
-    headroom_ms = _headroom_by_cat.get(top_cat)
+    # Deliberately no headroom. This skill's contribution is the *verdict* —
+    # which resource bounds the run — not a new pool of recoverable time. The
+    # cpu bucket is the same GPU-idle that gpu_idle_gaps already claims, and the
+    # comm bucket the same exposed NCCL that overlap_breakdown claims; measured
+    # on a real 82.5s profile the two idle figures were 79.0s and 78.5s, so
+    # claiming both would report ~157s recoverable out of 82.5s. Those skills
+    # keep the claim because they can also localize it to specific gaps and
+    # streams. The bucket sizes remain on the evidence row below, so nothing is
+    # lost — only the double count.
+    headroom_ms = None
 
     return [
         Finding(

--- a/src/nsys_ai/skills/builtins/critical_path.py
+++ b/src/nsys_ai/skills/builtins/critical_path.py
@@ -551,17 +551,15 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
     # bottleneck would return. A gpu-compute-bound path has no headroom here —
     # its recoverable time is a speed-of-light question (region MFU), not a
     # bucket that can simply be removed — so it is left unset.
-    # Deliberately no headroom. This skill's contribution is the *verdict* —
-    # which resource bounds the run — not a new pool of recoverable time. The
-    # cpu bucket is the same GPU-idle that gpu_idle_gaps already claims, and the
-    # comm bucket the same exposed NCCL that overlap_breakdown claims; measured
-    # on a real 82.5s profile the two idle figures were 79.0s and 78.5s, so
+    # This skill reports no headroom by design. Its contribution is the
+    # *verdict* — which resource bounds the run — not a new pool of recoverable
+    # time: the cpu bucket is the same GPU-idle gpu_idle_gaps already claims and
+    # the comm bucket the same exposed NCCL overlap_breakdown claims. Measured on
+    # a real 82.5s profile those two idle figures were 79.0s and 78.5s, so
     # claiming both would report ~157s recoverable out of 82.5s. Those skills
     # keep the claim because they can also localize it to specific gaps and
-    # streams. The bucket sizes remain on the evidence row below, so nothing is
-    # lost — only the double count.
-    headroom_ms = None
-
+    # streams; the bucket sizes stay on the evidence row, so only the double
+    # count is lost.
     return [
         Finding(
             type="region",
@@ -574,8 +572,6 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
             id=finding_id,
             category=_CATEGORY_TO_FINDING[top_cat],
             confidence=float(r.get("confidence", 0.0)),
-            headroom_ms=headroom_ms,
-            headroom_basis="capture_total" if headroom_ms is not None else None,
             evidence=[evidence_row],
             selection=selection,
             explanation=_EXPLANATION,

--- a/tests/test_critical_path.py
+++ b/tests/test_critical_path.py
@@ -386,10 +386,9 @@ def test_insufficient_on_path_time_reported_mixed():
 
 
 @pytest.mark.parametrize(
-    "label,kernels,expected_class,bucket",
+    "kernels,expected_class,bucket",
     [
         (
-            "cpu-bound",
             [
                 (0, 7, 1, 0, 100_000, 1),
                 (0, 7, 2, 20 * MS, 20 * MS + 100_000, 1),
@@ -399,7 +398,6 @@ def test_insufficient_on_path_time_reported_mixed():
             "cpu_ms",
         ),
         (
-            "comm-bound",
             [
                 (0, 7, 1, 0, 1 * MS, 1),  # 1ms compute
                 (0, 8, 2, 2 * MS, 20 * MS, 10),  # 18ms exposed NCCL
@@ -409,7 +407,7 @@ def test_insufficient_on_path_time_reported_mixed():
         ),
     ],
 )
-def test_reports_no_headroom_to_avoid_double_counting(label, kernels, expected_class, bucket):
+def test_reports_no_headroom_to_avoid_double_counting(kernels, expected_class, bucket):
     """The bound class is a verdict, not a new pool of recoverable time.
 
     Both committed branches must be covered: the cpu bucket is the idle

--- a/tests/test_critical_path.py
+++ b/tests/test_critical_path.py
@@ -385,26 +385,48 @@ def test_insufficient_on_path_time_reported_mixed():
 # ---------------------------------------------------------------------------
 
 
-def test_reports_no_headroom_to_avoid_double_counting():
-    """The bound class is a verdict, not a new pool of recoverable time. Its
-    cpu bucket is the idle gpu_idle_gaps already claims and its comm bucket the
-    exposed NCCL overlap_breakdown claims, so claiming it again would inflate
-    the opportunity ranking. The bucket sizes stay on the evidence row."""
-    cpu = [
-        (0, 7, 1, 0, 100_000, 1),
-        (0, 7, 2, 20 * MS, 20 * MS + 100_000, 1),
-        (0, 7, 3, 40 * MS, 40 * MS + 100_000, 1),
-    ]
-    conn = _make_conn(cpu)
+@pytest.mark.parametrize(
+    "label,kernels,expected_class,bucket",
+    [
+        (
+            "cpu-bound",
+            [
+                (0, 7, 1, 0, 100_000, 1),
+                (0, 7, 2, 20 * MS, 20 * MS + 100_000, 1),
+                (0, 7, 3, 40 * MS, 40 * MS + 100_000, 1),
+            ],
+            "cpu-bound",
+            "cpu_ms",
+        ),
+        (
+            "comm-bound",
+            [
+                (0, 7, 1, 0, 1 * MS, 1),  # 1ms compute
+                (0, 8, 2, 2 * MS, 20 * MS, 10),  # 18ms exposed NCCL
+            ],
+            "comm-bound",
+            "comm_ms",
+        ),
+    ],
+)
+def test_reports_no_headroom_to_avoid_double_counting(label, kernels, expected_class, bucket):
+    """The bound class is a verdict, not a new pool of recoverable time.
+
+    Both committed branches must be covered: the cpu bucket is the idle
+    gpu_idle_gaps already claims, and the comm bucket the exposed NCCL
+    overlap_breakdown already claims. Testing only cpu-bound left the comm
+    half — cited as half the justification for this change — unguarded.
+    """
+    conn = _make_conn(kernels)
     skill, r = _run(conn)
     findings = skill.to_findings_fn([r])
     conn.close()
 
-    assert r["bound_class"] == "cpu-bound"
+    assert r["bound_class"] == expected_class
     assert findings[0].headroom_ms is None
     assert findings[0].headroom_basis is None
     # The measurement itself is still reported, just not claimed as headroom.
-    assert findings[0].evidence[0].values["cpu_ms"] == r["breakdown"]["cpu_ms"]
+    assert findings[0].evidence[0].values[bucket] == r["breakdown"][bucket]
 
 
 def test_cpu_attribution_grounds_cpu_bucket():

--- a/tests/test_critical_path.py
+++ b/tests/test_critical_path.py
@@ -385,10 +385,11 @@ def test_insufficient_on_path_time_reported_mixed():
 # ---------------------------------------------------------------------------
 
 
-def test_headroom_is_dominant_bucket_for_confident_class():
-    """cpu-bound / comm-bound findings carry headroom == the recoverable bucket;
-    gpu-compute-bound carries none (its headroom is a speed-of-light question)."""
-    # cpu-bound
+def test_reports_no_headroom_to_avoid_double_counting():
+    """The bound class is a verdict, not a new pool of recoverable time. Its
+    cpu bucket is the idle gpu_idle_gaps already claims and its comm bucket the
+    exposed NCCL overlap_breakdown claims, so claiming it again would inflate
+    the opportunity ranking. The bucket sizes stay on the evidence row."""
     cpu = [
         (0, 7, 1, 0, 100_000, 1),
         (0, 7, 2, 20 * MS, 20 * MS + 100_000, 1),
@@ -398,17 +399,12 @@ def test_headroom_is_dominant_bucket_for_confident_class():
     skill, r = _run(conn)
     findings = skill.to_findings_fn([r])
     conn.close()
-    assert r["bound_class"] == "cpu-bound"
-    assert findings[0].headroom_ms == r["breakdown"]["cpu_ms"]
 
-    # gpu-compute-bound -> no bucket headroom
-    gpu = [(0, 7, 1, 0, 10 * MS, 1), (0, 7, 2, 10 * MS, 20 * MS, 1), (0, 7, 3, 20 * MS, 30 * MS, 1)]
-    conn = _make_conn(gpu)
-    skill, r = _run(conn)
-    findings = skill.to_findings_fn([r])
-    conn.close()
-    assert r["bound_class"] == "gpu-compute-bound"
+    assert r["bound_class"] == "cpu-bound"
     assert findings[0].headroom_ms is None
+    assert findings[0].headroom_basis is None
+    # The measurement itself is still reported, just not claimed as headroom.
+    assert findings[0].evidence[0].values["cpu_ms"] == r["breakdown"]["cpu_ms"]
 
 
 def test_cpu_attribution_grounds_cpu_bucket():

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -376,12 +376,13 @@ def test_pipeline_headroom_never_exceeds_the_profile_span(minimal_nsys_db_path):
     report more recoverable time than the profile contains — measured at ~157s
     of claims on an 82.5s profile before this was fixed.
 
-    This is a coarse net: it catches a future producer that grossly over-claims,
-    but the synthetic fixture is small enough that a modest double count stays
-    under the bound (verified by mutation — restoring critical_path's headroom
-    does not trip this, though it does trip the sibling test below). The precise
-    assertion for this case is
-    ``test_critical_path_is_in_the_pipeline_without_claiming_headroom``.
+    Scope, precisely: this guards the *other* producers. It cannot catch a
+    critical_path double count at any threshold, because that skill classifies
+    this fixture as ``mixed`` and ``_to_findings`` returns nothing for a
+    non-committed class — so it contributes zero findings here regardless of
+    what headroom it would claim. The critical_path case is covered by
+    ``test_critical_path_reports_no_headroom`` and
+    ``test_bound_class_finding_reaches_a_built_report``.
     """
     from nsys_ai.evidence_builder import EvidenceBuilder
     from nsys_ai.profile import Profile
@@ -403,23 +404,32 @@ def test_pipeline_headroom_never_exceeds_the_profile_span(minimal_nsys_db_path):
     )
 
 
-def test_critical_path_is_in_the_pipeline_without_claiming_headroom():
-    """It must be reachable from a report (#230) but contribute the verdict,
-    not a competing claim on time another skill already localizes."""
+def test_critical_path_is_registered_in_the_pipeline():
+    """`to_findings_fn` has exactly one production call site, driven by this
+    dict, so absence from it makes the finding unreachable (#230). This is a
+    removal guard only — that the skill actually *works* through the pipeline is
+    asserted by test_bound_class_finding_reaches_a_built_report."""
     from nsys_ai.evidence_builder import EvidenceBuilder
 
-    names = {v[0] for v in EvidenceBuilder._SKILL_PIPELINE.values()}
-    assert "critical_path" in names
+    assert "critical_path" in {v[0] for v in EvidenceBuilder._SKILL_PIPELINE.values()}
 
-    from nsys_ai.skills.builtins.critical_path import _to_findings
 
-    row = {
-        "bound_class": "cpu-bound", "confidence": 0.9, "device": 0,
-        "critical_path_ms": 100.0,
-        "breakdown": {"gpu_compute_ms": 10.0, "comm_ms": 0.0, "cpu_ms": 90.0,
-                      "gpu_compute_share": 0.1, "comm_share": 0.0, "cpu_share": 0.9},
-        "top_compute_kernels": [], "top_collectives": [], "note": "n",
-    }
-    (f,) = _to_findings([row])
-    assert f.headroom_ms is None
-    assert f.evidence[0].values["cpu_ms"] == 90.0  # the measurement is still reported
+def test_bound_class_finding_reaches_a_built_report(minimal_nsys_db_path):
+    """The point of #230: the verdict must actually appear in a report.
+
+    Every other critical_path test drives a raw sqlite connection, while the
+    pipeline runs on the DuckDB-backed one and `EvidenceBuilder.build` swallows
+    per-skill exceptions — so a failure confined to the pipeline path would be
+    silent. This exercises that path end to end. The trim is required because
+    the untrimmed fixture classifies as `mixed`, which emits no finding by
+    design.
+    """
+    from nsys_ai.evidence_builder import EvidenceBuilder
+    from nsys_ai.profile import Profile
+
+    with Profile(minimal_nsys_db_path) as prof:
+        report = EvidenceBuilder(prof, device=0, trim=(4_500_000, 9_000_000)).build()
+
+    cp = [f for f in report.findings if (f.provenance or {}).get("skill") == "critical_path"]
+    assert len(cp) == 1, "the bound-class verdict must reach the report"
+    assert cp[0].headroom_ms is None, "and must not claim time another skill localizes"

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -375,6 +375,13 @@ def test_pipeline_headroom_never_exceeds_the_profile_span(minimal_nsys_db_path):
     overlap_breakdown, so enrolling it while all three claimed headroom would
     report more recoverable time than the profile contains — measured at ~157s
     of claims on an 82.5s profile before this was fixed.
+
+    This is a coarse net: it catches a future producer that grossly over-claims,
+    but the synthetic fixture is small enough that a modest double count stays
+    under the bound (verified by mutation — restoring critical_path's headroom
+    does not trip this, though it does trip the sibling test below). The precise
+    assertion for this case is
+    ``test_critical_path_is_in_the_pipeline_without_claiming_headroom``.
     """
     from nsys_ai.evidence_builder import EvidenceBuilder
     from nsys_ai.profile import Profile
@@ -382,6 +389,12 @@ def test_pipeline_headroom_never_exceeds_the_profile_span(minimal_nsys_db_path):
     with Profile(minimal_nsys_db_path) as prof:
         span_ms = (prof.meta.time_range[1] - prof.meta.time_range[0]) / 1e6
         report = EvidenceBuilder(prof, device=0).build()
+
+    carriers = [f for f in report.findings if f.headroom_ms is not None]
+    assert carriers, (
+        "fixture produced no headroom-bearing findings, so the bound below is "
+        "trivially satisfied and this test proves nothing"
+    )
 
     claimed = sum(f.headroom_ms or 0.0 for f in report.findings)
     assert claimed <= span_ms * 1.05, (

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -380,6 +380,11 @@ def test_idle_headroom_is_claimed_by_exactly_one_finding(minimal_nsys_db_path):
     double count anywhere — a false positive on this project's core workload,
     which is worse in a guard than a missed bug. How many findings claim the
     same pool is basis-independent and is what double counting actually means.
+
+    Only ``idle`` is asserted, deliberately. A symmetric check on ``communication``
+    would be wrong: overlap_breakdown claims exposed NCCL while nccl_breakdown
+    claims straggler variance, and those are different pools that can legitimately
+    both fire on one profile — the same false positive in a new place.
     """
     from nsys_ai.evidence_builder import EvidenceBuilder
     from nsys_ai.profile import Profile

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -366,52 +366,32 @@ def test_every_headroom_producer_declares_a_capture_scoped_basis():
     assert not offenders, "every headroom_ms must declare a basis: " + "; ".join(offenders)
 
 
-def test_pipeline_headroom_never_exceeds_the_profile_span(minimal_nsys_db_path):
+def test_claimed_idle_headroom_never_exceeds_measured_idle(minimal_nsys_db_path):
     """Cross-skill single-count invariant (#230).
 
     Each skill enforces single-counting internally, but the pipeline runs
-    several together and nothing checked them against each other. critical_path
-    measures the same idle as gpu_idle_gaps and the same exposed NCCL as
-    overlap_breakdown, so enrolling it while all three claimed headroom would
-    report more recoverable time than the profile contains — measured at ~157s
-    of claims on an 82.5s profile before this was fixed.
+    several together and nothing checked them against each other.
 
-    Scope, precisely: this guards the *other* producers. It cannot catch a
-    critical_path double count at any threshold, because that skill classifies
-    this fixture as ``mixed`` and ``_to_findings`` returns nothing for a
-    non-committed class — so it contributes zero findings here regardless of
-    what headroom it would claim. The critical_path case is covered by
-    ``test_critical_path_reports_no_headroom`` and
-    ``test_bound_class_finding_reaches_a_built_report``.
+    The bound is per category, not per profile: what double counting violates is
+    that the idle a report offers as recoverable exceeds the idle actually
+    measured. A whole-profile-span bound is far too loose to catch it — with the
+    per-gap findings restored to also claim their gaps, so every idle
+    millisecond is counted twice, the total stayed comfortably inside the span.
     """
     from nsys_ai.evidence_builder import EvidenceBuilder
+    from nsys_ai.overlap import overlap_analysis
     from nsys_ai.profile import Profile
 
     with Profile(minimal_nsys_db_path) as prof:
-        span_ms = (prof.meta.time_range[1] - prof.meta.time_range[0]) / 1e6
+        measured_idle_ms = float(overlap_analysis(prof, 0).get("idle_ms", 0.0))
         report = EvidenceBuilder(prof, device=0).build()
 
-    carriers = [f for f in report.findings if f.headroom_ms is not None]
-    assert carriers, (
-        "fixture produced no headroom-bearing findings, so the bound below is "
-        "trivially satisfied and this test proves nothing"
+    claimed = sum(f.headroom_ms or 0.0 for f in report.findings if f.category == "idle")
+    assert claimed > 0, "fixture produced no idle headroom, so this proves nothing"
+    assert claimed <= measured_idle_ms + 0.01, (
+        f"report offers {claimed:.2f}ms of recoverable idle but only "
+        f"{measured_idle_ms:.2f}ms was measured — two skills are counting the same gaps"
     )
-
-    claimed = sum(f.headroom_ms or 0.0 for f in report.findings)
-    assert claimed <= span_ms * 1.05, (
-        f"pipeline claims {claimed:.1f}ms recoverable on a {span_ms:.1f}ms profile — "
-        "two skills are counting the same milliseconds"
-    )
-
-
-def test_critical_path_is_registered_in_the_pipeline():
-    """`to_findings_fn` has exactly one production call site, driven by this
-    dict, so absence from it makes the finding unreachable (#230). This is a
-    removal guard only — that the skill actually *works* through the pipeline is
-    asserted by test_bound_class_finding_reaches_a_built_report."""
-    from nsys_ai.evidence_builder import EvidenceBuilder
-
-    assert "critical_path" in {v[0] for v in EvidenceBuilder._SKILL_PIPELINE.values()}
 
 
 def test_bound_class_finding_reaches_a_built_report(minimal_nsys_db_path):
@@ -426,9 +406,25 @@ def test_bound_class_finding_reaches_a_built_report(minimal_nsys_db_path):
     """
     from nsys_ai.evidence_builder import EvidenceBuilder
     from nsys_ai.profile import Profile
+    from nsys_ai.skills.registry import get_skill
 
+    # The window spans the fixture's later kernels, where GPU-idle dominates
+    # clearly enough to commit to a class. Untrimmed, the fixture is `mixed` and
+    # correctly emits nothing, so the trim is load-bearing rather than cosmetic.
+    trim = (4_500_000, 9_000_000)
     with Profile(minimal_nsys_db_path) as prof:
-        report = EvidenceBuilder(prof, device=0, trim=(4_500_000, 9_000_000)).build()
+        conn = prof.db if prof.db is not None else prof.conn
+        classified = get_skill("critical_path").execute(conn, device=0,
+                                                        trim_start_ns=trim[0],
+                                                        trim_end_ns=trim[1])[0]
+        report = EvidenceBuilder(prof, device=0, trim=trim).build()
+
+    # Asserted first so a fixture change that flips the class fails here, saying
+    # why, instead of as an unexplained "verdict missing from the report".
+    assert classified["bound_class"] == "cpu-bound", (
+        f"fixture/trim no longer yields a committed class ({classified['bound_class']}); "
+        "adjust the window rather than the assertion below"
+    )
 
     cp = [f for f in report.findings if (f.provenance or {}).get("skill") == "critical_path"]
     assert len(cp) == 1, "the bound-class verdict must reach the report"

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -364,3 +364,49 @@ def test_every_headroom_producer_declares_a_capture_scoped_basis():
         if n_headroom != n_basis:
             offenders.append(f"{path.name}: {n_headroom} headroom_ms vs {n_basis} headroom_basis")
     assert not offenders, "every headroom_ms must declare a basis: " + "; ".join(offenders)
+
+
+def test_pipeline_headroom_never_exceeds_the_profile_span(minimal_nsys_db_path):
+    """Cross-skill single-count invariant (#230).
+
+    Each skill enforces single-counting internally, but the pipeline runs
+    several together and nothing checked them against each other. critical_path
+    measures the same idle as gpu_idle_gaps and the same exposed NCCL as
+    overlap_breakdown, so enrolling it while all three claimed headroom would
+    report more recoverable time than the profile contains — measured at ~157s
+    of claims on an 82.5s profile before this was fixed.
+    """
+    from nsys_ai.evidence_builder import EvidenceBuilder
+    from nsys_ai.profile import Profile
+
+    with Profile(minimal_nsys_db_path) as prof:
+        span_ms = (prof.meta.time_range[1] - prof.meta.time_range[0]) / 1e6
+        report = EvidenceBuilder(prof, device=0).build()
+
+    claimed = sum(f.headroom_ms or 0.0 for f in report.findings)
+    assert claimed <= span_ms * 1.05, (
+        f"pipeline claims {claimed:.1f}ms recoverable on a {span_ms:.1f}ms profile — "
+        "two skills are counting the same milliseconds"
+    )
+
+
+def test_critical_path_is_in_the_pipeline_without_claiming_headroom():
+    """It must be reachable from a report (#230) but contribute the verdict,
+    not a competing claim on time another skill already localizes."""
+    from nsys_ai.evidence_builder import EvidenceBuilder
+
+    names = {v[0] for v in EvidenceBuilder._SKILL_PIPELINE.values()}
+    assert "critical_path" in names
+
+    from nsys_ai.skills.builtins.critical_path import _to_findings
+
+    row = {
+        "bound_class": "cpu-bound", "confidence": 0.9, "device": 0,
+        "critical_path_ms": 100.0,
+        "breakdown": {"gpu_compute_ms": 10.0, "comm_ms": 0.0, "cpu_ms": 90.0,
+                      "gpu_compute_share": 0.1, "comm_share": 0.0, "cpu_share": 0.9},
+        "top_compute_kernels": [], "top_collectives": [], "note": "n",
+    }
+    (f,) = _to_findings([row])
+    assert f.headroom_ms is None
+    assert f.evidence[0].values["cpu_ms"] == 90.0  # the measurement is still reported

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -366,31 +366,35 @@ def test_every_headroom_producer_declares_a_capture_scoped_basis():
     assert not offenders, "every headroom_ms must declare a basis: " + "; ".join(offenders)
 
 
-def test_claimed_idle_headroom_never_exceeds_measured_idle(minimal_nsys_db_path):
+def test_idle_headroom_is_claimed_by_exactly_one_finding(minimal_nsys_db_path):
     """Cross-skill single-count invariant (#230).
 
     Each skill enforces single-counting internally, but the pipeline runs
     several together and nothing checked them against each other.
 
-    The bound is per category, not per profile: what double counting violates is
-    that the idle a report offers as recoverable exceeds the idle actually
-    measured. A whole-profile-span bound is far too loose to catch it — with the
-    per-gap findings restored to also claim their gaps, so every idle
-    millisecond is counted twice, the total stayed comfortably inside the span.
+    The invariant is stated as a count, not a magnitude. Comparing claimed idle
+    against a device-level idle measurement would be comparing different
+    quantities: gpu_idle_gaps sums gaps per stream, while the device is only
+    idle when *every* stream is. A compute stream idling while an NCCL stream
+    runs is legitimate and would make a magnitude bound fire with no
+    double count anywhere — a false positive on this project's core workload,
+    which is worse in a guard than a missed bug. How many findings claim the
+    same pool is basis-independent and is what double counting actually means.
     """
     from nsys_ai.evidence_builder import EvidenceBuilder
-    from nsys_ai.overlap import overlap_analysis
     from nsys_ai.profile import Profile
 
     with Profile(minimal_nsys_db_path) as prof:
-        measured_idle_ms = float(overlap_analysis(prof, 0).get("idle_ms", 0.0))
         report = EvidenceBuilder(prof, device=0).build()
 
-    claimed = sum(f.headroom_ms or 0.0 for f in report.findings if f.category == "idle")
-    assert claimed > 0, "fixture produced no idle headroom, so this proves nothing"
-    assert claimed <= measured_idle_ms + 0.01, (
-        f"report offers {claimed:.2f}ms of recoverable idle but only "
-        f"{measured_idle_ms:.2f}ms was measured — two skills are counting the same gaps"
+    claimants = [
+        f for f in report.findings if f.category == "idle" and f.headroom_ms is not None
+    ]
+    assert claimants, "fixture produced no idle headroom, so this proves nothing"
+    assert len(claimants) == 1, (
+        "the recoverable idle pool is claimed by "
+        + ", ".join(f"{f.id or f.label}" for f in claimants)
+        + " — it must be attributed to exactly one finding"
     )
 
 


### PR DESCRIPTION
Closes #230.

## Problem

`to_findings_fn` has exactly one production call site — `evidence_builder.py`, driven by `_SKILL_PIPELINE` — and `critical_path` was not in it:

```
pipeline: gpu_idle_gaps, h2d_distribution, iteration_timing, kernel_instances,
          memory_bandwidth, nccl_breakdown, overlap_breakdown,
          profile_health_manifest, top_kernels
```

So the bound-class Finding from #221, and the `headroom_ms` wired into it in #223, were unreachable from any report. Only `nsys-ai skill critical_path` reached the skill, and that renders `_format`, not the Finding.

## Why naive enrollment would have been wrong

Measured on a real 82.5s profile:

```
critical_path     headroom = 78999.8ms   (cpu-bound)
gpu_idle_gaps     headroom = 78529.7ms   (idle summary)
overlap_breakdown headroom =  1149.7ms   (exposed NCCL)
```

The first two are **the same idle**, differing only in measurement span. Enrolling as-is would have reported ~157s recoverable out of 82.5s. The comm bucket stands in the same relation to `overlap_breakdown`'s exposed NCCL.

## Fix

`critical_path` contributes the **verdict** and no headroom — which resource bounds the run, not a fresh pool of recoverable time. `gpu_idle_gaps` and `overlap_breakdown` keep the claim, because they can also *localize* it to specific gaps and streams. The bucket sizes remain on the evidence row, so the measurement is still reported; only the double count is removed.

This is the same single-count rule already applied within `gpu_idle_gaps` (summary vs per-gap) and `overlap_breakdown` (its two co-firing findings), extended across skills for the first time.

## The missing invariant

Each skill enforced single-counting internally and nothing checked the pipeline as a whole — which is exactly why this survived per-skill review. A test now asserts a built report cannot claim more recoverable time than the profile span.

## Verification

End-to-end on the real profile:

```
before:  bound-class finding never appeared;  claims ~190% of span
after:   Critical path is cpu-bound (headroom=None) present in the report
         total claimed 80796.6ms of an 82500.4ms span (97.9%)
         ranking: GPU Idle Summary 78529.7ms > exposed NCCL 1149.7ms > ...
```

Full suite 1238 passed / 135 skipped; ruff clean.

## Note

This depended on both earlier fixes: #233 gave the manifest and `critical_path` one overlap convention, and #234 put every `headroom_ms` on one comparable scale. Enrolling before either would have produced contradictory bound classes or an inverted ranking.