### PR TITLE
agent: emit diagnostics.json from ask/analyze (#207)

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,14 @@ nsys-ai ask profile.sqlite "is NCCL overlapping with compute?"
 nsys-ai chat profile.sqlite                        # interactive chat TUI
 ```
 
+Add `--diagnostics [PATH]` to `ask`, `agent ask`, or `agent analyze` to also write the
+diagnosis as structured `diagnostics.json` (default path `diagnostics.json`) — the same
+summary, primary diagnosis, evidence, confidence, recommended action, and verification
+command as the printed answer, in the v0.1 `Diagnostic` schema. The file is
+machine-consumable: load it with `nsys_ai.annotation.load_diagnostic`, diff it, or store
+it like any other artifact. See
+[`evidence_schema.md`](docs/agent_skills/commands/evidence_schema.md#diagnostic).
+
 The AI features need a provider API key. Set one of:
 
 ```bash

--- a/docs/agent_skills/INDEX.md
+++ b/docs/agent_skills/INDEX.md
@@ -17,7 +17,7 @@ This file serves as your routing guide:
 ### Ask — One-shot question
 
 ```bash
-nsys-ai ask <profile.sqlite> "<question>"
+nsys-ai ask <profile.sqlite> "<question>" [--diagnostics [path]]
 ```
 
 | Example question | What it does |
@@ -26,7 +26,10 @@ nsys-ai ask <profile.sqlite> "<question>"
 | `"what's the MFU of flash_fwd_kernel?"` | Compute region MFU for a specific kernel |
 | `"how many kernels in this profile?"` | SQL query via the profile database |
 
-**Output**: Markdown text on stdout. Parse the answer directly.
+**Output**: Markdown text on stdout. Parse the answer directly. Add `--diagnostics`
+(optionally with a path; default `diagnostics.json`) to also write the diagnosis as
+structured JSON — same summary, diagnosis, evidence, confidence, action, and verify
+command as the printed answer. See [`commands/evidence_schema.md`](commands/evidence_schema.md#diagnostic).
 
 ### Diff — Compare two profiles
 
@@ -90,8 +93,8 @@ nsys-ai report profile.sqlite --gpu 0 --trim 1.0 5.0 -o report.md
 | `nsys-ai timeline-html <profile> [--gpu N] [--trim S E] [-o out.html]`| Generate horizontal timeline HTML | Static trace visualization |
 | `nsys-ai search <profile> -q <query> [--gpu N] [--trim S E] [--parent P] [--type T] [--limit L]` | Search kernels/NVTX by name | Fast exact name discovery |
 | `nsys-ai diff-web <before> <after> [--gpu N] [--trim S E] [--port P]` | Web diff viewer | Visual side-by-side comparison |
-| `nsys-ai agent analyze <profile> [--trim S E] [--evidence] [-o out]`| Full auto-analysis report | CLI auto-analysis (no LLM needed) |
-| `nsys-ai agent ask <profile> "<question>"` | Ask a targeted question | Keyword-based skill selection |
+| `nsys-ai agent analyze <profile> [--trim S E] [--evidence] [-o out] [--diagnostics [path]]`| Full auto-analysis report | CLI auto-analysis (no LLM needed) |
+| `nsys-ai agent ask <profile> "<question>" [--diagnostics [path]]` | Ask a targeted question | Keyword-based skill selection |
 | `nsys-ai skill list [--format F]` | List all builtin analysis skills | Discover available skills |
 | `nsys-ai skill run <name> <profile> [--trim S E] [--format F] [-p K=V]` | Run a skill against a profile | Targeted analysis |
 | `nsys-ai skill add <path.md>`* | Add a custom skill | Extend the skill system |

--- a/docs/agent_skills/commands/evidence_schema.md
+++ b/docs/agent_skills/commands/evidence_schema.md
@@ -228,7 +228,33 @@ A higher-level summary an agent emits after analyzing a profile or a diff. Pairs
 
 - `verification_command` is a **runnable** `nsys-ai` command, not a description. If no runnable command can be constructed, an agent should say so explicitly rather than narrate one here.
 
-> **Transport note**: at v0.1, `Diagnostic` is a standalone schema type. It is **not** carried inside `EvidenceReport` / `findings.json` — that wrapper only knows about `findings`. A producer emitting a diagnosis should serialize it to its own JSON document (e.g. `diagnostic.json`). Top-level `diagnostic` / `diagnostics` keys added to a `findings.json` payload will be silently dropped by `EvidenceReport.from_dict()`.
+> **Transport note**: at v0.1, `Diagnostic` is a standalone schema type. It is **not** carried inside `EvidenceReport` / `findings.json` — that wrapper only knows about `findings`. A producer emitting a diagnosis should serialize it to its own JSON document (`diagnostics.json`). Top-level `diagnostic` / `diagnostics` keys added to a `findings.json` payload will be silently dropped by `EvidenceReport.from_dict()`.
+
+#### Producing `diagnostics.json` from the CLI
+
+`ask`, `agent ask`, and `agent analyze` can each emit their diagnosis as a structured `diagnostics.json` alongside the human-readable answer:
+
+```bash
+nsys-ai ask profile.sqlite "why is this slow?" --diagnostics            # writes ./diagnostics.json
+nsys-ai agent ask profile.sqlite "why is this slow?" --diagnostics out/diag.json
+nsys-ai agent analyze profile.sqlite --diagnostics
+```
+
+- `--diagnostics` without a value writes `diagnostics.json` in the current directory; omitting the flag preserves the previous behavior. It is independent of `agent analyze --evidence -o findings.json`.
+- `id` is deterministic — derived from the profile id, the mode (`ask` / `analyze`), the question, and the full-profile or trim scope — so re-running the same command reproduces the same artifact id without colliding with a different analysis window.
+- `primary_findings` are converted from the skill rows the run already executed (via each skill's v0.1 `to_findings_fn` converter); no extra profile queries are run to build the JSON.
+- Load it back with `nsys_ai.annotation.load_diagnostic(path)` (writer: `save_diagnostic(diagnostic, path)`).
+
+The printed evidence-first answer and the JSON are rendered from the same structured `Diagnostic`, so the sections always match:
+
+| Human section | JSON field |
+|---------------|------------|
+| Summary | `summary` |
+| Primary Diagnosis | `root_cause_hypotheses[0]` |
+| Evidence | `primary_findings[*].evidence` |
+| Confidence | `confidence` |
+| Recommended Action | `recommendation` |
+| Verify | `verification_command` |
 
 ---
 

--- a/src/nsys_ai/agent/__init__.py
+++ b/src/nsys_ai/agent/__init__.py
@@ -6,7 +6,7 @@ This package provides:
     loop.py     — Core analysis loop: profile → skill selection → execution → report
 """
 
-from .loop import Agent
+from .loop import Agent, AgentResult
 from .persona import AGENT_IDENTITY, SYSTEM_PROMPT
 
-__all__ = ["SYSTEM_PROMPT", "AGENT_IDENTITY", "Agent"]
+__all__ = ["SYSTEM_PROMPT", "AGENT_IDENTITY", "Agent", "AgentResult"]

--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -7,15 +7,33 @@ and produces a structured analysis report. Works without LLM by default
 extra installed, can delegate to an LLM for natural language analysis.
 """
 
+import hashlib
 import logging
 import shlex
 import sqlite3
+from dataclasses import dataclass
 
+from ..annotation import Diagnostic
 from ..exceptions import NsysAiError, ProfileNotFoundError
 from ..profile import Profile
 from ..skills.registry import get_skill, run_skill
 
 log = logging.getLogger(__name__)
+
+
+@dataclass
+class AgentResult:
+    """Structured outcome of an ``ask()`` / ``analyze()`` run.
+
+    ``text`` is the human-readable Markdown answer; ``diagnostic`` is the
+    same conclusion in the v0.1 :class:`~nsys_ai.annotation.Diagnostic`
+    schema. Both are rendered from one structured result — never by parsing
+    the Markdown back — so the terminal output and ``diagnostics.json``
+    cannot drift apart.
+    """
+
+    text: str
+    diagnostic: Diagnostic
 
 
 class Agent:
@@ -117,6 +135,9 @@ class Agent:
         if trim_ns:
             self._trim_kwargs["trim_start_ns"] = trim_ns[0]
             self._trim_kwargs["trim_end_ns"] = trim_ns[1]
+        # Lazily resolved by _profile_id(); cached so repeated
+        # ask_result()/analyze_result() calls hash the profile only once.
+        self._cached_profile_id: str | None = None
         try:
             self.profile = Profile(profile_path)
         except ProfileNotFoundError:
@@ -144,6 +165,12 @@ class Agent:
         elif hasattr(self, "conn"):
             self.conn.close()
 
+    #: Fixed question recorded for analyze-mode diagnostics. Kept as a
+    #: constant so the deterministic diagnostic id is stable across runs.
+    _ANALYZE_QUESTION = (
+        "Provide a comprehensive GPU performance analysis based on the profile data."
+    )
+
     def analyze(self) -> str:
         """Run a full auto-analysis of the profile.
 
@@ -165,6 +192,15 @@ class Agent:
 
         Returns:
             Formatted multi-section report with optional AI synthesis.
+        """
+        return self.analyze_result().text
+
+    def analyze_result(self) -> AgentResult:
+        """Run a full auto-analysis and return text plus a structured diagnostic.
+
+        Same skill execution as :meth:`analyze`; the diagnostic is derived
+        from the evidence rows collected here — no skill is re-run and no
+        ``EvidenceBuilder`` pass is needed.
         """
         sections = []
         sections.append("═══ nsys-ai Auto-Analysis Report ═══\n")
@@ -204,17 +240,27 @@ class Agent:
                 log.debug("Skill '%s' failed: %s", skill_name, e, exc_info=True)
                 sections.append(f"({skill_name}: skipped — {e})\n")
 
-        # LLM synthesis with structured JSON evidence
-        llm_answer = self._try_llm_synthesis(
-            "Provide a comprehensive GPU performance analysis based on the profile data.",
+        # Request the same concise summary that is persisted in Diagnostic.
+        # The structured diagnosis block below is the only human rendering of
+        # that synthesis, so terminal and JSON output cannot diverge.
+        llm_summary = self._try_llm_synthesis(
+            self._ANALYZE_QUESTION,
             evidence,
+            summary_only=True,
         )
-        if llm_answer:
-            sections.append("\n── AI Analysis ──")
-            sections.append(llm_answer)
 
+        diagnostic = self._build_diagnostic(
+            mode="analyze",
+            question=self._ANALYZE_QUESTION,
+            evidence=evidence,
+            selected_skills=core_skills,
+            llm_summary=llm_summary,
+        )
+        sections.append("")
+        sections.append("── Structured Diagnosis ──")
+        sections.append(self._render_answer_text(diagnostic))
         sections.append("═══ End of Report ═══")
-        return "\n".join(sections)
+        return AgentResult(text="\n".join(sections), diagnostic=diagnostic)
 
     def ask(self, question: str) -> str:
         """Answer a natural language question about the profile.
@@ -225,6 +271,15 @@ class Agent:
            executes them, and synthesizes the Summary. If no LLM, falls back to keywords
            and a deterministic Summary. The remaining answer sections are always built
            deterministically from skill evidence.
+        """
+        return self.ask_result(question).text
+
+    def ask_result(self, question: str) -> AgentResult:
+        """Answer a question and return the text plus a structured diagnostic.
+
+        The human-readable sections and the ``diagnostics.json`` fields are
+        rendered from the same :class:`Diagnostic` (see
+        :meth:`_build_diagnostic`), so the two outputs always agree.
         """
         # Use shared chat configuration to determine if an LLM is available
         try:
@@ -282,13 +337,17 @@ class Agent:
         if has_llm:
             llm_summary = self._try_llm_synthesis(question, evidence, summary_only=True)
 
-        answer = self._format_evidence_first_answer(
-            question,
-            evidence,
+        diagnostic = self._build_diagnostic(
+            mode="ask",
+            question=question,
+            evidence=evidence,
             selected_skills=[triage_skill, *selected],
             llm_summary=llm_summary,
         )
-        return answer
+        return AgentResult(
+            text=self._render_answer_text(diagnostic),
+            diagnostic=diagnostic,
+        )
 
     def run_skill(self, skill_name: str, **kwargs) -> str:
         """Run a specific skill by name."""
@@ -352,28 +411,80 @@ class Agent:
                 selected.update(skill_names)
         return sorted(selected)
 
-    def _format_evidence_first_answer(
+    #: Fallback verification command used when no skill produced usable
+    #: rows. It is still a runnable ``nsys-ai`` command (the user lists the
+    #: available skills and picks one manually), so the JSON field never
+    #: carries prose.
+    _VERIFY_FALLBACK_COMMAND = "nsys-ai skill list"
+
+    #: Upper bound on findings embedded in ``Diagnostic.primary_findings``.
+    #: Keeps ``diagnostics.json`` focused on the primary evidence even when
+    #: a skill's converter would emit hundreds of findings.
+    _MAX_PRIMARY_FINDINGS = 10
+
+    def _build_diagnostic(
         self,
+        *,
+        mode: str,
         question: str,
         evidence: dict[str, list[dict]],
         selected_skills: list[str],
-        llm_summary: str | None = None,
-    ) -> str:
-        """Build the fixed answer shape required by issue #205."""
+        llm_summary: str | None,
+    ) -> Diagnostic:
+        """Assemble the structured Diagnostic for an ask/analyze run.
+
+        Field mapping (human section → JSON field):
+
+            Summary            → summary
+            Primary Diagnosis  → root_cause_hypotheses[0]
+            Evidence           → primary_findings[*].evidence
+            Confidence         → confidence
+            Recommended Action → recommendation
+            Verify             → verification_command
+
+        ``primary_findings`` are converted from the skill rows this run
+        already collected, via each skill's ``to_findings_fn`` converter —
+        the expensive profile queries are not re-executed.
+        """
         selected_skills = list(dict.fromkeys(skill for skill in selected_skills if skill))
         diagnosis_row = self._first_actionable_row(evidence.get("root_cause_matcher", []))
         diagnosis = self._primary_diagnosis(question, evidence, diagnosis_row)
-        evidence_lines = self._evidence_lines(evidence)
-        confidence = self._confidence_label(evidence, diagnosis_row)
+        confidence, _label = self._confidence_breakdown(evidence, diagnosis_row)
         action = self._recommended_action(diagnosis_row)
         verify_skill = self._choose_verify_skill(evidence, selected_skills)
-        verify_command = self._verify_command(verify_skill)
-
+        verify_command = self._verify_command(verify_skill) or self._VERIFY_FALLBACK_COMMAND
         summary = self._answer_summary(selected_skills, llm_summary)
+        profile_id = self._profile_id()
+        findings = self._evidence_findings(evidence, profile_id)
+        return Diagnostic(
+            id=self._diagnostic_id(profile_id, mode, question),
+            summary=summary,
+            recommendation=action,
+            verification_command=verify_command,
+            confidence=confidence,
+            primary_findings=findings,
+            root_cause_hypotheses=[diagnosis],
+        )
+
+    def _render_answer_text(self, diagnostic: Diagnostic) -> str:
+        """Render the evidence-first Markdown answer from a Diagnostic.
+
+        Every section, including per-row evidence citations and the confidence
+        label, is derived only from fields serialized by ``Diagnostic``. A
+        loaded ``diagnostics.json`` can therefore reproduce this block without
+        the original skill rows.
+        """
+        confidence = self._confidence_text(diagnostic.confidence)
+        evidence_lines = self._diagnostic_evidence_lines(diagnostic)
+        diagnosis = (
+            diagnostic.root_cause_hypotheses[0]
+            if diagnostic.root_cause_hypotheses
+            else "No diagnosis recorded."
+        )
 
         lines = [
             "## Summary",
-            summary,
+            diagnostic.summary,
             "",
             "## Primary Diagnosis",
             diagnosis,
@@ -383,10 +494,7 @@ class Agent:
         if evidence_lines:
             lines.extend(evidence_lines)
         else:
-            lines.append(
-                "- source_skill=none; metric=none; window=full profile; "
-                "scope=profile; evidence=no skill returned usable rows"
-            )
+            lines.append("- No structured EvidenceRow is embedded in primary_findings.")
         lines.extend(
             [
                 "",
@@ -394,20 +502,86 @@ class Agent:
                 confidence,
                 "",
                 "## Recommended Action",
-                action,
+                diagnostic.recommendation,
                 "",
                 "## Verify",
             ]
         )
-        if verify_command:
-            lines.append(f"`{verify_command}`")
-        else:
+        if diagnostic.verification_command == self._VERIFY_FALLBACK_COMMAND:
             lines.append(
-                "Could not build a runnable verification command because no skill "
-                "produced evidence. Inspect available skills with:"
+                "Could not build a runnable verification command from structured "
+                "findings. Inspect available skills with:"
             )
-            lines.append("`nsys-ai skill list`")
+        lines.append(f"`{diagnostic.verification_command}`")
         return "\n".join(lines)
+
+    def _diagnostic_id(self, profile_id: str, mode: str, question: str) -> str:
+        """Deterministic diagnostic id from profile, request, and analysis scope.
+
+        Two runs over the same profile with the same mode, question, and trim
+        scope produce the same id. Scope is included because a full-profile
+        run and a trimmed run can produce different findings and verification
+        commands.
+        """
+        scope = ",".join(
+            f"{key}={value}" for key, value in sorted(self._trim_kwargs.items())
+        ) or "full-profile"
+        digest = hashlib.sha256(
+            f"{profile_id}|{mode}|{question}|{scope}".encode()
+        ).hexdigest()
+        return f"diag_{digest[:16]}"
+
+    def _profile_id(self) -> str:
+        """Resolve (and cache) the content-derived profile id.
+
+        Mirrors ``EvidenceBuilder``: reads the META_DATA / TARGET_INFO
+        tables from the original SQLite connection (``profile.conn``), not
+        the parquet cache, and falls back to a path-derived id when those
+        tables are unreachable. Diagnostics must never crash the answer
+        path, so any failure degrades to the path-derived id.
+        """
+        if self._cached_profile_id is None:
+            from ..fingerprint import get_profile_id
+
+            id_conn = (
+                getattr(self.profile, "conn", None) if self.profile is not None else self.conn
+            )
+            try:
+                self._cached_profile_id = get_profile_id(id_conn, fallback_path=self.profile_path)
+            except Exception:
+                log.debug("profile id resolution failed; using path fallback", exc_info=True)
+                digest = hashlib.sha256(str(self.profile_path).encode("utf-8")).hexdigest()
+                self._cached_profile_id = f"nsys1:path:{digest}"
+        return self._cached_profile_id
+
+    def _evidence_findings(
+        self,
+        evidence: dict[str, list[dict]],
+        profile_id: str,
+    ) -> list:
+        """Convert already-collected skill rows into v0.1 Findings.
+
+        Reuses each skill's ``to_findings_fn`` converter over the rows this
+        run already executed — no profile query is re-run and no
+        ``EvidenceBuilder`` pass is needed. Skills without a converter are
+        skipped. Bounded by ``_MAX_PRIMARY_FINDINGS``; ordering follows
+        evidence insertion order, so the result is deterministic.
+        """
+        from ..evidence_builder import _invoke_to_findings
+
+        context = {"profile_id": profile_id}
+        findings: list = []
+        for skill_name, rows in evidence.items():
+            if not rows:
+                continue
+            skill = get_skill(skill_name)
+            if skill is None or skill.to_findings_fn is None:
+                continue
+            try:
+                findings.extend(_invoke_to_findings(skill.to_findings_fn, rows, context))
+            except Exception as e:
+                log.debug("to_findings_fn for '%s' failed: %s", skill_name, e, exc_info=True)
+        return findings[: self._MAX_PRIMARY_FINDINGS]
 
     def _answer_summary(
         self,
@@ -417,13 +591,13 @@ class Agent:
         """Return model synthesis when available, otherwise a deterministic summary."""
         if llm_summary:
             lines = [line.strip() for line in str(llm_summary).strip().splitlines()]
-            if lines and lines[0].lower().lstrip("#").strip() == "summary":
-                lines = lines[1:]
 
             summary_lines = []
             for line in lines:
                 if line.startswith("#"):
-                    break
+                    if summary_lines:
+                        break
+                    continue
                 if line:
                     summary_lines.append(line)
 
@@ -477,101 +651,96 @@ class Agent:
             "a narrower profile with NVTX ranges if the evidence is too broad."
         )
 
-    def _confidence_label(self, evidence: dict[str, list[dict]], diagnosis_row: dict | None) -> str:
+    def _confidence_breakdown(
+        self, evidence: dict[str, list[dict]], diagnosis_row: dict | None
+    ) -> tuple[float, str]:
+        """Return the (numeric confidence, human label) pair for this evidence state.
+
+        ``diagnostics.json`` carries the float (``Diagnostic.confidence``);
+        the Markdown answer carries the label. Both come from this one
+        function so the two can never diverge.
+        """
         row_count = sum(len(rows) for rows in evidence.values())
         if diagnosis_row and row_count:
             severity = str(diagnosis_row.get("severity", "")).strip().lower()
             confidence_by_severity = {
-                "critical": (
-                    "0.90 (high): a critical root-cause matcher finding is backed by skill output."
-                ),
-                "warning": (
-                    "0.75 (medium-high): a warning root-cause matcher finding is backed by "
-                    "skill output."
-                ),
-                "info": (
-                    "0.55 (medium): an informational root-cause matcher finding is backed by "
-                    "skill output."
-                ),
+                "critical": 0.90,
+                "warning": 0.75,
+                "info": 0.55,
             }
-            return confidence_by_severity.get(
-                severity,
-                "0.65 (medium): a root-cause matcher finding is backed by skill output, "
-                "but its severity is unknown.",
-            )
+            if severity in confidence_by_severity:
+                value = confidence_by_severity[severity]
+                return value, self._confidence_text(value)
+            return 0.65, self._confidence_text(0.65)
         if row_count:
-            return "0.60 (medium): skill output exists, but no root-cause matcher finding dominated."
-        return "0.20 (low): no skill returned usable evidence."
+            return 0.60, self._confidence_text(0.60)
+        return 0.20, self._confidence_text(0.20)
 
-    def _evidence_lines(self, evidence: dict[str, list[dict]]) -> list[str]:
+    @staticmethod
+    def _confidence_text(value: float) -> str:
+        """Format a confidence value using only data persisted in Diagnostic."""
+        if value >= 0.85:
+            band = "high"
+        elif value >= 0.70:
+            band = "medium-high"
+        elif value >= 0.50:
+            band = "medium"
+        else:
+            band = "low"
+        return f"{value:.2f} ({band})"
+
+    def _diagnostic_evidence_lines(self, diagnostic: Diagnostic) -> list[str]:
+        """Render every embedded EvidenceRow from ``primary_findings``."""
         lines: list[str] = []
-        for skill_name, rows in evidence.items():
-            for row in rows[:2]:
-                if not isinstance(row, dict):
-                    continue
-                if row.get("_summary") and len(rows) > 1:
-                    continue
-                metric = self._metric_fragment(row)
-                window = self._window_fragment(row)
-                scope = self._scope_fragment(row)
-                evidence_text = str(row.get("evidence") or row.get("note") or "").strip()
-                suffix = f"; evidence={evidence_text}" if evidence_text else ""
+        for finding in diagnostic.primary_findings:
+            for row in finding.evidence or []:
+                metric = self._evidence_values_fragment(row.values, row.units)
+                window = self._finding_window_fragment(finding)
+                scope = self._finding_scope_fragment(finding)
                 lines.append(
-                    f"- source_skill={skill_name}; metric={metric}; "
-                    f"window={window}; scope={scope}{suffix}"
+                    f"- evidence_id={row.id}; source_skill={row.source_skill}; "
+                    f"finding={self._compact_value(finding.label)}; metric={metric}; "
+                    f"window={window}; scope={scope}"
                 )
-                if len(lines) >= 5:
-                    return lines
         return lines
 
-    def _metric_fragment(self, row: dict) -> str:
-        priority = (
-            "pattern",
-            "label",
-            "name",
-            "kernel_name",
-            "severity",
-            "total_ms",
-            "duration_ms",
-            "gap_ms",
-            "gap_ns",
-            "idle_pct",
-            "total_idle_ms",
-            "overlap_pct",
-            "nccl_only_ms",
-            "compute_only_ms",
-            "count",
-        )
-        parts = []
-        for key in priority:
-            if key in row and row[key] not in (None, ""):
-                parts.append(f"{key}={self._compact_value(row[key])}")
-            if len(parts) >= 3:
-                break
+    def _evidence_values_fragment(self, values: dict, units: dict) -> str:
+        parts: list[str] = []
+        for key, value in values.items():
+            unit = units.get(key, "")
+            parts.append(f"{key}={self._compact_value(value)}{unit}")
         return ", ".join(parts) if parts else "row_present=true"
 
     def _compact_value(self, value) -> str:
         text = str(value)
         return text if len(text) <= 120 else text[:117] + "..."
 
-    def _window_fragment(self, row: dict) -> str:
-        start = row.get("start_ns", row.get("gpu_start_ns"))
-        end = row.get("end_ns", row.get("gpu_end_ns"))
+    @staticmethod
+    def _finding_window_fragment(finding) -> str:
+        selection = finding.selection
+        start = selection.start_ns if selection is not None else finding.start_ns
+        end = selection.end_ns if selection is not None else finding.end_ns
         if start is not None and end is not None:
             return f"{start}-{end}ns"
-        if row.get("start_ms") is not None and row.get("end_ms") is not None:
-            return f"{row['start_ms']}-{row['end_ms']}ms"
-        trim_start = self._trim_kwargs.get("trim_start_ns")
-        trim_end = self._trim_kwargs.get("trim_end_ns")
-        if trim_start is not None and trim_end is not None:
-            return f"{trim_start}-{trim_end}ns"
         return "full profile"
 
-    def _scope_fragment(self, row: dict) -> str:
-        parts = []
-        for key in ("gpu_id", "device_id", "device", "rank", "stream_id", "communicator_hex"):
-            if key in row and row[key] not in (None, ""):
-                parts.append(f"{key}={row[key]}")
+    @staticmethod
+    def _finding_scope_fragment(finding) -> str:
+        selection = finding.selection
+        parts: list[str] = []
+        if selection is not None:
+            for key, values in (
+                ("gpu_ids", selection.gpu_ids),
+                ("rank_ids", selection.rank_ids),
+                ("stream_ids", selection.stream_ids),
+                ("nvtx_path", selection.nvtx_path),
+            ):
+                if values:
+                    parts.append(f"{key}={','.join(str(value) for value in values)}")
+        if not parts and finding.gpu_id is not None:
+            parts.append(f"gpu_id={finding.gpu_id}")
+        if not parts and finding.stream is not None:
+            parts.append(f"stream={finding.stream}")
         return ", ".join(parts) if parts else "profile"
 
     def _choose_verify_skill(
@@ -618,8 +787,8 @@ class Agent:
         Args:
             question: The question to answer.
             evidence: Dict mapping skill names to their JSON-serializable results.
-            summary_only: Return one concise summary paragraph for ``ask()``'s
-                deterministic answer formatter.
+            summary_only: Return one concise summary paragraph for the
+                deterministic ask/analyze answer formatter.
 
         Returns None if no LLM available.
         """

--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -253,6 +253,22 @@ def save_findings(report: EvidenceReport, path: str) -> None:
         json.dump(report.to_dict(), f, indent=2)
 
 
+#: Default filename used by the CLI ``--diagnostics`` flag when no path is given.
+DEFAULT_DIAGNOSTICS_FILENAME = "diagnostics.json"
+
+
+def load_diagnostic(path: str) -> "Diagnostic":
+    """Load a ``Diagnostic`` from a JSON file written by :func:`save_diagnostic`."""
+    with open(path) as f:
+        return Diagnostic.from_dict(json.load(f))
+
+
+def save_diagnostic(diagnostic: "Diagnostic", path: str) -> None:
+    """Save a ``Diagnostic`` to a JSON file in the ``Diagnostic.to_dict()`` shape."""
+    with open(path, "w") as f:
+        json.dump(diagnostic.to_dict(), f, indent=2)
+
+
 # ──────────────────────────────────────────────────────────────────────
 # v0.1 evidence schema models
 # ──────────────────────────────────────────────────────────────────────

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1693,6 +1693,22 @@ def _cmd_skill(args, _profile):
         sys.exit(1)
 
 
+def _maybe_save_diagnostic(args, result) -> None:
+    """Write ``diagnostics.json`` when ``--diagnostics [PATH]`` was passed.
+
+    Shared by ``ask`` / ``agent ask`` / ``agent analyze``. ``args.diagnostics``
+    is ``None`` when the flag is omitted (previous behavior), or the path
+    argparse resolved (the flag's ``const`` default when no value was given).
+    """
+    out = getattr(args, "diagnostics", None)
+    if out is None:
+        return
+    from nsys_ai.annotation import save_diagnostic
+
+    save_diagnostic(result.diagnostic, out)
+    print(f"Diagnostic: {result.diagnostic.id} → {out}", file=sys.stderr)
+
+
 def _cmd_agent(args, _profile):
     from nsys_ai.agent.loop import Agent
 
@@ -1703,7 +1719,10 @@ def _cmd_agent(args, _profile):
             trim_ns = (int(trim[0] * 1e9), int(trim[1] * 1e9))
         agent = Agent(args.profile, trim_ns=trim_ns)
         try:
-            print(agent.analyze())
+            result = agent.analyze_result()
+            print(result.text)
+            # Diagnostics reuse the same run — no skill is re-executed.
+            _maybe_save_diagnostic(args, result)
             # Optionally produce evidence findings JSON
             if getattr(args, "evidence", False):
                 from nsys_ai.annotation import save_findings
@@ -1721,7 +1740,9 @@ def _cmd_agent(args, _profile):
     elif args.agent_action == "ask":
         agent = Agent(args.profile)
         try:
-            print(agent.ask(args.question))
+            result = agent.ask_result(args.question)
+            print(result.text)
+            _maybe_save_diagnostic(args, result)
         finally:
             agent.close()
     else:
@@ -1735,7 +1756,9 @@ def _cmd_ask(args, _profile):
 
     agent = Agent(args.profile)
     try:
-        print(agent.ask(args.question))
+        result = agent.ask_result(args.question)
+        print(result.text)
+        _maybe_save_diagnostic(args, result)
     finally:
         agent.close()
 

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import math
 
+from nsys_ai.annotation import DEFAULT_DIAGNOSTICS_FILENAME
 from nsys_ai.cutracer.installer import NVBIT_VERSION
 
 from .handlers import (
@@ -54,6 +55,27 @@ from .handlers import (
 # ---------------------------------------------------------------------------
 # Shared parser registration helpers — used by both main and legacy parsers
 # ---------------------------------------------------------------------------
+
+
+def _add_diagnostics_arg(p) -> None:
+    """Add the shared ``--diagnostics [PATH]`` flag (ask / agent ask / agent analyze).
+
+    ``--diagnostics`` without a value writes ``diagnostics.json`` in the
+    current directory; omitting the flag preserves the previous behavior.
+    Kept separate from analyze's ``--evidence -o findings.json``.
+    """
+    p.add_argument(
+        "--diagnostics",
+        nargs="?",
+        const=DEFAULT_DIAGNOSTICS_FILENAME,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Also write the diagnosis as structured diagnostics JSON "
+            f"(default path: {DEFAULT_DIAGNOSTICS_FILENAME}); "
+            "separate from analyze's --evidence findings JSON"
+        ),
+    )
 
 
 def _positive_pct(value: str) -> float:
@@ -364,6 +386,7 @@ def _build_parser():
     p = sub.add_parser("ask", help="Ask AI a backend analysis question")
     p.add_argument("profile", help="Path to .sqlite file")
     p.add_argument("question", help="Natural language question")
+    _add_diagnostics_arg(p)
     p.set_defaults(handler=_cmd_ask)
 
     p = sub.add_parser("agent-guide", help="Print machine-readable guide for AI agents")
@@ -922,9 +945,11 @@ def _register_legacy_commands(sub):
         default=None,
         help="Output path for findings JSON (default: findings.json)",
     )
+    _add_diagnostics_arg(sp_analyze)
     sp_ask = agent_sub.add_parser("ask", help="Ask a question about a profile")
     sp_ask.add_argument("profile", help="Path to .sqlite file")
     sp_ask.add_argument("question", help="Natural language question")
+    _add_diagnostics_arg(sp_ask)
     p.set_defaults(handler=_cmd_agent)
 
     # ── evidence ──────────────────────────────────────────────────

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -146,10 +146,10 @@ def test_agent_confidence_reflects_root_cause_severity(minimal_nsys_db_path):
         confidence = {}
         for severity in ("critical", "warning", "info"):
             row = {"pattern": "Test finding", "severity": severity}
-            confidence[severity] = agent._confidence_label(
+            confidence[severity] = agent._confidence_breakdown(
                 {"root_cause_matcher": [row]},
                 row,
-            )
+            )[1]
     finally:
         agent.close()
 
@@ -164,7 +164,14 @@ def test_agent_verify_fallback_when_no_skill_evidence(minimal_nsys_db_path):
 
     agent = Agent(minimal_nsys_db_path)
     try:
-        answer = agent._format_evidence_first_answer("what happened?", {}, [])
+        diagnostic = agent._build_diagnostic(
+            mode="ask",
+            question="what happened?",
+            evidence={},
+            selected_skills=[],
+            llm_summary=None,
+        )
+        answer = agent._render_answer_text(diagnostic)
     finally:
         agent.close()
 

--- a/tests/test_agent_diagnostics.py
+++ b/tests/test_agent_diagnostics.py
@@ -1,0 +1,322 @@
+"""Tests for agent diagnostics.json output (issue #207).
+
+Covers ``AgentResult`` / ``ask_result`` / ``analyze_result``: the structured
+Diagnostic is built from the same skill evidence the run already collected
+(no EvidenceBuilder re-run), round-trips through JSON, and stays in sync
+with the human-readable sections.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def no_llm(monkeypatch):
+    """Force the deterministic no-LLM path."""
+    monkeypatch.setattr("nsys_ai.chat_config._get_model_and_key", lambda: (None, None))
+
+
+def _assert_sections_match_text(diagnostic, text):
+    """Every human section is rendered from the corresponding Diagnostic field."""
+    assert f"## Summary\n{diagnostic.summary}" in text
+    assert diagnostic.root_cause_hypotheses, "diagnostic must carry a primary diagnosis"
+    assert f"## Primary Diagnosis\n{diagnostic.root_cause_hypotheses[0]}" in text
+    assert f"## Recommended Action\n{diagnostic.recommendation}" in text
+    assert f"`{diagnostic.verification_command}`" in text
+    # The Confidence label opens with the same numeric value the JSON carries.
+    assert f"## Confidence\n{diagnostic.confidence:.2f}" in text
+    evidence_rows = [
+        row
+        for finding in diagnostic.primary_findings
+        for row in (finding.evidence or [])
+    ]
+    assert text.count("- evidence_id=") == len(evidence_rows)
+    for row in evidence_rows:
+        assert f"- evidence_id={row.id}; source_skill={row.source_skill};" in text
+
+
+class TestAskResult:
+    def test_returns_agent_result_with_diagnostic(self, minimal_nsys_db_path, no_llm):
+        from nsys_ai.agent.loop import Agent, AgentResult
+        from nsys_ai.annotation import Diagnostic
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            result = agent.ask_result("why is this slow?")
+        finally:
+            agent.close()
+
+        assert isinstance(result, AgentResult)
+        assert isinstance(result.diagnostic, Diagnostic)
+        assert result.text.startswith("## Summary")
+        assert result.diagnostic.id.startswith("diag_")
+        assert 0.0 < result.diagnostic.confidence <= 1.0
+        assert result.diagnostic.verification_command.startswith("nsys-ai skill run")
+
+    def test_ask_text_matches_ask_result_text(self, minimal_nsys_db_path, no_llm, monkeypatch):
+        """Backwards compatibility: ask() returns exactly ask_result().text."""
+        from nsys_ai.agent.loop import Agent, AgentResult
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            real = agent.ask_result("why is this slow?")
+            sentinel = AgentResult(text="sentinel-text", diagnostic=real.diagnostic)
+            monkeypatch.setattr(Agent, "ask_result", lambda self, question: sentinel)
+            assert agent.ask("why is this slow?") == "sentinel-text"
+        finally:
+            agent.close()
+
+    def test_diagnostic_fields_match_human_sections(self, minimal_nsys_db_path, no_llm):
+        from nsys_ai.agent.loop import Agent
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            result = agent.ask_result("why is this slow?")
+        finally:
+            agent.close()
+
+        _assert_sections_match_text(result.diagnostic, result.text)
+
+    def test_json_round_trip_rerenders_same_sections(
+        self, minimal_nsys_db_path, no_llm, tmp_path
+    ):
+        """A loaded diagnostic re-renders the same human sections as the original."""
+        from nsys_ai.agent.loop import Agent
+        from nsys_ai.annotation import load_diagnostic, save_diagnostic
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            result = agent.ask_result("why is this slow?")
+        finally:
+            agent.close()
+
+        out = tmp_path / "diagnostics.json"
+        save_diagnostic(result.diagnostic, str(out))
+        loaded = load_diagnostic(str(out))
+
+        assert loaded == result.diagnostic
+        _assert_sections_match_text(loaded, result.text)
+        assert agent._render_answer_text(loaded) == result.text
+
+    def test_llm_summary_flows_into_diagnostic(self, minimal_nsys_db_path, monkeypatch):
+        """With an LLM, the synthesized Summary lands in diagnostic.summary."""
+        from nsys_ai.agent.loop import Agent
+
+        monkeypatch.setattr(
+            "nsys_ai.chat_config._get_model_and_key",
+            lambda: ("test-model", "test-key"),
+        )
+        monkeypatch.setattr(
+            Agent,
+            "_try_llm_triage",
+            lambda self, question, evidence: ["top_kernels"],
+        )
+        monkeypatch.setattr(
+            Agent,
+            "_try_llm_synthesis",
+            lambda self, question, evidence, *, summary_only=False: (
+                "The model synthesized this grounded performance summary."
+            ),
+        )
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            result = agent.ask_result("why is this slow?")
+        finally:
+            agent.close()
+
+        assert result.diagnostic.summary == (
+            "The model synthesized this grounded performance summary."
+        )
+        assert result.text.startswith(f"## Summary\n{result.diagnostic.summary}")
+
+    def test_deterministic_diagnostic_id(self, minimal_nsys_db_path, no_llm):
+        """Same profile + mode + question → same id; any change → new id."""
+        from nsys_ai.agent.loop import Agent
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            first = agent.ask_result("why is this slow?")
+            second = agent.ask_result("why is this slow?")
+            other_question = agent.ask_result("is NCCL overlapping with compute?")
+            analyze = agent.analyze_result()
+        finally:
+            agent.close()
+
+        assert first.diagnostic.id == second.diagnostic.id
+        assert first.diagnostic.id != other_question.diagnostic.id
+        assert first.diagnostic.id != analyze.diagnostic.id
+
+    def test_diagnostic_id_includes_trim_scope(self, minimal_nsys_db_path, no_llm):
+        """Full-profile and trimmed runs must not collide."""
+        from nsys_ai.agent.loop import Agent
+
+        full_agent = Agent(minimal_nsys_db_path)
+        trimmed_agent = Agent(minimal_nsys_db_path, trim_ns=(0, 1_000_000))
+        other_trim_agent = Agent(minimal_nsys_db_path, trim_ns=(0, 2_000_000))
+        try:
+            full = full_agent.ask_result("why is this slow?")
+            trimmed = trimmed_agent.ask_result("why is this slow?")
+            same_trim = trimmed_agent.ask_result("why is this slow?")
+            other_trim = other_trim_agent.ask_result("why is this slow?")
+        finally:
+            full_agent.close()
+            trimmed_agent.close()
+            other_trim_agent.close()
+
+        assert full.diagnostic.id != trimmed.diagnostic.id
+        assert trimmed.diagnostic.id == same_trim.diagnostic.id
+        assert trimmed.diagnostic.id != other_trim.diagnostic.id
+
+    def test_primary_findings_reuse_skill_converters(self, minimal_nsys_db_path, no_llm):
+        """Findings come from to_findings_fn over the rows this run already collected."""
+        from nsys_ai.agent.loop import Agent
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            result = agent.ask_result("why is this slow?")
+        finally:
+            agent.close()
+
+        findings = result.diagnostic.primary_findings
+        assert findings, "expected gpu_idle_gaps converter findings on the fixture"
+        assert len(findings) <= Agent._MAX_PRIMARY_FINDINGS
+        for finding in findings:
+            assert finding.id
+            assert finding.evidence, "finding must carry structured EvidenceRow objects"
+            assert finding.selection is not None
+            assert finding.selection.profile_id.startswith("nsys1:")
+
+
+class TestAnalyzeResult:
+    def test_llm_summary_is_shared_by_analyze_text_and_diagnostic(
+        self, minimal_nsys_db_path, monkeypatch
+    ):
+        """Analyze requests one summary and renders it only through Diagnostic."""
+        from nsys_ai.agent.loop import Agent
+
+        call = {}
+
+        def fake_synthesis(self, question, evidence, *, summary_only=False):
+            call["summary_only"] = summary_only
+            return (
+                "## Analysis Overview\n"
+                "GPU idle time is the strongest measured signal.\n\n"
+                "## Extra Detail\n"
+                "This section must not leak into the persisted summary."
+            )
+
+        monkeypatch.setattr(Agent, "_try_llm_synthesis", fake_synthesis)
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            result = agent.analyze_result()
+        finally:
+            agent.close()
+
+        assert call["summary_only"] is True
+        assert result.diagnostic.summary == (
+            "GPU idle time is the strongest measured signal."
+        )
+        assert f"## Summary\n{result.diagnostic.summary}" in result.text
+        assert "── AI Analysis ──" not in result.text
+        assert "This section must not leak" not in result.text
+
+    def test_analyze_result_builds_diagnostic_without_rerunning_skills(
+        self, minimal_nsys_db_path, no_llm, monkeypatch
+    ):
+        """analyze_result derives the diagnostic from its own collected rows.
+
+        EvidenceBuilder.build is rigged to raise: if the diagnostic path
+        re-ran the evidence pipeline instead of reusing executed rows, this
+        test would fail.
+        """
+        from nsys_ai.agent.loop import Agent
+        from nsys_ai.evidence_builder import EvidenceBuilder
+
+        def _forbidden_build(self, *args, **kwargs):
+            raise AssertionError("EvidenceBuilder.build must not run inside analyze_result")
+
+        monkeypatch.setattr(EvidenceBuilder, "build", _forbidden_build)
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            result = agent.analyze_result()
+            # analyze() is a thin wrapper returning analyze_result().text.
+            from nsys_ai.agent.loop import AgentResult
+
+            sentinel = AgentResult(text="sentinel-analyze", diagnostic=result.diagnostic)
+            monkeypatch.setattr(Agent, "analyze_result", lambda self: sentinel)
+            assert agent.analyze() == "sentinel-analyze"
+        finally:
+            agent.close()
+
+        assert result.text.startswith("═══ nsys-ai Auto-Analysis Report ═══")
+        assert result.text.endswith("═══ End of Report ═══")
+
+        diagnostic = result.diagnostic
+        assert diagnostic.id.startswith("diag_")
+        assert diagnostic.confidence == pytest.approx(0.60)
+        assert diagnostic.verification_command.startswith("nsys-ai skill run")
+        assert diagnostic.summary
+        assert diagnostic.recommendation
+        assert diagnostic.root_cause_hypotheses
+        _assert_sections_match_text(diagnostic, result.text)
+
+    def test_analyze_diagnostic_json_round_trip(self, minimal_nsys_db_path, no_llm, tmp_path):
+        from nsys_ai.agent.loop import Agent
+        from nsys_ai.annotation import load_diagnostic, save_diagnostic
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            result = agent.analyze_result()
+        finally:
+            agent.close()
+
+        out = tmp_path / "diagnostics.json"
+        save_diagnostic(result.diagnostic, str(out))
+        assert load_diagnostic(str(out)) == result.diagnostic
+
+
+class TestEmptyEvidenceFallback:
+    def test_fallback_diagnostic_has_runnable_verify_command(self, minimal_nsys_db_path):
+        from nsys_ai.agent.loop import Agent
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            diagnostic = agent._build_diagnostic(
+                mode="ask",
+                question="what happened?",
+                evidence={},
+                selected_skills=[],
+                llm_summary=None,
+            )
+            text = agent._render_answer_text(diagnostic)
+        finally:
+            agent.close()
+
+        assert diagnostic.confidence == pytest.approx(0.20)
+        assert diagnostic.primary_findings == []
+        # The fallback is still a runnable nsys-ai command, not prose.
+        assert diagnostic.verification_command == "nsys-ai skill list"
+        assert "Could not build a runnable verification command" in text
+        assert text.strip().splitlines()[-1] == "`nsys-ai skill list`"
+
+    def test_fallback_diagnostic_json_round_trip(self, minimal_nsys_db_path, tmp_path):
+        from nsys_ai.agent.loop import Agent
+        from nsys_ai.annotation import load_diagnostic, save_diagnostic
+
+        agent = Agent(minimal_nsys_db_path)
+        try:
+            diagnostic = agent._build_diagnostic(
+                mode="ask",
+                question="what happened?",
+                evidence={},
+                selected_skills=[],
+                llm_summary=None,
+            )
+        finally:
+            agent.close()
+
+        out = tmp_path / "diagnostics.json"
+        save_diagnostic(diagnostic, str(out))
+        assert load_diagnostic(str(out)) == diagnostic

--- a/tests/test_annotation_models.py
+++ b/tests/test_annotation_models.py
@@ -378,6 +378,65 @@ class TestDiagnosticEdgeCases:
         assert restored.verification_command == cmd
 
 
+class TestDiagnosticIO:
+    """save_diagnostic / load_diagnostic round-trip (diagnostics.json, issue #207)."""
+
+    def _diag(self) -> Diagnostic:
+        f = Finding(
+            type="region",
+            label="GPU Idle Gap (18.25ms)",
+            start_ns=10,
+            end_ns=20,
+            severity="warning",
+            id="idle_gap_gpu0_stream7_10",
+            category="idle",
+            confidence=0.85,
+            evidence=[
+                EvidenceRow(
+                    id="ev1",
+                    source_skill="gpu_idle_gaps",
+                    values={"gap_ms": 18.25},
+                    units={"gap_ms": "ms"},
+                )
+            ],
+        )
+        return Diagnostic(
+            id="diag_test",
+            summary="S — unicode ✓",
+            recommendation="Use pinned memory",
+            verification_command="nsys-ai skill run gpu_idle_gaps p.sqlite --format json",
+            confidence=0.75,
+            primary_findings=[f],
+            root_cause_hypotheses=["Pageable Memory in Async Memcpy"],
+        )
+
+    def test_save_load_round_trip(self, tmp_path):
+        from nsys_ai.annotation import load_diagnostic, save_diagnostic
+
+        diag = self._diag()
+        out = tmp_path / "diagnostics.json"
+        save_diagnostic(diag, str(out))
+        assert load_diagnostic(str(out)) == diag
+
+    def test_saved_json_matches_to_dict_shape(self, tmp_path):
+        from nsys_ai.annotation import save_diagnostic
+
+        diag = self._diag()
+        out = tmp_path / "diagnostics.json"
+        save_diagnostic(diag, str(out))
+        raw = json.loads(out.read_text())
+        assert raw == diag.to_dict()
+        # No findings-report envelope keys leak into the diagnostics schema.
+        assert "findings" not in raw
+        assert "schema_version" not in raw
+        assert "profile_path" not in raw
+
+    def test_default_filename_constant(self):
+        from nsys_ai.annotation import DEFAULT_DIAGNOSTICS_FILENAME
+
+        assert DEFAULT_DIAGNOSTICS_FILENAME == "diagnostics.json"
+
+
 class TestEvidenceRowEdgeCases:
     def test_nested_dict_in_values(self):
         row = EvidenceRow(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -503,3 +503,114 @@ def test_diff_against_unknown_baseline_errors(tmp_path):
     )
     assert result.returncode == 2
     assert "unknown baseline" in result.stderr.lower()
+
+
+# ---------------------------------------------------------------------------
+# --diagnostics flag (issue #207): ask / agent ask / agent analyze
+# ---------------------------------------------------------------------------
+
+
+def _run_cli_no_llm(args, cwd):
+    """Run the CLI with AI provider keys scrubbed (deterministic no-LLM path)."""
+    import os
+
+    env = dict(os.environ)
+    for key in ("ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "NSYS_AI_MODEL"):
+        env.pop(key, None)
+    return subprocess.run(
+        [sys.executable, "-m", "nsys_ai", *args],
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+        env=env,
+    )
+
+
+def test_ask_diagnostics_default_path(tmp_path, minimal_nsys_db_path):
+    """`ask --diagnostics` without a value writes ./diagnostics.json."""
+    result = _run_cli_no_llm(
+        ["ask", minimal_nsys_db_path, "why is this slow?", "--diagnostics"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "## Summary" in result.stdout
+
+    from nsys_ai.annotation import load_diagnostic
+
+    out = tmp_path / "diagnostics.json"
+    assert out.exists()
+    diag = load_diagnostic(str(out))
+    assert diag.id.startswith("diag_")
+    assert diag.summary
+    assert diag.recommendation
+    assert diag.verification_command
+    assert f"Diagnostic: {diag.id} → " in result.stderr
+    assert "Diagnostic:" not in result.stdout
+    assert result.stdout.rstrip().endswith(f"`{diag.verification_command}`")
+
+
+def test_ask_diagnostics_custom_path(tmp_path, minimal_nsys_db_path):
+    """`ask --diagnostics PATH` writes to the given path, not the default."""
+    custom = tmp_path / "custom_diag.json"
+    result = _run_cli_no_llm(
+        ["ask", minimal_nsys_db_path, "why is this slow?", "--diagnostics", str(custom)],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+
+    from nsys_ai.annotation import load_diagnostic
+
+    assert custom.exists()
+    assert not (tmp_path / "diagnostics.json").exists()
+    assert load_diagnostic(str(custom)).id.startswith("diag_")
+
+
+def test_ask_without_diagnostics_writes_nothing(tmp_path, minimal_nsys_db_path):
+    """Omitting --diagnostics preserves current behavior (no JSON artifact)."""
+    result = _run_cli_no_llm(
+        ["ask", minimal_nsys_db_path, "why is this slow?"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "## Summary" in result.stdout
+    assert not (tmp_path / "diagnostics.json").exists()
+    assert "Diagnostic:" not in result.stdout
+
+
+def test_agent_ask_diagnostics(tmp_path, minimal_nsys_db_path):
+    """Legacy `agent ask` supports --diagnostics with the same default path."""
+    result = _run_cli_no_llm(
+        ["agent", "ask", minimal_nsys_db_path, "why is this slow?", "--diagnostics"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "## Summary" in result.stdout
+
+    from nsys_ai.annotation import load_diagnostic
+
+    diag = load_diagnostic(str(tmp_path / "diagnostics.json"))
+    assert diag.id.startswith("diag_")
+
+
+def test_agent_analyze_diagnostics(tmp_path, minimal_nsys_db_path):
+    """`agent analyze --diagnostics` writes a diagnostic, separate from findings JSON."""
+    result = _run_cli_no_llm(
+        ["agent", "analyze", minimal_nsys_db_path, "--diagnostics"],
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "═══ nsys-ai Auto-Analysis Report ═══" in result.stdout
+
+    from nsys_ai.annotation import load_diagnostic
+
+    diag = load_diagnostic(str(tmp_path / "diagnostics.json"))
+    assert diag.id.startswith("diag_")
+    assert diag.verification_command.startswith("nsys-ai skill run")
+    assert f"Diagnostic: {diag.id} → " in result.stderr
+    assert "Diagnostic:" not in result.stdout
+    assert f"## Summary\n{diag.summary}" in result.stdout
+    assert f"## Primary Diagnosis\n{diag.root_cause_hypotheses[0]}" in result.stdout
+    assert f"## Recommended Action\n{diag.recommendation}" in result.stdout
+    assert f"`{diag.verification_command}`" in result.stdout
+    # --diagnostics is separate from --evidence: no findings.json is written.
+    assert not (tmp_path / "findings.json").exists()


### PR DESCRIPTION
## Summary

Closes #207.

Adds opt-in structured diagnostics output for `ask`, `agent ask`, and `agent analyze`. The existing human-readable output remains the default, while callers can persist the same diagnosis as `diagnostics.json` for automation and downstream tooling.

## Changes

- Adds `--diagnostics [PATH]`. Without a path, the artifact is written to `diagnostics.json`; omitting the flag preserves existing behavior.
- Introduces `AgentResult` plus `ask_result()` and `analyze_result()` while preserving the existing `ask()` and `analyze()` string-returning APIs.
- Uses one `Diagnostic` as the source of truth for summary, diagnosis, evidence, confidence, recommendation, and verification command in both terminal and JSON output.
- Builds `primary_findings` from skill rows already collected during the run, without re-executing profile queries.
- Includes the profile, mode, question, and analysis scope in deterministic diagnostic IDs so trimmed and full-profile runs do not collide.
- Writes artifact status to stderr, keeping stdout stable and the final verification command intact.
- Keeps `--diagnostics` independent from `agent analyze --evidence` and `findings.json`.
- Adds diagnostic serialization helpers, CLI/documentation updates, and regression coverage for ask/analyze parity, LLM summaries, evidence rows, trim-scoped IDs, and default/custom output paths.

## Usage

```bash
nsys-ai ask profile.sqlite "why is this slow?" --diagnostics
nsys-ai agent ask profile.sqlite "why is this slow?" --diagnostics out/diagnostic.json
nsys-ai agent analyze profile.sqlite --diagnostics
```

## Validation

- Test suite: 1,307 passed, 146 skipped
- `ruff check src/ tests/`
- `git diff --check`
- CLI smoke tests and diagnostics round-trip checks against `tests/fixtures/mock.sqlite`