### PR TITLE
fix(cache): build nvtx_kernel_map on-demand so NVTX skills survive direct-attach

### DIFF
--- a/src/nsys_ai/nvtx_attribution.py
+++ b/src/nsys_ai/nvtx_attribution.py
@@ -233,6 +233,17 @@ def attribute_kernels_to_nvtx(
         adapter = wrap_connection(conn)
 
         if isinstance(adapter, DuckDBAdapter):
+            # Build nvtx_kernel_map on-demand when absent (issue #257), so the
+            # map-backed path below runs instead of the in-file IEJoin fallback
+            # that hangs sqlite_scanner on a direct-attached profile. Must run
+            # before the cached_nvtx_map_* probes, which memoize per connection.
+            try:
+                from .parquet_cache import ensure_nvtx_kernel_map
+
+                ensure_nvtx_kernel_map(conn)
+            except DB_ERRORS:
+                pass
+
             trim_sql = ""
             params = []
             if trim:

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1377,8 +1377,11 @@ def _build_nvtx_kernel_map_python(
 
 def _materialize_nvtx_kernel_map(db, results: list[dict]) -> None:
     """Create the ``nvtx_kernel_map`` + ``nvtx_path_dict`` temp tables on a
-    DuckDB connection from sweep ``results`` (the 7-column Python-fallback
-    schema; consumers degrade gracefully without the embedded TC columns)."""
+    DuckDB connection from sweep ``results``. Emits the full 9-column
+    cache-built schema, including the embedded ``is_tc_eligible``/``uses_tc``,
+    so consumers take their map-only fast path (a TC-less map would force
+    nvtx_layer_breakdown into a (start,end) kernels-join that double-counts
+    timestamp-colliding kernels)."""
     import pyarrow as pa
 
     paths = sorted({r["nvtx_path"] for r in results})
@@ -1392,6 +1395,10 @@ def _materialize_nvtx_kernel_map(db, results: list[dict]) -> None:
             "k_start": pa.array([r["k_start"] for r in results], pa.int64()),
             "k_end": pa.array([r["k_end"] for r in results], pa.int64()),
             "k_dur_ns": pa.array([r["k_dur_ns"] for r in results], pa.int64()),
+            "is_tc_eligible": pa.array(
+                [r.get("is_tc_eligible", 0) for r in results], pa.int32()
+            ),
+            "uses_tc": pa.array([r.get("uses_tc", 0) for r in results], pa.int32()),
         }
     )
     dict_tbl = pa.table(
@@ -1450,13 +1457,20 @@ def ensure_nvtx_kernel_map(conn) -> bool:
         text_expr = "n.text"
         text_join = ""
 
+    # kernel_name and the embedded TC flags resolved exactly as the cache-built
+    # map's TC-enriched ``kernels`` view (_tc_enriched_sql), so the on-demand map
+    # is a byte-for-byte drop-in: name = COALESCE(demangled, short, 'kernel_'||id),
+    # TC eligibility/use by the same name regexes.
+    tc_active = _TC_ACTIVE_PATTERN
+    tc_elig = _TC_ELIGIBLE_PATTERN
+    lname = "lower(COALESCE(sd.value, ss.value, ''))"
     try:
-        # kernel_name resolved as COALESCE(demangled, short) to match the
-        # cache-built map's ``k.name``, so consumers see identical names on the
-        # on-demand path.
         kr_rows = db.execute(
             f'SELECT r.globalTid, r.start, r."end", k.start, k."end", '
-            f"COALESCE(sd.value, ss.value) AS kernel_name "
+            f"COALESCE(sd.value, ss.value, 'kernel_' || CAST(k.shortName AS VARCHAR)) AS kernel_name, "
+            f"CAST(CASE WHEN regexp_matches({lname}, {tc_elig}) "
+            f"OR regexp_matches({lname}, {tc_active}) THEN 1 ELSE 0 END AS INTEGER) AS is_tc_eligible, "
+            f"CAST(CASE WHEN regexp_matches({lname}, {tc_active}) THEN 1 ELSE 0 END AS INTEGER) AS uses_tc "
             f"FROM {kernel_table} k "
             f"JOIN {runtime_table} r ON r.correlationId = k.correlationId "
             f"LEFT JOIN StringIds sd ON k.demangledName = sd.id "
@@ -1475,7 +1489,14 @@ def ensure_nvtx_kernel_map(conn) -> bool:
         log.debug("ensure_nvtx_kernel_map: source fetch failed (%s)", exc)
         return False
 
+    # Per-kernel TC flags (by k_start, k_end, name) to attach after the
+    # name-agnostic sweep, which only reads the first six fields.
+    tc_by_kernel = {(r[3], r[4], r[5]): (r[6], r[7]) for r in kr_rows}
     results = _sweep_nvtx_kernel_map(kr_rows, nvtx_rows)
+    for r in results:
+        r["is_tc_eligible"], r["uses_tc"] = tc_by_kernel.get(
+            (r["k_start"], r["k_end"], r["kernel_name"]), (0, 0)
+        )
     # Materialize even when empty: the existence check then passes and consumers
     # take the (empty) map path rather than re-entering the hanging IEJoin.
     _materialize_nvtx_kernel_map(db, results)

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1182,6 +1182,73 @@ def _build_nvtx_kernel_map(
         _build_nvtx_kernel_map_python(db, src_tables, cache_dir, sqlite_path)
 
 
+def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
+    """Per-thread sort-merge attributing each kernel to its innermost enclosing
+    NVTX range. O(N+M) per thread; the shared containment core used by both the
+    parquet-cache Python fallback and the on-demand builder (issue #257).
+
+    kr_rows: iterable of ``(globalTid, r_start, r_end, k_start, k_end,
+    kernel_name)`` — the kernel name already resolved by the caller (so each can
+    match its own map's convention). nvtx_rows: ``(globalTid, start, end, text)``
+    (PushPop ranges), sorted by ``(globalTid, start)``. Returns rows:
+    ``{nvtx_text, nvtx_depth, nvtx_path, kernel_name, k_start, k_end, k_dur_ns}``.
+    """
+    from collections import defaultdict
+
+    nvtx_by_tid: dict[int, list[tuple]] = defaultdict(list)
+    for n in nvtx_rows:
+        nvtx_by_tid[n[0]].append((n[1], n[2], n[3]))
+
+    kr_by_tid: dict[int, list[tuple]] = defaultdict(list)
+    for r in kr_rows:
+        kr_by_tid[r[0]].append((r[1], r[2], r[3], r[4], r[5]))
+
+    results: list[dict] = []
+    for tid in kr_by_tid:
+        if tid not in nvtx_by_tid:
+            continue
+
+        nvtx_list = nvtx_by_tid[tid]
+        kr_by_tid[tid].sort(key=lambda x: x[0])
+
+        nvtx_idx = 0
+        open_stack: list[tuple[int, int, str]] = []
+
+        for r_start, r_end, k_start, k_end, kernel_name in kr_by_tid[tid]:
+            while open_stack and open_stack[-1][1] < r_start:
+                open_stack.pop()
+            while nvtx_idx < len(nvtx_list) and nvtx_list[nvtx_idx][0] <= r_start:
+                if nvtx_list[nvtx_idx][1] >= r_start:
+                    open_stack.append(nvtx_list[nvtx_idx])
+                nvtx_idx += 1
+
+            best_nvtx = None
+            best_idx = -1
+            for i in range(len(open_stack) - 1, -1, -1):
+                ns, ne, nt = open_stack[i]
+                if ns <= r_start and ne >= r_end:
+                    best_nvtx = nt
+                    best_idx = i
+                    break
+
+            if best_nvtx is not None:
+                enclosing = [
+                    e for e in open_stack[: best_idx + 1] if e[0] <= r_start and e[1] >= r_end
+                ]
+                results.append(
+                    {
+                        "nvtx_text": best_nvtx,
+                        "nvtx_depth": len(enclosing) - 1,
+                        "nvtx_path": " > ".join(e[2] for e in enclosing),
+                        "kernel_name": kernel_name,
+                        "k_start": k_start,
+                        "k_end": k_end,
+                        "k_dur_ns": k_end - k_start,
+                    }
+                )
+    return results
+
+
 def _build_nvtx_kernel_map_python(
     db: duckdb.DuckDBPyConnection,
     src_tables: set[str],
@@ -1236,60 +1303,12 @@ def _build_nvtx_kernel_map_python(
         sid_map = dict(sid_rows)
 
     # ── Sort-merge sweep ──────────────────────────────────────────────
-    from collections import defaultdict
-
-    nvtx_by_tid: dict[int, list[tuple]] = defaultdict(list)
-    for n in nvtx_rows:
-        nvtx_by_tid[n[0]].append((n[1], n[2], n[3]))
-
-    kr_by_tid: dict[int, list[tuple]] = defaultdict(list)
-    for r in kr_rows:
-        kr_by_tid[r[0]].append((r[1], r[2], r[3], r[4], r[5]))
-
-    results: list[dict] = []
-
-    for tid in kr_by_tid:
-        if tid not in nvtx_by_tid:
-            continue
-
-        nvtx_list = nvtx_by_tid[tid]
-        kr_by_tid[tid].sort(key=lambda x: x[0])
-
-        nvtx_idx = 0
-        open_stack: list[tuple[int, int, str]] = []
-
-        for r_start, r_end, k_start, k_end, short_name in kr_by_tid[tid]:
-            while open_stack and open_stack[-1][1] < r_start:
-                open_stack.pop()
-            while nvtx_idx < len(nvtx_list) and nvtx_list[nvtx_idx][0] <= r_start:
-                if nvtx_list[nvtx_idx][1] >= r_start:
-                    open_stack.append(nvtx_list[nvtx_idx])
-                nvtx_idx += 1
-
-            best_nvtx = None
-            best_idx = -1
-            for i in range(len(open_stack) - 1, -1, -1):
-                ns, ne, nt = open_stack[i]
-                if ns <= r_start and ne >= r_end:
-                    best_nvtx = nt
-                    best_idx = i
-                    break
-
-            if best_nvtx is not None:
-                enclosing = [
-                    e for e in open_stack[: best_idx + 1] if e[0] <= r_start and e[1] >= r_end
-                ]
-                results.append(
-                    {
-                        "nvtx_text": best_nvtx,
-                        "nvtx_depth": len(enclosing) - 1,
-                        "nvtx_path": " > ".join(e[2] for e in enclosing),
-                        "kernel_name": sid_map.get(short_name, f"kernel_{short_name}"),
-                        "k_start": k_start,
-                        "k_end": k_end,
-                        "k_dur_ns": k_end - k_start,
-                    }
-                )
+    # Resolve the kernel name (shortName here, as this fallback always has) into
+    # the row before the sweep, which is name-agnostic.
+    kr_named = [
+        (r[0], r[1], r[2], r[3], r[4], sid_map.get(r[5], f"kernel_{r[5]}")) for r in kr_rows
+    ]
+    results = _sweep_nvtx_kernel_map(kr_named, nvtx_rows)
 
     if not results:
         return
@@ -1354,6 +1373,113 @@ def _build_nvtx_kernel_map_python(
         db.unregister("_nvtx_path_dict")
         del map_table
         del dict_table
+
+
+def _materialize_nvtx_kernel_map(db, results: list[dict]) -> None:
+    """Create the ``nvtx_kernel_map`` + ``nvtx_path_dict`` temp tables on a
+    DuckDB connection from sweep ``results`` (the 7-column Python-fallback
+    schema; consumers degrade gracefully without the embedded TC columns)."""
+    import pyarrow as pa
+
+    paths = sorted({r["nvtx_path"] for r in results})
+    path_to_id = {p: i + 1 for i, p in enumerate(paths)}
+    map_tbl = pa.table(
+        {
+            "path_id": pa.array([path_to_id[r["nvtx_path"]] for r in results], pa.int64()),
+            "nvtx_text": pa.array([r["nvtx_text"] for r in results], pa.string()),
+            "nvtx_depth": pa.array([r["nvtx_depth"] for r in results], pa.int32()),
+            "kernel_name": pa.array([r["kernel_name"] for r in results], pa.string()),
+            "k_start": pa.array([r["k_start"] for r in results], pa.int64()),
+            "k_end": pa.array([r["k_end"] for r in results], pa.int64()),
+            "k_dur_ns": pa.array([r["k_dur_ns"] for r in results], pa.int64()),
+        }
+    )
+    dict_tbl = pa.table(
+        {
+            "path_id": pa.array([path_to_id[p] for p in paths], pa.int64()),
+            "nvtx_path": pa.array(paths, pa.string()),
+        }
+    )
+    db.register("_odm_nkm", map_tbl)
+    db.register("_odm_npd", dict_tbl)
+    try:
+        db.execute("CREATE TEMP TABLE nvtx_kernel_map AS SELECT * FROM _odm_nkm")
+        db.execute("CREATE TEMP TABLE nvtx_path_dict AS SELECT * FROM _odm_npd")
+    finally:
+        db.unregister("_odm_nkm")
+        db.unregister("_odm_npd")
+
+
+def ensure_nvtx_kernel_map(conn) -> bool:
+    """Materialize ``nvtx_kernel_map`` + ``nvtx_path_dict`` as temp tables on a
+    DuckDB connection when they are absent, so NVTX-attribution skills take their
+    fast map-backed path instead of an in-file IEJoin that hangs DuckDB's
+    ``sqlite_scanner`` on a direct-attached profile with no parquet cache (#257).
+
+    Returns True when the map is present afterwards (already there, or just
+    built). Returns False — changing nothing — for a non-DuckDB connection or
+    when the source tables are missing, so the caller keeps its existing path.
+    The build is a flat fetch (fast on every backend) plus the shared Python
+    sort-merge; it never issues the range join that chokes the scanner.
+    """
+    from .connection import DB_ERRORS, DuckDBAdapter, wrap_connection
+
+    adapter = wrap_connection(conn)
+    if not isinstance(adapter, DuckDBAdapter):
+        return False
+
+    db = adapter.raw_conn
+    # Already present — the parquet-cache path, or a prior call on this conn.
+    try:
+        db.execute("SELECT 1 FROM nvtx_kernel_map LIMIT 1")
+        return True
+    except DB_ERRORS:
+        pass
+
+    tables = adapter.resolve_activity_tables()
+    kernel_table = tables.get("kernel")
+    runtime_table = tables.get("runtime")
+    nvtx_table = tables.get("nvtx", "NVTX_EVENTS")
+    if not kernel_table or not runtime_table:
+        return False
+
+    if adapter.detect_nvtx_text_id():
+        text_expr = "COALESCE(n.text, s.value)"
+        text_join = "LEFT JOIN StringIds s ON n.textId = s.id"
+    else:
+        text_expr = "n.text"
+        text_join = ""
+
+    try:
+        # kernel_name resolved as COALESCE(demangled, short) to match the
+        # cache-built map's ``k.name``, so consumers see identical names on the
+        # on-demand path.
+        kr_rows = db.execute(
+            f'SELECT r.globalTid, r.start, r."end", k.start, k."end", '
+            f"COALESCE(sd.value, ss.value) AS kernel_name "
+            f"FROM {kernel_table} k "
+            f"JOIN {runtime_table} r ON r.correlationId = k.correlationId "
+            f"LEFT JOIN StringIds sd ON k.demangledName = sd.id "
+            f"LEFT JOIN StringIds ss ON k.shortName = ss.id "
+            f"ORDER BY r.globalTid, r.start"
+        ).fetchall()
+        # nvtx must arrive sorted by start: the sweep advances a single index
+        # over it per thread without re-sorting (matches _build_nvtx_kernel_map_python).
+        nvtx_rows = db.execute(
+            f'SELECT n.globalTid, n.start, n."end", {text_expr} AS text '
+            f"FROM {nvtx_table} n {text_join} "
+            f'WHERE n.eventType = 59 AND n."end" > n.start '
+            f"ORDER BY n.globalTid, n.start"
+        ).fetchall()
+    except DB_ERRORS as exc:
+        log.debug("ensure_nvtx_kernel_map: source fetch failed (%s)", exc)
+        return False
+
+    results = _sweep_nvtx_kernel_map(kr_rows, nvtx_rows)
+    # Materialize even when empty: the existence check then passes and consumers
+    # take the (empty) map path rather than re-entering the hanging IEJoin.
+    _materialize_nvtx_kernel_map(db, results)
+    return True
 
 
 def _check_cache_size(cache_dir: Path, sqlite_path: str) -> None:

--- a/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
@@ -126,6 +126,16 @@ def _execute(conn, **kwargs):
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")
 
+    # Build nvtx_kernel_map on-demand when absent, so the map-backed fast path
+    # below is taken instead of the in-file IEJoin that hangs sqlite_scanner on a
+    # direct-attached profile (issue #257). No-op when the map is already present.
+    try:
+        from ...parquet_cache import ensure_nvtx_kernel_map
+
+        ensure_nvtx_kernel_map(conn)
+    except DB_ERRORS:
+        pass
+
     # Check if nvtx_kernel_map exists or can be built
     adapter = None
     try:

--- a/tests/test_nvtx_kernel_map_ondemand.py
+++ b/tests/test_nvtx_kernel_map_ondemand.py
@@ -1,0 +1,128 @@
+"""On-demand nvtx_kernel_map builder (issue #257).
+
+The four skills that attribute kernels to NVTX regions depend on a precomputed
+`nvtx_kernel_map`, built only during the parquet-cache build. On the direct-attach
+no-cache path the map is absent and each skill falls to an in-file IEJoin that
+hangs DuckDB's sqlite_scanner. `ensure_nvtx_kernel_map` materialises the map
+on-demand via the shared Python sort-merge (`_sweep_nvtx_kernel_map`), fed by
+flat fetches that run fine on every backend.
+"""
+
+import sqlite3
+
+import pytest
+
+from nsys_ai.parquet_cache import _sweep_nvtx_kernel_map, ensure_nvtx_kernel_map
+
+# ── The sort-merge sweep (shared containment core) ──────────────────────────
+
+
+def test_sweep_attributes_kernel_to_innermost_nvtx():
+    """A kernel is credited to its innermost enclosing NVTX range, with the full
+    outer>inner path and the nesting depth."""
+    # nvtx rows sorted by (tid, start): train_step[0,100] ⊃ forward[10,50]
+    nvtx = [(1, 0, 100, "train_step"), (1, 10, 50, "forward")]
+    # kr rows: (tid, r_start, r_end, k_start, k_end, kernel_name)
+    kr = [
+        (1, 15, 20, 1000, 1005, "gemm"),  # inside forward (⊂ train_step)
+        (1, 60, 65, 2000, 2010, "add"),  # inside train_step only (forward closed)
+    ]
+    out = {r["kernel_name"]: r for r in _sweep_nvtx_kernel_map(kr, nvtx)}
+
+    assert out["gemm"]["nvtx_text"] == "forward"
+    assert out["gemm"]["nvtx_depth"] == 1
+    assert out["gemm"]["nvtx_path"] == "train_step > forward"
+    assert out["gemm"]["k_dur_ns"] == 5
+
+    assert out["add"]["nvtx_text"] == "train_step"
+    assert out["add"]["nvtx_depth"] == 0
+    assert out["add"]["nvtx_path"] == "train_step"
+    assert out["add"]["k_dur_ns"] == 10
+
+
+def test_sweep_drops_kernels_with_no_enclosing_range():
+    nvtx = [(1, 0, 10, "phase")]
+    kr = [(1, 50, 60, 100, 110, "orphan")]  # runtime after the range closed
+    assert _sweep_nvtx_kernel_map(kr, nvtx) == []
+
+
+def test_sweep_isolates_by_thread():
+    """A range on one thread never encloses a kernel launched on another."""
+    nvtx = [(1, 0, 100, "t1_range")]
+    kr = [(2, 10, 20, 500, 505, "other_thread_kernel")]
+    assert _sweep_nvtx_kernel_map(kr, nvtx) == []
+
+
+# ── ensure_nvtx_kernel_map materialisation ──────────────────────────────────
+
+
+def _duckdb_profile():
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect()
+    con.execute("CREATE TABLE StringIds(id BIGINT, value VARCHAR)")
+    con.execute(
+        'CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL(start BIGINT, "end" BIGINT, deviceId INT, '
+        'streamId INT, correlationId BIGINT, shortName BIGINT, demangledName BIGINT)'
+    )
+    con.execute(
+        'CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME(globalTid BIGINT, correlationId BIGINT, '
+        'start BIGINT, "end" BIGINT)'
+    )
+    con.execute(
+        'CREATE TABLE NVTX_EVENTS(globalTid BIGINT, start BIGINT, "end" BIGINT, text VARCHAR, '
+        "eventType INT, textId BIGINT)"
+    )
+    # gemm (short id 1 / demangled id 2), add (3/4)
+    con.execute(
+        "INSERT INTO StringIds VALUES (1,'gemm'),(2,'void gemm<float>'),(3,'add'),(4,'void add<float>')"
+    )
+    # kernels + their runtime launches on tid 1
+    con.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES "
+        "(1000,1005,0,7,101,1,2), (2000,2010,0,7,102,3,4)"
+    )
+    con.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (1,101,15,20), (1,102,60,65)"
+    )
+    # NVTX PushPop ranges (eventType 59) on tid 1
+    con.execute(
+        "INSERT INTO NVTX_EVENTS VALUES (1,0,100,'train_step',59,NULL), (1,10,50,'forward',59,NULL)"
+    )
+    return con
+
+
+def test_ensure_builds_map_with_demangled_names():
+    con = _duckdb_profile()
+    assert ensure_nvtx_kernel_map(con) is True
+
+    rows = con.execute(
+        "SELECT nvtx_text, nvtx_depth, kernel_name, k_dur_ns FROM nvtx_kernel_map "
+        "ORDER BY k_start"
+    ).fetchall()
+    assert rows == [
+        ("forward", 1, "void gemm<float>", 5),  # demangled name, not shortName
+        ("train_step", 0, "void add<float>", 10),
+    ]
+    # path_dict populated and joinable
+    paths = dict(
+        con.execute(
+            "SELECT d.nvtx_path, m.nvtx_text FROM nvtx_kernel_map m "
+            "JOIN nvtx_path_dict d ON m.path_id = d.path_id"
+        ).fetchall()
+    )
+    assert paths == {"train_step > forward": "forward", "train_step": "train_step"}
+
+
+def test_ensure_is_noop_when_map_present():
+    con = _duckdb_profile()
+    assert ensure_nvtx_kernel_map(con) is True
+    before = con.execute("SELECT COUNT(*) FROM nvtx_kernel_map").fetchone()[0]
+    # Second call must see the existing table and not rebuild/duplicate.
+    assert ensure_nvtx_kernel_map(con) is True
+    after = con.execute("SELECT COUNT(*) FROM nvtx_kernel_map").fetchone()[0]
+    assert before == after == 2
+
+
+def test_ensure_returns_false_for_sqlite_connection():
+    # Non-DuckDB connection: unchanged, caller keeps its own path.
+    assert ensure_nvtx_kernel_map(sqlite3.connect(":memory:")) is False

--- a/tests/test_nvtx_kernel_map_ondemand.py
+++ b/tests/test_nvtx_kernel_map_ondemand.py
@@ -96,12 +96,14 @@ def test_ensure_builds_map_with_demangled_names():
     assert ensure_nvtx_kernel_map(con) is True
 
     rows = con.execute(
-        "SELECT nvtx_text, nvtx_depth, kernel_name, k_dur_ns FROM nvtx_kernel_map "
-        "ORDER BY k_start"
+        "SELECT nvtx_text, nvtx_depth, kernel_name, k_dur_ns, is_tc_eligible, uses_tc "
+        "FROM nvtx_kernel_map ORDER BY k_start"
     ).fetchall()
     assert rows == [
-        ("forward", 1, "void gemm<float>", 5),  # demangled name, not shortName
-        ("train_step", 0, "void add<float>", 10),
+        # demangled name (not shortName); the 9-col schema carries embedded TC —
+        # "gemm" is TC-eligible, "add" is not — so consumers take the map-only path.
+        ("forward", 1, "void gemm<float>", 5, 1, 0),
+        ("train_step", 0, "void add<float>", 10, 0, 0),
     ]
     # path_dict populated and joinable
     paths = dict(
@@ -111,6 +113,39 @@ def test_ensure_builds_map_with_demangled_names():
         ).fetchall()
     )
     assert paths == {"train_step > forward": "forward", "train_step": "train_step"}
+
+
+def test_ensure_orders_nvtx_so_paths_are_correct():
+    """The nvtx fetch must ORDER BY start: the sweep advances a single index over
+    nvtx per thread without re-sorting, so out-of-order rows would build the path
+    inner>outer. Insert the ranges reversed and require the correct outer>inner."""
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect()
+    con.execute("CREATE TABLE StringIds(id BIGINT, value VARCHAR)")
+    con.execute(
+        'CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL(start BIGINT, "end" BIGINT, deviceId INT, '
+        'streamId INT, correlationId BIGINT, shortName BIGINT, demangledName BIGINT)'
+    )
+    con.execute(
+        'CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME(globalTid BIGINT, correlationId BIGINT, '
+        'start BIGINT, "end" BIGINT)'
+    )
+    con.execute(
+        'CREATE TABLE NVTX_EVENTS(globalTid BIGINT, start BIGINT, "end" BIGINT, text VARCHAR, '
+        "eventType INT, textId BIGINT)"
+    )
+    con.execute("INSERT INTO StringIds VALUES (1,'gemm'),(2,'void gemm<float>')")
+    con.execute("INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (1000,1005,0,7,101,1,2)")
+    con.execute("INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (1,101,15,20)")
+    # inner range inserted BEFORE the outer one — reverse of start order
+    con.execute(
+        "INSERT INTO NVTX_EVENTS VALUES (1,10,50,'forward',59,NULL), (1,0,100,'train_step',59,NULL)"
+    )
+    ensure_nvtx_kernel_map(con)
+    path = con.execute(
+        "SELECT d.nvtx_path FROM nvtx_kernel_map m JOIN nvtx_path_dict d ON m.path_id = d.path_id"
+    ).fetchone()[0]
+    assert path == "train_step > forward"
 
 
 def test_ensure_is_noop_when_map_present():


### PR DESCRIPTION
Closes #257. The systemic (approach-2) fix agreed for the sqlite_scanner robustness class.

## Root cause

Four skills attribute kernels to NVTX regions through a precomputed `nvtx_kernel_map`: `nvtx_kernel_map`, `nvtx_layer_breakdown`, `nccl_compile_context_breakdown`, and `profile_health_manifest` (transitively via `root_cause_matcher`). That map is built **only** during the parquet-cache build; on the direct-attach no-cache fallback it is absent, and each skill drops to its own in-file IEJoin over DuckDB's `sqlite_scanner`, which does not complete — on `attn_only` (1.25M NVTX) all three skills hung past 110s while running in ~1.6s on the cache. This is the shared substrate behind the #248 and #258 symptoms.

## Fix — at the root, not per skill

`ensure_nvtx_kernel_map(conn)` materialises the map as DuckDB temp tables when absent, via flat fetches (fast on every backend — kr 0.3s, nvtx 0.8s) plus the existing per-thread sort-merge, extracted into `_sweep_nvtx_kernel_map` and shared with the cache-build Python fallback. It emits the **full 9-column cache schema** — resolving `kernel_name` and the `is_tc_eligible`/`uses_tc` flags with the exact `_tc_enriched_sql` expressions — so it is a byte-for-byte drop-in.

Wired at two points covering all four consumers (top of `nvtx_layer_breakdown._execute`, and the DuckDB block of `attribute_kernels_to_nvtx`). A future map consumer inherits the fallback for free; the fragile per-skill IEJoin fast-paths become dead code.

## Verification

- **Map parity**: byte-for-byte on all 9 columns across `attn_only` (134446 rows), `nano_vllm` (576238), `megatron` (63796) — on-demand == cache.
- **Skill parity**: `nvtx_kernel_map`, `nvtx_layer_breakdown`, `nccl_compile_context_breakdown` produce identical output on the direct-attach and cache paths, in ~2s instead of hanging.
- **Cache path unchanged**: `ensure` is a single `SELECT 1 … LIMIT 1` no-op when the map exists; the extracted sweep is behaviour-preserving for the cache-build fallback (still shortName).
- Independent review confirmed the map/skill parity and cache-build preservation; two items it flagged are fixed here (the 9-column TC drop-in eliminating a count divergence, and a test gap on the load-bearing nvtx ORDER BY).

New `tests/test_nvtx_kernel_map_ondemand.py`: the sweep's containment/depth/path/thread-isolation, the 9-column materialisation with demangled names + TC flags, the ORDER BY dependency, no-op-when-present, and non-DuckDB returns False. 1293 passed, 135 skipped; ruff clean.