### PR TITLE
fix(findings): stop NCCL variability from double-counting the exposed-comm bucket

### DIFF
--- a/src/nsys_ai/skills/builtins/nccl_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_breakdown.py
@@ -135,14 +135,17 @@ def _serialization_confidence(nccl_capture_pct: float, captured_ms: float = 0.0)
         return 0.85
     return 0.70
 
-def _variability_headroom_ms(row: dict) -> float | None:
-    """Capture-scoped recoverable time for a high-variability collective.
+def _recoverable_if_balanced_ms(row: dict) -> float | None:
+    """Aggregate collective time saved if every instance ran at the fastest
+    observed time: ``count * (avg - min)``.
 
-    If every instance ran at the fastest observed time instead of the average,
-    ``count * (avg - min)`` would be saved. An upper bound — some spread is
-    unavoidable — but it spans the whole capture, so it is comparable with the
-    other headroom producers. Returns ``None`` when the row lacks the fields to
-    compute it honestly rather than guessing a value.
+    Reported as a measurement on the evidence row, *not* as ``headroom_ms``.
+    It is not an independent pool of recoverable wall-clock: this excess lives
+    inside the NCCL kernels, whose exposed portion ``overlap_breakdown`` already
+    claims as the comm headroom and whose overlapped portion is hidden and not
+    recoverable at all. Claiming it again would double-count that bucket — see
+    the deferral note at the finding below and ``critical_path``'s matching one.
+    Returns ``None`` when the row lacks the fields to compute it honestly.
     """
     count = row.get("count")
     avg_ms = row.get("avg_ms")
@@ -295,7 +298,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None)-> list:
     for r in rows:
         if r["avg_ms"] > 0 and r["max_ms"] / r["avg_ms"] > _VARIABILITY_RATIO_THRESHOLD and r["pct"] >= _VARIABILITY_MIN_PCT:
             ratio = round(r["max_ms"] / r["avg_ms"], 1)
-            variability_headroom_ms = _variability_headroom_ms(r)
+            recoverable_if_balanced_ms = _recoverable_if_balanced_ms(r)
             finding_id = f"nccl_high_variability_{r['type']}_stream{r['stream_id']}"
             selection = TraceSelection(
                 id=f"sel_{finding_id}",
@@ -314,8 +317,16 @@ def _to_findings(rows: list[dict], *, context: dict | None = None)-> list:
                     "avg_ms": round(r["avg_ms"], 3),
                     "max_ms": round(r["max_ms"], 3),
                     "max_avg_ratio": ratio,
+                    # Reported measurement, not a headroom (see deferral below):
+                    # aggregate time saved if every instance ran at the fastest.
+                    "recoverable_if_balanced_ms": recoverable_if_balanced_ms,
                 },
-                units={"avg_ms": "ms", "max_ms": "ms", "max_avg_ratio": "ratio"},
+                units={
+                    "avg_ms": "ms",
+                    "max_ms": "ms",
+                    "max_avg_ratio": "ratio",
+                    "recoverable_if_balanced_ms": "ms",
+                },
                 selection_id=selection.id,
                 provenance={"row_kind": "high_variability", "collective_type": r["type"], "root_cause": "#8_proxy"},
             )
@@ -330,15 +341,17 @@ def _to_findings(rows: list[dict], *, context: dict | None = None)-> list:
                 id=finding_id,
                 category="communication",
                 confidence=_variability_confidence(ratio, r.get("count", 0)),
-                # Recoverable time across the whole capture if the variability
-                # were eliminated and every instance ran at the fastest observed
-                # time: count x (avg - min). An upper bound — some spread is
-                # unavoidable — but capture-scoped, so it is comparable with the
-                # other headroom producers. (The previous value, one instance's
-                # max - avg, undercounted by a factor of `count` and made a
-                # thousand slow collectives rank below a single idle gap.)
-                headroom_ms=variability_headroom_ms,
-                headroom_basis="capture_total" if variability_headroom_ms else None,
+                # No headroom, by design. The variability excess lives inside
+                # the NCCL kernels: its exposed portion is the same comm bucket
+                # `overlap_breakdown` already claims as headroom, and its
+                # overlapped portion is hidden and not recoverable. Claiming it
+                # here would double-count that bucket — the exact deconfliction
+                # `critical_path` makes for the same reason. Comm still ranks
+                # correctly via `overlap_breakdown`'s exposed-NCCL headroom; this
+                # finding stays as the straggler diagnostic, with the "if
+                # balanced" figure reported on the evidence row above.
+                headroom_ms=None,
+                headroom_basis=None,
                 evidence=[evidence_row],
                 selection=selection,
                 explanation=_HIGH_VARIABILITY_EXPLANATION,

--- a/src/nsys_ai/sol_gate.py
+++ b/src/nsys_ai/sol_gate.py
@@ -218,9 +218,11 @@ def evaluate_sol_gates(
             # the measured region — almost always step-scoped FLOPs applied to a
             # sub-region, or the wrong peak. Passing here would be the failure
             # mode this module exists to prevent: a green gate that never really
-            # ran. (Reported as a gate failure rather than raising, because an
-            # FP8/sparse run can legitimately exceed an auto-detected BF16-dense
-            # peak, and that is a threshold problem the user must resolve.)
+            # ran. Raised as a configuration error (exit 2), not a gate failure
+            # (exit 1): an implausible MFU means the inputs don't describe this
+            # region — e.g. an FP8/sparse run measured against an auto-detected
+            # BF16-dense peak — which the user must resolve before the gate can
+            # mean anything.
             raise SolGateError(
                 f"--gate-sol {spec}: implausible MFU {mfu:.1f}% for region "
                 f"{spec.region!r} — above the hardware ceiling. Check that "

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -291,9 +291,11 @@ def test_iteration_timing_headroom_is_aggregated_and_counted_once():
     assert carriers[0].headroom_basis == "capture_total"
 
 
-def test_nccl_variability_headroom_is_capture_scoped():
-    """The recoverable total across the whole capture, not one instance's
-    excess — otherwise 1000 slow collectives rank below a single idle gap."""
+def test_nccl_variability_defers_comm_headroom_to_overlap_breakdown():
+    """The variability finding claims no headroom: the excess it points at lives
+    inside the NCCL kernels, whose recoverable (exposed) portion is the comm
+    bucket overlap_breakdown already owns. Claiming it again would double-count
+    that bucket. The 'if balanced' figure is still reported, as evidence."""
     from nsys_ai.skills.builtins.nccl_breakdown import _to_findings
 
     rows = [{
@@ -303,13 +305,16 @@ def test_nccl_variability_headroom_is_capture_scoped():
     }]
     findings = _to_findings(rows, context={"profile_id": "p"})
     var = next(f for f in findings if "Variability" in f.label)
-    assert var.headroom_ms == 30.0  # count(10) * (avg 5 - min 2)
-    assert var.headroom_basis == "capture_total"
+    assert var.headroom_ms is None, "must not co-rank against the same exposed-comm bucket"
+    assert var.headroom_basis is None
+    # The measurement survives on the evidence row: count(10) * (avg 5 - min 2).
+    assert var.evidence[0].values["recoverable_if_balanced_ms"] == 30.0
+    assert var.evidence[0].units["recoverable_if_balanced_ms"] == "ms"
 
 
-def test_nccl_variability_headroom_absent_when_fields_missing():
-    """Without min_ms the capture-scoped value cannot be computed honestly, so
-    no headroom is claimed rather than a guessed one."""
+def test_nccl_variability_if_balanced_absent_when_fields_missing():
+    """Without min_ms the 'if balanced' figure cannot be computed honestly, so
+    it is None on the evidence row rather than a guessed value."""
     from nsys_ai.skills.builtins.nccl_breakdown import _to_findings
 
     rows = [{
@@ -321,7 +326,7 @@ def test_nccl_variability_headroom_absent_when_fields_missing():
         f for f in _to_findings(rows, context={"profile_id": "p"}) if "Variability" in f.label
     )
     assert var.headroom_ms is None
-    assert var.headroom_basis is None
+    assert var.evidence[0].values["recoverable_if_balanced_ms"] is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #246. Found during a code review of the finding-producing skills.

`overlap_breakdown` and `nccl_breakdown` both run in `_SKILL_PIPELINE` and both emit `category="communication"` headroom from the same NCCL budget:

- `overlap_breakdown` claims the exposed collective wall-clock (recoverable by overlapping).
- `nccl_breakdown` claimed `count*(avg-min)` straggler excess *inside those same collectives* (recoverable by load-balancing).

`rank_findings` orders by `headroom_ms` magnitude, so the two co-ranked as independent pools of time. On `fastvideo.sqlite`:

```
hr=  1149.68  Low Compute/NCCL Overlap (0.0%)        [communication]
hr=  1117.28  High NCCL Variability (sendrecv 5.3x)  [communication]
----------
     2266.96  claimed, against 1149.68ms of NCCL that physically exists (1.97x)
```

The variability excess is not independent: its exposed portion is the bucket `overlap_breakdown` owns, its overlapped portion is hidden and not recoverable. This is the exact deconfliction `critical_path` already makes (`critical_path.py:551` — *"the comm bucket the same exposed NCCL that overlap_breakdown claims... only the double count is dropped"*).

## Change

- The variability finding sets `headroom_ms=None` and defers the comm bucket to `overlap_breakdown`. It stays as the straggler diagnostic (5.3x ratio, note, `severity=warning`).
- The `count*(avg-min)` figure is kept as a reported measurement on the evidence row (`recoverable_if_balanced_ms`), mirroring how `critical_path` keeps bucket sizes on evidence while dropping the headroom.
- Helper renamed `_variability_headroom_ms` → `_recoverable_if_balanced_ms`.
- Drive-by: corrected a stale `sol_gate.py` comment that described an implausible-MFU `raise` (exit 2, config error) as a gate failure (exit 1).

## Verification

After the fix, total `communication` headroom on `fastvideo.sqlite` = 1149.68ms = exposed NCCL (was 2266.96). The variability finding still fires with its ratio and its 1117ms "if balanced" figure on evidence. 1245 passed, 135 skipped; ruff clean. Mutation-tested: restoring the headroom (and 4 subtler variants) each fails the new regression test.

## Follow-up (pre-existing, not from this change)

`overlap_breakdown` only attaches its exposed-NCCL headroom to its `low_overlap` (overlap < 30%) or `comm_dominated` findings. On a moderate-overlap, balanced profile neither fires, so comm carries no headroom anywhere. That is an `overlap_breakdown` firing-threshold limitation independent of this double-count; the variability figure was never a valid measure of *exposed* time, so deferring is still correct. Worth a separate issue to broaden `overlap_breakdown`'s emission.