### PR TITLE
fix(findings): do not report heuristic gap-segments as iterations

### DIFF
--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -545,10 +545,19 @@ def detect_iterations(
             iterations.append(n)
             last_end = n["end"]
 
+    # Whether the iterations came from a matched NVTX marker (a user-declared
+    # boundary) or from the heuristic gap fallback below. Consumers that make
+    # confident claims — an iteration count, a variance verdict, a slow-iteration
+    # finding — trust only the former: with no user marker, the "iterations" are
+    # inferred from inter-kernel pauses and on a non-looping capture are not
+    # iterations at all (issue #215).
+    used_heuristic = False
+
     # --- Heuristic Fallback ---
     # If no NVTX markers match, fall back to detecting iterations by finding
     # large gaps in kernel execution on the primary CPU thread across all streams.
     if not iterations:
+        used_heuristic = True
         rt_all = prof._duckdb_query(
             f"""
             SELECT correlationId, start, [end] FROM {runtime_table}
@@ -651,6 +660,7 @@ def detect_iterations(
             {
                 "iteration": i,
                 "text": it["text"] if "text" in it else "",
+                "heuristic": used_heuristic,
                 "gpu_start_ns": gpu_start,
                 "gpu_end_ns": gpu_end,
                 "gpu_start_s": round(gpu_start / 1e9, 4),

--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -112,7 +112,7 @@ def _to_findings(rows: list[dict]) -> list:
 def _format(rows):
     if not rows:
         return "(No iterations detected — NVTX marker not found and no large gaps found)"
-    is_heuristic = any(it.get("text", "").startswith("heuristic") for it in rows)
+    is_heuristic = any(it.get("heuristic", False) for it in rows)
     title = (
         "── Iteration Timings (Heuristic Fallback) ──"
         if is_heuristic

--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -33,10 +33,16 @@ def _to_findings(rows: list[dict]) -> list:
     from nsys_ai.annotation import Finding
 
     findings = []
-    # Only judge variance over real iterations — a loose NVTX marker can match
-    # many sub-ms op ranges whose contaminated median makes every real iteration
-    # look thousands of percent slow.
-    real = [it for it in rows if it.get("is_real_iteration", True)]
+    # Only judge variance over genuine iterations: real (not the sub-ms op ranges
+    # a loose NVTX marker matches, whose contaminated median makes every real
+    # iteration look thousands of percent slow) AND NVTX-marker-based (not the
+    # heuristic gap fallback, which on a non-looping capture emits pauses that are
+    # not iterations, so a "slow iteration" finding over them is phantom — #215).
+    real = [
+        it
+        for it in rows
+        if it.get("is_real_iteration", True) and not it.get("heuristic", False)
+    ]
     if len(real) < 3:
         return findings
 

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -270,6 +270,35 @@ def _auto_select_trim_window(prof) -> tuple[int, int] | None:
     return (mid - half, mid + half)
 
 
+def _summarize_iterations(iter_rows: list[dict]) -> dict:
+    """Iteration count + variance metrics for the manifest, over genuine
+    iterations only.
+
+    A count, a median and a variance verdict are meaningful only over real
+    iterations (not the sub-iteration op ranges a loose NVTX marker matches) that
+    came from a user NVTX marker (not the heuristic gap fallback). On a single
+    inference run the heuristic path synthesises hundreds of inter-kernel pauses
+    whose median/slowest read as a wildly non-uniform loop — a confidently-wrong
+    signal (issue #215). Return an empty summary rather than that.
+    """
+    real = [
+        r
+        for r in iter_rows
+        if r.get("is_real_iteration", True) and not r.get("heuristic", False)
+    ]
+    if not real:
+        return {}
+    # Skip iter 0 (warm-up) when computing variance metrics.
+    steady = real[1:] if len(real) > 1 else real
+    durs = sorted(r.get("duration_ms", 0) for r in steady)
+    mid = len(durs) // 2
+    return {
+        "iteration_count": len(real),
+        "median_iter_ms": round(durs[mid], 1),
+        "slowest_iter_ms": round(max(durs), 1),
+    }
+
+
 def _execute(conn, **kwargs):
     """Build a compact profile health manifest."""
     from ...profile import Profile
@@ -523,15 +552,7 @@ def _execute(conn, **kwargs):
         _log.debug("manifest: aggregate_nvtx_ranges failed: %s", exc)
 
     iter_rows = _safe_skill_run("iteration_timing", conn, device=device, **trim_kwargs)
-    if iter_rows:
-        nvtx_summary["iteration_count"] = len(iter_rows)
-        # Skip iter 0 (warm-up) when computing variance metrics
-        steady = iter_rows[1:] if len(iter_rows) > 1 else iter_rows
-        if steady:
-            durs = sorted(r.get("duration_ms", 0) for r in steady)
-            mid = len(durs) // 2
-            nvtx_summary["median_iter_ms"] = round(durs[mid], 1)
-            nvtx_summary["slowest_iter_ms"] = round(max(durs), 1)
+    nvtx_summary.update(_summarize_iterations(iter_rows))
 
     # ── 7. Root cause findings (count + top severity) ────────────
     # Pass precomputed communicator rows to avoid re-running the expensive

--- a/tests/test_iteration_noise.py
+++ b/tests/test_iteration_noise.py
@@ -108,3 +108,70 @@ def test_findings_empty_when_fewer_than_three_real():
     rows += [_row(0.3, iteration=100 + i) for i in range(50)]
     _flag_real_iterations(rows)
     assert _to_findings(rows) == []
+
+
+# ── Heuristic-fallback phantom iterations (issue #215) ──────────────────────
+# When no user NVTX iteration marker matches, detect_iterations falls back to
+# synthesising segments from inter-kernel gaps. On a non-looping capture those
+# are pauses, not iterations, and must not drive a confident count, variance
+# verdict, or slow-iteration finding.
+
+
+def test_to_findings_ignores_heuristic_iterations():
+    """Heuristic gap-segments produce no findings even when they would survive
+    the compute-noise filter. Uniform compute (so is_real_iteration keeps them
+    all) plus one genuinely-slower segment: the ONLY thing suppressing the
+    finding is the heuristic flag, so this isolates it from the compute filter."""
+    rows = [_row(500.0, iteration=i, compute_ms=480.0, heuristic=True) for i in range(6)]
+    rows.append(_row(1500.0, iteration=99, compute_ms=1450.0, heuristic=True))
+    _flag_real_iterations(rows)
+    assert all(r["is_real_iteration"] for r in rows), "compute filter must keep them"
+    assert _to_findings(rows) == [], "but heuristic detection must yield no findings"
+
+
+def test_to_findings_still_fires_for_nvtx_iterations():
+    """The NVTX-marker path (heuristic absent/False) is unchanged: a genuine
+    slow iteration among uniform ones still yields a finding."""
+    rows = [_row(500.0, iteration=i) for i in range(6)]  # no heuristic key -> False
+    rows.append(_row(1500.0, iteration=99))
+    _flag_real_iterations(rows)
+    finds = _to_findings(rows)
+    assert finds, "a real slow NVTX iteration must still be reported"
+    assert any("Slow Iteration" in f.label for f in finds)
+
+
+def test_manifest_summary_drops_heuristic_iterations():
+    from nsys_ai.skills.builtins.profile_health_manifest import _summarize_iterations
+
+    rows = [_row(2.0, iteration=i, heuristic=True) for i in range(20)]
+    rows.append(_row(5000.0, iteration=99, heuristic=True))
+    _flag_real_iterations(rows)
+    # No count, no median, no slowest -> the variance-spike verdict cannot fire.
+    assert _summarize_iterations(rows) == {}
+
+
+def test_manifest_summary_counts_nvtx_iterations():
+    from nsys_ai.skills.builtins.profile_health_manifest import _summarize_iterations
+
+    rows = [_row(500.0, iteration=i) for i in range(5)]  # NVTX-based (heuristic False)
+    rows.append(_row(900.0, iteration=99))
+    _flag_real_iterations(rows)
+    summary = _summarize_iterations(rows)
+    assert summary["iteration_count"] == 6
+    assert summary["median_iter_ms"] == 500.0  # warm-up (iter 0) skipped
+    assert summary["slowest_iter_ms"] == 900.0
+
+
+def test_detect_iterations_flags_source(minimal_nsys_conn):
+    """detect_iterations tags rows heuristic=False when a user NVTX marker
+    matched, True when it fell back to gap-segments — the flag the consumers
+    above rely on."""
+    from nsys_ai.overlap import detect_iterations
+    from nsys_ai.profile import Profile
+
+    prof = Profile._from_conn(minimal_nsys_conn)
+    matched = detect_iterations(prof, 0, marker="train_step")
+    assert matched and all(r.get("heuristic") is False for r in matched)
+
+    fallback = detect_iterations(prof, 0, marker="zzz_no_such_marker_zzz")
+    assert fallback and all(r.get("heuristic") is True for r in fallback)


### PR DESCRIPTION
Closes #215.

`iteration_timing`/`detect_iterations` fall back to synthesising iteration boundaries from inter-kernel gaps when no user NVTX marker matches. On a non-looping capture (a single inference run) that emits hundreds of pauses, and `profile_health_manifest` reported them as iterations. Reproduced on repo profiles:

```
nano_vllm_qwen3_4b:  84 'iterations', median 2.3ms, slowest 5644ms  -> variance-spike verdict at 2400x median
fastvideo:          619 'iterations', median 1.5ms, slowest 963ms
```

A reader or downstream agent takes 'slowest 5644ms' as a slow training iteration to investigate, when there is no loop at all.

## Two faults

- `detect_iterations` did not distinguish marker-based from heuristic detection.
- The manifest counted `len(iter_rows)` and computed median/slowest over **every** row, ignoring `is_real_iteration`.

## Fix

`detect_iterations` tags each row `heuristic=True/False` (True only in the gap-fallback branch — all-or-nothing, since the fallback runs only when zero NVTX markers matched). The confident consumers trust only genuine iterations — `is_real_iteration and not heuristic`:

- `profile_health_manifest._summarize_iterations` (extracted, now unit-testable) counts/averages only those, and returns `{}` when there are none, so the variance-spike verdict cannot fire.
- `iteration_timing._to_findings` emits slow-iteration findings only over those.

The raw skill output still lists heuristic segments, labelled 'Heuristic Fallback', for direct inspection. A profile with genuine NVTX iteration markers is unchanged (verified via the `minimal_nsys_conn` fixture: marker 'train_step' -> `heuristic=False`, still counted).

## Testing

After the fix, both real profiles report `iteration_count=None` (no phantom count, no variance spike). New tests pin: the heuristic flag at the source (marker match vs fallback), manifest suppression + NVTX counting, and `_to_findings` suppression using **uniform-compute** heuristic rows so the check isolates the heuristic flag from the compute-noise filter. Mutation-tested — dropping the `not heuristic` filter from either consumer, or forcing `heuristic=False` at the source, each fails a distinct test. Independent review confirmed no over-suppression path (marker rows are never wrongly flagged) and no crash on any real-count. 1258 passed, 135 skipped; ruff clean.

## Trade-off

A real training loop that lacks NVTX markers loses heuristic iteration reporting in the manifest/findings. That is the intended lesser evil — a confidently-wrong phantom is worse than silence. A uniformity-gated restoration (trust heuristic segments only when they form a plausible uniform loop) could bring it back more precisely, as a follow-up.