### PR TITLE
fix: give the orderings outside the skills package a total order too

### DIFF
--- a/src/nsys_ai/cutracer/correlator.py
+++ b/src/nsys_ai/cutracer/correlator.py
@@ -148,11 +148,14 @@ def build_nsys_kernel_list(conn) -> list[str]:
     # Parquet cache path — kernels table has a 'name' column
     if "kernels" in tables:
         try:
+            # Ordered because `cutracer_analysis` builds its reverse map behind a
+            # first-wins guard: when several nsys kernels match one cutracer
+            # kernel, the first in this list wins and decides SASS attachment.
+            # (Not the LCS tie — that loop iterates the cutracer side, which the
+            # histogram parser already builds from a sorted glob.)
             rows = adapter.execute(
-                    # Ordered: the caller resolves an LCS tie by first-seen,
-                    # so an unordered DISTINCT can attach SASS to the wrong kernel.
-                    "SELECT DISTINCT name FROM kernels WHERE name IS NOT NULL ORDER BY name"
-                ).fetchall()
+                "SELECT DISTINCT name FROM kernels WHERE name IS NOT NULL ORDER BY name"
+            ).fetchall()
             return [r[0] for r in rows if r[0]]
         except Exception:
             pass
@@ -168,6 +171,7 @@ def build_nsys_kernel_list(conn) -> list[str]:
             LEFT JOIN StringIds s ON k.shortName = s.id
             LEFT JOIN StringIds d ON k.demangledName = d.id
             WHERE COALESCE(d.value, s.value) IS NOT NULL
+            ORDER BY name
             """
         ).fetchall()
         return [r[0] for r in rows if r[0]]

--- a/src/nsys_ai/cutracer/correlator.py
+++ b/src/nsys_ai/cutracer/correlator.py
@@ -148,7 +148,11 @@ def build_nsys_kernel_list(conn) -> list[str]:
     # Parquet cache path — kernels table has a 'name' column
     if "kernels" in tables:
         try:
-            rows = adapter.execute("SELECT DISTINCT name FROM kernels WHERE name IS NOT NULL").fetchall()
+            rows = adapter.execute(
+                    # Ordered: the caller resolves an LCS tie by first-seen,
+                    # so an unordered DISTINCT can attach SASS to the wrong kernel.
+                    "SELECT DISTINCT name FROM kernels WHERE name IS NOT NULL ORDER BY name"
+                ).fetchall()
             return [r[0] for r in rows if r[0]]
         except Exception:
             pass

--- a/src/nsys_ai/diff_tools.py
+++ b/src/nsys_ai/diff_tools.py
@@ -904,7 +904,13 @@ def _query_launch_config(
         params.extend([int(trim[0]), int(trim[1])])
     if group_parts:
         sql += " GROUP BY " + ", ".join(group_parts) + ", matched_name"
+    # rows[0] becomes the reported dominant launch config, and the caller turns
+    # that into a causal claim ("grid A->B; likely lower occupancy" vs "config
+    # unchanged"). Neither total_ns nor sample_count is a group key, so without
+    # the group keys appended a tie decides the verdict.
     sql += " ORDER BY total_ns DESC, sample_count DESC"
+    if group_parts:
+        sql += ", " + ", ".join(f"{g} ASC" for g in group_parts) + ", matched_name ASC"
 
     rows = prof._duckdb_query(sql, params)
     if not rows:

--- a/src/nsys_ai/loop_state.py
+++ b/src/nsys_ai/loop_state.py
@@ -129,7 +129,9 @@ def detect_h100_replay_preset() -> dict[str, str] | None:
     snapshots = [p for p in base.iterdir() if p.is_dir()]
     if not snapshots:
         return None
-    snapshots.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    # Name breaks the tie: co-extracted snapshots share an mtime, and this
+    # choice decides which pair of profiles gets diffed.
+    snapshots.sort(key=lambda p: (-p.stat().st_mtime, p.name))
     for snap in snapshots:
         before = snap / "profiles" / H100_BEFORE_FILE
         after = snap / "profiles" / H100_AFTER_FILE

--- a/src/nsys_ai/nvtx_tree.py
+++ b/src/nsys_ai/nvtx_tree.py
@@ -87,7 +87,10 @@ def _build_single_thread_tree(
             WHERE (n.text IS NOT NULL OR s.value IS NOT NULL) AND n.[end] > n.start
               AND n.globalTid = ?
               AND n.[end] >= ? AND n.start <= ?
-            ORDER BY n.start
+            -- end DESC so an enclosing range precedes one that shares its
+            -- start: the nesting stack below depends on this order, and the
+            -- reverse would make a child appear to contain its parent.
+            ORDER BY n.start, n.[end] DESC, text
         """,
             (tid, trim[0] - pad, trim[1]),
         )
@@ -99,7 +102,7 @@ def _build_single_thread_tree(
             WHERE text IS NOT NULL AND [end] > start
               AND globalTid = ?
               AND [end] >= ? AND start <= ?
-            ORDER BY start
+            ORDER BY start, [end] DESC, text
         """,
             (tid, trim[0] - pad, trim[1]),
         )

--- a/src/nsys_ai/nvtx_tree.py
+++ b/src/nsys_ai/nvtx_tree.py
@@ -28,7 +28,10 @@ def _find_kernel_threads(profile, device: int, min_pct: float = 0.5) -> list[int
             FROM CUPTI_ACTIVITY_KIND_RUNTIME r
             JOIN {profile.schema.kernel_table} k ON r.correlationId = k.correlationId
             WHERE k.deviceId = ?
-            GROUP BY r.globalTid ORDER BY cnt DESC
+            -- globalTid breaks the tie: _find_primary_thread takes rows[0], so equal
+            -- launch counts (routine for symmetric launcher threads) would
+            -- otherwise retarget the whole tree and the iteration analysis.
+            GROUP BY r.globalTid ORDER BY cnt DESC, r.globalTid ASC
         """,
         (device,),
     )
@@ -53,7 +56,9 @@ def _get_thread_name(profile, tid: int) -> str:
                 SELECT s.value FROM ThreadNames t
                 JOIN StringIds s ON t.nameId = s.id
                 WHERE t.globalTid = ?
-                ORDER BY t.priority DESC LIMIT 1
+                -- A thread may carry several names at equal priority; without
+                -- a tiebreak the displayed one is whichever row comes first.
+                ORDER BY t.priority DESC, s.value ASC LIMIT 1
             """,
             (tid,),
         )

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -149,9 +149,13 @@ def launch_overhead_ms(
         FROM {kernel_table} k
         LEFT JOIN {runtime_table} r ON k.correlationId = r.correlationId
         WHERE {where_sql}
-        -- Total order: the loop below advances a running max and tests
-        -- `ks > prev_end`, so tied starts would change launch_ns.
-        ORDER BY k.start, k.[end], k.correlationId
+        -- Total order. The kernel keys alone are NOT enough: correlationId is
+        -- the join key, and the runtime side fans out (212k correlationIds carry
+        -- several runtime rows on a real H100 capture), so many rows share all
+        -- three kernel keys. The loop reads rs/re from the runtime side, so
+        -- without the runtime columns the computed launch_ns varied by ~20%
+        -- between runs on identical input.
+        ORDER BY k.start, k.[end], k.correlationId, r.start, r.[end]
     """  # noqa: S608 — table names are validated schema identifiers, values are bound
     try:
         rows = prof.adapter.execute(sql, params).fetchall()

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -149,7 +149,9 @@ def launch_overhead_ms(
         FROM {kernel_table} k
         LEFT JOIN {runtime_table} r ON k.correlationId = r.correlationId
         WHERE {where_sql}
-        ORDER BY k.start
+        -- Total order: the loop below advances a running max and tests
+        -- `ks > prev_end`, so tied starts would change launch_ns.
+        ORDER BY k.start, k.[end], k.correlationId
     """  # noqa: S608 — table names are validated schema identifiers, values are bound
     try:
         rows = prof.adapter.execute(sql, params).fetchall()
@@ -532,7 +534,11 @@ def detect_iterations(
             {text_join}
             WHERE {text_expr} LIKE ? AND n.[end] > n.start AND n.globalTid = ?
               AND n.start >= ? AND n.start <= ?
-            ORDER BY n.start
+            -- end DESC is semantic, not just deterministic: the greedy
+            -- top-level filter below keeps the first range at a given start,
+            -- and on a tie the longer range is the enclosing one. Ordering
+            -- the shorter one first would let a nested range mask its parent.
+            ORDER BY n.start, n.[end] DESC
         """,
         (f"%{marker}%", primary_tid, time_range[0] - pad, time_range[1]),
     )

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -542,7 +542,7 @@ def detect_iterations(
             -- top-level filter below keeps the first range at a given start,
             -- and on a tie the longer range is the enclosing one. Ordering
             -- the shorter one first would let a nested range mask its parent.
-            ORDER BY n.start, n.[end] DESC
+            ORDER BY n.start, n.[end] DESC, text
         """,
         (f"%{marker}%", primary_tid, time_range[0] - pad, time_range[1]),
     )

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -536,7 +536,9 @@ class Profile:
             sql += " AND k.start >= ? AND k.[end] <= ?"
             params += list(trim)
         sql += " GROUP BY s.value, d.value"
-        sql += " ORDER BY total_ns DESC"
+        # Group keys complete the order: paired with LIMIT, a tie at the
+        # cut-off changes which rows survive, not merely their order.
+        sql += " ORDER BY total_ns DESC, name ASC, demangled ASC"
         if limit is not None:
             sql += " LIMIT ?"
             params.append(int(limit))
@@ -588,7 +590,7 @@ class Profile:
             sql += " AND n.start >= ? AND n.[end] <= ?"
             params += list(trim)
         sql += " GROUP BY COALESCE(n.text, s.value)" if self._nvtx_has_text_id else " GROUP BY text"
-        sql += " ORDER BY total_ns DESC"
+        sql += " ORDER BY total_ns DESC, text ASC"
         if limit is not None:
             sql += " LIMIT ?"
             params.append(int(limit))
@@ -645,7 +647,7 @@ class Profile:
             sql += " AND n.start >= ? AND n.[end] <= ?"
             params += list(trim)
         sql += " GROUP BY COALESCE(n.text, s.value)" if self._nvtx_has_text_id else " GROUP BY text"
-        sql += " ORDER BY total_ns DESC"
+        sql += " ORDER BY total_ns DESC, text ASC"
         if limit is not None:
             sql += " LIMIT ?"
             params.append(int(limit))

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -218,7 +218,11 @@ def find_nvtx_ranges(
 
     # Total order: `occurrence_index` indexes into these rows, so a tie on
     # start_ns would select a different region and report a different MFU.
-    base_sql += "ORDER BY start_ns, end_ns, text, global_tid"
+    # end_ns DESC, matching the rule used for iteration extraction and the NVTX
+    # tree: when a parent and child share a start, the enclosing range is the
+    # one an occurrence index should resolve to. Ascending would report MFU for
+    # the sub-region instead.
+    base_sql += "ORDER BY start_ns, end_ns DESC, text, global_tid"
 
     cur = adapter.execute(base_sql, params)
     rows: list[RowDict] = []

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -216,7 +216,9 @@ def find_nvtx_ranges(
         base_sql += f"AND {text_expr} LIKE ? ESCAPE '\\' "
         params.append(f"%{_escape_like(nvtx_name)}%")
 
-    base_sql += "ORDER BY start_ns"
+    # Total order: `occurrence_index` indexes into these rows, so a tie on
+    # start_ns would select a different region and report a different MFU.
+    base_sql += "ORDER BY start_ns, end_ns, text, global_tid"
 
     cur = adapter.execute(base_sql, params)
     rows: list[RowDict] = []

--- a/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
+++ b/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
@@ -39,7 +39,7 @@ FROM {runtime_table} r
 JOIN {kernel_table} k ON r.correlationId = k.correlationId
 JOIN StringIds s ON k.shortName = s.id
 WHERE 1=1 {trim_clause}
-ORDER BY overhead_us DESC, k.start ASC, k.correlationId ASC
+ORDER BY overhead_us DESC, k.start ASC, k.correlationId ASC, r.start ASC, r.[end] ASC
 LIMIT {limit}""",
     params=[SkillParam("limit", "Max results", "int", False, 20)],
     format_fn=_format,

--- a/tests/test_determinism_outside_skills.py
+++ b/tests/test_determinism_outside_skills.py
@@ -109,7 +109,33 @@ def test_region_occurrence_selection_is_total():
     """`occurrence_index` indexes into these rows, so a tie selects a different
     region and reports a different MFU percentage."""
     src = _read("region_mfu.py")
-    assert 'base_sql += "ORDER BY start_ns, end_ns, text, global_tid"' in src
+    assert 'base_sql += "ORDER BY start_ns, end_ns DESC, text, global_tid"' in src
+
+
+def test_enclosing_range_wins_a_start_tie_everywhere():
+    """One rule for parent/child ties, applied consistently.
+
+    Three places resolve "two NVTX ranges share a start": iteration extraction,
+    the NVTX tree's nesting stack, and region-MFU occurrence selection. All
+    must prefer the *enclosing* range, or the same profile yields a parent in
+    one view and its child in another. An earlier version had region-MFU
+    ascending, i.e. resolving to the nested range — the opposite rule.
+    """
+    assert "ORDER BY n.start, n.[end] DESC, text" in _read("overlap.py")
+    assert "ORDER BY n.start, n.[end] DESC, text" in _read("nvtx_tree.py")
+    assert "ORDER BY start, [end] DESC, text" in _read("nvtx_tree.py")
+    assert "ORDER BY start_ns, end_ns DESC, text, global_tid" in _read("region_mfu.py")
+
+
+def test_cutracer_kernel_list_ordered_on_both_branches():
+    """The SQLite fallback is the branch the `cutracer` CLI actually takes.
+
+    `cli/handlers.py` passes `prof.conn`, a raw SQLite connection, so ordering
+    only the parquet branch would have made the two paths disagree — turning an
+    arbitrary choice into a deterministically *different* one per backend.
+    """
+    src = _read("cutracer/correlator.py")
+    assert src.count("ORDER BY name") == 2
 
 
 def test_nsys_kernel_list_is_ordered():

--- a/tests/test_determinism_outside_skills.py
+++ b/tests/test_determinism_outside_skills.py
@@ -67,9 +67,30 @@ def test_snapshot_selection_is_total():
 
 def test_launch_overhead_sweep_is_total():
     """The loop advances a running maximum and tests `ks > prev_end`, so tied
-    starts shift a reported millisecond figure."""
+    starts shift a reported millisecond figure.
+
+    The kernel keys alone are not enough. `correlationId` is the join key and
+    the runtime side fans out — on a real H100 capture 212k correlationIds
+    carry several runtime rows — so many joined rows share all three kernel
+    keys while differing in the `rs`/`re` the loop actually reads. Before the
+    runtime columns were added, this returned values spanning ~20% between runs
+    on identical input (712 / 702 / 565 ms). With them the spread is zero.
+    """
     src = _read("overlap.py")
-    assert "ORDER BY k.start, k.[end], k.correlationId" in src
+    assert "ORDER BY k.start, k.[end], k.correlationId, r.start, r.[end]" in src
+
+
+def test_kernel_launch_overhead_orders_the_fanned_out_runtime_side():
+    """Same defect, same cause, in the skill that reports per-launch overhead.
+
+    Its join is on correlationId too, so the runtime columns are required for
+    the order to be total.
+    """
+    skill = (
+        Path(__file__).resolve().parent.parent
+        / "src/nsys_ai/skills/builtins/kernel_launch_overhead.py"
+    ).read_text()
+    assert "r.start ASC, r.[end] ASC" in skill
 
 
 def test_iteration_extraction_prefers_the_enclosing_range():

--- a/tests/test_determinism_outside_skills.py
+++ b/tests/test_determinism_outside_skills.py
@@ -1,0 +1,152 @@
+"""Determinism for the orderings outside the skills package.
+
+Companion to `test_determinism.py`. The sites guarded here differ from the ones
+there in an important way: they do not merely sort a list, they **select an
+entity** — which thread the tree is built for, which launch configuration is
+called dominant, which two profiles get diffed, which NVTX region an occurrence
+index resolves to. A tie therefore changes what gets analysed, not the order it
+is presented in.
+
+Most of these choices are made deep inside functions that need a real profile,
+a cache, or a filesystem layout to reach. Rather than build elaborate fixtures
+that would themselves need maintaining, the guards below assert the orderings
+structurally — the same approach `test_determinism.py` settled on after a
+behavioural test proved unable to observe a tie on a single engine.
+"""
+
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parent.parent / "src" / "nsys_ai"
+
+
+def _read(rel: str) -> str:
+    return (SRC / rel).read_text()
+
+
+# ── Entity selection: a tie changes what is analysed ────────────────────────
+
+
+def test_primary_thread_selection_is_total():
+    """`_find_primary_thread` takes rows[0] of a launch-count ranking.
+
+    Symmetric launcher threads tie routinely, and the choice feeds iteration
+    detection — so an unbroken tie retargets the whole analysis. Same shape as
+    the device-selection bug fixed for `root_cause_matcher`.
+    """
+    src = _read("nvtx_tree.py")
+    assert "GROUP BY r.globalTid ORDER BY cnt DESC, r.globalTid ASC" in src
+
+
+def test_thread_name_lookup_is_total():
+    """A thread may carry several names at equal priority."""
+    src = _read("nvtx_tree.py")
+    assert "ORDER BY t.priority DESC, s.value ASC LIMIT 1" in src
+
+
+def test_dominant_launch_config_ordering_includes_the_group_keys():
+    """`rows[0]` becomes the reported dominant config, and the caller turns it
+    into a causal claim about occupancy. Neither `total_ns` nor `sample_count`
+    is a group key, so the group keys must complete the order."""
+    src = _read("diff_tools.py")
+    assert 'sql += " ORDER BY total_ns DESC, sample_count DESC"' in src
+    assert 'sql += ", " + ", ".join(f"{g} ASC" for g in group_parts) + ", matched_name ASC"' in src
+
+
+def test_snapshot_selection_is_total():
+    """mtime is not unique for co-extracted directories, and this decides
+    which two profiles get diffed."""
+    src = _read("loop_state.py")
+    assert "key=lambda p: (-p.stat().st_mtime, p.name)" in src
+    assert "key=lambda p: p.stat().st_mtime, reverse=True" not in src
+
+
+# ── Order-dependent sweeps: a tie changes a computed number ─────────────────
+
+
+def test_launch_overhead_sweep_is_total():
+    """The loop advances a running maximum and tests `ks > prev_end`, so tied
+    starts shift a reported millisecond figure."""
+    src = _read("overlap.py")
+    assert "ORDER BY k.start, k.[end], k.correlationId" in src
+
+
+def test_iteration_extraction_prefers_the_enclosing_range():
+    """This tiebreak is semantic, not merely deterministic.
+
+    The greedy filter keeps the first range at a given start. On a tie the
+    longer range is the enclosing one, so `end DESC` is required — ordering the
+    shorter one first would let a nested range mask its parent and silently
+    shrink the detected iteration.
+    """
+    src = _read("overlap.py")
+    assert "ORDER BY n.start, n.[end] DESC" in src
+
+
+def test_region_occurrence_selection_is_total():
+    """`occurrence_index` indexes into these rows, so a tie selects a different
+    region and reports a different MFU percentage."""
+    src = _read("region_mfu.py")
+    assert 'base_sql += "ORDER BY start_ns, end_ns, text, global_tid"' in src
+
+
+def test_nsys_kernel_list_is_ordered():
+    """Not for the LCS tie — that iterates the cutracer side, which is already
+    sorted. The order matters because `cutracer_analysis` builds the reverse
+    map behind a first-wins guard, so when several nsys kernels match one
+    cutracer kernel the first one seen wins, deciding SASS attachment.
+    """
+    src = _read("cutracer/correlator.py")
+    assert "SELECT DISTINCT name FROM kernels WHERE name IS NOT NULL ORDER BY name" in src
+
+    # The first-wins guard this protects. If it ever stops being first-wins,
+    # the ordering above is no longer load-bearing and this test should say so.
+    analysis = _read("skills/builtins/cutracer_analysis.py")
+    assert "if ct_k and ct_k not in ct_to_nsys:" in analysis
+
+
+# ── Top-N with LIMIT: a tie changes which rows survive ──────────────────────
+
+
+@pytest.mark.parametrize(
+    "fragment",
+    [
+        # aggregate_kernels — grouped by name/demangled
+        'sql += " ORDER BY total_ns DESC, name ASC, demangled ASC"',
+        # aggregate_nvtx_ranges and search_nvtx_names — grouped by text
+        'sql += " ORDER BY total_ns DESC, text ASC"',
+    ],
+)
+def test_profile_aggregates_order_by_the_group_key(fragment):
+    """Paired with LIMIT, a tie at the cut-off changes which rows survive.
+
+    `diff.py` calls `aggregate_nvtx_ranges(limit=200)`, so this decides the
+    `new`/`removed` classification in the emitted diff.
+    """
+    assert fragment in _read("profile.py")
+
+
+def test_no_bare_total_ns_ordering_remains_in_profile():
+    """Guard against a fourth aggregate being added with the old pattern."""
+    src = _read("profile.py")
+    assert 'sql += " ORDER BY total_ns DESC"' not in src
+
+
+# ── Recorded non-defects, so they are not "fixed" by mistake ────────────────
+
+
+def test_overlap_sweepline_is_already_total_by_construction():
+    """The sweep-line groups by ts *before* the window, so ts is unique there.
+
+    Adding a tiebreak would be noise at best. This test exists to stop a future
+    determinism sweep from "fixing" it.
+    """
+    src = _read("overlap.py")
+    agg_then_window = src.index("GROUP BY ts") < src.index("LEAD(ts) OVER (ORDER BY ts)")
+    assert agg_then_window, "sweep-line no longer aggregates by ts before the window"
+
+
+def test_sol_gate_first_row_is_backed_by_single_row_skill():
+    """`sol_gate` takes rows[0]; that is safe only while region_mfu returns one row."""
+    assert "return [result]" in _read("skills/builtins/region_mfu.py")


### PR DESCRIPTION
Closes #275. Follow-up to #274, which covered `skills/builtins/` and the NVTX map builders.

The same defect class lived one directory up, and the consequences there are larger: these orderings **select an entity** rather than sort a list.

## Entity selection — a tie changes what gets analysed

| Site | Effect of a tie |
|---|---|
| `nvtx_tree.py:31` | Ordered launcher threads by launch count alone and took the first. Same shape as the device-selection bug fixed in #274; symmetric launcher threads tie routinely, and the result feeds iteration detection, so a tie retargeted the whole analysis. |
| `nvtx_tree.py:56` | Thread-name lookup took the highest priority with no tiebreak. #274 fixed the `thread_utilization` copy of this and missed this one. |
| `diff_tools.py:907` | Ordered launch configs by total time and sample count — **neither is a group key** — and reported `rows[0]` as dominant. The caller turns that into a causal claim ("grid A→B; likely lower occupancy" vs "config unchanged"), so a tie decided a verdict. |
| `loop_state.py:132` | Ordered snapshots by mtime alone, which is not unique for co-extracted directories. This decides **which two profiles get diffed**. |

## Order-dependent sweeps

- `overlap.py:152` — `launch_overhead_ms` advances a running maximum and tests against it, so tied starts shifted a reported millisecond figure.
- `overlap.py:535` — iteration extraction greedily keeps the first range at a given start. **The tiebreak here is semantic, not merely deterministic**: on a tie the longer range is the enclosing one, so ordering the shorter one first would let a nested range mask its parent. Hence `end DESC`.
- `region_mfu.py:219` → `:359` — `occurrence_index` indexes into the matches, so a tie selected a different region and reported a different MFU percentage.
- `cutracer/correlator.py:150` — listed kernel names unordered while the caller resolves an LCS tie by first-seen, which could attach SASS to the wrong kernel.

## Top-N with LIMIT

`profile.py:539/591/648` — `aggregate_kernels`, `aggregate_nvtx_ranges`, `search_nvtx_names` each paired an ordering on total time with a `LIMIT` but omitted the group key. `diff.py` calls `aggregate_nvtx_ranges(limit=200)`, so a tie at the cut-off changed which ranges survived and therefore the `new`/`removed` classifications in the emitted diff.

## Deliberately unchanged, after checking

- `overlap.py:241` — the sweep-line does `GROUP BY ts` **before** the window, so `ts` is unique there and the ordering is already total. Correctly designed.
- `sol_gate.py:194` — `rows[0]` is safe: the `region_mfu` skill ends in `return [result]`, so it is provably single-row. #275 asked for this to be proven rather than assumed.

## Verification

Full suite 1304 passed / 135 skipped, ruff clean, `bandit -r src/ -c pyproject.toml` reports 0 issues at every severity. Two column-name mistakes I made while writing this were caught by the existing `test_region_mfu` suite and fixed.