### PR TITLE
perf(overlap): memoize overlap_analysis per connection

### DIFF
--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -5,6 +5,7 @@ Quantifies how much GPU compute overlaps with NCCL communication,
 detects training iterations, and breaks down collective operations.
 """
 
+import copy
 import logging
 from collections import defaultdict
 
@@ -47,7 +48,35 @@ def overlap_analysis(prof: Profile, device: int, trim: tuple[int, int] | None = 
         overlap_ms:       Time both compute and NCCL run concurrently
         idle_ms:          Time no kernels are running
         total_ms:         Wall-clock span
+
+    Memoized per connection: the sweep is pure in ``(connection, device,
+    trim)`` and a single ``EvidenceBuilder.build()`` asks for the same triple
+    seven times (gpu_idle_gaps, overlap_breakdown and critical_path, several
+    re-run inside the manifest). One build over a 3.5GB profile without the
+    DuckDB cache spent ~7s of the ~7 identical calls here. The cache is keyed
+    on the underlying connection — not the ``Profile`` — because gpu_idle_gaps
+    calls in through a throwaway ``Profile._from_conn`` wrapper around the same
+    connection, so a per-Profile cache would miss it.
+
+    A deep copy is handed back on every call: callers (overlap_breakdown)
+    mutate the dict, and the cached entry must stay pristine.
     """
+    from .connection import _PROBE_MISS, _probe_cache_get, _probe_cache_set
+
+    conn = prof.db if prof.db is not None else prof.conn
+    cache_key = f"overlap_analysis:{device}:{trim}"
+    cached = _probe_cache_get(conn, cache_key)
+    if cached is not _PROBE_MISS:
+        return copy.deepcopy(cached)
+
+    result = _overlap_analysis_uncached(prof, device, trim)
+    _probe_cache_set(conn, cache_key, result)
+    return copy.deepcopy(result)
+
+
+def _overlap_analysis_uncached(
+    prof: Profile, device: int, trim: tuple[int, int] | None
+) -> dict:
     if _has_duckdb(prof):
         from .connection import DB_ERRORS
 

--- a/tests/test_overlap_analysis.py
+++ b/tests/test_overlap_analysis.py
@@ -173,3 +173,90 @@ class TestDiagnostics:
             prof.close()
         assert diag["error"] == "no kernels found"
         assert diag["available_devices"][0] == 5
+
+
+class TestMemoization:
+    """overlap_analysis is memoized per connection (issue #242): a build asks
+    for the same (connection, device, trim) up to seven times and must compute
+    the sweep only once."""
+
+    def _count_computes(self, monkeypatch):
+        import nsys_ai.overlap as ov
+
+        calls = []
+        real = ov._overlap_analysis_uncached
+        monkeypatch.setattr(
+            ov,
+            "_overlap_analysis_uncached",
+            lambda p, d, t: calls.append((d, t)) or real(p, d, t),
+        )
+        return calls
+
+    def test_repeated_calls_compute_once(self, duckdb_conn, monkeypatch):
+        calls = self._count_computes(monkeypatch)
+        prof = Profile._from_conn(duckdb_conn)
+        try:
+            first = overlap_analysis(prof, device=0)
+            for _ in range(6):
+                again = overlap_analysis(prof, device=0)
+            assert len(calls) == 1, "sweep recomputed despite identical args"
+            assert again == first
+        finally:
+            prof.close()
+
+    def test_cache_hit_equals_fresh_compute(self, duckdb_conn):
+        prof = Profile._from_conn(duckdb_conn)
+        try:
+            fresh = _overlap_analysis_python(prof, 0, None)
+            overlap_analysis(prof, device=0)  # populate cache
+            cached = overlap_analysis(prof, device=0)
+            for k, v in fresh.items():
+                assert cached[k] == pytest.approx(v) if isinstance(v, float) else cached[k] == v
+        finally:
+            prof.close()
+
+    def test_caller_mutation_does_not_corrupt_cache(self, duckdb_conn):
+        """overlap_breakdown adds keys like device_id to the result; a shared
+        cached dict would leak that into the next caller. Every returned dict is
+        mutated here — both the miss-path result and a hit-path result — so a
+        missing copy on *either* path corrupts the final read."""
+        prof = Profile._from_conn(duckdb_conn)
+        try:
+            a = overlap_analysis(prof, device=0)  # miss -> compute
+            baseline_idle = a["idle_ms"]
+            a["device_id"] = 999  # mutate the miss-path result
+            a["idle_ms"] = -1
+            b = overlap_analysis(prof, device=0)  # hit
+            b["injected"] = ["x"]  # mutate a hit-path result
+            b["idle_ms"] = -2
+            c = overlap_analysis(prof, device=0)  # hit -> must be pristine
+            assert "device_id" not in c and "injected" not in c
+            assert c["idle_ms"] == baseline_idle
+        finally:
+            prof.close()
+
+    def test_distinct_trim_recomputes(self, duckdb_conn, monkeypatch):
+        calls = self._count_computes(monkeypatch)
+        prof = Profile._from_conn(duckdb_conn)
+        try:
+            overlap_analysis(prof, device=0, trim=None)
+            overlap_analysis(prof, device=0, trim=(1_000_000, 9_000_000))
+            overlap_analysis(prof, device=0, trim=None)  # back to first key -> hit
+            assert len(calls) == 2, "trim must be part of the cache key"
+        finally:
+            prof.close()
+
+    def test_shared_across_profile_wrappers_on_one_conn(self, duckdb_conn, monkeypatch):
+        """gpu_idle_gaps reaches overlap_analysis through a throwaway
+        Profile._from_conn around the same connection; the cache keys on the
+        connection so that call reuses the entry rather than recomputing."""
+        calls = self._count_computes(monkeypatch)
+        p1 = Profile._from_conn(duckdb_conn)
+        p2 = Profile._from_conn(duckdb_conn)  # distinct Profile, same conn
+        try:
+            overlap_analysis(p1, device=0)
+            overlap_analysis(p2, device=0)
+            assert len(calls) == 1, "cache must key on the connection, not the Profile"
+        finally:
+            p1.close()
+            p2.close()


### PR DESCRIPTION
Closes #242.

`overlap_analysis(prof, device, trim)` is pure in `(connection, device, trim)`, but a single `EvidenceBuilder.build()` asks for the same triple **seven times** — gpu_idle_gaps, overlap_breakdown and critical_path each call it, and several re-run inside the profile-health manifest. Instrumented on `nano_vllm_qwen3_4b.sqlite`: 7 calls, all `(device=0, trim=(19853232852, 95413684097))`, identical connection. On a 3.5GB profile without the DuckDB cache the sweep costs ~2.3s a call, so the six redundant calls added ~14s.

## Change

Memoized through the **existing** per-connection probe cache (`_probe_cache_get/set` in connection.py), keyed on `(device, trim)`. Confirmed 7 sweeps collapse to **1** with findings unchanged.

Two design points:
- **Keyed on the connection, not the Profile.** gpu_idle_gaps reaches `overlap_analysis` through a throwaway `Profile._from_conn(conn)` wrapper around the same connection, so a per-Profile cache would miss it. All 7 callers resolve to the same underlying conn object (verified: one conn id across the build).
- **Deep copy returned on every call.** `overlap_breakdown` mutates the result (adds `device_id`, `same_stream_*` fields), so the cached entry must stay pristine. deepcopy is required for the no-kernels diagnostic path (nested `available_devices`) and costs ~3µs vs seconds of sweep.

## Testing

New `TestMemoization`: compute-once, cache-hit==fresh, mutation isolation (mutates both a miss-path and a hit-path result, so a missing copy on either path is caught), trim-sensitivity, and the cross-Profile-same-conn case reproducing the gpu_idle_gaps scenario. Mutation-tested — disabling the cache, dropping either deepcopy, or dropping trim from the key each fails a test. 1253 passed, 135 skipped; ruff clean.

## Follow-up (noted in #242, not addressed here)

The manifest and root-cause matcher re-run `gpu_idle_gaps`/`overlap_breakdown` wholesale, which is what makes overlap_analysis get called 7×. Memoizing overlap collapses the expensive shared sweep, but the surrounding gap-SQL still re-runs. Collapsing those nested skill executions would cut the remaining redundancy at its source — a larger refactor worth its own issue.