### PR TITLE
fix(findings): report exposed NCCL in the moderate-overlap regime

### DIFF
--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -214,6 +214,24 @@ def _overlap_confidence(overlap_pct: float, nccl_ms: float, total_ms: float) -> 
     return round(min(0.95, 0.55 + 0.25 * overlap_signal + 0.15 * nccl_share), 3)
 
 
+# Exposed NCCL below this share of the span is left unreported: on an otherwise
+# healthy profile a sliver of unhidden collective is noise, and manufacturing a
+# finding for it is the "call a 1% cost a bottleneck" failure mode.
+_MIN_EXPOSED_SHARE = 0.02
+
+# The fallback finding reports recoverable time without diagnosing a cause, so
+# it is not asserted as strongly as the threshold findings.
+_MODERATE_OVERLAP_CONFIDENCE = 0.6
+
+_EXPOSED_COMM_EXPLANATION = (
+    "Communication that runs while the GPU has no compute to do is exposed: it "
+    "adds to step time instead of hiding behind work. This finding reports how "
+    "much of that time exists without claiming a specific cause — overlap is "
+    "neither low enough nor communication dominant enough to name one. Treat it "
+    "as an upper bound on what better overlap could recover."
+)
+
+
 def _ratio_confidence(ratio: float) -> float:
     """Heuristic confidence for communication-dominated findings."""
     if ratio < 0.25:
@@ -399,6 +417,76 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                     provenance={
                         "skill": "overlap_breakdown",
                         "row_kind": "communication_dominated",
+                    },
+                )
+            )
+            headroom_claimed = True
+
+    # Coverage fallback for the moderate-overlap, balanced-compute regime.
+    #
+    # The two findings above are threshold-shaped: one fires below 30% overlap,
+    # the other below a 0.5 compute/NCCL ratio. A profile sitting between them —
+    # say 40% overlap with compute and NCCL roughly balanced — trips neither, so
+    # nothing carried the exposed-NCCL headroom even though that time is just as
+    # recoverable. This skill owns the communication bucket (nccl_breakdown and
+    # critical_path defer their comm headroom here), so a gap here means the time
+    # is reported by nobody and drops out of the ROI ranking entirely.
+    #
+    # This is deliberately not a third diagnosis: it makes no claim about *why*
+    # overlap is imperfect, only that exposed NCCL exists and is worth this many
+    # ms. Severity stays "info" for that reason.
+    if not headroom_claimed and exposed_nccl_ms is not None:
+        exposed = float(exposed_nccl_ms)
+        # Material relative to the span, so a sliver of exposed NCCL on an
+        # otherwise healthy profile does not manufacture a finding.
+        if exposed > 0 and total_ms > 0 and (exposed / total_ms) >= _MIN_EXPOSED_SHARE:
+            finding_id = f"overlap_exposed_comm_gpu{device}_{start_ns}"
+            selection = TraceSelection(
+                id=f"sel_{finding_id}",
+                profile_id=profile_id,
+                source="skill:overlap_breakdown",
+                start_ns=start_ns,
+                end_ns=end_ns,
+                gpu_ids=[device],
+                label=f"Exposed Communication ({exposed:.1f}ms)",
+            )
+            ev_values, ev_units = _common_evidence_values(r, nccl_ms=nccl_ms)
+            evidence_row = EvidenceRow(
+                id=f"ev_{finding_id}",
+                source_skill="overlap_breakdown",
+                values=ev_values,
+                units=ev_units,
+                selection_id=selection.id,
+                provenance={"row_kind": "exposed_communication", "device": device},
+            )
+            findings.append(
+                Finding(
+                    type="region",
+                    label=f"Exposed Communication ({exposed:.1f}ms)",
+                    start_ns=start_ns,
+                    end_ns=end_ns,
+                    gpu_id=device,
+                    severity="info",
+                    note=(
+                        f"{exposed:.1f}ms of NCCL runs with no compute to hide it "
+                        f"({exposed / total_ms * 100:.1f}% of the {total_ms:.1f}ms span), "
+                        f"at {overlap_pct}% overlap. Neither the low-overlap nor the "
+                        f"communication-dominated threshold fired, so this reports the "
+                        f"recoverable time without diagnosing a cause."
+                    ),
+                    id=finding_id,
+                    category="communication",
+                    confidence=_MODERATE_OVERLAP_CONFIDENCE,
+                    headroom_ms=exposed,
+                    headroom_basis="capture_total",
+                    evidence=[evidence_row],
+                    selection=selection,
+                    explanation=_EXPOSED_COMM_EXPLANATION,
+                    suggested_actions=list(_SUGGESTED_ACTIONS),
+                    false_positive_notes=list(_FALSE_POSITIVE_NOTES),
+                    provenance={
+                        "skill": "overlap_breakdown",
+                        "row_kind": "exposed_communication",
                     },
                 )
             )

--- a/tests/test_overlap_comm_headroom.py
+++ b/tests/test_overlap_comm_headroom.py
@@ -61,6 +61,46 @@ def test_moderate_overlap_balanced_profile_reports_its_exposed_nccl():
     assert f.provenance["row_kind"] == "exposed_communication"
 
 
+def test_real_capture_window_that_previously_reported_nothing():
+    """Numbers taken from a real capture, not invented.
+
+    `mfu_h1002_nsys.sqlite` device 1, a 1.34s window: 30.8% overlap with
+    compute vastly exceeding NCCL. It clears the low-overlap threshold by
+    0.8 points and is nowhere near communication-dominated, so before this
+    change 31.19ms of recoverable time was claimed by nobody.
+
+    Scanning that capture and its postfix counterpart at two window sizes
+    turned up 37 windows in this regime, so it is the normal shape of a
+    well-overlapped training step rather than a contrived corner.
+    """
+    row = _row(
+        overlap_pct=30.8,
+        compute_only_ms=1251.17,
+        nccl_only_ms=31.19,
+        overlap_ms=13.9,
+        total_ms=1341.3,
+    )
+    findings = _to_findings([row], context={"profile_id": "real"})
+    assert _comm_headroom(findings) == [31.19]
+
+
+def test_improving_overlap_does_not_silence_the_report():
+    """Crossing the 30% threshold must not make recoverable time vanish.
+
+    The same capture has windows at 24-27% overlap that fire `low_overlap`
+    and report their exposed NCCL. If improving overlap past 30% dropped the
+    report to nothing, the tool would answer an optimisation by going quiet —
+    and a before/after diff would read the improvement as headroom disappearing
+    rather than shrinking.
+    """
+    below = _row(overlap_pct=26.6, compute_only_ms=1251.17, nccl_only_ms=31.19,
+                 overlap_ms=13.9, total_ms=1341.3)
+    above = _row(overlap_pct=30.8, compute_only_ms=1251.17, nccl_only_ms=31.19,
+                 overlap_ms=13.9, total_ms=1341.3)
+    assert _comm_headroom(_to_findings([below], context={"profile_id": "p"})) == [31.19]
+    assert _comm_headroom(_to_findings([above], context={"profile_id": "p"})) == [31.19]
+
+
 # ── Single-count discipline: exactly one finding may claim the ms ──────────
 
 

--- a/tests/test_overlap_comm_headroom.py
+++ b/tests/test_overlap_comm_headroom.py
@@ -1,0 +1,150 @@
+"""Exposed NCCL must be reported as recoverable time in every overlap regime.
+
+`overlap_breakdown` owns the communication bucket — `nccl_breakdown` and
+`critical_path` both defer their comm headroom to it — so a coverage gap here
+means the time is claimed by nobody and drops out of the ROI ranking entirely.
+
+Its two diagnoses are threshold-shaped: one fires below 30% overlap, the other
+below a 0.5 compute/NCCL ratio. A profile between them (issue #252) tripped
+neither and reported no comm headroom at all, despite having exposed NCCL.
+"""
+
+import pytest
+
+from nsys_ai.skills.builtins.overlap_breakdown import _to_findings
+
+
+def _row(*, overlap_pct, compute_only_ms, nccl_only_ms, overlap_ms, total_ms):
+    return {
+        "device_id": 0,
+        "overlap_pct": overlap_pct,
+        "compute_only_ms": compute_only_ms,
+        "nccl_only_ms": nccl_only_ms,
+        "overlap_ms": overlap_ms,
+        "idle_ms": 0.0,
+        "total_ms": total_ms,
+        "span_start_ns": 0,
+        "span_end_ns": int(total_ms * 1e6),
+    }
+
+
+def _comm_headroom(findings):
+    return [f.headroom_ms for f in findings if f.headroom_ms is not None]
+
+
+# ── The regression this closes ─────────────────────────────────────────────
+
+
+def test_moderate_overlap_balanced_profile_reports_its_exposed_nccl():
+    """~40% overlap, compute and NCCL balanced — neither threshold fires.
+
+    Before #252 this returned no finding carrying headroom, so 30ms of real
+    recoverable time was invisible to the ranking.
+    """
+    row = _row(
+        overlap_pct=40,
+        compute_only_ms=100.0,
+        nccl_only_ms=30.0,
+        overlap_ms=20.0,
+        total_ms=150.0,
+    )
+    findings = _to_findings([row], context={"profile_id": "p1"})
+
+    claimed = _comm_headroom(findings)
+    assert claimed == [30.0], f"expected the exposed NCCL to be claimed once, got {claimed}"
+
+    f = next(f for f in findings if f.headroom_ms is not None)
+    assert f.category == "communication"
+    # It reports recoverable time without diagnosing a cause, so it must not
+    # masquerade as a diagnosis.
+    assert f.severity == "info"
+    assert f.provenance["row_kind"] == "exposed_communication"
+
+
+# ── Single-count discipline: exactly one finding may claim the ms ──────────
+
+
+@pytest.mark.parametrize(
+    "label,row",
+    [
+        (
+            "low overlap",
+            _row(overlap_pct=10, compute_only_ms=100.0, nccl_only_ms=50.0,
+                 overlap_ms=5.0, total_ms=160.0),
+        ),
+        (
+            "comm dominated",
+            _row(overlap_pct=40, compute_only_ms=10.0, nccl_only_ms=50.0,
+                 overlap_ms=20.0, total_ms=90.0),
+        ),
+        (
+            "both fire at once",
+            _row(overlap_pct=10, compute_only_ms=10.0, nccl_only_ms=50.0,
+                 overlap_ms=5.0, total_ms=70.0),
+        ),
+        (
+            "moderate overlap (the new path)",
+            _row(overlap_pct=40, compute_only_ms=100.0, nccl_only_ms=30.0,
+                 overlap_ms=20.0, total_ms=150.0),
+        ),
+    ],
+)
+def test_exposed_nccl_is_claimed_exactly_once(label, row):
+    """Whichever finding fires, the same millisecond is never counted twice.
+
+    Two findings can describe one inefficiency, so carrying the headroom on
+    both would corrupt the opportunity ranking.
+    """
+    findings = _to_findings([row], context={"profile_id": "p1"})
+    claimed = _comm_headroom(findings)
+    assert len(claimed) <= 1, f"{label}: {len(claimed)} findings claimed headroom"
+    if claimed:
+        assert claimed[0] == row["nccl_only_ms"], (
+            f"{label}: claimed {claimed[0]} but exposed NCCL is {row['nccl_only_ms']}"
+        )
+
+
+def test_total_comm_headroom_never_exceeds_exposed_nccl():
+    """The issue's stated done-criterion, across a sweep of regimes."""
+    for overlap_pct in (0, 10, 29, 30, 40, 60, 90):
+        for compute in (5.0, 50.0, 200.0):
+            row = _row(
+                overlap_pct=overlap_pct,
+                compute_only_ms=compute,
+                nccl_only_ms=30.0,
+                overlap_ms=20.0,
+                total_ms=compute + 50.0,
+            )
+            total = sum(_comm_headroom(_to_findings([row], context={"profile_id": "p1"})))
+            assert total <= 30.0, (
+                f"overlap={overlap_pct}% compute={compute}: claimed {total} > exposed 30.0"
+            )
+
+
+# ── Not manufacturing findings out of noise ────────────────────────────────
+
+
+def test_a_sliver_of_exposed_nccl_is_not_reported():
+    """Calling a ~1% cost a bottleneck is the failure that erases trust.
+
+    A healthy profile with a trace of unhidden collective must stay quiet.
+    """
+    row = _row(
+        overlap_pct=95,
+        compute_only_ms=1000.0,
+        nccl_only_ms=1.0,  # 0.1% of the span
+        overlap_ms=100.0,
+        total_ms=1101.0,
+    )
+    assert _comm_headroom(_to_findings([row], context={"profile_id": "p1"})) == []
+
+
+def test_no_nccl_at_all_reports_nothing():
+    row = _row(
+        overlap_pct=0,
+        compute_only_ms=100.0,
+        nccl_only_ms=0.0,
+        overlap_ms=0.0,
+        total_ms=100.0,
+    )
+    assert _comm_headroom(_to_findings([row], context={"profile_id": "p1"})) == []


### PR DESCRIPTION
Closes #252.

`overlap_breakdown` **owns the communication bucket** — `nccl_breakdown` and `critical_path` both defer their comm headroom to it — so a gap in its coverage means the time is claimed by nobody and drops out of the ROI ranking entirely.

Both of its findings are threshold-shaped: `low_overlap` fires below 30% overlap, `comm_dominated` below a 0.5 compute/NCCL ratio. A profile between them — say 40% overlap with compute and communication roughly balanced — trips neither, so nothing carried the exposed-NCCL headroom, even though that time is exactly as recoverable as it would be a few percent either side.

## What the fallback is, and what it is not

It is **not a third diagnosis**. It makes no claim about *why* overlap is imperfect, only that exposed communication exists and is worth this many milliseconds — severity `info` for that reason, and the note says as much.

Time below **2% of the span** stays unreported. Manufacturing a finding for a sliver on an otherwise healthy profile is precisely the "call a 1% cost a bottleneck" failure that costs a verify-first tool its credibility, and a guard against it is cheaper than the reputation.

## A latent bug found while doing this

The `comm_dominated` branch never set `headroom_claimed = True`. It didn't matter before, because nothing ran after it. With a fallback behind it, that omission would have double-counted the same milliseconds whenever that branch fired. Fixed, and the single-count tests cover the case where both thresholds fire at once.

## Verification

- 8 new tests; every one **mutation-verified**: removing the fallback fails the regression test, dropping the materiality guard fails the sliver test, and omitting `headroom_claimed` fails two single-count tests.
- The issue's stated done-criterion is asserted directly as a sweep — total comm headroom never exceeds exposed NCCL across 21 overlap/compute combinations.
- Suite 1328 passed / 135 skipped, ruff clean.

**Honest limitation:** the real captures I validated against (`fastvideo/profile_results`, 482 MB H100 two-GPU) all sit at **0% overlap**, so they take the existing `low_overlap` path — they confirm no regression but do not exercise the new branch. The moderate-overlap regime is covered by synthetic rows only. A labelled profile in that regime would be worth adding to the eval corpus (#262).