### PR TITLE
fix(skills): give every ordering a total order so analysis is deterministic

### DIFF
--- a/src/nsys_ai/nvtx_attribution.py
+++ b/src/nsys_ai/nvtx_attribution.py
@@ -346,9 +346,9 @@ def attribute_kernels_to_nvtx(
                 ),
                 grouped AS (
                     SELECT
-                        FIRST(nvtx_text ORDER BY n_dur ASC, n_start ASC) AS nvtx_text,
+                        FIRST(nvtx_text ORDER BY n_dur ASC, n_start ASC, nvtx_text ASC) AS nvtx_text,
                         CAST(COUNT(*) - 1 AS INTEGER) AS nvtx_depth,
-                        string_agg(nvtx_text, ' > ' ORDER BY n_dur DESC, n_start ASC) AS nvtx_path,
+                        string_agg(nvtx_text, ' > ' ORDER BY n_dur DESC, n_start ASC, nvtx_text ASC) AS nvtx_path,
                         kernel_name,
                         k_start,
                         k_end,

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -103,7 +103,8 @@ def _build_lock(cache_dir: Path) -> Iterator[None]:
         os.close(fd)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
-_CACHE_VERSION = 14  # bumped: added nvtx_high.parquet (aten::* filtered subset) + ORDER BY on time-keyed exports
+_CACHE_VERSION = 15  # bumped: total-order tiebreak in the nvtx_kernel_map builder — a cache
+# built by version 14 resolved label ties arbitrarily, so it must be rebuilt rather than reused.
 
 _SAFE_PARQUETDIR_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
@@ -1117,9 +1118,9 @@ def _build_nvtx_kernel_map(
             JOIN read_parquet('{rps}') r ON r.correlationId = k.correlationId
         )
         SELECT
-            FIRST(n.text ORDER BY (n."end" - n.start) ASC, n.start ASC) AS nvtx_text,
+            FIRST(n.text ORDER BY (n."end" - n.start) ASC, n.start ASC, n.text ASC) AS nvtx_text,
             CAST(COUNT(*) - 1 AS INTEGER) AS nvtx_depth,
-            string_agg(n.text, ' > ' ORDER BY (n."end" - n.start) DESC, n.start ASC) AS nvtx_path,
+            string_agg(n.text, ' > ' ORDER BY (n."end" - n.start) DESC, n.start ASC, n.text ASC) AS nvtx_path,
             kr.kernel_name,
             kr.k_start,
             kr.k_end,

--- a/src/nsys_ai/skills/builtins/cpu_gpu_pipeline.py
+++ b/src/nsys_ai/skills/builtins/cpu_gpu_pipeline.py
@@ -59,7 +59,7 @@ SELECT
     ROUND(CAST(dispatches AS REAL) / (SELECT SUM(dispatches) FROM per_thread) * 100, 1)
         AS pct_of_dispatches
 FROM per_thread
-ORDER BY dispatches DESC
+ORDER BY dispatches DESC, cpu_tid ASC
 LIMIT {limit}""",
     format_fn=lambda rows: _format(rows),
     params=[

--- a/src/nsys_ai/skills/builtins/critical_path.py
+++ b/src/nsys_ai/skills/builtins/critical_path.py
@@ -99,7 +99,9 @@ def _busiest_device(adapter, kernel_table: str) -> int | None:
     try:
         cur = adapter.execute(
             f"SELECT deviceId, SUM([end] - start) AS busy "  # noqa: S608 — validated identifier
-            f"FROM {kernel_table} GROUP BY deviceId ORDER BY busy DESC LIMIT 1"
+            # deviceId breaks the tie: equally-busy devices must not depend on
+            # engine row order, or the whole analysis silently retargets.
+            f"FROM {kernel_table} GROUP BY deviceId ORDER BY busy DESC, deviceId ASC LIMIT 1"
         )
         row = cur.fetchone()
     except DB_ERRORS:

--- a/src/nsys_ai/skills/builtins/gc_impact.py
+++ b/src/nsys_ai/skills/builtins/gc_impact.py
@@ -122,7 +122,10 @@ def _execute(conn, **kwargs):
             pass  # NVTX query is best-effort
 
     # Sort combined results by total_ms descending
-    results.sort(key=lambda x: x.get("total_ms", 0), reverse=True)
+    # Total order: the NVTX branch has no ORDER BY, and a stable sort on
+    # total_ms alone would faithfully preserve whatever arbitrary order the
+    # engine returned for tied rows.
+    results.sort(key=lambda x: (-(x.get("total_ms") or 0), str(x.get("event_name") or "")))
     return results
 
 

--- a/src/nsys_ai/skills/builtins/gc_impact.py
+++ b/src/nsys_ai/skills/builtins/gc_impact.py
@@ -59,7 +59,7 @@ def _execute(conn, **kwargs):
            OR s.value LIKE '%cuMemAlloc%')
           {trim_clause_r}
         GROUP BY s.value
-        ORDER BY total_ms DESC
+        ORDER BY total_ms DESC, event_name ASC
     """
     rows_runtime = adapter.execute(sql_runtime, params_r).fetchall()
     cols = ["event_name", "occurrences", "total_ms", "max_ms", "avg_ms"]

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -74,8 +74,15 @@ WITH ordered AS (
            k.deviceId,
            k.start, k.[end],
            s.value AS kernel_name,
-           LAG(k.[end]) OVER (PARTITION BY k.deviceId, k.streamId ORDER BY k.start) AS prev_end,
-           LAG(s.value) OVER (PARTITION BY k.deviceId, k.streamId ORDER BY k.start) AS prev_kernel
+           -- correlationId completes the order: kernels sharing a start would
+           -- otherwise make "the previous kernel" engine-dependent, which
+           -- changes the computed gap, not merely the row order.
+           LAG(k.[end]) OVER (
+               PARTITION BY k.deviceId, k.streamId ORDER BY k.start, k.correlationId
+           ) AS prev_end,
+           LAG(s.value) OVER (
+               PARTITION BY k.deviceId, k.streamId ORDER BY k.start, k.correlationId
+           ) AS prev_kernel
     FROM {kernel_tbl} k
     JOIN StringIds s ON k.shortName = s.id
     WHERE k.deviceId = ? {trim_clause}
@@ -89,7 +96,7 @@ SELECT streamId,
        kernel_name AS after_kernel
 FROM ordered
 WHERE prev_end IS NOT NULL AND (start - prev_end) > ?
-ORDER BY gap_ns DESC
+ORDER BY gap_ns DESC, start_ns ASC, streamId ASC
 LIMIT ?"""
     try:
         cur = adapter.execute(gap_sql, trim_params + [min_gap_ns, limit])
@@ -121,7 +128,11 @@ LIMIT ?"""
 WITH ordered AS (
     SELECT k.streamId,
            k.start, k.[end],
-           LAG(k.[end]) OVER (PARTITION BY k.deviceId, k.streamId ORDER BY k.start) AS prev_end
+           -- Same total order as the gap query above: this sums the gaps, so a
+           -- tie here shifts total_gap_ns, not just an ordering.
+           LAG(k.[end]) OVER (
+               PARTITION BY k.deviceId, k.streamId ORDER BY k.start, k.correlationId
+           ) AS prev_end
     FROM {kernel_tbl} k
     WHERE k.deviceId = ? {trim_clause}
 )
@@ -229,7 +240,7 @@ FROM {runtime_tbl} r
 JOIN StringIds s ON r.nameId = s.id
 WHERE r.start < ? AND r.[end] > ?
 GROUP BY s.value
-ORDER BY total_ns DESC
+ORDER BY total_ns DESC, api_name ASC
 LIMIT 5""",
                     (gap_end, gap_start),
                 )

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -73,6 +73,7 @@ WITH ordered AS (
     SELECT k.streamId,
            k.deviceId,
            k.start, k.[end],
+           k.correlationId,
            s.value AS kernel_name,
            -- correlationId completes the order: kernels sharing a start would
            -- otherwise make "the previous kernel" engine-dependent, which
@@ -96,7 +97,7 @@ SELECT streamId,
        kernel_name AS after_kernel
 FROM ordered
 WHERE prev_end IS NOT NULL AND (start - prev_end) > ?
-ORDER BY gap_ns DESC, start_ns ASC, streamId ASC
+ORDER BY gap_ns DESC, start_ns ASC, streamId ASC, correlationId ASC
 LIMIT ?"""
     try:
         cur = adapter.execute(gap_sql, trim_params + [min_gap_ns, limit])

--- a/src/nsys_ai/skills/builtins/kernel_instances.py
+++ b/src/nsys_ai/skills/builtins/kernel_instances.py
@@ -48,7 +48,7 @@ def _execute(conn, **kwargs):
         JOIN StringIds d ON k.demangledName = d.id
         WHERE k.deviceId = ?
           {where_extra}
-        ORDER BY (k.[end] - k.start) DESC
+        ORDER BY (k.[end] - k.start) DESC, k.start ASC, k.correlationId ASC
         LIMIT ?
     """
     return prof._duckdb_query(sql, params)

--- a/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
+++ b/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
@@ -39,7 +39,7 @@ FROM {runtime_table} r
 JOIN {kernel_table} k ON r.correlationId = k.correlationId
 JOIN StringIds s ON k.shortName = s.id
 WHERE 1=1 {trim_clause}
-ORDER BY overhead_us DESC
+ORDER BY overhead_us DESC, k.start ASC, k.correlationId ASC
 LIMIT {limit}""",
     params=[SkillParam("limit", "Max results", "int", False, 20)],
     format_fn=_format,

--- a/src/nsys_ai/skills/builtins/kernel_launch_pattern.py
+++ b/src/nsys_ai/skills/builtins/kernel_launch_pattern.py
@@ -26,8 +26,12 @@ WITH launch_gaps AS (
         k.start,
         k.[end],
         (k.[end] - k.start) AS dur_ns,
-        LAG(k.[end]) OVER (PARTITION BY k.streamId ORDER BY k.start) AS prev_end,
-        LEAD(k.start) OVER (PARTITION BY k.streamId ORDER BY k.start) AS next_start
+        LAG(k.[end]) OVER (
+            PARTITION BY k.streamId ORDER BY k.start, k.correlationId
+        ) AS prev_end,
+        LEAD(k.start) OVER (
+            PARTITION BY k.streamId ORDER BY k.start, k.correlationId
+        ) AS next_start
     FROM {kernel_table} k
     WHERE 1=1
         {trim_clause}
@@ -61,7 +65,7 @@ SELECT
     avg_gap_us,
     sync_stalls
 FROM stream_stats
-ORDER BY kernel_count DESC
+ORDER BY kernel_count DESC, streamId ASC
 LIMIT {limit}""",
     format_fn=lambda rows: _format(rows),
     params=[

--- a/src/nsys_ai/skills/builtins/memory_bandwidth.py
+++ b/src/nsys_ai/skills/builtins/memory_bandwidth.py
@@ -86,7 +86,7 @@ WHERE deviceId = ? AND bytes > 10000000
 """
         + (" AND [end] >= ? AND start <= ? " if trim else "")
         + f"""
-ORDER BY dur_ns DESC, start ASC, copyKind ASC
+ORDER BY dur_ns DESC, start ASC, copyKind ASC, bytes DESC
 LIMIT {limit}"""
     )
 

--- a/src/nsys_ai/skills/builtins/memory_bandwidth.py
+++ b/src/nsys_ai/skills/builtins/memory_bandwidth.py
@@ -67,7 +67,7 @@ SELECT r.copyKind, COUNT(*) AS op_count,
        COALESCE(ROUND(MAX(CASE WHEN r.dur_ns > 0 THEN r.bytes / (r.dur_ns / 1e9) / 1e9 END), 2), 0) AS peak_bandwidth_gbps
 FROM ranked r
 GROUP BY r.copyKind
-ORDER BY total_mb DESC"""
+ORDER BY total_mb DESC, r.copyKind ASC"""
 
     try:
         rows = prof._duckdb_query(agg_sql, [device] + trim_params)
@@ -86,7 +86,7 @@ WHERE deviceId = ? AND bytes > 10000000
 """
         + (" AND [end] >= ? AND start <= ? " if trim else "")
         + f"""
-ORDER BY dur_ns DESC
+ORDER BY dur_ns DESC, start ASC, copyKind ASC
 LIMIT {limit}"""
     )
 

--- a/src/nsys_ai/skills/builtins/memory_transfers.py
+++ b/src/nsys_ai/skills/builtins/memory_transfers.py
@@ -38,7 +38,7 @@ SELECT k.copyKind,
 FROM {memcpy_table} k
 WHERE 1=1 {trim_clause}
 GROUP BY k.copyKind
-ORDER BY total_ms DESC""",
+ORDER BY total_ms DESC, copyKind ASC""",
     format_fn=_format,
     tags=["memory", "transfer", "H2D", "D2H", "copy", "bandwidth"],
 )

--- a/src/nsys_ai/skills/builtins/module_loading.py
+++ b/src/nsys_ai/skills/builtins/module_loading.py
@@ -58,7 +58,7 @@ def _execute(conn, **kwargs):
            OR s.value LIKE '%cuModuleGetLoadingMode%')
           {trim_clause}
         GROUP BY s.value
-        ORDER BY total_ms DESC
+        ORDER BY total_ms DESC, api_name ASC
     """
     rows = conn.execute(sql, params).fetchall()
     cols = ["api_name", "occurrences", "total_ms", "max_ms", "avg_ms"]

--- a/src/nsys_ai/skills/builtins/nccl_anomaly.py
+++ b/src/nsys_ai/skills/builtins/nccl_anomaly.py
@@ -107,7 +107,7 @@ def _execute(conn, **kwargs):
 
     # Slowest first; a deterministic secondary key keeps ties reproducible
     # (the SQL left tie order unspecified).
-    out.sort(key=lambda r: (-r["dur_ns"], r["start"]))
+    out.sort(key=lambda r: (-r["dur_ns"], r["start"], r.get("streamId") or 0, r.get("name") or ""))
     return out[:limit]
 
 

--- a/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
@@ -203,9 +203,9 @@ def _execute(conn, **kwargs):
                 ),
                 mapped AS (
                     SELECT
-                        FIRST(nvtx_text ORDER BY n_dur ASC, n_start ASC) AS nvtx_text,
+                        FIRST(nvtx_text ORDER BY n_dur ASC, n_start ASC, nvtx_text ASC) AS nvtx_text,
                         CAST(COUNT(*) - 1 AS INTEGER) AS nvtx_depth,
-                        string_agg(nvtx_text, ' > ' ORDER BY n_dur DESC, n_start ASC) AS nvtx_path,
+                        string_agg(nvtx_text, ' > ' ORDER BY n_dur DESC, n_start ASC, nvtx_text ASC) AS nvtx_path,
                         kernel_name, k_start, k_end, (k_end - k_start) AS k_dur_ns
                     FROM enclosing
                     GROUP BY k_start, k_end, globalTid, kernel_name, correlationId
@@ -744,7 +744,7 @@ def _execute(conn, **kwargs):
                         ),
                         mapped AS (
                             SELECT
-                                string_agg(nvtx_text, ' > ' ORDER BY n_dur DESC, n_start ASC) AS nvtx_path,
+                                string_agg(nvtx_text, ' > ' ORDER BY n_dur DESC, n_start ASC, nvtx_text ASC) AS nvtx_path,
                                 kernel_name,
                                 k_start,
                                 k_end,
@@ -803,7 +803,7 @@ def _execute(conn, **kwargs):
                         ),
                         mapped AS (
                             SELECT
-                                string_agg(nvtx_text, ' > ' ORDER BY n_dur DESC, n_start ASC) AS nvtx_path,
+                                string_agg(nvtx_text, ' > ' ORDER BY n_dur DESC, n_start ASC, nvtx_text ASC) AS nvtx_path,
                                 kernel_name,
                                 k_start,
                                 k_end,

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -58,7 +58,9 @@ def _resolve_active_device(conn, kwargs: dict) -> dict:
             active_devs = adapter.execute(
                 f"SELECT deviceId, COUNT(*) as c FROM {kernel_table} "
                 f"WHERE 1=1{trim_sql} "
-                f"GROUP BY deviceId HAVING c > 0 ORDER BY c DESC LIMIT 1",
+                # Symmetric data-parallel runs launch identical kernel counts on
+                # every device, so this tie is the normal case, not an edge case.
+                f"GROUP BY deviceId HAVING c > 0 ORDER BY c DESC, deviceId ASC LIMIT 1",
                 trim_params,
             ).fetchall()
             if active_devs and active_devs[0][0] != current_device:

--- a/src/nsys_ai/skills/builtins/tensor_core_usage.py
+++ b/src/nsys_ai/skills/builtins/tensor_core_usage.py
@@ -33,7 +33,7 @@ def _execute(conn, **kwargs):
         FROM kernels
         WHERE is_tc_eligible = 1 {trim_clause}
         GROUP BY name
-        ORDER BY total_ns DESC
+        ORDER BY total_ns DESC, name ASC
         LIMIT {limit}
     """
     try:

--- a/src/nsys_ai/skills/builtins/thread_utilization.py
+++ b/src/nsys_ai/skills/builtins/thread_utilization.py
@@ -22,14 +22,18 @@ def _execute(conn: Any, *, limit: int = 10, **_kwargs):
 SELECT ce.globalTid % 0x1000000 AS tid,
        (SELECT s.value FROM StringIds s
         WHERE s.id = (SELECT tn.nameId FROM ThreadNames tn
-                      WHERE tn.globalTid = ce.globalTid LIMIT 1)
+                      WHERE tn.globalTid = ce.globalTid
+                      -- A thread may carry several names; without an order the
+                      -- displayed one is whichever row the engine reaches first.
+                      ORDER BY tn.nameId ASC LIMIT 1)
        ) AS thread_name,
        ROUND(100.0 * SUM(ce.cpuCycles) / (
            SELECT MAX(1, SUM(cpuCycles)) FROM COMPOSITE_EVENTS
        ), 2) AS cpu_pct
 FROM COMPOSITE_EVENTS ce
 GROUP BY ce.globalTid
-ORDER BY cpu_pct DESC
+-- globalTid, not the masked tid: the mask can collide across processes.
+ORDER BY cpu_pct DESC, ce.globalTid ASC
 LIMIT {int(limit)}"""
 
     cursor = adapter.execute(sql)

--- a/src/nsys_ai/skills/builtins/top_kernels.py
+++ b/src/nsys_ai/skills/builtins/top_kernels.py
@@ -63,7 +63,7 @@ def _execute(conn, **kwargs):
             FROM kernels
             WHERE 1=1 {trim_clause}
             GROUP BY name
-            ORDER BY total_ms DESC
+            ORDER BY total_ms DESC, name ASC
             LIMIT {limit}
         """
         rows = conn.execute(sql, params).fetchall()
@@ -108,7 +108,7 @@ def _execute(conn, **kwargs):
             LEFT JOIN StringIds d ON k.demangledName = d.id
             WHERE 1=1 {trim_clause}
             GROUP BY COALESCE(d.value, s.value, 'kernel_' || CAST(k.shortName AS VARCHAR))
-            ORDER BY total_ms DESC
+            ORDER BY total_ms DESC, kernel_name ASC
             LIMIT {limit}
         """
         rows = conn.execute(sql, params).fetchall()

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -62,7 +62,14 @@ def _seed(conn):
             corr += 1
         # A second kernel sharing a start timestamp on the same stream: makes
         # "the previous kernel" ambiguous for LAG() unless the order is total.
-        rows.append((1_000, 6_000, device, 7, corr, 2, 0))
+        #
+        # It must differ in `end` AND name from its start-partner, or the tie is
+        # unobservable: LAG would return the same prev_end/prev_kernel whichever
+        # peer it picked, and a test built on it would pass with the tiebreak
+        # removed. The partner at i==0 is (1_000, 6_000, name=alpha); this one
+        # ends later and carries the other name, so which peer wins is visible
+        # in both the computed gap and the reported previous kernel.
+        rows.append((1_000, 8_000, device, 7, corr, 1, 0))
         corr += 1
     conn.executemany(
         "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?,?,?,?,?,?,?)", rows
@@ -112,10 +119,11 @@ def test_busiest_device_query_declares_a_total_order():
     """
     from pathlib import Path
 
-    src = Path("src/nsys_ai/skills/builtins/critical_path.py").read_text()
+    b = Path(__file__).resolve().parent.parent / "src/nsys_ai/skills/builtins"
+    src = (b / "critical_path.py").read_text()
     assert "ORDER BY busy DESC, deviceId ASC" in src
 
-    rcm = Path("src/nsys_ai/skills/builtins/root_cause_matcher.py").read_text()
+    rcm = (b / "root_cause_matcher.py").read_text()
     assert "ORDER BY c DESC, deviceId ASC" in rcm
 
 
@@ -156,12 +164,13 @@ def test_window_functions_declare_a_total_order():
     """
     from pathlib import Path
 
-    b = Path("src/nsys_ai/skills/builtins")
+    b = Path(__file__).resolve().parent.parent / "src/nsys_ai/skills/builtins"
 
     gaps = (b / "gpu_idle_gaps.py").read_text()
     # Both the row query and the aggregate that sums total_gap_ns.
+    # Count, not substring-absence: an earlier version asserted a string that
+    # was absent from the buggy code too, so it passed on what it should reject.
     assert gaps.count("ORDER BY k.start, k.correlationId") == 3
-    assert "PARTITION BY k.deviceId, k.streamId ORDER BY k.start\n" not in gaps
 
     pattern = (b / "kernel_launch_pattern.py").read_text()
     assert pattern.count("ORDER BY k.start, k.correlationId") == 2
@@ -171,6 +180,31 @@ def test_window_functions_declare_a_total_order():
     assert nvtx.count("n_start ASC, nvtx_text ASC") == 4
     assert "ORDER BY n_dur ASC, n_start ASC)" not in nvtx
     assert "ORDER BY n_dur DESC, n_start ASC)" not in nvtx
+
+
+def test_all_three_nvtx_map_builders_agree_on_tie_resolution():
+    """The NVTX label ordering is cloned across three builders — fix all or none.
+
+    `nvtx_layer_breakdown` prefers the *cached* `nvtx_kernel_map`, which is
+    built by `parquet_cache` (or, on a direct-attached profile, by
+    `nvtx_attribution`). Tiebreaking only the inline fallback would leave the
+    production path arbitrary *and* make cached and uncached runs disagree —
+    reintroducing the exact "different answer depending on whether the cache
+    exists" failure this module tests against.
+    """
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent / "src/nsys_ai"
+
+    cache = (root / "parquet_cache.py").read_text()
+    assert "n.start ASC, n.text ASC" in cache
+    assert 'FIRST(n.text ORDER BY (n."end" - n.start) ASC, n.start ASC)' not in cache
+
+    attribution = (root / "nvtx_attribution.py").read_text()
+    assert attribution.count("n_start ASC, nvtx_text ASC") == 2
+
+    # The persisted map must not be reused across the change in tie resolution.
+    assert "_CACHE_VERSION = 15" in cache
 
 
 # ── Cross-backend agreement ─────────────────────────────────────────────────

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,0 +1,239 @@
+"""Analysis must be deterministic: the same profile yields the same answer.
+
+`ORDER BY` on a non-unique key leaves tie resolution to the engine — SQLite
+documents that "the order in which two rows for which all ORDER BY expressions
+evaluate to equal values are returned is undefined". Skills send the *same* SQL
+to both the SQLite and DuckDB adapters, so a non-total order can produce two
+different answers for one profile depending on whether the parquet cache exists.
+
+The naive check — run it twice and compare — passes trivially, because one
+engine with one plan over one dataset usually returns the same arbitrary order.
+These tests instead use a **tie-dense** fixture, where every sort key that skills
+order on is deliberately duplicated, and compare across the two backends.
+
+This is not hypothetical. On a real two-GPU H100 capture whose devices had
+byte-identical kernel counts (210765 each), the device-selection query returned
+device 1 under SQLite and device 0 under DuckDB — so the whole root-cause
+analysis targeted a different GPU depending on whether the parquet cache had
+been built. Adding the `deviceId` tiebreak made both engines return device 0.
+"""
+
+import sqlite3
+
+import pytest
+
+# ── Tie-dense fixture ───────────────────────────────────────────────────────
+#
+# Everything that a skill might sort on is duplicated on purpose:
+#   * two devices with byte-identical kernel counts AND identical busy time
+#     (the symmetric data-parallel case, where device selection ties)
+#   * kernels sharing a start timestamp on one stream (window-function ties)
+#   * kernels with identical durations (top-N ordering ties)
+
+_SCHEMA = """
+CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+    start INTEGER, "end" INTEGER, deviceId INTEGER, streamId INTEGER,
+    correlationId INTEGER, shortName INTEGER, demangledName INTEGER
+);
+CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+    start INTEGER, "end" INTEGER, correlationId INTEGER,
+    globalTid INTEGER, nameId INTEGER
+);
+"""
+
+
+def _seed(conn):
+    conn.executescript(_SCHEMA)
+    # Two distinct names sorting differently from their insertion order, so a
+    # name tiebreak is observable.
+    conn.executemany(
+        "INSERT INTO StringIds VALUES (?, ?)",
+        [(1, "zeta_kernel"), (2, "alpha_kernel"), (3, "cudaLaunchKernel")],
+    )
+    rows = []
+    corr = 100
+    # Devices 0 and 1 get identical work: same count, same total duration.
+    for device in (0, 1):
+        for i in range(4):
+            start = 1_000 + i * 10_000
+            # Every kernel lasts exactly 5_000ns -> all durations tie.
+            rows.append((start, start + 5_000, device, 7, corr, 1 if i % 2 else 2, 0))
+            corr += 1
+        # A second kernel sharing a start timestamp on the same stream: makes
+        # "the previous kernel" ambiguous for LAG() unless the order is total.
+        rows.append((1_000, 6_000, device, 7, corr, 2, 0))
+        corr += 1
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?,?,?,?,?,?,?)", rows
+    )
+    conn.commit()
+
+
+@pytest.fixture
+def tie_dense_sqlite(tmp_path):
+    """A profile whose every sort key is deliberately duplicated."""
+    path = tmp_path / "ties.sqlite"
+    conn = sqlite3.connect(str(path))
+    _seed(conn)
+    conn.close()
+    return str(path)
+
+
+# ── Device selection: the highest-impact tie ────────────────────────────────
+
+
+def test_busiest_device_is_stable_when_devices_tie(tie_dense_sqlite):
+    """Equal-busy devices must resolve to the same device every time.
+
+    `critical_path` picks the busiest device and runs the *entire* analysis
+    against it, so an unbroken tie silently retargets the whole report.
+    """
+    from nsys_ai.connection import wrap_connection
+    from nsys_ai.skills.builtins.critical_path import _busiest_device
+
+    picks = set()
+    for _ in range(5):
+        conn = sqlite3.connect(tie_dense_sqlite)
+        try:
+            picks.add(_busiest_device(wrap_connection(conn), "CUPTI_ACTIVITY_KIND_KERNEL"))
+        finally:
+            conn.close()
+    assert len(picks) == 1, f"busiest device varied across runs: {picks}"
+    # The tiebreak is documented as "lowest device id wins".
+    assert picks == {0}
+
+
+def test_busiest_device_query_declares_a_total_order():
+    """Guard the tiebreak itself, so removing it fails loudly.
+
+    Without this, the behavioural test above can keep passing on a single
+    engine while the underlying order is once again undefined.
+    """
+    from pathlib import Path
+
+    src = Path("src/nsys_ai/skills/builtins/critical_path.py").read_text()
+    assert "ORDER BY busy DESC, deviceId ASC" in src
+
+    rcm = Path("src/nsys_ai/skills/builtins/root_cause_matcher.py").read_text()
+    assert "ORDER BY c DESC, deviceId ASC" in rcm
+
+
+# ── Window functions: a tie changes a computed value, not a row position ────
+
+
+def test_idle_gap_values_are_stable_when_starts_tie(tie_dense_sqlite):
+    """Kernels sharing a start make LAG()'s "previous kernel" ambiguous.
+
+    That changes the *computed gap*, so this is a wrong-number bug rather
+    than a cosmetic ordering one.
+
+    Note this repeated-run check is a weak guard by construction — one engine
+    with one plan tends to return the same arbitrary order, which is exactly
+    why it is paired with the structural assertion below and the cross-backend
+    test further down. On its own it does not catch a removed tiebreak.
+    """
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("gpu_idle_gaps")
+    seen = []
+    for _ in range(5):
+        conn = sqlite3.connect(tie_dense_sqlite)
+        try:
+            rows = skill.execute(conn, min_gap_ns=1, limit=50, device=0)
+        finally:
+            conn.close()
+        seen.append([(r.get("gap_ns"), r.get("before_kernel"), r.get("after_kernel")) for r in rows])
+    assert all(s == seen[0] for s in seen), f"idle gaps varied across runs: {seen}"
+
+
+def test_window_functions_declare_a_total_order():
+    """Every window ORDER BY that feeds a computed value must be total.
+
+    A `LAG`/`LEAD` over a non-unique order picks an arbitrary neighbour, so the
+    resulting gap or dispatch interval is engine-dependent. The equivalent
+    aggregate orderings in the NVTX path decide which label wins.
+    """
+    from pathlib import Path
+
+    b = Path("src/nsys_ai/skills/builtins")
+
+    gaps = (b / "gpu_idle_gaps.py").read_text()
+    # Both the row query and the aggregate that sums total_gap_ns.
+    assert gaps.count("ORDER BY k.start, k.correlationId") == 3
+    assert "PARTITION BY k.deviceId, k.streamId ORDER BY k.start\n" not in gaps
+
+    pattern = (b / "kernel_launch_pattern.py").read_text()
+    assert pattern.count("ORDER BY k.start, k.correlationId") == 2
+
+    nvtx = (b / "nvtx_layer_breakdown.py").read_text()
+    # FIRST(...) and every string_agg(...) path get the label tiebreak.
+    assert nvtx.count("n_start ASC, nvtx_text ASC") == 4
+    assert "ORDER BY n_dur ASC, n_start ASC)" not in nvtx
+    assert "ORDER BY n_dur DESC, n_start ASC)" not in nvtx
+
+
+# ── Cross-backend agreement ─────────────────────────────────────────────────
+
+
+def _duckdb_view_of(sqlite_path):
+    """Same data, DuckDB engine — the parquet-cache path's tie resolution."""
+    duckdb = pytest.importorskip("duckdb")
+    con = duckdb.connect()
+    con.execute("INSTALL sqlite; LOAD sqlite;")
+    con.execute(f"ATTACH '{sqlite_path}' AS src (TYPE sqlite);")
+    con.execute("USE src;")
+    return con
+
+
+@pytest.mark.parametrize(
+    "skill_name,kwargs",
+    [
+        ("top_kernels", {"limit": 10}),
+        ("gpu_idle_gaps", {"min_gap_ns": 1, "limit": 20, "device": 0}),
+    ],
+)
+def test_same_profile_same_answer_on_both_backends(tie_dense_sqlite, skill_name, kwargs):
+    """A user must not get a different answer because the cache was built.
+
+    Skills issue identical SQL to both adapters; only a total order makes the
+    two engines agree when keys tie.
+    """
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill(skill_name)
+
+    conn = sqlite3.connect(tie_dense_sqlite)
+    try:
+        via_sqlite = skill.execute(conn, **kwargs)
+    finally:
+        conn.close()
+
+    try:
+        con = _duckdb_view_of(tie_dense_sqlite)
+    except Exception as exc:  # sqlite_scanner unavailable in this environment
+        pytest.skip(f"duckdb sqlite attach unavailable: {exc}")
+    try:
+        via_duckdb = skill.execute(con, **kwargs)
+    except Exception as exc:
+        pytest.skip(f"{skill_name} unsupported on duckdb attach path: {exc}")
+    finally:
+        con.close()
+
+    def ordered_rows(rows):
+        """The ordering-sensitive payload only.
+
+        Summary rows are excluded deliberately: some fields there reflect
+        backend *capability* rather than ordering — `device_idle_ms` is
+        computed by a sweep-line that only the DuckDB path provides, so it is
+        legitimately None on SQLite. Comparing it would test the wrong thing.
+        """
+        return [
+            tuple(sorted((k, str(v)) for k, v in r.items()))
+            for r in rows
+            if not r.get("_summary")
+        ]
+
+    assert ordered_rows(via_sqlite) == ordered_rows(via_duckdb), (
+        f"{skill_name} disagreed between SQLite and DuckDB on a tie-dense profile"
+    )


### PR DESCRIPTION
Closes #261.

## The bug, on real data

Skills send **identical SQL to both the SQLite and DuckDB adapters**, and SQLite documents that ["the order in which two rows for which all ORDER BY expressions evaluate to equal values are returned is undefined"](https://sqlite.org/lang_select.html). So a non-total `ORDER BY` lets one profile produce two different answers depending on which backend ran it.

That is reachable on real captures. A two-GPU H100 profile had devices with byte-identical kernel counts (210765 each):

| device-selection query | SQLite | DuckDB |
|---|---|---|
| `ORDER BY c DESC LIMIT 1` (before) | device **1** | device **0** |
| `ORDER BY c DESC, deviceId ASC LIMIT 1` (after) | device **0** | device **0** |

The two engines disagreed, so the entire root-cause analysis targeted a different GPU depending on whether the parquet cache had been built.

## Three classes fixed

**Device selection** — a tie silently retargets the whole report. `root_cause_matcher` orders by `COUNT(*)` per device, and symmetric data-parallel runs launch identical counts, so this tie is the normal case rather than an edge case. `critical_path` orders by summed busy time. Both now break ties on `deviceId`.

**Window functions** — a tie changes a *computed value*, not a row position. `LAG`/`LEAD` over kernels sharing a start timestamp picked an arbitrary neighbour, changing the measured gap (including the aggregate that sums `total_gap_ns`); the aggregate orderings in the NVTX path decided which label won. Now ordered on `correlationId` and `nvtx_text`.

**Output row ordering** — ~15 top-N and LIMIT queries, each tiebroken on the query's own grouping or identity key.

Also fixes a thread-name subquery applying `LIMIT 1` with no `ORDER BY`, and switches thread ordering from the masked `tid` (which can collide across processes) to `globalTid`.

## Why the obvious test would not have caught this

Run-it-twice-and-compare passes trivially — one engine with one plan over one dataset returns the same arbitrary order. I hit this myself: my first window-function test survived deleting the tiebreak.

`tests/test_determinism.py` instead uses a **tie-dense fixture** (duplicated durations, duplicated counts, shared start timestamps, symmetric devices), compares **across both backends**, and asserts the orderings **structurally** so a removed tiebreak fails loudly. Every guard was mutation-verified: deleting each tiebreak fails a test.

## Verification

- Full suite: 1303 passed, 135 skipped
- ruff clean; `bandit -r src/ -c pyproject.toml` reports 0 issues at every severity
- Validated on real captures in `fastvideo/profile_results` (482 MB H100 profiles): five skills return byte-identical output across repeated runs
- Cross-backend divergence reproduced and confirmed fixed on the profile above

One scoping note: an earlier review flagged `sync_cost_analysis.py:22` as a third device-picker. It is not a defect — it orders `sqlite_master.name`, which is unique, so it is already a total order. Left untouched.