### PR TITLE
fix(findings): iteration slow-finding defers headroom to idle and comm

### DIFF
--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -55,15 +55,6 @@ def _to_findings(rows: list[dict]) -> list:
         return findings
 
     slow = [it for it in real if it.get("duration_ms", 0) > 1.5 * med]
-    # The recoverable opportunity is the total slack across every slow
-    # iteration, which is a capture-scoped quantity comparable with the other
-    # headroom producers. A single iteration's slack is not: ranking it against
-    # a profile-wide idle total silently favours the aggregate. Following the
-    # gpu_idle_gaps convention, the aggregate is carried once — by the worst
-    # iteration, which is where a reader would start — and the remaining
-    # findings carry none, so no millisecond is attributed twice.
-    total_slack_ms = round(sum(it["duration_ms"] - med for it in slow), 3)
-    worst = max(slow, key=lambda it: it["duration_ms"], default=None)
 
     for it in slow:
         pct = 100 * it["duration_ms"] / med
@@ -79,17 +70,11 @@ def _to_findings(rows: list[dict]) -> list:
         else:
             end_ns = int(end_ns)
 
-        carries_headroom = it is worst
         note = (
             f"{it['duration_ms']:.1f}ms "
             f"({pct:.0f}% of median {med:.1f}ms), "
             f"{it.get('kernel_count', 0)} kernels"
         )
-        if carries_headroom and len(slow) > 1:
-            note += (
-                f". Headroom is the total slack across all {len(slow)} slow "
-                "iterations, counted once here."
-            )
 
         findings.append(
             Finding(
@@ -101,9 +86,17 @@ def _to_findings(rows: list[dict]) -> list:
                     "device_id", 0
                 ),  # Assuming device_id is available or defaults to 0
                 severity="warning",
+                # No headroom, by design. A slow iteration's excess over the
+                # median is wall-clock time whose idle and exposed-comm parts are
+                # already claimed in full by gpu_idle_gaps (device idle) and
+                # overlap_breakdown (exposed NCCL); any remainder is extra
+                # compute the iteration genuinely did, not recoverable. Claiming
+                # the slack here would double-count that time — the same
+                # deferral critical_path and nccl_breakdown make. The finding
+                # stays as the variance locator: which iteration to investigate.
+                headroom_ms=None,
+                headroom_basis=None,
                 note=note,
-                headroom_ms=total_slack_ms if carries_headroom else None,
-                headroom_basis="capture_total" if carries_headroom else None,
             )
         )
     return findings

--- a/tests/test_finding_headroom.py
+++ b/tests/test_finding_headroom.py
@@ -253,7 +253,11 @@ def test_overlap_breakdown_headroom_single_count():
     assert sum(h for h in headrooms if h is not None) == 30.0
 
 
-def test_iteration_timing_headroom_is_slack_over_median():
+def test_iteration_timing_defers_headroom_to_idle_and_comm():
+    """A slow iteration fires as a variance locator but claims no headroom: its
+    excess over the median is wall-clock whose idle/exposed-comm parts are
+    already owned by gpu_idle_gaps and overlap_breakdown, and any remainder is
+    extra compute, not recoverable. Claiming the slack would double-count."""
     from nsys_ai.skills.builtins.iteration_timing import _to_findings
 
     rows = [
@@ -265,15 +269,16 @@ def test_iteration_timing_headroom_is_slack_over_median():
          "gpu_end_ns": 60_000_000, "kernel_count": 5},
     ]
     findings = _to_findings(rows)
-    assert len(findings) == 1  # only iter 3 exceeds 1.5x median
-    assert findings[0].headroom_ms == 30.0  # 40ms - median(10ms)
-    assert findings[0].headroom_basis == "capture_total"
+    assert len(findings) == 1  # only iter 3 exceeds 1.5x median — still located
+    assert findings[0].label.endswith("3")
+    assert findings[0].headroom_ms is None, "slow-iteration slack must not co-rank"
+    assert findings[0].headroom_basis is None
+    assert "median 10" in findings[0].note  # the diagnostic survives
 
 
-def test_iteration_timing_headroom_is_aggregated_and_counted_once():
-    """With several slow iterations the headroom is the total slack across all
-    of them, carried by the worst one only — a per-iteration value would not be
-    comparable with the capture-scoped producers."""
+def test_iteration_timing_slow_findings_never_claim_headroom():
+    """Every slow iteration defers, not just the worst — none co-rank against
+    the idle/comm pools their slack overlaps."""
     from nsys_ai.skills.builtins.iteration_timing import _to_findings
 
     rows = [
@@ -282,13 +287,9 @@ def test_iteration_timing_headroom_is_aggregated_and_counted_once():
         for i, d in enumerate([10.0, 10.0, 10.0, 40.0, 25.0])
     ]
     findings = _to_findings(rows)
-    assert len(findings) == 2  # iterations of 40ms and 25ms exceed 1.5x median(10)
-    carriers = [f for f in findings if f.headroom_ms is not None]
-    assert len(carriers) == 1, "the aggregate must be attributed exactly once"
-    # (40-10) + (25-10) = 45ms total slack, on the worst iteration.
-    assert carriers[0].headroom_ms == 45.0
-    assert carriers[0].label.endswith("3")  # the 40ms iteration
-    assert carriers[0].headroom_basis == "capture_total"
+    assert len(findings) == 2  # 40ms and 25ms both exceed 1.5x median(10)
+    assert all(f.headroom_ms is None for f in findings)
+    assert all(f.headroom_basis is None for f in findings)
 
 
 def test_nccl_variability_defers_comm_headroom_to_overlap_breakdown():


### PR DESCRIPTION
Found in a holistic review of this session's findings changes — the one remaining gap in the single-count invariant.

`iteration_timing._to_findings` emitted `headroom_ms = total slack over the median` on the worst slow iteration. But a slow iteration's excess over the median is wall-clock time whose **idle** and **exposed-comm** components are already claimed in full by `gpu_idle_gaps` (device idle) and `overlap_breakdown` (exposed NCCL); any remainder is extra compute the iteration genuinely did, not recoverable. So the slack double-counts those pools.

It was the one headroom producer coordinating single-count only *within its own findings* ('counted once here'), not across skills — unlike `critical_path` and `nccl_breakdown`, which set `headroom_ms=None` with cross-referencing deferral notes (the convention this session established).

```python
# 5 real iterations at ~500ms, one slow at 900ms:
Slow Iteration 99: headroom_ms=400.0 basis=capture_total   # 400ms = the slack
```

That 400ms is exactly the idle/comm/compute the iteration spent; the idle and comm parts are already in `device_idle` / `exposed_nccl`.

## Why latent (but real)

The pipeline's default `sample_0` marker falls to the heuristic path, now suppressed as non-iterations (#253), and the real corpus has no `sample_0`-matched training capture — so `total_headroom == device_idle + exposed_comm` held empirically on nano_vllm/fastvideo. But a training capture with matched iterations and an idle/comm-caused slow one would claim the same recoverable millisecond twice in the ranking.

## Fix

The slow-iteration finding sets `headroom_ms=None` and defers to the idle/comm owners, matching `critical_path`/`nccl_breakdown`. It still fires as the variance **locator** — which iteration to investigate, its duration and percent of median — it just no longer claims the slack as separate recoverable time.

## Testing

Two tests updated to pin the deferral (finding fires, headroom None, diagnostic note survives) plus that *every* slow finding defers, not just the worst. Mutation-tested: restoring the headroom fails both. Re-verified the composed-pipeline invariant `total_headroom == device_idle + exposed_comm` still holds. 1276 passed, 135 skipped; ruff clean.