### PR TITLE
test(schema): declare and enforce the required-column contract

### DIFF
--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -525,10 +525,10 @@ def _check_profile_health(prof: Any, *, deep: bool = False) -> DoctorSection:
     devices = list(meta.devices or [])
     span_ns = (meta.time_range[1] - meta.time_range[0]) if meta.time_range else 0
 
-    # Schema contract, first — it gates everything below. A future Nsight export
-    # that drops or renames a table/column the analysis layer selects by name
-    # should fail here, naming it, rather than surface as a wrong or empty number
-    # downstream (issue #237).
+    # Schema contract, reported first. A future Nsight export that drops or
+    # renames a table/column the analysis layer selects by name should be named
+    # here — an upfront diagnostic rather than a deep stack trace when a skill's
+    # JOIN later hits the missing column (issue #237).
     schema = getattr(prof, "schema", None)
     if schema is not None:
         sv = schema.schema_version or "unknown"
@@ -541,7 +541,7 @@ def _check_profile_health(prof: Any, *, deep: bool = False) -> DoctorSection:
                     f"export {sv}: missing {', '.join(missing)}",
                     hint=(
                         "This Nsight export lacks tables/columns the analysis "
-                        "layer requires, so results may be wrong or empty. The "
+                        "layer requires; skills that use them will fail. The "
                         "export schema likely changed — please file an issue "
                         "quoting the export schema version above."
                     ),

--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -525,6 +525,31 @@ def _check_profile_health(prof: Any, *, deep: bool = False) -> DoctorSection:
     devices = list(meta.devices or [])
     span_ns = (meta.time_range[1] - meta.time_range[0]) if meta.time_range else 0
 
+    # Schema contract, first — it gates everything below. A future Nsight export
+    # that drops or renames a table/column the analysis layer selects by name
+    # should fail here, naming it, rather than surface as a wrong or empty number
+    # downstream (issue #237).
+    schema = getattr(prof, "schema", None)
+    if schema is not None:
+        sv = schema.schema_version or "unknown"
+        missing = schema.missing_required_columns()
+        if missing:
+            checks.append(
+                CheckResult(
+                    "Schema compatibility",
+                    "fail",
+                    f"export {sv}: missing {', '.join(missing)}",
+                    hint=(
+                        "This Nsight export lacks tables/columns the analysis "
+                        "layer requires, so results may be wrong or empty. The "
+                        "export schema likely changed — please file an issue "
+                        "quoting the export schema version above."
+                    ),
+                )
+            )
+        else:
+            checks.append(CheckResult("Schema compatibility", "ok", f"export schema {sv}"))
+
     checks.append(CheckResult("Duration", "ok", f"{span_ns / 1e9:.1f}s"))
     # GPUs — COUNT(DISTINCT deviceId), not the fingerprint heuristic.
     checks.append(CheckResult("GPUs", "ok", str(len(devices))))

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -188,6 +188,64 @@ class NsightSchema:
 
         return None
 
+    # ── Schema contract ────────────────────────────────────────────────
+    # Columns the core analysis path selects by name. Their absence is not a
+    # graceful degradation but a crash or a silently-wrong number, so a future
+    # Nsight export that drops or renames one should fail loudly and by name
+    # rather than surface as a user bug report (issue #237). NVIDIA documents
+    # that the SQLite export schema "can and will change". Optional surface —
+    # NVTX_EVENTS, META_DATA_* — is deliberately excluded: skills degrade around
+    # it, so a --trace=cuda capture with no NVTX must not trip the contract.
+    _REQUIRED_KERNEL_COLUMNS = (
+        "deviceId",
+        "streamId",
+        "start",
+        "end",
+        "shortName",
+        "demangledName",
+        "correlationId",
+    )
+    _REQUIRED_STRINGIDS_COLUMNS = ("id", "value")
+
+    def _resolve_table(self, name: str) -> str | None:
+        """Actual table name matching ``name`` case-insensitively, or None."""
+        lname = name.lower()
+        for t in self.tables:
+            if t.lower() == lname:
+                return t
+        return None
+
+    def _missing_columns(self, table: str, required) -> list[str]:
+        try:
+            present = {str(c).lower() for c in self._adapter.get_table_columns(table)}
+        except DB_ERRORS:
+            return [f"{table} (columns unreadable)"]
+        return [f"{table}.{c}" for c in required if c.lower() not in present]
+
+    def missing_required_columns(self) -> list[str]:
+        """Descriptors of hard-required tables/columns absent from this export.
+
+        Empty when the schema is compatible with the core analysis path. Each
+        entry names exactly what is missing (``CUPTI_ACTIVITY_KIND_KERNEL.start``,
+        or a table name) so a diagnostic points straight at the drift.
+        """
+        missing: list[str] = []
+
+        if not self.kernel_table:
+            missing.append(
+                "kernel activity table (CUPTI_ACTIVITY_KIND_KERNEL or a *KERNEL* table)"
+            )
+        else:
+            missing += self._missing_columns(self.kernel_table, self._REQUIRED_KERNEL_COLUMNS)
+
+        stringids = self._resolve_table("StringIds")
+        if not stringids:
+            missing.append("StringIds")
+        else:
+            missing += self._missing_columns(stringids, self._REQUIRED_STRINGIDS_COLUMNS)
+
+        return missing
+
 
 @dataclass
 class GpuInfo:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -96,6 +96,14 @@ CREATE TABLE IF NOT EXISTS NVTX_EVENTS (
     rangeId         INTEGER DEFAULT 0,
     textId          INTEGER DEFAULT NULL
 );
+
+-- Export metadata (name/value shape, as real nsys exports use). Present so
+-- version detection has synthetic coverage — without it NsightSchema.schema_version
+-- read as None in every synthetic test.
+CREATE TABLE IF NOT EXISTS META_DATA_EXPORT (
+    name            TEXT,
+    value           TEXT
+);
 """
 
 _NSYS_SEED_SQL = """\
@@ -110,6 +118,11 @@ INSERT INTO StringIds VALUES
     -- Additional for V3 overlap diagnosis
     (25, 'cudaStreamSynchronize'),
     (11, 'nccl_ReduceScatter_kernel');
+
+INSERT INTO META_DATA_EXPORT (name, value) VALUES
+    ('EXPORT_PRODUCT_NAME', 'NVIDIA Nsight Systems'),
+    ('EXPORT_PRODUCT_VERSION', '2026.1.1.204'),
+    ('EXPORT_SCHEMA_VERSION', '3.24.14');
 
 INSERT INTO TARGET_INFO_GPU VALUES
     (0, 'NVIDIA Test GPU', '0000:00:00.0', 8589934592, 108, 'TestChip', 0);
@@ -250,6 +263,9 @@ CREATE TABLE NVTX_EVENTS (
 CREATE TABLE ThreadNames (
     globalTid INTEGER, nameId INTEGER, priority INTEGER DEFAULT 0
 );
+CREATE TABLE META_DATA_EXPORT (
+    name VARCHAR, value VARCHAR
+);
 """
 
 
@@ -324,6 +340,12 @@ def duckdb_conn():
     """)
     db.execute("""
         INSERT INTO ThreadNames VALUES (100, 24, 1)
+    """)
+    db.execute("""
+        INSERT INTO META_DATA_EXPORT (name, value) VALUES
+            ('EXPORT_PRODUCT_NAME', 'NVIDIA Nsight Systems'),
+            ('EXPORT_PRODUCT_VERSION', '2026.1.1.204'),
+            ('EXPORT_SCHEMA_VERSION', '3.24.14')
     """)
     yield db
     db.close()

--- a/tests/test_duckdb_path.py
+++ b/tests/test_duckdb_path.py
@@ -230,8 +230,7 @@ class TestDuckDBCompatibilityFixes:
         p = Profile._from_conn(duckdb_conn)
         # Should have successfully detected version and NVTX text ID
         assert p._nvtx_has_text_id is True
-        # DuckDB mocked schema doesn't have META_DATA_EXPORT so version is None,
-        # but the method should have run without crashing on PRAGMA
+        # The method should have run without crashing on PRAGMA / metadata reads.
         assert type(p.meta).__name__ == "ProfileMeta"
 
     def test_memory_transfers_duckdb_error(self, duckdb_conn):

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -1,0 +1,135 @@
+"""Schema contract — the tables/columns the core analysis path requires
+(issue #237).
+
+NVIDIA documents that the Nsight SQLite export schema "can and will change".
+``NsightSchema.missing_required_columns`` makes the hard requirements explicit
+so a future export that drops or renames one fails loudly, by name, in CI and
+in ``doctor`` — rather than surfacing as a subtly-wrong number in a report.
+"""
+
+import sqlite3
+
+import pytest
+
+from nsys_ai.profile import NsightSchema, Profile
+
+
+def _synthetic_conn():
+    from tests.conftest import _NSYS_SCHEMA_SQL, _NSYS_SEED_SQL
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_NSYS_SCHEMA_SQL)
+    conn.executescript(_NSYS_SEED_SQL)
+    return conn
+
+
+# ── The contract passes on real and synthetic exports ───────────────────────
+
+
+def test_committed_fixture_satisfies_the_contract():
+    """The checked-in nsys export (mock.sqlite, schema 3.24.14) must pass — this
+    is the CI guard: a fixture update to an incompatible export fails here."""
+    with Profile("tests/fixtures/mock.sqlite") as prof:
+        assert prof.schema.missing_required_columns() == []
+        # Fixture schema version is recorded, not implicit.
+        assert prof.schema.schema_version == "3.24.14"
+
+
+def test_synthetic_fixture_satisfies_the_contract():
+    schema = NsightSchema(_synthetic_conn())
+    assert schema.missing_required_columns() == []
+
+
+# ── Version detection now has synthetic coverage ────────────────────────────
+
+
+def test_synthetic_conn_exposes_export_versions():
+    """conftest seeds META_DATA_EXPORT, so version detection is exercised
+    without a binary fixture (it read as None before)."""
+    schema = NsightSchema(_synthetic_conn())
+    assert schema.schema_version == "3.24.14"
+    assert schema.version == "2026.1.1.204"
+
+
+# ── The contract fails loudly, naming exactly what is missing ───────────────
+
+
+@pytest.mark.parametrize(
+    "column",
+    ["deviceId", "streamId", "start", "end", "shortName", "demangledName", "correlationId"],
+)
+def test_missing_kernel_column_is_named(column):
+    conn = _synthetic_conn()
+    conn.execute(f"ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL RENAME COLUMN {column} TO {column}_gone")
+    missing = NsightSchema(conn).missing_required_columns()
+    assert f"CUPTI_ACTIVITY_KIND_KERNEL.{column}" in missing
+
+
+@pytest.mark.parametrize("column", ["id", "value"])
+def test_missing_stringids_column_is_named(column):
+    conn = _synthetic_conn()
+    conn.execute(f"ALTER TABLE StringIds RENAME COLUMN {column} TO {column}_gone")
+    missing = NsightSchema(conn).missing_required_columns()
+    assert f"StringIds.{column}" in missing
+
+
+def test_missing_kernel_table_is_named():
+    conn = _synthetic_conn()
+    conn.execute("DROP TABLE CUPTI_ACTIVITY_KIND_KERNEL")
+    missing = NsightSchema(conn).missing_required_columns()
+    assert any("kernel activity table" in m for m in missing)
+
+
+def test_missing_stringids_table_is_named():
+    conn = _synthetic_conn()
+    conn.execute("DROP TABLE StringIds")
+    assert "StringIds" in NsightSchema(conn).missing_required_columns()
+
+
+def test_optional_tables_do_not_trip_the_contract():
+    """A --trace=cuda capture has no NVTX_EVENTS; skills degrade around it, so
+    its absence must not be a contract violation."""
+    conn = _synthetic_conn()
+    conn.execute("DROP TABLE NVTX_EVENTS")
+    assert NsightSchema(conn).missing_required_columns() == []
+
+
+def test_column_check_is_case_insensitive():
+    """Real exports vary column case; the contract must not false-fail on it."""
+    conn = _synthetic_conn()
+    conn.execute("ALTER TABLE StringIds RENAME COLUMN value TO VALUE")
+    assert "StringIds.value" not in NsightSchema(conn).missing_required_columns()
+
+
+# ── doctor surfaces the contract at runtime ─────────────────────────────────
+
+
+def test_doctor_reports_schema_compatibility_ok():
+    from nsys_ai.doctor import _check_profile_health
+
+    with Profile("tests/fixtures/mock.sqlite") as prof:
+        section = _check_profile_health(prof)
+    check = next(c for c in section.checks if c.name == "Schema compatibility")
+    assert check.status == "ok"
+    assert "3.24.14" in check.detail
+
+
+def test_doctor_fails_on_missing_required_column():
+    from nsys_ai.doctor import _check_profile_health
+
+    # `demangledName` is required by the analysis path but not read during
+    # Profile construction (_discover keys off deviceId/streamId/start/end), so
+    # the profile still builds and doctor can surface the drift as a clean fail.
+    # Columns _discover itself needs would instead raise at construction — a loud
+    # failure of a different kind, out of scope for this check.
+    conn = _synthetic_conn()
+    conn.execute(
+        "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL RENAME COLUMN demangledName TO demangledName_gone"
+    )
+    prof = Profile._from_conn(conn)
+    section = _check_profile_health(prof)
+    check = next(c for c in section.checks if c.name == "Schema compatibility")
+    assert check.status == "fail"
+    assert "CUPTI_ACTIVITY_KIND_KERNEL.demangledName" in check.detail
+    assert check.hint  # actionable

--- a/tests/test_schema_contract.py
+++ b/tests/test_schema_contract.py
@@ -5,24 +5,15 @@ NVIDIA documents that the Nsight SQLite export schema "can and will change".
 ``NsightSchema.missing_required_columns`` makes the hard requirements explicit
 so a future export that drops or renames one fails loudly, by name, in CI and
 in ``doctor`` — rather than surfacing as a subtly-wrong number in a report.
-"""
 
-import sqlite3
+Uses the ``minimal_nsys_conn`` fixture (a function-scoped, seeded in-memory
+sqlite connection) rather than importing conftest internals, so the synthetic
+schema stays a single source of truth and imports work under any pytest rootdir.
+"""
 
 import pytest
 
 from nsys_ai.profile import NsightSchema, Profile
-
-
-def _synthetic_conn():
-    from tests.conftest import _NSYS_SCHEMA_SQL, _NSYS_SEED_SQL
-
-    conn = sqlite3.connect(":memory:")
-    conn.row_factory = sqlite3.Row
-    conn.executescript(_NSYS_SCHEMA_SQL)
-    conn.executescript(_NSYS_SEED_SQL)
-    return conn
-
 
 # ── The contract passes on real and synthetic exports ───────────────────────
 
@@ -36,18 +27,17 @@ def test_committed_fixture_satisfies_the_contract():
         assert prof.schema.schema_version == "3.24.14"
 
 
-def test_synthetic_fixture_satisfies_the_contract():
-    schema = NsightSchema(_synthetic_conn())
-    assert schema.missing_required_columns() == []
+def test_synthetic_fixture_satisfies_the_contract(minimal_nsys_conn):
+    assert NsightSchema(minimal_nsys_conn).missing_required_columns() == []
 
 
 # ── Version detection now has synthetic coverage ────────────────────────────
 
 
-def test_synthetic_conn_exposes_export_versions():
+def test_synthetic_conn_exposes_export_versions(minimal_nsys_conn):
     """conftest seeds META_DATA_EXPORT, so version detection is exercised
     without a binary fixture (it read as None before)."""
-    schema = NsightSchema(_synthetic_conn())
+    schema = NsightSchema(minimal_nsys_conn)
     assert schema.schema_version == "3.24.14"
     assert schema.version == "2026.1.1.204"
 
@@ -59,47 +49,43 @@ def test_synthetic_conn_exposes_export_versions():
     "column",
     ["deviceId", "streamId", "start", "end", "shortName", "demangledName", "correlationId"],
 )
-def test_missing_kernel_column_is_named(column):
-    conn = _synthetic_conn()
-    conn.execute(f"ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL RENAME COLUMN {column} TO {column}_gone")
-    missing = NsightSchema(conn).missing_required_columns()
+def test_missing_kernel_column_is_named(minimal_nsys_conn, column):
+    minimal_nsys_conn.execute(
+        f"ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL RENAME COLUMN {column} TO {column}_gone"
+    )
+    missing = NsightSchema(minimal_nsys_conn).missing_required_columns()
     assert f"CUPTI_ACTIVITY_KIND_KERNEL.{column}" in missing
 
 
 @pytest.mark.parametrize("column", ["id", "value"])
-def test_missing_stringids_column_is_named(column):
-    conn = _synthetic_conn()
-    conn.execute(f"ALTER TABLE StringIds RENAME COLUMN {column} TO {column}_gone")
-    missing = NsightSchema(conn).missing_required_columns()
+def test_missing_stringids_column_is_named(minimal_nsys_conn, column):
+    minimal_nsys_conn.execute(f"ALTER TABLE StringIds RENAME COLUMN {column} TO {column}_gone")
+    missing = NsightSchema(minimal_nsys_conn).missing_required_columns()
     assert f"StringIds.{column}" in missing
 
 
-def test_missing_kernel_table_is_named():
-    conn = _synthetic_conn()
-    conn.execute("DROP TABLE CUPTI_ACTIVITY_KIND_KERNEL")
-    missing = NsightSchema(conn).missing_required_columns()
+def test_missing_kernel_table_is_named(minimal_nsys_conn):
+    minimal_nsys_conn.execute("DROP TABLE CUPTI_ACTIVITY_KIND_KERNEL")
+    missing = NsightSchema(minimal_nsys_conn).missing_required_columns()
     assert any("kernel activity table" in m for m in missing)
 
 
-def test_missing_stringids_table_is_named():
-    conn = _synthetic_conn()
-    conn.execute("DROP TABLE StringIds")
-    assert "StringIds" in NsightSchema(conn).missing_required_columns()
+def test_missing_stringids_table_is_named(minimal_nsys_conn):
+    minimal_nsys_conn.execute("DROP TABLE StringIds")
+    assert "StringIds" in NsightSchema(minimal_nsys_conn).missing_required_columns()
 
 
-def test_optional_tables_do_not_trip_the_contract():
+def test_optional_tables_do_not_trip_the_contract(minimal_nsys_conn):
     """A --trace=cuda capture has no NVTX_EVENTS; skills degrade around it, so
     its absence must not be a contract violation."""
-    conn = _synthetic_conn()
-    conn.execute("DROP TABLE NVTX_EVENTS")
-    assert NsightSchema(conn).missing_required_columns() == []
+    minimal_nsys_conn.execute("DROP TABLE NVTX_EVENTS")
+    assert NsightSchema(minimal_nsys_conn).missing_required_columns() == []
 
 
-def test_column_check_is_case_insensitive():
+def test_column_check_is_case_insensitive(minimal_nsys_conn):
     """Real exports vary column case; the contract must not false-fail on it."""
-    conn = _synthetic_conn()
-    conn.execute("ALTER TABLE StringIds RENAME COLUMN value TO VALUE")
-    assert "StringIds.value" not in NsightSchema(conn).missing_required_columns()
+    minimal_nsys_conn.execute("ALTER TABLE StringIds RENAME COLUMN value TO VALUE")
+    assert "StringIds.value" not in NsightSchema(minimal_nsys_conn).missing_required_columns()
 
 
 # ── doctor surfaces the contract at runtime ─────────────────────────────────
@@ -115,7 +101,7 @@ def test_doctor_reports_schema_compatibility_ok():
     assert "3.24.14" in check.detail
 
 
-def test_doctor_fails_on_missing_required_column():
+def test_doctor_fails_on_missing_required_column(minimal_nsys_conn):
     from nsys_ai.doctor import _check_profile_health
 
     # `demangledName` is required by the analysis path but not read during
@@ -123,11 +109,10 @@ def test_doctor_fails_on_missing_required_column():
     # the profile still builds and doctor can surface the drift as a clean fail.
     # Columns _discover itself needs would instead raise at construction — a loud
     # failure of a different kind, out of scope for this check.
-    conn = _synthetic_conn()
-    conn.execute(
+    minimal_nsys_conn.execute(
         "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL RENAME COLUMN demangledName TO demangledName_gone"
     )
-    prof = Profile._from_conn(conn)
+    prof = Profile._from_conn(minimal_nsys_conn)
     section = _check_profile_health(prof)
     check = next(c for c in section.checks if c.name == "Schema compatibility")
     assert check.status == "fail"


### PR DESCRIPTION
Closes #237.

Nothing in CI would catch a future Nsight export dropping or renaming a table/column the analysis layer selects by name; NVIDIA documents the SQLite export schema 'can and will change'. Today that surfaces as a user bug report or a deferred stack trace rather than a red build.

## Change

- **`NsightSchema.missing_required_columns()`** declares the hard requirements — the kernel table's `deviceId/streamId/start/end/shortName/demangledName/correlationId` and `StringIds`' `id/value` — and names exactly what is absent. The required-column list was cross-checked against every kernel-aliased reference in `profile.py`, `overlap.py`, and all 18 skills: it is exactly the set selected by name, neither over- nor under-claiming. Optional surface (`NVTX_EVENTS`, `META_DATA_*`) is excluded so a `--trace=cuda` capture is not flagged. Matching is case-insensitive and the kernel table name is resolved (versioned-safe), so real 3.24.14 / 3.25.0 / 3.27.0 exports all pass with `[]`.
- **`doctor`** runs it as a 'Schema compatibility' check, so a user opening an incompatible export gets a named diagnostic + hint instead of a deep stack trace.
- **`conftest`** now seeds `META_DATA_EXPORT` (both sqlite and duckdb fixtures), giving version detection synthetic coverage — `schema_version` read as `None` in every synthetic test before.

## Testing

New `tests/test_schema_contract.py`: the committed fixture satisfies the contract (CI guard — a fixture swap to an incompatible export fails here) and its schema version is recorded; every required kernel/StringIds column, when renamed, is named in the diagnostic (parametrized); optional tables don't trip it; case-insensitivity holds; and doctor surfaces both ok and fail. Independent review verified the required list matches actual usage exactly, confirmed `[]` on all five real profiles across three schema versions, and killed every mutation (blanket-pass, dropped required column, broken case-insensitivity, hardcoded-ok doctor).

1276 passed, 135 skipped; ruff clean.

## Scope note

For the four kernel columns `_discover` itself reads (`deviceId/streamId/start/end`), Profile construction raises before doctor runs — a loud failure of a different kind. The doctor check catches the post-construction columns; the contract's own unit tests cover all seven directly. Making Profile construction degrade to a clean diagnostic on those four is a separate hardening, out of scope here.