### PR TITLE
fix(skills): compute host-sync attribution by sweep, not an in-engine range join

### DIFF
--- a/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
+++ b/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
@@ -118,17 +118,20 @@ def _sweep_containment(parents, children):
     how the SQL drops a range matching itself (and, as in the SQL, a distinct
     range sharing the child's exact ``[start, end]``).
 
-    An active set keyed on ``end`` — not a stack. eventType-60 (StartEnd) ranges
-    are not guaranteed to nest, so ranges can cross; a stack-pop would evict the
-    wrong range and misattribute a later child. Sorted by start, the active set
-    holds ranges that have opened and not yet ended, so it is bounded by NVTX
-    nesting depth and the sweep is O(n log n + matches).
+    Containment is decided per candidate by the ``pe >= ce`` check, not by the
+    active set's shape — so this does not assume ranges nest. That matters
+    because eventType-60 (StartEnd) ranges can cross, and treating the active
+    set as a nesting stack (crediting whatever is "open" without re-checking
+    end) would misattribute a child to a range that started before it but ended
+    first. The sort-by-start plus ``end >= cs`` eviction is only there to keep
+    the active set to the ranges spanning the current child, so the per-child
+    scan stays O(depth) and the sweep is O(n log n + matches).
 
     ``parents`` is every range in the profile and is held in memory (labels are
-    near-unique per instance, so interning does not shrink it): ~1.25M rows is
-    ~200MB on the largest profile seen. Acceptable — the in-engine SQL this
-    replaces could not process that profile at all — but the reason the input is
-    fetched as plain rows rather than streamed.
+    near-unique per instance, so interning does not shrink it): ~1.25M rows
+    measured ~425MB peak on the largest profile in hand. Acceptable — the
+    in-engine SQL this replaces could not process that profile at all — but the
+    reason the input is fetched as plain rows rather than streamed.
     """
     p_by_tid = defaultdict(list)
     c_by_tid = defaultdict(list)

--- a/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
+++ b/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
@@ -7,6 +7,8 @@ report the total sync time and event count. Used by Mode 6 to localize
 code via `grep` (PRINCIPLES.md §5.7 Step 1).
 """
 
+from collections import defaultdict
+
 from ...connection import DB_ERRORS, wrap_connection
 from ..base import Skill, SkillParam
 
@@ -15,7 +17,8 @@ from ..base import Skill, SkillParam
 # justified by an observed bottleneck class, not speculative.
 DEFAULT_PATTERNS = "item,_local_scalar_dense,cudaStreamSynchronize"
 
-# Cap on `limit` — guards the O(n²) ancestry self-join on pathological input.
+# Cap on `limit` — the sweep credits every enclosing ancestor, so a deeply
+# nested profile can produce many parent rows; bound what we return.
 _MAX_LIMIT = 1000
 
 
@@ -65,86 +68,33 @@ def _execute(conn, **kwargs):
         like_params.append(f"%{p.lower()}%")
     like_clause = " OR ".join(like_parts)
 
-    # Self-exclusion predicate: parent must cover child strictly (either a
-    # different start or a different end). This keeps same-labeled but
-    # distinct ancestors — e.g. nested `train_step` scopes — while still
-    # preventing a range from matching itself.
-    #
-    # Event-type filter: 59 = PushPop range, 60 = StartEnd range; markers
-    # and counter/payload events are excluded so they don't inflate the
-    # ancestry join or misattribute sync time.
-    #
-    # Performance: we pre-filter sync children into their own CTE so the
-    # ancestry join runs over only the rows that match the sync patterns,
-    # instead of the full NVTX set.
-    sql = f"""
-        WITH resolved AS (
-            SELECT {label_expr} AS label,
-                   n.globalTid   AS tid,
-                   n.start       AS start,
-                   n.[end]       AS end_ns
-            FROM {nvtx_table} n
-            {label_join}
-            WHERE n.[end] > n.start
-              AND n.eventType IN (59, 60)
-              {trim_where}
-        ),
-        sync_children AS (
-            SELECT label, tid, start, end_ns
-            FROM resolved
-            WHERE ({like_clause}) AND label IS NOT NULL
-        ),
-        matched AS (
-            SELECT parent.label                 AS parent_range,
-                   child.label                  AS child_label,
-                   child.end_ns - child.start   AS sync_ns
-            FROM sync_children child
-            JOIN resolved parent
-              ON parent.tid = child.tid
-             AND parent.start <= child.start
-             AND parent.end_ns >= child.end_ns
-             AND (parent.start != child.start OR parent.end_ns != child.end_ns)
-            WHERE parent.label IS NOT NULL
-        ),
-        parent_totals AS (
-            SELECT parent_range,
-                   COUNT(*)     AS n_syncs,
-                   SUM(sync_ns) AS sync_ns
-            FROM matched
-            GROUP BY parent_range
-        ),
-        child_totals AS (
-            SELECT parent_range,
-                   child_label,
-                   COUNT(*)     AS child_n_syncs,
-                   SUM(sync_ns) AS child_sync_ns
-            FROM matched
-            GROUP BY parent_range, child_label
-        ),
-        ranked_children AS (
-            SELECT parent_range,
-                   child_label,
-                   ROW_NUMBER() OVER (
-                       PARTITION BY parent_range
-                       ORDER BY child_sync_ns DESC, child_n_syncs DESC, child_label ASC
-                   ) AS rn
-            FROM child_totals
-        )
-        SELECT pt.parent_range,
-               pt.n_syncs,
-               pt.sync_ns,
-               rc.child_label AS top_child_label
-        FROM parent_totals pt
-        LEFT JOIN ranked_children rc
-          ON rc.parent_range = pt.parent_range
-         AND rc.rn = 1
-        ORDER BY pt.sync_ns DESC
-        LIMIT {int(limit)}
+    # The attribution is a two-sided interval-containment join: a sync child is
+    # credited to every range that covers it (parent.start <= child.start AND
+    # parent.end >= child.end) on the same tid. Neither engine can run that as
+    # SQL here: SQLite's nested-loop-only planner has no range-join operator, so
+    # on an NVTX-heavy profile (~1.25M ranges, a handful of tids) it degrades to
+    # ~n*m and never completes; and DuckDB's sqlite_scanner crashes optimizing
+    # the CTE when the profile is direct-attached (no parquet cache). Both are
+    # the no-cache paths issue #245 is about. So we do the containment ourselves
+    # with a per-tid sweep, fed by two simple pattern/label queries that both
+    # engines run without trouble.
+    base = f"""
+        SELECT {label_expr} AS label, n.globalTid AS tid,
+               n.start AS start, n.[end] AS end_ns
+        FROM {nvtx_table} n
+        {label_join}
+        WHERE n.[end] > n.start AND n.eventType IN (59, 60) {trim_where}
     """
-
     try:
-        cur = adapter.execute(sql, trim_params + like_params)
-        rows = cur.fetchall()
+        parents = adapter.execute(
+            f"SELECT label, tid, start, end_ns FROM ({base}) WHERE label IS NOT NULL",
+            trim_params,
+        ).fetchall()
+        children = adapter.execute(
+            f"SELECT label, tid, start, end_ns FROM ({base}) "
+            f"WHERE ({like_clause}) AND label IS NOT NULL",
+            trim_params + like_params,
+        ).fetchall()
     except DB_ERRORS as exc:
         return [
             {
@@ -155,13 +105,101 @@ def _execute(conn, **kwargs):
             }
         ]
 
-    cols = ["parent_range", "n_syncs", "sync_ns", "top_child_label"]
+    return _aggregate_matched(_sweep_containment(parents, children), limit)
+
+
+def _sweep_containment(parents, children):
+    """Yield ``(parent_label, child_label, sync_ns)`` for every strict containment.
+
+    A child is credited to *every* range that contains it on the same tid
+    (``parent.start <= child.start`` and ``parent.end >= child.end``), matching
+    the SQL's multi-ancestor crediting — a child nested three deep credits all
+    three enclosing ranges. The identical-coordinate pair is excluded, which is
+    how the SQL drops a range matching itself (and, as in the SQL, a distinct
+    range sharing the child's exact ``[start, end]``).
+
+    An active set keyed on ``end`` — not a stack. eventType-60 (StartEnd) ranges
+    are not guaranteed to nest, so ranges can cross; a stack-pop would evict the
+    wrong range and misattribute a later child. Sorted by start, the active set
+    holds ranges that have opened and not yet ended, so it is bounded by NVTX
+    nesting depth and the sweep is O(n log n + matches).
+
+    ``parents`` is every range in the profile and is held in memory (labels are
+    near-unique per instance, so interning does not shrink it): ~1.25M rows is
+    ~200MB on the largest profile seen. Acceptable — the in-engine SQL this
+    replaces could not process that profile at all — but the reason the input is
+    fetched as plain rows rather than streamed.
+    """
+    p_by_tid = defaultdict(list)
+    c_by_tid = defaultdict(list)
+    for label, tid, start, end_ns in parents:
+        p_by_tid[tid].append((start, end_ns, label))
+    for label, tid, start, end_ns in children:
+        c_by_tid[tid].append((start, end_ns, label))
+
+    matched = []
+    for tid, clist in c_by_tid.items():
+        plist = p_by_tid.get(tid)
+        if not plist:
+            continue
+        plist.sort(key=lambda r: r[0])
+        clist.sort(key=lambda r: r[0])
+        active = []
+        pi = 0
+        npar = len(plist)
+        for cs, ce, clabel in clist:
+            while pi < npar and plist[pi][0] <= cs:
+                active.append(plist[pi])
+                pi += 1
+            if active:
+                # A range with end < the current (and every later) child.start
+                # can contain none of them, so drop it for good.
+                active = [p for p in active if p[1] >= cs]
+            sync_ns = ce - cs
+            for ps, pe, plabel in active:
+                if pe >= ce and not (ps == cs and pe == ce):
+                    matched.append((plabel, clabel, sync_ns))
+    return matched
+
+
+def _aggregate_matched(matched, limit):
+    """Roll matched pairs up into the skill's output rows.
+
+    Same contract as the SQL's parent_totals / child_totals / ranked_children:
+    group by parent label, pick each parent's top child by aggregated sync time
+    (tie-break: count desc, then label asc), order parents by sync_ns desc then
+    label asc, and take the first ``limit``.
+    """
+    parent_n = defaultdict(int)
+    parent_ns = defaultdict(int)
+    child_n = defaultdict(int)
+    child_ns = defaultdict(int)
+    for plabel, clabel, sync_ns in matched:
+        parent_n[plabel] += 1
+        parent_ns[plabel] += sync_ns
+        child_n[(plabel, clabel)] += 1
+        child_ns[(plabel, clabel)] += sync_ns
+
+    # Top child per parent: smallest of (-sync_ns, -count, label) == largest
+    # sync_ns, largest count, alphabetically first — the SQL's rn=1 ordering.
+    top_children = defaultdict(list)
+    for (plabel, clabel), n in child_n.items():
+        top_children[plabel].append((-child_ns[(plabel, clabel)], -n, clabel))
+    top_child = {p: min(cands)[2] for p, cands in top_children.items()}
+
+    ordered = sorted(parent_ns, key=lambda p: (-parent_ns[p], p))
     out = []
-    for r in rows:
-        d = dict(zip(cols, r))
-        d["sync_ns"] = int(d["sync_ns"] or 0)
-        d["sync_ms"] = round(d["sync_ns"] / 1e6, 3)
-        out.append(d)
+    for plabel in ordered[:limit]:
+        sync_ns = int(parent_ns[plabel])
+        out.append(
+            {
+                "parent_range": plabel,
+                "n_syncs": parent_n[plabel],
+                "sync_ns": sync_ns,
+                "sync_ms": round(sync_ns / 1e6, 3),
+                "top_child_label": top_child.get(plabel),
+            }
+        )
     return out
 
 

--- a/tests/test_host_sync_parent_ranges.py
+++ b/tests/test_host_sync_parent_ranges.py
@@ -331,3 +331,201 @@ class TestHostSyncParentRanges:
         assert s is not None
         assert s.name == "host_sync_parent_ranges"
         assert {p.name for p in s.params} == {"limit", "patterns"}
+
+
+# Rows shaped (label, start, end, tid, eventType). One dataset exercising the
+# cases the sweep must reproduce byte-for-byte against the SQL: multi-ancestor
+# nesting, crossing StartEnd(60) ranges (where a stack-pop would diverge),
+# an identical-coordinate twin (self-exclusion by coords), tid isolation, and
+# a parent-order tie (the deterministic secondary key).
+_PARITY_ROWS = [
+    # tid 1: three-deep nesting — item credits train_step; _local_scalar_dense
+    # credits train_step AND aten::item.
+    ("train_step", 0, 10_000_000, 1, 59),
+    ("aten::item", 1_000_000, 2_000_000, 1, 59),
+    ("aten::_local_scalar_dense", 1_400_000, 1_600_000, 1, 59),
+    # tid 2: two crossing StartEnd ranges. childA is inside both; childB starts
+    # after rangeA has closed, so it credits rangeB only — the case a stack gets
+    # wrong.
+    ("rangeA", 0, 10_000_000, 2, 60),
+    ("rangeB", 5_000_000, 15_000_000, 2, 60),
+    ("cudaStreamSynchronize_a", 6_000_000, 7_000_000, 2, 60),
+    ("cudaStreamSynchronize_b", 11_000_000, 12_000_000, 2, 60),
+    # tid 3: identical-coordinate twin. Two distinct ranges share [0, 5_000_000];
+    # a child at exactly [0, 5_000_000] is excluded from both (coord self-match),
+    # while a strictly-inner child credits both twins.
+    ("twin_one", 0, 5_000_000, 3, 59),
+    ("twin_two", 0, 5_000_000, 3, 59),
+    ("aten::item_exact", 0, 5_000_000, 3, 59),
+    ("aten::item_inner", 1_000_000, 2_000_000, 3, 59),
+    # tid 4: two parents with identical total sync_ns — pins the sync_ns-tie
+    # ordering (deterministic parent_range ASC secondary).
+    ("zeta_phase", 0, 10_000_000, 4, 59),
+    ("aten::item_z", 1_000_000, 1_500_000, 4, 59),
+    ("alpha_phase", 20_000_000, 30_000_000, 4, 59),
+    ("aten::item_a", 21_000_000, 21_500_000, 4, 59),
+]
+
+
+def _build_duckdb(rows):
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect()
+    con.execute(
+        'CREATE TABLE StringIds (id BIGINT, value VARCHAR); '
+        'CREATE TABLE NVTX_EVENTS (globalTid BIGINT, start BIGINT, "end" BIGINT, '
+        'text VARCHAR, "textId" BIGINT, "eventType" INTEGER);'
+    )
+    for label, start, end_ns, tid, etype in rows:
+        con.execute(
+            'INSERT INTO NVTX_EVENTS (globalTid, start, "end", text, "eventType") '
+            "VALUES (?, ?, ?, ?, ?)",
+            [tid, start, end_ns, label, etype],
+        )
+    return con
+
+
+def _build_sqlite(rows):
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+        CREATE TABLE NVTX_EVENTS (
+            globalTid INTEGER, start INTEGER, end INTEGER,
+            text TEXT, textId INTEGER, eventType INTEGER
+        );
+        """
+    )
+    conn.executemany(
+        "INSERT INTO NVTX_EVENTS (globalTid, start, end, text, eventType) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [(tid, s, e, label, et) for (label, s, e, tid, et) in rows],
+    )
+    conn.commit()
+    return conn
+
+
+# The original containment CTE, kept here as an independent oracle. Production
+# replaced it with the Python sweep (it hangs on SQLite and crashes DuckDB's
+# sqlite_scanner on real profiles), but on a *native* DuckDB connection with
+# small data it runs fine and defines the exact semantics the sweep must match.
+_ORACLE_SQL = """
+    WITH resolved AS (
+        SELECT COALESCE(n.text, s.value) AS label, n.globalTid AS tid,
+               n.start AS start, n.[end] AS end_ns
+        FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId = s.id
+        WHERE n.[end] > n.start AND n.eventType IN (59, 60) {trim}
+    ),
+    sync_children AS (
+        SELECT label, tid, start, end_ns FROM resolved
+        WHERE ({like}) AND label IS NOT NULL
+    ),
+    matched AS (
+        SELECT parent.label AS parent_range, child.label AS child_label,
+               child.end_ns - child.start AS sync_ns
+        FROM sync_children child JOIN resolved parent
+          ON parent.tid = child.tid
+         AND parent.start <= child.start AND parent.end_ns >= child.end_ns
+         AND (parent.start != child.start OR parent.end_ns != child.end_ns)
+        WHERE parent.label IS NOT NULL
+    ),
+    parent_totals AS (
+        SELECT parent_range, COUNT(*) AS n_syncs, SUM(sync_ns) AS sync_ns
+        FROM matched GROUP BY parent_range
+    ),
+    child_totals AS (
+        SELECT parent_range, child_label, COUNT(*) AS child_n_syncs,
+               SUM(sync_ns) AS child_sync_ns
+        FROM matched GROUP BY parent_range, child_label
+    ),
+    ranked_children AS (
+        SELECT parent_range, child_label, ROW_NUMBER() OVER (
+            PARTITION BY parent_range
+            ORDER BY child_sync_ns DESC, child_n_syncs DESC, child_label ASC
+        ) AS rn FROM child_totals
+    )
+    SELECT pt.parent_range, pt.n_syncs, pt.sync_ns, rc.child_label AS top_child_label
+    FROM parent_totals pt LEFT JOIN ranked_children rc
+      ON rc.parent_range = pt.parent_range AND rc.rn = 1
+    ORDER BY pt.sync_ns DESC, pt.parent_range ASC
+    LIMIT {limit}
+"""
+
+
+def _oracle_rows(duckdb_conn, patterns, limit):
+    from nsys_ai.connection import wrap_connection
+
+    like_parts, like_params = [], []
+    for p in patterns:
+        like_parts.append("LOWER(label) LIKE ?")
+        like_params.append(f"%{p.lower()}%")
+    sql = _ORACLE_SQL.format(trim="", like=" OR ".join(like_parts), limit=int(limit))
+    rows = wrap_connection(duckdb_conn).execute(sql, like_params).fetchall()
+    out = []
+    for parent_range, n_syncs, sync_ns, top_child_label in rows:
+        sync_ns = int(sync_ns or 0)
+        out.append(
+            {
+                "parent_range": parent_range,
+                "n_syncs": n_syncs,
+                "sync_ns": sync_ns,
+                "sync_ms": round(sync_ns / 1e6, 3),
+                "top_child_label": top_child_label,
+            }
+        )
+    return out
+
+
+def test_sweep_matches_the_sql_oracle_exactly():
+    """The sweep must reproduce the original containment SQL byte-for-byte.
+
+    Same synthetic data through the Python sweep and the reference CTE (run on
+    a native DuckDB connection where it still works). If the sweep ever diverges
+    on containment, crossing ranges, twin exclusion, tid isolation, top-child
+    choice, or ordering, this fails.
+    """
+    patterns = ["item", "_local_scalar_dense", "cudastreamsynchronize"]
+    sweep_out = skill_mod._execute(_build_sqlite(_PARITY_ROWS), limit=1000)
+    oracle_out = _oracle_rows(_build_duckdb(_PARITY_ROWS), patterns, 1000)
+
+    assert "error" not in (sweep_out[0] if sweep_out else {})
+    assert sweep_out == oracle_out, "sweep diverged from the SQL oracle"
+    # The crossing case specifically (a stack-pop would get this wrong): rangeA
+    # must NOT be credited with the child that starts after it closed.
+    a_rows = [r for r in sweep_out if r["parent_range"] == "rangeA"]
+    assert a_rows and a_rows[0]["n_syncs"] == 1  # only cudaStreamSynchronize_a
+
+
+def test_sweep_matches_across_engines():
+    """The sweep is engine-agnostic: identical output on SQLite and DuckDB."""
+    duck_out = skill_mod._execute(_build_duckdb(_PARITY_ROWS), limit=1000)
+    lite_out = skill_mod._execute(_build_sqlite(_PARITY_ROWS), limit=1000)
+    assert duck_out == lite_out
+
+
+def test_sweep_matches_oracle_with_trim():
+    """Parity with the oracle must also hold under a trim window."""
+    patterns = ["item", "_local_scalar_dense", "cudastreamsynchronize"]
+    trim = {"trim_start_ns": 0, "trim_end_ns": 12_000_000}
+    sweep_out = skill_mod._execute(_build_sqlite(_PARITY_ROWS), limit=1000, **trim)
+
+    from nsys_ai.connection import wrap_connection
+
+    like_parts = ["LOWER(label) LIKE ?" for _ in patterns]
+    like_params = [f"%{p.lower()}%" for p in patterns]
+    sql = _ORACLE_SQL.format(
+        trim="AND n.start >= 0 AND n.[end] <= 12000000",
+        like=" OR ".join(like_parts),
+        limit=1000,
+    )
+    rows = wrap_connection(_build_duckdb(_PARITY_ROWS)).execute(sql, like_params).fetchall()
+    oracle_out = [
+        {
+            "parent_range": pr,
+            "n_syncs": n,
+            "sync_ns": int(s or 0),
+            "sync_ms": round(int(s or 0) / 1e6, 3),
+            "top_child_label": tc,
+        }
+        for pr, n, s, tc in rows
+    ]
+    assert sweep_out == oracle_out

--- a/tests/test_host_sync_parent_ranges.py
+++ b/tests/test_host_sync_parent_ranges.py
@@ -364,6 +364,16 @@ _PARITY_ROWS = [
     ("aten::item_z", 1_000_000, 1_500_000, 4, 59),
     ("alpha_phase", 20_000_000, 30_000_000, 4, 59),
     ("aten::item_a", 21_000_000, 21_500_000, 4, 59),
+    # tid 5: boundary-coincident, non-identity children. p_start shares its start
+    # with the child (start==parent.start, end<parent.end) so containment is by
+    # `parent.start <= child.start`, not `<`; p_end shares its end with the child
+    # (end==parent.end, start>parent.start) so it is by `parent.end >= child.end`,
+    # not `>`. Neither is the identical-coordinate self-match. These pin the two
+    # boundary predicates that a strict `<`/`>` would silently break.
+    ("p_start", 0, 10_000_000, 5, 59),
+    ("aten::item_at_start", 0, 3_000_000, 5, 59),
+    ("p_end", 20_000_000, 30_000_000, 5, 59),
+    ("aten::item_at_end", 27_000_000, 30_000_000, 5, 59),
 ]
 
 


### PR DESCRIPTION
Closes #245.

`host_sync_parent_ranges` credited each sync child to every NVTX range containing it (`parent.start <= child.start AND parent.end >= child.end`, same tid) via a CTE. Neither no-cache engine path can run that:

- **raw SQLite** has no range-join operator, so on an NVTX-heavy profile (~1.25M ranges, a few tids) it degrades to ~n*m and never completes;
- **direct-attach DuckDB** (`sqlite_scanner`, no parquet cache) crashes its optimizer on the CTE with an internal error.

On `attn_only.sqlite` (1.25M NVTX events) the raw-SQLite path did not finish in 600s; the direct-attach path returned an error row. Both are the no-cache paths the issue is about — `Profile` falls back to one of them whenever the DuckDB cache is unavailable (`profile.py:283`).

## Change

Replaced the CTE with a per-tid **sweep** in Python, fed by two simple label/pattern queries both engines run without trouble. Same result in **~2s** on both paths (was: hang / crash):

```
raw SQLite:            2.05s, 3 rows   (was >600s, never completed)
direct-attach DuckDB:  1.93s, 3 rows   (was internal-error row)
parity:                MATCH
```

The sweep decides containment per candidate (`parent.end >= child.end`), so it does not assume ranges nest — eventType-60 (StartEnd) ranges can cross, and the SQL credited every containing ancestor. Multi-ancestor crediting, identical-coordinate exclusion, top-child tie-break, and ordering are all preserved; parent ordering gains a deterministic `parent_range` secondary key (the SQL left ties unspecified).

## Testing

The original CTE is kept as an **independent oracle** in the test — it runs on a native DuckDB connection (where it still works) and the sweep is asserted byte-identical to it, including the crossing-range case, identical-coordinate twins, tid isolation, boundary-coincident children (start==parent.start / end==parent.end), and a trim window. Independent adversarial review fuzzed the sweep against a brute-force reference (20k trials) and against the oracle SQL (3k trials) with zero divergence, and confirmed cross-engine type parity on the real profile. Mutation-tested: strict-inequality or dropped-identity regressions each fail the oracle test.

1248 passed, 135 skipped; ruff clean.

## Note

The DuckDB `sqlite_scanner` CTE crash is an upstream DuckDB bug; this change sidesteps it for this skill by not sending it a complex CTE. Other skills that still run heavy CTEs over a direct-attached profile may hit the same crash — worth a separate audit.