### PR TITLE
fix(skills): compute nccl_anomaly in Python, not a multi-CTE self-join

### DIFF
--- a/src/nsys_ai/skills/builtins/nccl_anomaly.py
+++ b/src/nsys_ai/skills/builtins/nccl_anomaly.py
@@ -2,87 +2,113 @@
 
 Beyond the basic nccl_breakdown (aggregated stats), this skill identifies
 individual NCCL operations whose duration is significantly above the
-median for their operation type — indicating potential network stalls,
+average for their operation type — indicating potential network stalls,
 GPU imbalance, or contention.
+
+The per-op-type average and outlier selection are computed in Python from a
+single flat fetch rather than a multi-CTE self-join. The join a SQL version
+needs (every op against its type's average) re-materialises the NCCL scan and
+crashes / hangs DuckDB's ``sqlite_scanner`` on a direct-attached profile with
+no parquet cache (issue #251) — the same failure mode as host_sync (#248). The
+flat fetch runs fine on every path.
 """
 
+from ...connection import DB_ERRORS
 from ..base import Skill, SkillParam
 
-SKILL = Skill(
-    name="nccl_anomaly",
-    title="NCCL Anomaly Detection",
-    description=(
-        "Detects outlier NCCL collective operations whose duration exceeds "
-        "a threshold relative to the median for their op type. "
-        "Identifies network stalls, GPU imbalance, and contention. "
-        "Returns individual anomalous operations with timing and context."
-    ),
-    category="communication",
-    sql="""\
-WITH nccl_ops AS (
-    SELECT
-        s.value AS name,
-        k.correlationId,
-        k.streamId,
-        k.start,
-        k.[end],
-        (k.[end] - k.start) AS dur_ns
-    FROM {kernel_table} k
-    JOIN StringIds s ON k.shortName = s.id
-    WHERE (s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%')
-        {trim_clause}
-),
-op_stats AS (
-    SELECT
-        -- Normalize: strip device/rank suffixes to group by op type
-        CASE
-            WHEN name LIKE '%AllReduce%' THEN 'AllReduce'
-            WHEN name LIKE '%AllGather%' THEN 'AllGather'
-            WHEN name LIKE '%ReduceScatter%' THEN 'ReduceScatter'
-            WHEN name LIKE '%Broadcast%' THEN 'Broadcast'
-            WHEN name LIKE '%AllToAll%' THEN 'AllToAll'
-            WHEN name LIKE '%Reduce%' THEN 'Reduce'
-            ELSE 'Other'
-        END AS op_type,
-        name,
-        dur_ns,
-        start,
-        correlationId,
-        streamId
-    FROM nccl_ops
-),
--- SQLite lacks native MEDIAN; AVG is a reasonable proxy for outlier detection
-op_averages AS (
-    SELECT op_type,
-           AVG(dur_ns) AS avg_dur_ns,
-           COUNT(*) AS total_count
-    FROM op_stats
-    GROUP BY op_type
-)
-SELECT
-    o.op_type,
-    o.name,
-    o.dur_ns,
-    ROUND(o.dur_ns / 1e6, 3) AS dur_ms,
-    ROUND(a.avg_dur_ns / 1e6, 3) AS avg_ms,
-    ROUND(CAST(o.dur_ns AS REAL) / NULLIF(a.avg_dur_ns, 0), 1) AS ratio_to_avg,
-    o.start,
-    o.streamId,
-    a.total_count
-FROM op_stats o
-JOIN op_averages a ON o.op_type = a.op_type
-WHERE o.dur_ns > a.avg_dur_ns * {threshold}
-ORDER BY o.dur_ns DESC
-LIMIT {limit}""",
-    format_fn=lambda rows: _format(rows),
-    params=[
-        SkillParam(
-            "threshold", "Anomaly threshold: ratio to average duration", "float", False, 3.0
-        ),
-        SkillParam("limit", "Max anomalies to return", "int", False, 20),
-    ],
-    tags=["nccl", "anomaly", "outlier", "stall", "communication", "distributed"],
-)
+# Checked in order: more specific names first, so "AllReduce" and
+# "ReduceScatter" are classified before the bare "Reduce" substring.
+_OP_TYPES = ("AllReduce", "AllGather", "ReduceScatter", "Broadcast", "AllToAll", "Reduce")
+
+
+def _op_type(name: str) -> str:
+    for op in _OP_TYPES:
+        if op in name:
+            return op
+    return "Other"
+
+
+def _execute(conn, **kwargs):
+    from ...connection import wrap_connection
+
+    try:
+        threshold = float(kwargs.get("threshold", 3.0))
+    except (TypeError, ValueError):
+        threshold = 3.0
+    try:
+        limit = int(kwargs.get("limit", 20))
+    except (TypeError, ValueError):
+        limit = 20
+
+    adapter = wrap_connection(conn)
+    kernel_table = adapter.resolve_activity_tables().get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
+
+    trim_start = kwargs.get("trim_start_ns")
+    trim_end = kwargs.get("trim_end_ns")
+    trim_clause = ""
+    params: list = []
+    if trim_start is not None and trim_end is not None:
+        trim_clause = "AND k.start >= ? AND k.[end] <= ?"
+        params = [int(trim_start), int(trim_end)]
+
+    # Flat fetch of every NCCL collective. LIKE is lower-cased-agnostic on
+    # SQLite but case-sensitive on DuckDB, so match both spellings.
+    sql = f"""
+        SELECT s.value AS name, k.streamId AS stream_id, k.start AS start,
+               (k.[end] - k.start) AS dur_ns
+        FROM {kernel_table} k
+        JOIN StringIds s ON k.shortName = s.id
+        WHERE (s.value LIKE '%nccl%' OR s.value LIKE '%NCCL%') {trim_clause}
+    """
+    try:
+        rows = adapter.execute(sql, params).fetchall()
+    except DB_ERRORS as exc:
+        return [
+            {
+                "error": (
+                    f"nccl_anomaly query failed: {exc}. "
+                    "The kernel table or StringIds may be absent."
+                )
+            }
+        ]
+
+    # Group by op type: running sum + count for the average, and keep the ops.
+    ops = []
+    sum_ns: dict[str, int] = {}
+    count: dict[str, int] = {}
+    for name, stream_id, start, dur_ns in rows:
+        if name is None:
+            continue
+        ot = _op_type(name)
+        dur_ns = int(dur_ns or 0)
+        ops.append((ot, name, stream_id, start, dur_ns))
+        sum_ns[ot] = sum_ns.get(ot, 0) + dur_ns
+        count[ot] = count.get(ot, 0) + 1
+
+    out = []
+    for ot, name, stream_id, start, dur_ns in ops:
+        n = count[ot]
+        avg = sum_ns[ot] / n if n else 0.0
+        if avg <= 0 or dur_ns <= avg * threshold:
+            continue
+        out.append(
+            {
+                "op_type": ot,
+                "name": name,
+                "dur_ns": dur_ns,
+                "dur_ms": round(dur_ns / 1e6, 3),
+                "avg_ms": round(avg / 1e6, 3),
+                "ratio_to_avg": round(dur_ns / avg, 1),
+                "start": start,
+                "streamId": stream_id,
+                "total_count": n,
+            }
+        )
+
+    # Slowest first; a deterministic secondary key keeps ties reproducible
+    # (the SQL left tie order unspecified).
+    out.sort(key=lambda r: (-r["dur_ns"], r["start"]))
+    return out[:limit]
 
 
 def _format(rows):
@@ -102,3 +128,25 @@ def _format(rows):
     count = rows[0]["total_count"] if rows else 0
     lines.append(f"\n  {len(rows)} anomalies found out of {count} total ops")
     return "\n".join(lines)
+
+
+SKILL = Skill(
+    name="nccl_anomaly",
+    title="NCCL Anomaly Detection",
+    description=(
+        "Detects outlier NCCL collective operations whose duration exceeds "
+        "a threshold relative to the average for their op type. "
+        "Identifies network stalls, GPU imbalance, and contention. "
+        "Returns individual anomalous operations with timing and context."
+    ),
+    category="communication",
+    execute_fn=_execute,
+    format_fn=_format,
+    params=[
+        SkillParam(
+            "threshold", "Anomaly threshold: ratio to average duration", "float", False, 3.0
+        ),
+        SkillParam("limit", "Max anomalies to return", "int", False, 20),
+    ],
+    tags=["nccl", "anomaly", "outlier", "stall", "communication", "distributed"],
+)

--- a/tests/test_nccl_anomaly.py
+++ b/tests/test_nccl_anomaly.py
@@ -1,0 +1,126 @@
+"""Tests for the nccl_anomaly skill.
+
+It detects NCCL collectives whose duration is an outlier for their op type.
+The computation moved from a multi-CTE SQL self-join to a flat fetch + Python
+(issue #251) — the SQL crashed/hung DuckDB's sqlite_scanner on a direct-attached
+profile. These tests pin the anomaly logic, the op-type classification order,
+and that both engines agree (the robustness the rewrite is for).
+"""
+
+import sqlite3
+
+import pytest
+
+from nsys_ai.skills.builtins import nccl_anomaly as skill_mod
+
+_MS = 1_000_000
+# (start_ns, dur_ms, streamId, name)
+_SCHEMA_COLS = "start INT, [end] INT, deviceId INT, streamId INT, correlationId INT, shortName INT, demangledName INT"
+
+
+def _rows(named_kernels):
+    """Return (stringids, kernels) for the given named kernels."""
+    names = {}
+    for _, _, _, name in named_kernels:
+        names.setdefault(name, len(names) + 1)
+    stringids = [(sid, n) for n, sid in names.items()]
+    kernels = [
+        (start_ns, start_ns + int(dur_ms * _MS), 0, stream, i, names[name], names[name])
+        for i, (start_ns, dur_ms, stream, name) in enumerate(named_kernels)
+    ]
+    return stringids, kernels
+
+
+def _build_sqlite(named_kernels):
+    conn = sqlite3.connect(":memory:")
+    conn.execute("CREATE TABLE StringIds(id INTEGER PRIMARY KEY, value TEXT)")
+    conn.execute(f"CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL({_SCHEMA_COLS})")
+    stringids, kernels = _rows(named_kernels)
+    conn.executemany("INSERT INTO StringIds VALUES(?,?)", stringids)
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL(start, [end], deviceId, streamId, "
+        "correlationId, shortName, demangledName) VALUES(?,?,?,?,?,?,?)",
+        kernels,
+    )
+    conn.commit()
+    return conn
+
+
+def _build_duckdb(named_kernels):
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect()
+    con.execute("CREATE TABLE StringIds(id BIGINT, value VARCHAR)")
+    con.execute(
+        'CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL(start BIGINT, "end" BIGINT, deviceId INT, '
+        'streamId INT, correlationId INT, shortName BIGINT, demangledName BIGINT)'
+    )
+    stringids, kernels = _rows(named_kernels)
+    for r in stringids:
+        con.execute("INSERT INTO StringIds VALUES(?,?)", list(r))
+    for r in kernels:
+        con.execute(
+            'INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL(start, "end", deviceId, streamId, '
+            "correlationId, shortName, demangledName) VALUES(?,?,?,?,?,?,?)",
+            list(r),
+        )
+    return con
+
+
+# 5 AllReduce (4x 1ms + 1x 20ms) -> avg 4.8ms, the 20ms one is the anomaly at 3x.
+# 2 ReduceScatter at 5ms (uniform, no anomaly). 1 non-NCCL gemm (excluded).
+_KERNELS = [
+    (0, 1.0, 8, "ncclDevKernel_AllReduce_x"),
+    (2 * _MS, 1.0, 8, "ncclDevKernel_AllReduce_x"),
+    (4 * _MS, 1.0, 8, "ncclDevKernel_AllReduce_x"),
+    (6 * _MS, 1.0, 8, "ncclDevKernel_AllReduce_x"),
+    (8 * _MS, 20.0, 8, "ncclDevKernel_AllReduce_x"),
+    (40 * _MS, 5.0, 9, "ncclDevKernel_ReduceScatter_y"),
+    (50 * _MS, 5.0, 9, "ncclDevKernel_ReduceScatter_y"),
+    (60 * _MS, 3.0, 7, "ampere_sgemm_128x64"),
+]
+
+
+def test_flags_slow_collective_with_correct_ratio():
+    rows = skill_mod._execute(_build_sqlite(_KERNELS), threshold=3.0, limit=20)
+    assert len(rows) == 1, "only the 20ms AllReduce is >3x its type's average"
+    r = rows[0]
+    assert r["op_type"] == "AllReduce"
+    assert r["dur_ms"] == 20.0
+    assert r["avg_ms"] == 4.8  # (4*1 + 20)/5
+    assert r["ratio_to_avg"] == 4.2  # 20 / 4.8
+    assert r["total_count"] == 5  # all AllReduce ops of that type
+    assert r["streamId"] == 8
+
+
+def test_op_type_classification_order():
+    """AllReduce and ReduceScatter must not be swallowed by the bare 'Reduce'
+    substring — the classifier checks specific names first."""
+    assert skill_mod._op_type("ncclDevKernel_AllReduce_x") == "AllReduce"
+    assert skill_mod._op_type("ncclDevKernel_ReduceScatter_y") == "ReduceScatter"
+    assert skill_mod._op_type("ncclDevKernel_Reduce_z") == "Reduce"
+    assert skill_mod._op_type("ncclDevKernel_AllGather_w") == "AllGather"
+    assert skill_mod._op_type("some_unlabelled_nccl_kernel") == "Other"
+
+
+def test_uniform_durations_have_no_anomaly():
+    kernels = [(i * 10 * _MS, 5.0, 8, "ncclDevKernel_AllReduce_x") for i in range(6)]
+    assert skill_mod._execute(_build_sqlite(kernels), threshold=3.0, limit=20) == []
+
+
+def test_no_nccl_returns_empty():
+    kernels = [(0, 5.0, 7, "ampere_sgemm"), (10 * _MS, 50.0, 7, "ampere_sgemm")]
+    assert skill_mod._execute(_build_sqlite(kernels), threshold=3.0, limit=20) == []
+
+
+def test_threshold_controls_sensitivity():
+    # Same data; a threshold above the 4.2x ratio drops the anomaly.
+    assert len(skill_mod._execute(_build_sqlite(_KERNELS), threshold=3.0)) == 1
+    assert skill_mod._execute(_build_sqlite(_KERNELS), threshold=5.0) == []
+
+
+def test_engine_parity_sqlite_matches_duckdb():
+    """The whole point of the rewrite: identical output on both engines, with no
+    CTE for the sqlite_scanner to choke on."""
+    lite = skill_mod._execute(_build_sqlite(_KERNELS), threshold=2.0, limit=20)
+    duck = skill_mod._execute(_build_duckdb(_KERNELS), threshold=2.0, limit=20)
+    assert lite == duck and lite  # non-empty and equal


### PR DESCRIPTION
Part of the #251 audit (see the audit summary comment there).

`nccl_anomaly` joined every collective against its op-type average through a chain of CTEs (`nccl_ops → op_stats → op_averages`, then `op_stats JOIN op_averages`). That self-join re-materialises the NCCL scan and hangs DuckDB's `sqlite_scanner` on a direct-attached profile (no parquet cache):

```
attn_only.sqlite   parquet cache: 0.1s     direct-attach: >110s, killed
```

Same failure mode as host_sync (#248). The scan itself is fast on every path (0.3s direct-attach) — it is the CTE self-join that chokes the scanner.

## Change

A single flat fetch of the NCCL collectives + the grouping, averaging, and outlier selection in Python. Byte-identical to the old SQL on nano_vllm and megatron (via the cache oracle), and **0.2s** on the direct-attach path that used to hang.

Op-type classification keeps the specific-before-general order (AllReduce and ReduceScatter before the bare `Reduce` substring); parent ordering gains a deterministic secondary key the SQL left unspecified.

## Testing

New `tests/test_nccl_anomaly.py` (the skill had no behavioural test before): the anomaly detection with exact ratio/avg/count, the op-type ordering, threshold sensitivity, empty cases, and **engine parity** (sqlite == duckdb on the same data — the robustness the rewrite is for). 1286 passed, 135 skipped; ruff clean.

## Audit outcome

The full #251 audit is posted on the issue. Two of three broken skills fixed (host_sync #248, nccl_anomaly here); `nvtx_layer_breakdown` (~967 lines, an IEJoin containment) is tracked in #257 for its own change.