### PR TITLE
fix(diff): gate comparability on export schema, not nsys build version

### DIFF
--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -48,6 +48,10 @@ class NvtxAgg:
 class ProfileSummary:
     path: str
     gpu: int | None
+    # Export *schema* version (e.g. "3.24.14") — the table/column layout, and
+    # the only thing that can make two profiles structurally incomparable.
+    # Distinct from `product_version`, the nsys build that wrote them
+    # (e.g. "2026.1.1.204"), which moves far more often than the schema does.
     schema_version: str | None
     total_gpu_ns: int
     kernel_rows: int
@@ -55,6 +59,7 @@ class ProfileSummary:
     nvtx: list[NvtxAgg]
     overlap: dict
     profile_id: str = ""
+    product_version: str | None = None
 
 
 @dataclass(frozen=True)
@@ -258,7 +263,8 @@ def build_profile_summary(
     return ProfileSummary(
         path=prof.path,
         gpu=gpu,
-        schema_version=prof.schema.version,
+        schema_version=prof.schema.schema_version,
+        product_version=prof.schema.version,
         total_gpu_ns=total_gpu_ns,
         kernel_rows=kernel_rows,
         kernels=kernels,
@@ -285,9 +291,23 @@ def collect_sanity_warnings(
         and before.schema_version != after.schema_version
     ):
         warnings.append(
-            f"Nsight schema/version differs: before='{before.schema_version}' after='{after.schema_version}'."
+            f"Nsight export schema differs: before='{before.schema_version}' "
+            f"after='{after.schema_version}'."
         )
         c_schema = 0.0
+    elif (
+        before.product_version
+        and after.product_version
+        and before.product_version != after.product_version
+    ):
+        # Same schema, different nsys build. Worth saying, but it does not make
+        # the two structurally incomparable, and zeroing confidence here would
+        # fire on the ordinary case of re-profiling after a toolkit update:
+        # 2026.1.1.204 and 2026.1.2.63 both export schema 3.24.14.
+        warnings.append(
+            f"Nsight build differs: before='{before.product_version}' "
+            f"after='{after.product_version}' (same export schema, still comparable)."
+        )
     if before.gpu is not None and after.gpu is not None and before.gpu != after.gpu:
         warnings.append("Different GPU IDs selected between before/after (unexpected).")
         c_gpu = 0.0

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -600,6 +600,7 @@ def to_diff_dict(data: ProfileDiffSummary) -> dict:
             "profile_id": data.before.profile_id,
             "gpu": data.before.gpu,
             "schema_version": data.before.schema_version,
+            "product_version": data.before.product_version,
             "total_gpu_ns": data.before.total_gpu_ns,
         },
         "after": {
@@ -607,6 +608,7 @@ def to_diff_dict(data: ProfileDiffSummary) -> dict:
             "profile_id": data.after.profile_id,
             "gpu": data.after.gpu,
             "schema_version": data.after.schema_version,
+            "product_version": data.after.product_version,
             "total_gpu_ns": data.after.total_gpu_ns,
         },
         "warnings": list(data.warnings),

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -171,12 +171,13 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
     )
 
     # Device-level idle: time when *no* stream had a kernel running, computed by
-    # the same sweep-line union overlap_analysis uses. This is what is actually
-    # recoverable, and it is not `total_idle_ms`: gaps are summed per stream, so
-    # a stream idling while another stream keeps the device busy inflates that
-    # total without any device time being lost. Measured on a two-stream vLLM
-    # profile the per-stream sum was 1.86x the device idle. Left as None when it
-    # cannot be computed, so callers can decline to claim rather than overstate.
+    # the same sweep-line union overlap_analysis uses. It differs from
+    # `total_idle_ms`, which sums gaps per stream and so counts a stream idling
+    # while another keeps the device busy — 1.86x the device figure on a
+    # two-stream vLLM profile. Note this sweep ignores `min_gap_ns` and includes
+    # sub-threshold slivers, so it is a bound on recoverable time rather than the
+    # recoverable time itself; `_to_findings` takes the min of the two. Left as
+    # None when it cannot be computed, so callers can decline to claim.
     device_idle_ms: float | None = None
     try:
         from ...overlap import overlap_analysis
@@ -432,16 +433,17 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                         gpu_id=target_device,
                         severity="info" if pct < 15 else "warning",
                         # The gap sum is per stream, so on a multi-stream profile
-                        # it exceeds the wall-clock the device actually lost. Say
-                        # both numbers, or the reader cannot reconcile the note
-                        # with the smaller headroom claimed below.
+                        # it exceeds the wall-clock the device lost and the
+                        # headroom below is visibly smaller than the number
+                        # narrated here. Name the gap when there is one; when the
+                        # two agree the clause would only repeat itself.
                         note=(
                             f"Total: {total_idle_ms:.1f}ms idle across "
                             f"{gap_count} gaps ({pct}% of profiled span)"
                             + (
-                                f"; {headroom_ms:.1f}ms of that is device-level "
-                                "idle and recoverable"
-                                if headroom_ms is not None
+                                f"; {headroom_ms:.1f}ms of that is recoverable "
+                                "device time"
+                                if headroom_ms is not None and headroom_ms < total_idle_ms
                                 else ""
                             )
                         ),

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -9,6 +9,7 @@ import logging
 import sqlite3
 
 from nsys_ai.connection import DB_ERRORS, wrap_connection
+from nsys_ai.exceptions import SchemaError
 
 from ..base import Skill, SkillParam
 
@@ -181,11 +182,21 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
         from ...overlap import overlap_analysis
         from ...profile import Profile
 
-        _trim = (int(trim_start), int(trim_end)) if trim_start and trim_end else None
+        # `is not None`, matching the trim clause above: a window starting at
+        # ns 0 is falsy, and treating it as absent would scope the device idle
+        # to the whole profile while the gaps were scoped to the window.
+        _trim = (
+            (int(trim_start), int(trim_end))
+            if trim_start is not None and trim_end is not None
+            else None
+        )
         _ov = overlap_analysis(Profile._from_conn(conn), device, trim=_trim)
         if "error" not in _ov:
             device_idle_ms = float(_ov.get("idle_ms", 0.0))
-    except Exception:  # noqa: BLE001 — enrichment only; absence is handled above
+    except (*DB_ERRORS, SchemaError):
+        # The two ways this can legitimately fail: an engine error, or a profile
+        # with no kernel activity for overlap_analysis to sweep. Anything else is
+        # a bug and should surface rather than silently drop the headroom.
         _log.debug("gpu_idle_gaps device-idle enrichment failed", exc_info=True)
 
     summary = {
@@ -263,6 +274,10 @@ def _format(rows):
             f"{summary['total_idle_ms']:.1f}ms idle "
             f"({summary['pct_of_profile']}% of profile)"
         )
+        # Summed per stream above; on a multi-stream profile that overstates the
+        # wall-clock lost, so show what the device itself idled when known.
+        if summary.get("device_idle_ms") is not None:
+            lines.append(f"  Device-level idle: {summary['device_idle_ms']:.1f}ms")
         lines.append(
             f"  Distribution: "
             f"{summary['gaps_1_5ms']} × 1-5ms, "
@@ -364,6 +379,20 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 total_idle_ms = r.get("total_idle_ms", 0)
                 device_idle_ms = r.get("device_idle_ms")
                 gap_count = r.get("gap_count", 0)
+                # Both figures are upper bounds on what is recoverable, and they
+                # bind in opposite directions, so the claim is the smaller one:
+                #   - device idle bounds it because time the device spent busy on
+                #     some other stream was never lost in the first place;
+                #   - the per-stream sum bounds it because it only counts gaps
+                #     above `min_gap_ns`, and the sub-threshold slivers device
+                #     idle also sweeps up are launch overhead, not real stalls
+                #     (see _FALSE_POSITIVE_NOTES).
+                # On a two-stream vLLM profile the first bound removed 59s; on a
+                # single-stream one the second removed 4.3s of 1ms-and-under
+                # slivers that device idle alone would have claimed.
+                headroom_ms = (
+                    min(device_idle_ms, total_idle_ms) if device_idle_ms is not None else None
+                )
                 finding_id = f"idle_summary_gpu{target_device}"
 
                 selection = TraceSelection(
@@ -386,6 +415,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                     },
                     units={
                         "total_idle_ms": "ms",
+                        "device_idle_ms": "ms",
                         "gap_count": "count",
                         "pct_of_profile": "percent",
                     },
@@ -401,21 +431,26 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                         end_ns=profile_end_ns,
                         gpu_id=target_device,
                         severity="info" if pct < 15 else "warning",
+                        # The gap sum is per stream, so on a multi-stream profile
+                        # it exceeds the wall-clock the device actually lost. Say
+                        # both numbers, or the reader cannot reconcile the note
+                        # with the smaller headroom claimed below.
                         note=(
                             f"Total: {total_idle_ms:.1f}ms idle across "
                             f"{gap_count} gaps ({pct}% of profiled span)"
+                            + (
+                                f"; {headroom_ms:.1f}ms of that is device-level "
+                                "idle and recoverable"
+                                if headroom_ms is not None
+                                else ""
+                            )
                         ),
                         # v0.1 fields
                         id=finding_id,
                         category="idle",
                         confidence=min(0.95, 0.4 + pct / 100),
-                        # Only device-level idle is recoverable. `total_idle_ms`
-                        # sums gaps per stream, so a stream idling while another
-                        # keeps the device busy inflates it without any device
-                        # time being lost. When the device figure is unavailable
-                        # no headroom is claimed, rather than overstating it.
-                        headroom_ms=device_idle_ms,
-                        headroom_basis="capture_total" if device_idle_ms is not None else None,
+                        headroom_ms=headroom_ms,
+                        headroom_basis="capture_total" if headroom_ms is not None else None,
                         evidence=[evidence_row],
                         selection=selection,
                         explanation=_EXPLANATION,

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -169,10 +169,30 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
         min(round(100 * total_gap_ns / effective_span, 1), 100.0) if effective_span > 0 else 0
     )
 
+    # Device-level idle: time when *no* stream had a kernel running, computed by
+    # the same sweep-line union overlap_analysis uses. This is what is actually
+    # recoverable, and it is not `total_idle_ms`: gaps are summed per stream, so
+    # a stream idling while another stream keeps the device busy inflates that
+    # total without any device time being lost. Measured on a two-stream vLLM
+    # profile the per-stream sum was 1.86x the device idle. Left as None when it
+    # cannot be computed, so callers can decline to claim rather than overstate.
+    device_idle_ms: float | None = None
+    try:
+        from ...overlap import overlap_analysis
+        from ...profile import Profile
+
+        _trim = (int(trim_start), int(trim_end)) if trim_start and trim_end else None
+        _ov = overlap_analysis(Profile._from_conn(conn), device, trim=_trim)
+        if "error" not in _ov:
+            device_idle_ms = float(_ov.get("idle_ms", 0.0))
+    except Exception:  # noqa: BLE001 — enrichment only; absence is handled above
+        _log.debug("gpu_idle_gaps device-idle enrichment failed", exc_info=True)
+
     summary = {
         "_summary": True,
         "gap_count": agg.get("gap_count") or 0,
         "total_idle_ms": round(total_gap_ns / 1e6, 2),
+        "device_idle_ms": round(device_idle_ms, 2) if device_idle_ms is not None else None,
         "pct_of_profile": pct_of_profile,
         "gaps_1_5ms": agg.get("gaps_1_5ms") or 0,
         "gaps_5_50ms": agg.get("gaps_5_50ms") or 0,
@@ -342,6 +362,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 and profile_end_ns > profile_start_ns
             ):
                 total_idle_ms = r.get("total_idle_ms", 0)
+                device_idle_ms = r.get("device_idle_ms")
                 gap_count = r.get("gap_count", 0)
                 finding_id = f"idle_summary_gpu{target_device}"
 
@@ -359,6 +380,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                     source_skill="gpu_idle_gaps",
                     values={
                         "total_idle_ms": total_idle_ms,
+                        "device_idle_ms": device_idle_ms,
                         "gap_count": gap_count,
                         "pct_of_profile": pct,
                     },
@@ -387,10 +409,13 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                         id=finding_id,
                         category="idle",
                         confidence=min(0.95, 0.4 + pct / 100),
-                        # All idle time on the pipeline is candidate recoverable
-                        # time — the opportunity if the bubbles were closed.
-                        headroom_ms=total_idle_ms,
-                        headroom_basis="capture_total",
+                        # Only device-level idle is recoverable. `total_idle_ms`
+                        # sums gaps per stream, so a stream idling while another
+                        # keeps the device busy inflates it without any device
+                        # time being lost. When the device figure is unavailable
+                        # no headroom is claimed, rather than overstating it.
+                        headroom_ms=device_idle_ms,
+                        headroom_basis="capture_total" if device_idle_ms is not None else None,
                         evidence=[evidence_row],
                         selection=selection,
                         explanation=_EXPLANATION,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,9 +1,12 @@
 import json
 import os
+import pathlib
 import sqlite3
 import subprocess
 import sys
 from dataclasses import replace
+
+import pytest
 
 
 def _make_db_with_target_info(path: str, gpu_name: str = "NVIDIA A100-SXM4-80GB"):
@@ -2398,7 +2401,7 @@ def test_v01_collect_sanity_warnings_returns_confidence():
     matched = ProfileSummary(
         path="x",
         gpu=0,
-        schema_version="2024.1.1",
+        schema_version="3.24.14",
         total_gpu_ns=100,
         kernel_rows=100,
         kernels=[],
@@ -2416,7 +2419,7 @@ def test_v01_collect_sanity_warnings_returns_confidence():
     other = ProfileSummary(
         path="y",
         gpu=0,
-        schema_version="2025.2.2",
+        schema_version="3.25.0",
         total_gpu_ns=100,
         kernel_rows=100,
         kernels=[],
@@ -2426,6 +2429,69 @@ def test_v01_collect_sanity_warnings_returns_confidence():
     warnings, conf = collect_sanity_warnings(matched, other)
     assert conf == 0.0
     assert any("schema" in w.lower() for w in warnings)
+
+
+def _summary(**over):
+    from nsys_ai.diff import ProfileSummary
+
+    base = dict(
+        path="x", gpu=0, schema_version="3.24.14", total_gpu_ns=100,
+        kernel_rows=100, kernels=[], nvtx=[], overlap={},
+    )
+    return ProfileSummary(**{**base, **over})
+
+
+def test_nsys_build_bump_alone_does_not_zero_comparability():
+    """A different nsys build on the same export schema is still comparable.
+
+    ``ProfileSummary.schema_version`` used to be fed the *product* version, so
+    re-profiling after any toolkit update zeroed the comparability confidence
+    and suppressed the verdict. Real case from the local corpus: 2026.1.1.204
+    and 2026.1.2.63 both export schema 3.24.14.
+    """
+    from nsys_ai.diff import collect_sanity_warnings
+
+    before = _summary(product_version="2026.1.1.204")
+    after = _summary(product_version="2026.1.2.63")
+
+    warnings, conf = collect_sanity_warnings(before, after)
+    assert conf == 1.0, "same export schema must stay fully comparable"
+    assert any("build differs" in w for w in warnings), "the bump is still worth reporting"
+    assert not any("export schema differs" in w for w in warnings)
+
+
+def test_export_schema_mismatch_still_zeros_comparability():
+    """The hard gate must survive: a real schema change is incomparable."""
+    from nsys_ai.diff import collect_sanity_warnings
+
+    warnings, conf = collect_sanity_warnings(
+        _summary(schema_version="3.24.14", product_version="2026.1.1.204"),
+        _summary(schema_version="3.27.0", product_version="2026.1.1.204"),
+    )
+    assert conf == 0.0
+    assert any("export schema differs" in w for w in warnings)
+
+
+def test_build_profile_summary_reads_export_schema_not_product_version():
+    """Guards the assignment itself, end-to-end on a real export.
+
+    The two are trivially told apart by shape — export schema is "3.24.14",
+    the nsys build is "2026.1.1.204" — so this fails loudly if the fields are
+    ever swapped back.
+    """
+    from nsys_ai.diff import build_profile_summary
+    from nsys_ai.profile import Profile
+
+    fixture = pathlib.Path(__file__).parent / "fixtures" / "mock.sqlite"
+    if not fixture.exists():
+        pytest.skip("mock.sqlite fixture not present")
+
+    with Profile(str(fixture)) as prof:
+        s = build_profile_summary(prof, gpu=None, trim=None)
+
+    assert s.schema_version == prof.schema.schema_version == "3.24.14"
+    assert s.product_version == prof.schema.version
+    assert s.product_version != s.schema_version
 
 
 def test_v01_diff_json_envelope_and_verdict(tmp_path):
@@ -2618,7 +2684,7 @@ def test_v01_confidence_separates_schema_and_gpu_mismatch():
     a = ProfileSummary(
         path="a",
         gpu=0,
-        schema_version="2024.1.1",
+        schema_version="3.24.14",
         total_gpu_ns=100,
         kernel_rows=100,
         kernels=[],
@@ -2628,7 +2694,7 @@ def test_v01_confidence_separates_schema_and_gpu_mismatch():
     b = ProfileSummary(
         path="b",
         gpu=1,  # different GPU id, same schema
-        schema_version="2024.1.1",
+        schema_version="3.24.14",
         total_gpu_ns=100,
         kernel_rows=100,
         kernels=[],
@@ -2650,7 +2716,7 @@ def test_v01_no_signal_propagates_through_pipeline():
     good = ProfileSummary(
         path="b",
         gpu=0,
-        schema_version="2024.1.1",
+        schema_version="3.24.14",
         total_gpu_ns=100,
         kernel_rows=100,
         kernels=[],
@@ -2660,7 +2726,7 @@ def test_v01_no_signal_propagates_through_pipeline():
     bad = ProfileSummary(
         path="a",
         gpu=0,
-        schema_version="2024.1.1",
+        schema_version="3.24.14",
         total_gpu_ns=0,
         kernel_rows=0,
         kernels=[],

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -1,5 +1,7 @@
 """Tests for Finding.headroom_ms and opportunity-based ranking (#190)."""
 
+import pytest
+
 from nsys_ai.annotation import Finding, rank_findings
 from nsys_ai.loop_state import _normalize_findings
 
@@ -163,14 +165,20 @@ def test_normalize_findings_largest_first_then_none_last():
 # ---------------------------------------------------------------------------
 
 
-def test_gpu_idle_gaps_headroom():
+def test_gpu_idle_gaps_headroom_is_device_level():
+    """Headroom must be the device-level idle, not the per-stream gap sum.
+
+    Gaps are summed per stream, so a stream idling while another keeps the
+    device busy inflates that total without any device time being recoverable —
+    measured at 1.86x on a two-stream vLLM profile.
+    """
     from nsys_ai.skills.builtins.gpu_idle_gaps import _to_findings
 
     rows = [
-        {  # summary row
+        {  # summary row: per-stream sum is 40ms, but the device idled only 25ms
             "_summary": True, "pct_of_profile": 20, "gpu_id": 0,
             "profile_start_ns": 0, "profile_end_ns": 100_000_000,
-            "total_idle_ms": 40.0, "gap_count": 3,
+            "total_idle_ms": 40.0, "device_idle_ms": 25.0, "gap_count": 3,
         },
         {  # a single 5ms gap
             "gap_ns": 5_000_000, "start_ns": 10_000_000, "end_ns": 15_000_000,
@@ -180,8 +188,24 @@ def test_gpu_idle_gaps_headroom():
     findings = _to_findings(rows, context={"profile_id": "p"})
     summary = next(f for f in findings if "Summary" in f.label)
     gap = next(f for f in findings if "Gap" in f.label)
-    assert summary.headroom_ms == 40.0  # aggregate idle opportunity, counted once
+    assert summary.headroom_ms == 25.0, "must claim device idle, not the 40ms stream sum"
+    assert summary.evidence[0].values["total_idle_ms"] == 40.0  # still reported
     assert gap.headroom_ms is None  # per-gap not double-counted against the summary
+
+
+def test_gpu_idle_gaps_declines_to_claim_without_a_device_figure():
+    """If device idle could not be computed, claim nothing rather than fall back
+    to the inflated per-stream sum."""
+    from nsys_ai.skills.builtins.gpu_idle_gaps import _to_findings
+
+    rows = [{
+        "_summary": True, "pct_of_profile": 20, "gpu_id": 0,
+        "profile_start_ns": 0, "profile_end_ns": 100_000_000,
+        "total_idle_ms": 40.0, "device_idle_ms": None, "gap_count": 3,
+    }]
+    summary = next(f for f in _to_findings(rows, context={"profile_id": "p"}) if "Summary" in f.label)
+    assert summary.headroom_ms is None
+    assert summary.headroom_basis is None
 
 
 def test_overlap_breakdown_headroom_single_count():
@@ -438,3 +462,60 @@ def test_bound_class_finding_reaches_a_built_report(minimal_nsys_db_path):
     cp = [f for f in report.findings if (f.provenance or {}).get("skill") == "critical_path"]
     assert len(cp) == 1, "the bound-class verdict must reach the report"
     assert cp[0].headroom_ms is None, "and must not claim time another skill localizes"
+
+
+def test_idle_headroom_not_inflated_by_a_busy_parallel_stream(tmp_path):
+    """End-to-end guard for #240 on the layout that exposed it.
+
+    One stream idles for 49ms while another keeps the device busy throughout.
+    Nothing is recoverable — the GPU never stopped working — but the per-stream
+    gap sum reports 49ms. This is the compute-stream + NCCL-stream shape this
+    project targets, so the inflation appears on real workloads (1.86x measured
+    on a two-stream vLLM profile).
+    """
+    import sqlite3
+
+    from nsys_ai.profile import Profile
+    from nsys_ai.skills.registry import get_skill
+
+    ms = 1_000_000
+    db = tmp_path / "two_stream.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        "CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT NOT NULL);"
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (globalPid INTEGER DEFAULT 0,"
+        " deviceId INTEGER DEFAULT 0, streamId INTEGER DEFAULT 0,"
+        " correlationId INTEGER DEFAULT 0, start INTEGER, end INTEGER,"
+        " shortName INTEGER, demangledName INTEGER DEFAULT 0);"
+    )
+    conn.execute("INSERT INTO StringIds VALUES (1,'compute_kernel')")
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL "
+        "(deviceId,streamId,correlationId,start,end,shortName,demangledName)"
+        " VALUES (?,?,?,?,?,?,?)",
+        [
+            (0, 7, 1, 0, 1 * ms, 1, 1),          # stream 7 runs, then idles...
+            (0, 8, 3, 1 * ms, 50 * ms, 1, 1),    # ...while stream 8 covers the device
+            (0, 7, 2, 50 * ms, 51 * ms, 1, 1),   # stream 7 resumes
+        ],
+    )
+    conn.commit()
+    conn.close()
+
+    skill = get_skill("gpu_idle_gaps")
+    with Profile(str(db)) as prof:
+        c = prof.db if prof.db is not None else prof.conn
+        rows = skill.execute(c, device=0)
+        findings = skill.to_findings_fn(rows, context={"profile_id": "p"})
+
+    summary_row = next(r for r in rows if r.get("_summary"))
+    assert summary_row["total_idle_ms"] == pytest.approx(49.0, abs=0.5), (
+        "precondition: the per-stream sum should see the 49ms gap"
+    )
+    assert summary_row["device_idle_ms"] == pytest.approx(0.0, abs=0.5), (
+        "the device was busy throughout, so no time is recoverable"
+    )
+    claimed = [f.headroom_ms for f in findings if f.headroom_ms is not None]
+    assert all(h == pytest.approx(0.0, abs=0.5) for h in claimed), (
+        f"no recoverable time exists, but {claimed} was claimed"
+    )

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -193,6 +193,27 @@ def test_gpu_idle_gaps_headroom_is_device_level():
     assert gap.headroom_ms is None  # per-gap not double-counted against the summary
 
 
+def test_gpu_idle_gaps_headroom_excludes_sub_threshold_slivers():
+    """The per-stream sum bounds the claim from the other side.
+
+    Device idle sweeps up every sliver between kernels; the gap sum only counts
+    gaps above ``min_gap_ns``. On a single-stream profile the device figure is
+    therefore the *larger* of the two, and claiming it would book sub-1ms launch
+    overhead as recoverable — measured at 4.3s on a 3.5GB single-stream profile.
+    """
+    from nsys_ai.skills.builtins.gpu_idle_gaps import _to_findings
+
+    rows = [{  # one busy stream: device idle exceeds the thresholded gap sum
+        "_summary": True, "pct_of_profile": 20, "gpu_id": 0,
+        "profile_start_ns": 0, "profile_end_ns": 100_000_000,
+        "total_idle_ms": 139179.81, "device_idle_ms": 143531.45, "gap_count": 3,
+    }]
+    summary = next(f for f in _to_findings(rows, context={"profile_id": "p"}) if "Summary" in f.label)
+    assert summary.headroom_ms == 139179.81, "must not claim idle below min_gap_ns"
+    assert summary.evidence[0].values["device_idle_ms"] == 143531.45  # still reported
+    assert summary.evidence[0].units["device_idle_ms"] == "ms"
+
+
 def test_gpu_idle_gaps_declines_to_claim_without_a_device_figure():
     """If device idle could not be computed, claim nothing rather than fall back
     to the inflated per-stream sum."""

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -190,6 +190,9 @@ def test_gpu_idle_gaps_headroom_is_device_level():
     gap = next(f for f in findings if "Gap" in f.label)
     assert summary.headroom_ms == 25.0, "must claim device idle, not the 40ms stream sum"
     assert summary.evidence[0].values["total_idle_ms"] == 40.0  # still reported
+    # Both numbers must appear, or the 40ms in the note reads as the opportunity
+    # while the ranking is driven by a 25ms headroom the reader never sees.
+    assert "40.0ms idle" in summary.note and "25.0ms of that is recoverable" in summary.note
     assert gap.headroom_ms is None  # per-gap not double-counted against the summary
 
 
@@ -212,6 +215,10 @@ def test_gpu_idle_gaps_headroom_excludes_sub_threshold_slivers():
     assert summary.headroom_ms == 139179.81, "must not claim idle below min_gap_ns"
     assert summary.evidence[0].values["device_idle_ms"] == 143531.45  # still reported
     assert summary.evidence[0].units["device_idle_ms"] == "ms"
+    # The headroom equals the narrated gap sum here, so the reconciling clause
+    # would just repeat the same number back — and calling it "device" time
+    # would misname it, the device idled 143531.45ms.
+    assert "recoverable" not in summary.note
 
 
 def test_gpu_idle_gaps_declines_to_claim_without_a_device_figure():


### PR DESCRIPTION
Closes #243. Found while surveying schema-version coverage for #237.

`build_profile_summary` fed `NsightSchema.version` — the nsys *build* — into a field named `schema_version`, and `collect_sanity_warnings` zeroed `c_schema` on any difference. The export schema version is the separate `NsightSchema.schema_version`.

Since the build string moves far more often than the schema, this fired on the ordinary before/after case of re-profiling across a toolkit update:

```
fastvideo.sqlite             schema=3.24.14  build=2026.1.1.204
nano_vllm_qwen3_4b.sqlite    schema=3.24.14  build=2026.1.2.63
```

Identical export schema, but comparability confidence was driven to 0.0 and the verdict suppressed. For scale: the real export-schema delta across 2026.1.1 → 2026.2.1 → 2026.3.1 (3.24.14 → 3.25.0 → 3.27.0) is **one** added column on `CUPTI_ACTIVITY_KIND_KERNEL` plus one added optional table. Schema changes are rare; build changes are routine.

## Change

- `ProfileSummary` carries both `schema_version` and `product_version`; both are emitted per side in the diff JSON.
- The hard `c_schema = 0.0` gate keys off the export schema alone.
- A build difference still produces a warning, without zeroing confidence.
- Test fixtures passing product-version strings (`"2024.1.1"`) into `schema_version` are corrected to export-schema strings — they encoded the same confusion.

## Verification

Same two profiles after the fix:

```
confidence: 0.059
 - Nsight build differs: before='2026.1.1.204' after='2026.1.2.63' (same export schema, still comparable).
 - Kernel row counts differ a lot (before=31770, after=108898); ...
```

The residual low confidence is now the legitimate workload-size factor — these genuinely are different workloads — rather than a spurious schema gate.

1245 passed, 135 skipped; ruff clean. Mutation-tested: reverting the assignment to `prof.schema.version`, and separately re-adding `c_schema = 0.0` to the build-difference branch, each fail exactly one test. The hard gate is covered by its own test so a real schema change still zeros comparability.