### PR TITLE
docs: add develop, review-change and contribute skills for this repo

### DIFF
--- a/.claude/skills/contribute/SKILL.md
+++ b/.claude/skills/contribute/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: contribute
+description: >
+  Use when getting a reviewed nsys-ai change into the upstream repo — committing,
+  pushing, opening or updating a pull request, checking CI, updating issue labels, or
+  merging. Also use when the user says "push", "open a PR", "ship it", or asks about
+  git identity, branch naming, or commit message conventions here. Do not use for
+  writing the change (use the develop skill) or for reviewing and testing it (use the
+  review-change skill) — both come first.
+---
+
+# Getting a change into nsys-ai
+
+This is a fork setup, so several defaults are wrong here:
+
+```
+origin    https://github.com/rich7420/nsys-tui.git      <- your fork; push here
+upstream  https://github.com/GindaChen/nsys-ai.git      <- the real repo; PR here
+```
+
+Do not open the PR without `--repo GindaChen/nsys-ai --head rich7420:<branch>`, and do
+not push to `upstream`.
+
+## Step 0 — Pre-flight
+
+Before writing a line of the PR, check nobody is already doing this:
+
+```bash
+gh pr list --repo GindaChen/nsys-ai --state open --search "<keywords>"
+
+# open PRs touching a path you are about to touch
+gh pr list --repo GindaChen/nsys-ai --state open --json number,title,files \
+  --jq '.[] | select(any(.files[]; .path | test("<path>"))) | "\(.number)  \(.title)"'
+```
+
+Use `any(.files[]; …)` rather than `.files[].path | test(…)` — the latter emits the PR
+once per matching file, so a PR touching six files looks like six PRs.
+
+If an open PR touches the same files, coordinate rather than opening a conflicting one.
+Prefer a small focused PR to a broad refactor of shared files.
+
+## Step 1 — Identity gate
+
+**Check before every push. Not once per repo — every push.**
+
+```bash
+git fetch upstream --quiet
+git config --get user.email    # must be 101171023+rich7420@users.noreply.github.com
+
+n=$(git rev-list --count upstream/main..HEAD)
+bad=$(git log upstream/main..HEAD --format='%an <%ae>' | sort -u \
+      | grep -vFx 'rich7420 <101171023+rich7420@users.noreply.github.com>')
+if [ -n "$bad" ]; then printf 'FAIL — %s commit(s) checked, wrong identity:\n%s\n' "$n" "$bad"
+else printf 'OK — all %s commit(s) carry the correct identity\n' "$n"; fi
+```
+
+It prints the commit count deliberately. A bare `git log … | sort -u` prints nothing on
+an empty range, which is indistinguishable from "everything passed" — the exact failure
+this repo already has a rule against elsewhere. `OK — all 0 commit(s)` tells you the
+check ran and had nothing to look at.
+
+This is not ceremonial. The global git config on this machine is
+`rc910420@gmail.com`, and it wins anywhere the repo-local config is missing — a fresh
+clone, a new worktree, a container. Eight commits already carry that address. Once
+pushed it is public and permanent.
+
+`references/IDENTITY.md` has the fix for each case, and the `.mailmap` situation.
+
+## Step 2 — Commit
+
+```bash
+git commit -m "fix(skills): abstain when the memcpy table is absent"
+```
+
+- Describe what the code now does. Nothing else.
+- **No** roadmap numbers, `#001`-style milestone handles, `§5.1`/`E#.#` refs, or phase
+  markers (`P0`, `PR-A`, `Stage C2`). Those live in the PR body if anywhere.
+- **No `Co-Authored-By` trailer.** Not for Claude, not for anyone.
+- GitHub issue numbers are only ever real GitHub issue numbers — roadmap item numbers
+  are not GitHub numbers, and using one as the other links the wrong issue.
+
+## Step 3 — Branch and push
+
+```bash
+git checkout -b feat/issue-<N>-<short-description>   # or fix/…, docs/…, ci/…, test/…
+git push -u origin feat/issue-<N>-<short-description>
+```
+
+Never push to `main` directly, and never to `upstream`.
+
+## Step 4 — Open the PR
+
+Write the body to a file — never inline with `--body "..."`, which invites shell
+interpolation and leaks anything in the environment:
+
+```bash
+gh pr create --repo GindaChen/nsys-ai \
+  --head rich7420:feat/issue-<N>-<short-description> \
+  --base main \
+  --title "<type>: <description>" \
+  --body-file /tmp/pr_body.md
+```
+
+Fill out `.github/PULL_REQUEST_TEMPLATE.md` — Summary, Changes, Backward compatibility,
+Test plan, Out of scope, Linked issues. The test plan checkboxes are claims: only tick
+what the review-change skill actually ran. `references/PR.md` has the body template and
+the label workflow.
+
+## Step 5 — CI and review
+
+```bash
+gh pr checks <PR> --repo GindaChen/nsys-ai --watch
+```
+
+`lint`, `test` (3.10/3.11/3.12) and `security` run on every PR and must be green.
+`smoke` only runs when the PR touches `skills/**`, `.claude-plugin/**` or the smoke
+scripts, and `credentialed` never runs on pull requests — forks cannot read secrets. For
+those two, absence is expected rather than a failure.
+
+A Copilot bot leaves inline comments automatically. Treat them as review input: triage
+by severity, fix or push back with a technical reason, reply in the thread. Hand the
+actual fixing back to the **review-change** skill.
+
+## Step 6 — Merge
+
+```bash
+gh pr merge <PR> --repo GindaChen/nsys-ai --squash --delete-branch
+```
+
+Only when green and approved. Confirm the base branch is `main` before merging — merging
+into the wrong base is expensive to undo.
+
+## Issue labels
+
+If the work came from a GitHub issue, move it along the state machine:
+
+```bash
+# on claiming
+gh issue edit <N> --repo GindaChen/nsys-ai --remove-label agent-ready --add-label agent-in-progress
+# after opening the PR
+gh issue edit <N> --repo GindaChen/nsys-ai --remove-label agent-in-progress --add-label agent-review
+```
+
+`agent-ready → agent-in-progress → agent-review → merged`, with `agent-blocked` as the
+side exit.
+
+## Never
+
+- Put env values, API keys, tokens, or raw command output into a commit message, PR
+  title, PR body, or comment. If it happens: sanitize the GitHub surface, rotate the
+  credential, then open a support ticket for cache and notification redaction.
+- Commit `.claude/worktrees/` (85 MB of live worktrees) or `.claude/settings.local.json`
+  (machine-local permissions). `.claude/skills/` is meant to be committed.
+- Commit a profile `.sqlite` that is not a deliberate, size-checked fixture.
+
+## References
+
+| File | Read when |
+|------|-----------|
+| `references/IDENTITY.md` | Step 1 — fixing a wrong author, and the `.mailmap` gap |
+| `references/PR.md` | Step 4 — PR body template, titles, labels, release flow |

--- a/.claude/skills/contribute/references/IDENTITY.md
+++ b/.claude/skills/contribute/references/IDENTITY.md
@@ -1,0 +1,129 @@
+# Git identity
+
+## The one correct identity
+
+```
+rich7420 <101171023+rich7420@users.noreply.github.com>
+```
+
+Nothing else. Not the gmail address, not a display name variant.
+
+## Why this needs a check every push
+
+The repo-local config is correct today:
+
+```
+local   user.name  = rich7420
+local   user.email = 101171023+rich7420@users.noreply.github.com
+```
+
+The global config on this machine is not:
+
+```
+global  user.email = rc910420@gmail.com
+```
+
+Local overrides global — inside this checkout. Anywhere the local config is absent, the
+global one applies: a fresh clone, a `git worktree add` in a new location, a container,
+a CI runner, a machine set up later. That is how these eight commits happened:
+
+```
+f666c64 release: v0.2.3
+00bb99b lint errors
+2d5360d update and improve
+a6f1228 fix ci errors
+f52cb1b feat: migrate TUI tree/timeline to Textual with tests
+100fcb8 test: add trajectory-based agent regression suite
+164b97d feat ai: refine Brain & Navigator UX across web + TUI
+1f70643 Make nsys-ai schema/version aware for Nsight 2026 SQLite exports
+```
+
+A private address in a public commit cannot be recalled. The check is two commands and
+runs before every push.
+
+## The check
+
+```bash
+git fetch upstream --quiet
+
+# 1. is the environment right, right now?
+git config --get user.email
+
+# 2. does every commit about to be pushed carry the right identity?
+n=$(git rev-list --count upstream/main..HEAD)
+bad=$(git log upstream/main..HEAD --format='%an <%ae>' | sort -u \
+      | grep -vFx 'rich7420 <101171023+rich7420@users.noreply.github.com>')
+if [ -n "$bad" ]; then printf 'FAIL — %s commit(s) checked, wrong identity:\n%s\n' "$n" "$bad"
+else printf 'OK — all %s commit(s) carry the correct identity\n' "$n"; fi
+```
+
+The first catches the environment being wrong now. The second catches commits already
+made with a wrong identity — including ones cherry-picked or rebased in from elsewhere.
+The second is the one that actually protects the push.
+
+Three details that are not incidental:
+
+- **`git fetch upstream` first.** A stale `upstream/main` makes the range wrong, and a
+  wrong range checks the wrong commits while still reporting confidently.
+- **It prints a verdict with a count, not a list.** A bare
+  `git log … | sort -u` prints nothing when the range is empty, and nothing looks
+  exactly like "all clean". `OK — all 0 commit(s)` says the check ran and found nothing
+  to check, which is a different statement.
+- **`grep -vFx`** — fixed-string, whole-line. A substring match would pass
+  `rich7420 <101171023+rich7420@users.noreply.github.com.evil>`.
+
+Verified against `f666c64`, one of the eight below: the check reports
+`FAIL — 1 commit(s) checked, wrong identity: rich7420 <rc910420@gmail.com>`.
+
+## Fixes
+
+**Config is wrong, nothing committed yet:**
+
+```bash
+git config --local user.name  "rich7420"
+git config --local user.email "101171023+rich7420@users.noreply.github.com"
+```
+
+Set it locally, not globally — changing the global config affects the user's other
+repos, which is not yours to decide.
+
+**The last commit is wrong, not yet pushed:**
+
+```bash
+git commit --amend --reset-author --no-edit
+```
+
+**Several unpushed commits are wrong:**
+
+```bash
+git rebase -i --exec 'git commit --amend --reset-author --no-edit' upstream/main
+```
+
+Rewriting history is safe only while the commits are unpushed. If they are already on
+`origin`, say so and ask before force-pushing — someone may have branched from them.
+
+**Already on `upstream/main`:** it stays. Do not rewrite shared history. Record it and
+move on; `.mailmap` below limits the damage to attribution, though not to the exposure.
+
+## The name drift, and `.mailmap`
+
+One email, two names:
+
+```
+rich7420        <101171023+rich7420@users.noreply.github.com>   # committed locally
+KUAN-HAO HUANG  <101171023+rich7420@users.noreply.github.com>   # merged via the GitHub UI
+```
+
+Merging through the web UI stamps the GitHub display name, so the same person appears
+twice in `git shortlog -sn`, and merge commits read as two contributors. The repo has
+no `.mailmap` yet. The standard fix — the one the kernel and git itself use — is to add
+one at the repo root:
+
+```
+rich7420 <101171023+rich7420@users.noreply.github.com> KUAN-HAO HUANG <101171023+rich7420@users.noreply.github.com>
+rich7420 <101171023+rich7420@users.noreply.github.com> rich7420 <rc910420@gmail.com>
+```
+
+It rewrites nothing; `git shortlog`, `git log --use-mailmap`, and GitHub's contributor
+list read it and collapse the aliases. This is a standalone change — propose it as its
+own small PR rather than smuggling it into a feature branch.

--- a/.claude/skills/contribute/references/PR.md
+++ b/.claude/skills/contribute/references/PR.md
@@ -1,0 +1,124 @@
+# Pull requests
+
+## Title
+
+`<type>: <what changed>` — `feat`, `fix`, `docs`, `test`, `ci`, `refactor`, `chore`.
+
+Describe the code. No roadmap numbers, no phase markers (`P0`, `PR-A`, `Stage C2`), no
+`§5.1` or `E#.#` handles — those are internal planning handles and mean nothing to a
+reader of the git log. If a GitHub issue exists, link it in the body, not the title.
+
+Good: `fix(skills): abstain when the memcpy table is absent`
+Bad: `P1 / PR-B: implement #043 per roadmap §5.2`
+
+## Body
+
+Write it to a file and pass `--body-file`. Never `--body "..."` — shell interpolation
+there is how environment values end up in a public PR.
+
+Follow `.github/PULL_REQUEST_TEMPLATE.md`. Empty sections may be deleted; Summary and
+Test plan may not.
+
+```markdown
+## Summary
+- <what this changes, and why — 1–3 bullets>
+
+## Changes
+- `src/nsys_ai/skills/builtins/foo.py` — <what>
+- `tests/test_foo.py` — <what>
+
+## Backward compatibility
+Yes. <Or: No — name the break and the migration path.>
+
+## Test plan
+- [x] Tests added or updated for the new behavior
+- [x] `python -m nsys_ai --help` — CLI loads without error
+- [x] `pytest tests/ -v --tb=short` passes locally
+- [x] `ruff check src/ tests/` clean
+- [ ] Manually exercised the changed CLI / GUI path — n/a, no user-facing surface change
+
+## Out of scope
+- <what this deliberately does not do, and the follow-up issue if there is one>
+
+## Linked issues
+Closes #<N>
+```
+
+A ticked box is a claim that the command was run and passed. Tick only what the review
+skill actually ran; leave the rest unticked with a reason. An unticked box with an
+honest note reads better than a ticked one that turns out to be false.
+
+Say what is out of scope. A reviewer who cannot tell whether an omission is an oversight
+or a decision has to ask, which costs a round trip.
+
+## Commands
+
+```bash
+# create
+gh pr create --repo GindaChen/nsys-ai \
+  --head rich7420:<branch> --base main \
+  --title "<type>: <description>" --body-file /tmp/pr_body.md
+
+# update after pushing more commits
+gh pr edit <PR> --repo GindaChen/nsys-ai --body-file /tmp/pr_body.md
+
+# CI
+gh pr checks <PR> --repo GindaChen/nsys-ai --watch
+
+# review comments
+gh pr view <PR> --repo GindaChen/nsys-ai --comments
+
+# merge
+gh pr merge <PR> --repo GindaChen/nsys-ai --squash --delete-branch
+```
+
+`--head rich7420:<branch>` is required — `origin` is the fork, and without it `gh`
+looks for the branch on `GindaChen/nsys-ai`, where it does not exist.
+
+## Required checks
+
+`lint`, `test` (3.10 / 3.11 / 3.12), and `security` run on every PR.
+
+`smoke` (`plugin-smoke.yml`) is path-gated — it only runs when the PR touches
+`skills/**`, `scripts/smoke_test.sh`, `scripts/build_fixture.py`, `.claude-plugin/**`,
+or `tests/fixtures/mock.sqlite`.
+
+`credentialed` is excluded from `pull_request` on purpose — forks cannot read secrets,
+so running it would fail for every external contributor rather than skip.
+
+For the last two, absence on a PR is correct, not a missing check.
+
+## Copilot review
+
+A Copilot bot posts inline comments automatically. Triage by severity like any review:
+blocking first, then trivial, then the ones needing thought. Reply in the comment
+thread rather than as a new top-level comment, and push back with a technical reason
+when it is wrong — it does not know this repo's contracts and will sometimes suggest
+changes that break the SQLite fallback path or the abstention contract.
+
+## Issue labels
+
+```bash
+gh issue edit <N> --repo GindaChen/nsys-ai --remove-label agent-ready       --add-label agent-in-progress
+gh issue edit <N> --repo GindaChen/nsys-ai --remove-label agent-in-progress --add-label agent-review
+```
+
+`agent-ready → agent-in-progress → agent-review → merged`, with `agent-blocked` as the
+side exit when work stalls on missing information. Priority is `P0-critical` through
+`P3-low`; pillars are `pillar/ai` and `pillar/ui`. `project-sync.yml` moves the project
+board off these labels, so a stale label leaves the board wrong.
+
+## Release
+
+Only when asked. A `v*` tag triggers `workflow.yml` ("Publish to PyPI"), which builds
+and uploads using the `PYPI_TOKEN` secret. A published version cannot be unpublished, so
+the tag push is the point of no return — confirm the version and that `main` is green
+before pushing it.
+
+1. Bump `version` in `pyproject.toml`
+2. `git commit -m "chore: bump to vX.Y.Z"`
+3. `git tag vX.Y.Z && git push upstream main --tags`
+
+Note that `AGENTS.md` and `CLAUDE.md` both still describe this as `publish.yml` using a
+trusted publisher. Neither is true — the file is `workflow.yml` and it authenticates
+with a token. Worth a docs fix in a separate PR.

--- a/.claude/skills/develop/SKILL.md
+++ b/.claude/skills/develop/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: develop
+description: >
+  Use when about to change code in this nsys-ai repo — implementing a GitHub issue,
+  adding a CLI subcommand or builtin analysis skill, fixing a bug, or picking up a
+  ROADMAP item. Also use when handed an issue number, or asked to "implement", "add",
+  "fix", or "make X work". Do not use for reviewing work that is already written
+  (use the review-change skill), for opening a pull request (use the contribute skill), or
+  for analyzing a .sqlite GPU profile (that is the nsys-ai plugin skill under skills/).
+---
+
+# Developing a change in nsys-ai
+
+Four phases, each with a gate. The gates exist because the expensive failures in this
+repo are not typos — they are changes built on a wrong reading of the profile schema,
+or a second implementation of something `src/nsys_ai/` already does. Both are cheap to
+avoid before writing code and expensive to unwind afterwards.
+
+Work through the phases in order. Announce which phase you are in.
+
+## Phase 1 — Research
+
+**Gate: do not write implementation code until the research note exists.**
+
+Produce a short research note (in the conversation, or `docs/notes/<topic>.md` if the
+work spans sessions) covering all four:
+
+1. **The problem, restated.** If there is an issue: `gh issue view <N> -R GindaChen/nsys-ai --comments`.
+   Restate what breaks and for whom. If the issue is vague, say so and ask — a vague
+   issue implemented confidently is the most expensive outcome here.
+2. **What the repo already does.** Search before designing. Half of "new" work in this
+   repo already exists under a different name — see `references/REPO_MAP.md` for where
+   to look and what the existing seams are.
+3. **What you need to know that you do not.** Nsight Systems changes its SQLite schema
+   between versions; NCCL/HTA accounting has conventions that are easy to get backwards.
+   Look it up rather than infer. `references/RESEARCH.md` lists the sources that have
+   actually paid off, and the facts already established (so you do not re-derive them).
+4. **How other projects solved it.** ROADMAP.md already cites NAV, nsys_recipes,
+   nsys_easy and the OpenHackathons bootcamp; HTA and PyTorch Profiler are the other
+   standing references. Read the actual implementation, not the README. Say what you
+   are taking and what you are deliberately not taking.
+
+Ending Phase 1 with "this is straightforward" and nothing written means the phase did
+not happen.
+
+## Phase 2 — Plan
+
+**Gate: the plan names every file it will touch, before any of them is opened for edit.**
+
+Write the plan as a task list. Each task carries:
+
+- **Files** — exact paths, split into create / modify / test.
+- **Interface** — the signature or JSON shape it produces, and who consumes it.
+- **Verification** — the command that proves the task landed, and the expected result.
+
+Rules that keep plans honest, from `references/PLAN.md`:
+
+- No `TBD`, no "handle edge cases", no "similar to task 2". If you cannot write the
+  step concretely, the research phase is not finished.
+- Split by responsibility, not by layer. A task that touches one module and its test is
+  reviewable; a task called "add the SQL for everything" is not.
+- Prefer the smallest change that is actually correct. This repo has a documented
+  preference for minimizing diff surface — a refactor bundled into a feature PR makes
+  both harder to review and is the most common review rejection here.
+
+State the plan and get agreement before building anything non-trivial.
+
+## Phase 3 — Build
+
+Follow the plan. When reality contradicts the plan — and it will — stop, say what
+changed, and revise the plan rather than quietly diverging.
+
+Constraints that apply to every change in this repo:
+
+- **Match the surrounding code.** No formatter is configured. `ruff check src/ tests/`
+  must stay clean (`E,W,F,I,UP`; line length 100 but `E501` is not enforced).
+- **Never `assert` for a safety guard in `src/`.** Bandit B101 fails the `security` CI
+  job. Use `if not ...: raise ValueError(...)`.
+- **Never hardcode Nsight table names.** Use the `{kernel_table}` / `{nvtx_table}` /
+  `{memcpy_table}` placeholders — `Skill.execute` resolves them, because these tables
+  are `_V2`/`_V3` suffixed on newer Nsight exports.
+- **A skill that cannot run must abstain, not return `[]` and not raise.** Call
+  `abstain(reason)` from `skills/base.py`. Empty list means "ran, found nothing";
+  those are different answers and consumers depend on the difference. Formatters must
+  not special-case abstention — `Skill.format_rows` handles it centrally.
+- **New CLI subcommand → smoke test in `tests/test_cli.py`.** Not optional; CI checks it.
+- **A new skipped test must be registered in `tests/test_ci_coverage.py`.** An
+  unregistered skip fails the build, deliberately — a skip nobody reads is a test that
+  does not exist.
+- **Stay off new runtime dependencies.** SQL analysis and the web server are stdlib
+  (`sqlite3`, `http.server`, `string.Template`) on purpose. No Flask, no Jinja2.
+  AI features live behind the `[agent]` / `[chat]` extras and must degrade cleanly when
+  those are absent.
+
+Adding a builtin analysis skill has its own shape — read `references/BUILTIN_SKILL.md`
+before starting one.
+
+## Phase 4 — Hand off
+
+Do not claim the work is done here. Invoke the **review-change** skill: it runs the
+repo-specific review pass and the verification gate. Only after that reports clean does
+the **contribute** skill open the PR.
+
+## References
+
+| File | Read when |
+|------|-----------|
+| `references/REPO_MAP.md` | Phase 1 — where things already live, and the seams to extend |
+| `references/RESEARCH.md` | Phase 1 — external sources, and settled facts not to re-derive |
+| `references/PLAN.md` | Phase 2 — plan format and the task template |
+| `references/BUILTIN_SKILL.md` | Phase 3 — adding a skill to `src/nsys_ai/skills/builtins/` |

--- a/.claude/skills/develop/references/BUILTIN_SKILL.md
+++ b/.claude/skills/develop/references/BUILTIN_SKILL.md
@@ -1,0 +1,137 @@
+# Adding a builtin analysis skill
+
+A builtin skill lives in `src/nsys_ai/skills/builtins/<name>.py` and is auto-discovered:
+`registry._load_builtins()` imports every module in that package and registers its
+module-level `SKILL` (or each item of a `SKILLS` list). There is no registration list
+to edit — but there is also nothing to catch a skill that silently fails to import.
+
+Read `top_kernels.py` as the reference implementation; it exercises every part of the
+contract.
+
+## Before writing one
+
+Check it does not already exist. There are 37, and the names are not always what you
+would guess:
+
+```bash
+python -m nsys_ai skill list
+rg -n "tags=" src/nsys_ai/skills/builtins/ | rg "<your concept>"
+```
+
+## Anatomy
+
+```python
+"""<One line: what this analyzes.>"""
+
+from ..base import Skill, SkillParam
+
+
+def _execute(conn, **kwargs):
+    """Return list[dict]. One dict per row, stable key set."""
+
+
+def _format(rows):
+    """Return the human-readable string. Do NOT handle abstention here."""
+
+
+def _to_findings(rows, *, context=None):
+    """Optional. Return list[Finding] for the evidence/timeline pipeline."""
+
+
+SKILL = Skill(
+    name="my_skill",            # snake_case, must match the CLI argument
+    title="Human Readable Title",
+    description="What it analyzes and when it is useful.",
+    category="kernels",         # kernels | memory | nvtx | communication | system | utility
+    execute_fn=_execute,        # or sql="SELECT ..." for the SQL path
+    params=[SkillParam("limit", "Max rows", "int", False, 15)],
+    format_fn=_format,
+    to_findings_fn=_to_findings,
+    tags=["...", "..."],        # drives skill discovery — be generous and specific
+)
+```
+
+Two execution paths: set `sql=` for a template query (`Skill.execute` substitutes
+params and table names), or `execute_fn=` for Python. Use `execute_fn` when the analysis
+needs branching, a fallback path, or post-processing — the SQL path cannot do those.
+
+## The five contracts
+
+**1. Abstain, do not return `[]` and do not raise.**
+
+`[]` means "ran, found nothing". If the profile lacks a table you need, that is a
+different answer and callers depend on the difference — `EvidenceBuilder` catches
+exceptions and logs, so a raising skill just vanishes from the output with no trace.
+
+```python
+from ..base import abstain, requires_nvtx
+
+def _execute(conn, **kwargs):
+    if (a := requires_nvtx(conn, needs="Layer attribution")) is not None:
+        return a
+    ...
+    return abstain("This profile has no CUPTI_ACTIVITY_KIND_MEMCPY table, so "
+                   "transfer sizes are unavailable. Re-capture with --trace=cuda.")
+```
+
+The reason is user-facing. Say what is missing, what that prevents, and what to do
+about it. `Skill.format_rows` renders it — never write abstention handling into a
+`format_fn`, and never index data columns before checking.
+
+**2. Never hardcode Nsight table names.**
+
+They are `_V2`/`_V3` suffixed on newer exports. In SQL templates use `{kernel_table}`,
+`{runtime_table}`, `{nvtx_table}`, `{memcpy_table}`, `{memset_table}`, `{sync_table}`,
+`{sync_type_table}`. In `execute_fn` resolve them:
+
+```python
+from nsys_ai.connection import wrap_connection
+tables = wrap_connection(conn).resolve_activity_tables()
+kernel_table = tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
+```
+
+For NVTX text, use `{nvtx_text_expr}` / `{nvtx_text_join}` — they cover both the legacy
+`text` column and the `textId → StringIds` schema. Picking one breaks the other.
+
+**3. Deterministic output.**
+
+`ORDER BY` must be total — add a tiebreaker (`ORDER BY total_ms DESC, name ASC`). Two
+test files exist solely because non-determinism broke golden-loop comparisons.
+
+**4. Silence over a weak claim.**
+
+If a signal is unavailable on the current path — `tc_eligible` is `None` on the pure
+SQLite fallback, for example — emit nothing rather than guessing. A finding the user
+cannot act on costs more than an absent one.
+
+**5. Findings carry their own doubt.**
+
+If you write `to_findings_fn`, each `Finding` needs `explanation`, `suggested_actions`,
+`false_positive_notes`, and a `confidence` that actually varies with sample size.
+Centralize thresholds as module constants with a comment saying why that number.
+Use `type="highlight"` with `start_ns=0` when the span is the kernel's whole invocation
+envelope — `type="region"` claims a localization you do not have.
+
+## Wiring and tests
+
+- Nothing to register — auto-discovery handles it. Confirm with `nsys-ai skill list`.
+- If you also add a CLI subcommand: `cli/parsers.py` + `cli/handlers.py`, and a smoke
+  test in `tests/test_cli.py`.
+- Add `tests/test_<name>.py`. Cover: the happy path, the abstention path, and the
+  fallback path if you wrote one.
+- If a test must skip (needs a real profile, needs an API key), register the skip in
+  `tests/test_ci_coverage.py` — an unregistered skip fails CI deliberately.
+
+## Verify
+
+```bash
+python -m nsys_ai skill list | grep <name>
+python -m nsys_ai skill run <name> tests/fixtures/mock.sqlite
+python -m nsys_ai skill run <name> tests/fixtures/mock.sqlite --format json \
+  | python -c "import json,sys; json.load(sys.stdin)"
+pytest tests/test_<name>.py tests/test_abstention.py -v
+ruff check src/ tests/
+```
+
+A skill that cannot run against `mock.sqlite` must print its abstention reason and
+exit 0 — CI asserts exactly this shape for `nvtx_kernel_map`. A traceback fails the build.

--- a/.claude/skills/develop/references/PLAN.md
+++ b/.claude/skills/develop/references/PLAN.md
@@ -1,0 +1,66 @@
+# Plan format
+
+A plan exists so a reviewer can accept or reject each piece independently, and so a
+later session can resume without re-reading the whole conversation. Both fail if the
+plan is prose.
+
+## Task template
+
+```markdown
+### Task N — <one line: what changes, not how>
+
+**Files**
+- create: src/nsys_ai/skills/builtins/foo.py
+- modify: src/nsys_ai/cli/parsers.py, src/nsys_ai/cli/handlers.py
+- test:   tests/test_foo.py, tests/test_cli.py
+
+**Interface**
+- produces: `SKILL = Skill(name="foo", category="kernels", ...)` returning rows with
+  keys `kernel_name: str, total_ms: float, device: int`
+- consumed by: `registry.get("foo")`, `nsys-ai skill run foo`
+
+**Steps**
+- [ ] <the actual change, concretely>
+- [ ] <…>
+
+**Verification**
+```bash
+python -m nsys_ai skill run foo tests/fixtures/mock.sqlite --format json
+```
+expected: valid JSON, non-empty rows, exit 0
+```
+
+## Rules
+
+**Every step contains the content, not a pointer to it.** No `TBD`, no "handle the
+edge cases", no "same as Task 2". If a step cannot be written concretely, Phase 1
+research is not finished — go back rather than deferring the unknown into the build.
+
+**Split by responsibility, not by layer.** "Add the skill and its test" is one
+reviewable task. "Write all the SQL" then "write all the tests" is two tasks that
+must both land to mean anything, and neither can be judged alone.
+
+**Smallest correct change.** Do not bundle a refactor into a feature. If the feature
+genuinely needs a refactor first, make it Task 1 with its own verification, and say in
+the PR that it is separable. Bundled refactors are the most common review rejection in
+this repo.
+
+**Every task ends with a command.** A task whose verification is "looks right" is not
+verifiable, and the review-change skill will send it back.
+
+## Sizing
+
+Aim for tasks a reviewer can hold in their head — roughly one module plus its test.
+A task that touches eight files across four subsystems is a plan that has not been
+decomposed yet.
+
+## When the plan breaks
+
+It will. Say so explicitly:
+
+> Task 3 assumed `NVTX_EVENTS` has a `text` column. This export uses `textId` →
+> `StringIds`. Revising Task 3 to use the `{nvtx_text_expr}` placeholder; Task 4 is
+> unaffected.
+
+Quietly building something other than the agreed plan is worse than the original
+mis-plan, because the review is then against the wrong specification.

--- a/.claude/skills/develop/references/REPO_MAP.md
+++ b/.claude/skills/develop/references/REPO_MAP.md
@@ -1,0 +1,64 @@
+# Where things already live
+
+Read this in Phase 1, before designing anything. The recurring failure mode in this
+repo is building a second implementation of something that already exists under a
+different name.
+
+## Search first
+
+```bash
+rg -n "<concept>" src/nsys_ai/          # the concept, not the filename you imagined
+python -m nsys_ai skill list            # 37 builtin analysis skills — is yours there?
+python -m nsys_ai --help                # ~30 subcommands — is the command there?
+gh issue list -R GindaChen/nsys-ai --search "<keywords>" --state all
+gh pr list -R GindaChen/nsys-ai --search "<keywords>" --state all
+```
+
+The last two matter as much as the code search: a closed issue often records *why* the
+obvious approach was rejected, and an open PR may already be touching your files.
+
+## The seams
+
+| You want to add | Extend here | Not here |
+|---|---|---|
+| A profile analysis | `src/nsys_ai/skills/builtins/<name>.py` (see `BUILTIN_SKILL.md`) | A new top-level module |
+| A CLI subcommand | `cli/parsers.py` (argparse) + `cli/handlers.py` (`_cmd_*`) | `__main__.py` — it only delegates to `cli/app.py:main` |
+| A profile-level query helper | `profile.py` (`Profile`, `NsightSchema`) | Inline `sqlite3` in a new module |
+| Schema/table-name resolution | `connection.py` (`wrap_connection`, `resolve_activity_tables`) | Hardcoded `CUPTI_ACTIVITY_KIND_*` strings |
+| Before/after comparison | `diff.py` / `diff_tools.py` / `diff_render.py` / `diff_web.py` | A parallel comparison path |
+| A web page or endpoint | `web.py` (stdlib `http.server`) + `templates/` (`string.Template`) | Flask, Jinja2, or any new server dep |
+| A TUI view | `tree/` or `timeline/` (Textual) | A curses or Rich-only reimplementation |
+| Agent behavior | `agent/persona.py` (prompt) / `agent/loop.py` (orchestration) | Prompt text scattered into call sites |
+| LLM tool plumbing | `chat.py`, `chat_tools.py`, `chat_config.py`, `tools_profile.py` | A new provider client |
+| Shared duration/number formatting | `formatting.py` (`fmt_dur`, `fmt_ns`, `fmt_relative`) | A local helper |
+
+## Contracts you must not break
+
+- **Abstention** — `skills/base.py`: `abstain()`, `is_abstention()`, `requires_nvtx()`.
+  `[]` means "ran, nothing found"; `[{"_abstained": True, ...}]` means "could not run".
+  Rendering of abstention is centralized in `Skill.format_rows` — do not re-handle it
+  in a `format_fn`. Tested by `tests/test_abstention.py`.
+- **Versioned tables** — SQL templates use `{kernel_table}`, `{runtime_table}`,
+  `{nvtx_table}`, `{memcpy_table}`, `{memset_table}`, `{sync_table}`. `Skill.execute`
+  substitutes them from `resolve_activity_tables()`.
+- **NVTX text** — `{nvtx_text_expr}` / `{nvtx_text_join}` cover both the legacy `text`
+  column and the modern `textId → StringIds` schema. Do not pick one.
+- **Overlap accounting** — `overlap_ms` counts as *compute* (HTA convention). Exposed
+  communication is `exposed_comm_ms`; there is no `communication_ms` field. Getting this
+  backwards silently inverts every diff verdict.
+- **Determinism** — `tests/test_determinism.py` and `test_determinism_outside_skills.py`
+  exist because non-deterministic output broke golden-loop tests. Sort before emitting.
+- **Trim + device params** — many skills take `trim_start_ns`/`trim_end_ns` and `device`;
+  `region_mfu` uses `device_id`, not `device`. Check the skill's `params` before assuming.
+
+## Tests
+
+`tests/` is large and named by subject — `test_<module>.py` or `test_<skill>.py`. Two
+are load-bearing beyond their own subject:
+
+- `tests/test_cli.py` — every CLI subcommand needs a smoke test here.
+- `tests/test_ci_coverage.py` — the registry of accepted skips. A new skip that is not
+  registered fails CI on purpose.
+
+Integration tests need `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`; without
+it they skip (which `test_ci_coverage.py` knows about).

--- a/.claude/skills/develop/references/RESEARCH.md
+++ b/.claude/skills/develop/references/RESEARCH.md
@@ -1,0 +1,72 @@
+# Research sources, and facts already settled
+
+Two purposes: point at sources that have actually paid off, and record conclusions so
+they are not re-derived (or re-derived *wrong*) every session.
+
+## Look it up rather than infer
+
+Nsight Systems changes its SQLite schema between releases, and GPU-performance
+accounting has conventions that are easy to invert. Both are areas where a confident
+guess produces output that looks right and is wrong. When a change depends on either,
+verify against a real profile or a primary source before building on it.
+
+```bash
+python -m nsys_ai skill run schema_inspect <profile.sqlite>   # what this export actually has
+sqlite3 <profile.sqlite> ".tables"
+```
+
+## Primary sources
+
+| Source | Use for |
+|---|---|
+| NVIDIA Nsight Systems docs + release notes | Export schema changes, table renames, CLI flags |
+| `docs/02-sqlite-schema.md`, `docs/sqlite-explorer/` | This repo's own map of the schema |
+| `docs/root-causes/` | The Book of Root Causes — existing cause→fix write-ups |
+| NCCL docs | Collective semantics, communicator/topology fields |
+| PyTorch Profiler / HTA (HolisticTraceAnalysis) | Accounting conventions, metric definitions |
+
+## Prior art already cited by ROADMAP.md
+
+Read the implementation, not the README, and say explicitly what you are taking and
+what you are rejecting:
+
+- [NAV](https://github.com/eshama1/NSYS-Analyzer-and-Visualizer) — comparative analysis
+- [nsys_recipes](https://github.com/hyxcl/nsys_recipes) — overlap matrix, per-stream NCCL
+- [nsys_easy](https://github.com/harrism/nsys_easy) — ergonomics of the capture wrapper
+- [Profiling-AI-Software-Bootcamp](https://github.com/openhackathons-org/Profiling-AI-Software-Bootcamp)
+
+## Settled facts — do not re-derive
+
+- `overlap_ms` counts as **compute**, per HTA. Exposed communication is
+  `exposed_comm_ms`. There is no `communication_ms`.
+- Diff verdict gate: ±5% on step_time, with comparability ≥ 0.5. Per-bucket defaults
+  are already defined in `diff.py` — read them before proposing new thresholds.
+- Package naming: PyPI `nsys-ai`, Python module `nsys_ai`. `nsys_tui` was a pre-rename
+  name and is gone; both `nsys-ai` and `nsys-tui` CLI entry points remain.
+- Runtime deps are `duckdb` + `pyarrow` (Parquet cache) and `rich` + `textual` (TUI).
+  SQL analysis and the web server are stdlib. "Zero runtime dependencies" is stale and
+  was corrected — do not reintroduce the claim.
+- CUTracer: v0.2.1 is pinned and latest; output is byte-identical v0.1.0 → main. Two
+  known parser gaps remain (no `cycles` column; `iterN_` infix).
+
+## Writing the research note
+
+Four headings, short. It exists to be read by the reviewer and by the next session:
+
+```markdown
+## Problem
+<what breaks, for whom, restated from the issue — not copied>
+
+## What already exists
+<files/skills/commands found, and why they do not cover it>
+
+## What I had to look up
+<schema facts, conventions, API behavior — with the source>
+
+## Prior art
+<project → what it does → taking / not taking, and why>
+```
+
+If the work spans sessions, save it as `docs/notes/<topic>.md`. Follow the repo doc
+style: reader-first, no emoji in new docs, no enumeration of PR numbers, and the
+content must match the code as it is now.

--- a/.claude/skills/review-change/SKILL.md
+++ b/.claude/skills/review-change/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: review-change
+description: >
+  Use after writing or changing code in this nsys-ai repo and before claiming it works
+  or opening a PR — when asked to "review", "check", "verify", "is this done", "run the
+  tests", or when finishing a task from the develop skill. Also use when responding to
+  review comments on an open PR. Do not use for planning or writing the change itself
+  (use the develop skill), or for the push/PR mechanics (use the contribute skill).
+---
+
+# Reviewing a change in nsys-ai
+
+Two things happen here, in order: a review pass that looks for defects, and a
+verification gate that produces evidence the change works. Neither substitutes for the
+other — a clean review of untested code proves nothing, and a green test run does not
+catch a violated contract that has no test yet.
+
+## Step 1 — Establish the diff
+
+```bash
+git status --short
+git diff main...HEAD --stat
+git log main..HEAD --oneline
+```
+
+If the change is uncommitted, review the working diff. State explicitly which range is
+under review; a review of the wrong range is worse than none.
+
+## Step 2 — Review pass
+
+Dispatch a subagent to do the reading rather than reading the diff yourself. The
+reviewer gets the diff and the requirements in its own context and returns only
+findings; your context stays free for fixing them. Give it:
+
+- the base and head SHAs (or "uncommitted working diff"),
+- the plan or issue the change was meant to satisfy,
+- `references/CHECKLIST.md` as the criteria.
+
+The general-purpose `/code-review` command covers ordinary defect classes well and can
+run alongside. What it will not know is `references/CHECKLIST.md` — the contracts that
+are specific to this repo and have each already shipped as a bug once. Those are the
+ones worth spending the review on.
+
+Rank findings by severity:
+
+| Severity | Meaning | Action |
+|---|---|---|
+| Blocking | breaks behavior, violates a contract in the checklist, fails a CI gate | fix before anything else |
+| Important | correctness risk, missing test, contract not covered | fix before opening the PR |
+| Minor | naming, comment, style | fix if cheap, else note it in the PR |
+
+Disagreeing is allowed and sometimes correct. Say why, technically — "this would break
+the SQLite fallback path, which has no cache and therefore no `tc_eligible`" — rather
+than accepting a change that makes the code worse. If it turns out the reviewer was
+right, say so plainly and fix it.
+
+## Step 3 — Verification gate
+
+**Do not claim anything passes without having just run it and read the output.**
+
+The failure this prevents is specific and common: reporting a green suite from memory,
+from a partial run, or from a subagent's summary. Run it, read the exit code and the
+failure count, then report.
+
+```bash
+ruff check src/ tests/
+bandit -r src/ -c pyproject.toml
+python -m nsys_ai --help
+NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite pytest tests/ -v --tb=short -rs
+pytest tests/test_ci_coverage.py -v --tb=short
+```
+
+Add, when the change touches them:
+
+```bash
+pip-audit .                       # dependency change
+bash scripts/smoke_test.sh        # skills/ or CLI surface change
+pytest tests/test_cli.py -v       # new or changed CLI subcommand
+```
+
+`references/VERIFY.md` has the full matrix of what to run for which kind of change,
+plus what each CI job actually asserts.
+
+## Step 4 — Report
+
+State what was run, what it produced, and what remains. Concretely:
+
+> `ruff` clean. `bandit` clean. `pytest tests/` — 812 passed, 137 skipped, 0 failed.
+> `test_ci_coverage` passed (no new unregistered skips). Review found 1 Blocking
+> (abstention row indexed in `_format` before the guard) — fixed and re-ran. 1 Minor
+> (threshold constant lacks a rationale comment) — left, noted in the PR.
+
+If something failed, say that, with the output. If a step was skipped, say which and
+why. "Should work now", "I'm confident", and "the subagent said it passed" are not
+verification — they are the absence of it.
+
+Only once this reports clean does the **contribute** skill open the PR.
+
+## References
+
+| File | Read when |
+|------|-----------|
+| `references/CHECKLIST.md` | Step 2 — the repo-specific contracts to review against |
+| `references/VERIFY.md` | Step 3 — which commands for which change, and what CI asserts |

--- a/.claude/skills/review-change/references/CHECKLIST.md
+++ b/.claude/skills/review-change/references/CHECKLIST.md
@@ -1,0 +1,84 @@
+# Review checklist — nsys-ai
+
+These are the contracts specific to this repo. Each has shipped as a bug at least once,
+which is why it is written down rather than left to judgement. A general-purpose review
+will not catch them.
+
+## Blocking — CI fails, or behavior is wrong
+
+- [ ] **No `assert` used as a safety guard in `src/`.** Bandit B101 fails the `security`
+      job. Use `if not ...: raise ValueError(...)`. (B110 and B608 are skipped in
+      `pyproject.toml`; B101 is not.)
+- [ ] **`ruff check src/ tests/` clean.** Rules `E,W,F,I,UP`. `E501` is not enforced,
+      so long lines are fine; unsorted imports (`I`) and outdated syntax (`UP`) are not.
+- [ ] **No hardcoded Nsight table names.** `CUPTI_ACTIVITY_KIND_KERNEL` and friends are
+      `_V2`/`_V3` suffixed on newer exports. SQL templates use `{kernel_table}` etc.;
+      `execute_fn` resolves via `wrap_connection(conn).resolve_activity_tables()`.
+      A hardcoded name works on the fixture and fails on the user's profile.
+- [ ] **NVTX text handled both ways.** `{nvtx_text_expr}` / `{nvtx_text_join}`, not a
+      bare `n.text` and not a bare `textId` join.
+- [ ] **Abstention contract.** A skill that cannot run returns `abstain(reason)` — not
+      `[]`, not an exception. `[]` means "ran, found nothing" and callers act on the
+      difference. Rendering is centralized in `Skill.format_rows`; a `format_fn` must
+      not re-handle abstention, and must not index data columns that an abstention row
+      does not have.
+- [ ] **Overlap accounting.** `overlap_ms` counts as compute (HTA convention). Exposed
+      communication is `exposed_comm_ms`. There is no `communication_ms` — a reference
+      to it is either a typo or an inverted metric.
+- [ ] **New CLI subcommand has a smoke test in `tests/test_cli.py`.**
+- [ ] **New skipped test is registered in `tests/test_ci_coverage.py`.** An
+      unregistered skip fails the build on purpose: a skip nobody reads is a test that
+      does not exist.
+- [ ] **No new runtime dependency.** SQL analysis and the web server are stdlib
+      (`sqlite3`, `http.server`, `string.Template`) deliberately — no Flask, no Jinja2.
+      AI features stay behind the `[agent]` / `[chat]` extras and must degrade cleanly
+      when those are not installed.
+- [ ] **No secrets in any output.** Never inline PR text with `--body "..."`; write a
+      file and use `--body-file`. Never echo env values, keys, or tokens into commit
+      messages, PR bodies, comments, or logs.
+
+## Important — correctness risk
+
+- [ ] **Deterministic ordering.** `ORDER BY` has a total tiebreaker. Non-determinism
+      breaks the golden-loop tests, which is why `tests/test_determinism.py` and
+      `test_determinism_outside_skills.py` exist.
+- [ ] **Silence over a weak claim.** When a signal is unavailable on the current path
+      (`tc_eligible` is `None` on the pure-SQLite fallback), emit nothing rather than
+      guessing. An unactionable finding costs more than an absent one.
+- [ ] **Findings carry doubt.** A new `Finding` has `explanation`, `suggested_actions`,
+      `false_positive_notes`, and a `confidence` that varies with sample size. Magic
+      thresholds are module constants with a comment saying why that number.
+- [ ] **Params match the skill.** `region_mfu` takes `device_id`; most others take
+      `device`. Passing the wrong one fails silently — it does not scope, and does not
+      error.
+- [ ] **Fallback paths are tested.** If the change adds a "try the cache, else raw
+      SQLite" branch, both branches need coverage. The fallback is the one users on old
+      exports actually hit.
+- [ ] **Tests assert behavior, not implementation.** A test that would still pass with
+      the function body deleted is not coverage.
+
+## Important — scope
+
+- [ ] **Minimal diff.** A refactor bundled into a feature is the most common rejection
+      here. If the refactor was genuinely needed first, it should be a separate commit
+      with its own justification, and the PR should say so.
+- [ ] **No dead code left behind.** Superseded helper, unused import, commented-out
+      block — delete it. Git has the history.
+- [ ] **Reuses existing seams.** A second implementation of formatting, schema
+      resolution, or overlap classification is a defect even if it works. The seam list
+      is in `.claude/skills/develop/references/REPO_MAP.md`.
+
+## Minor — but check
+
+- [ ] **Docs match the code as it is now.** If the change alters behavior described in
+      `README.md`, `CLAUDE.md`, `AGENTS.md`, or `docs/`, update it in the same PR.
+- [ ] **New docs are reader-first**: no emoji, no enumeration of PR numbers, and they
+      follow the conventions of comparable projects rather than inventing a format.
+- [ ] **Comments say why, not what.** The code already says what.
+
+## When reviewing PR feedback rather than your own diff
+
+Order the work: blocking breakage first, then trivial fixes (typo, import), then the
+ones needing thought. Test each fix separately so a later one does not mask an earlier
+regression. Reply in the inline comment thread, not as a new top-level PR comment.
+State what changed — no thanks, no preamble.

--- a/.claude/skills/review-change/references/VERIFY.md
+++ b/.claude/skills/review-change/references/VERIFY.md
@@ -1,0 +1,80 @@
+# Verification — what to run, and what CI actually asserts
+
+## The rule
+
+Identify the command that would prove the claim, run it fresh and completely, read the
+exit code and the failure count, then decide whether the output supports the claim. Only
+then say it. Skipping a step is not a faster verification; it is not a verification.
+
+Reporting a suite as green from memory, from a partial run, or from a subagent's summary
+is the specific failure this exists to prevent.
+
+## Always
+
+```bash
+ruff check src/ tests/
+bandit -r src/ -c pyproject.toml
+python -m nsys_ai --help
+NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite pytest tests/ -v --tb=short -rs
+pytest tests/test_ci_coverage.py -v --tb=short
+```
+
+`NSYS_TEST_PROFILE` matters: without it the integration tests skip, and a green run
+that skipped them is a weaker claim than it looks. `-rs` prints every skip and its
+reason — read them.
+
+## By what changed
+
+| Changed | Also run |
+|---|---|
+| A builtin skill | `python -m nsys_ai skill run <name> tests/fixtures/mock.sqlite` and the same with `--format json` piped through `json.load` |
+| A CLI subcommand | `pytest tests/test_cli.py -v`, plus the command by hand |
+| `skills/` (the plugin) or CLI surface | `bash scripts/smoke_test.sh` |
+| Dependencies / `pyproject.toml` | `pip-audit .` |
+| Abstention or schema resolution | `pytest tests/test_abstention.py tests/test_determinism.py -v` |
+| Diff / verdict logic | `python -m nsys_ai diff tests/fixtures/healthy_1pct.sqlite tests/fixtures/healthy_1pct.sqlite --format json` |
+| Agent / chat | `pip install -e '.[all,dev]'` first; note that provider-backed tests run nightly, not per-PR |
+| `site/` | open `site/index.html` and confirm it renders |
+
+## What CI asserts
+
+Three workflows run on every pull request; a fourth is path-gated.
+
+**`lint`** (`ci.yml`) — `ruff check src/ tests/` on 3.12.
+
+**`test`** (`ci.yml`) — matrix 3.10 / 3.11 / 3.12. Each runs:
+- `pip install -e '.[tui,dev]'`
+- `python -m nsys_ai --help`
+- `pytest tests/ -v --tb=short -rs` with `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`
+- `pytest tests/test_ci_coverage.py` — the "no unexpected skips" gate
+- a CLI smoke block that asserts, among others:
+  - `skill run nvtx_kernel_map mock.sqlite` prints `not applicable` and exits 0 —
+    a traceback here fails the build,
+  - `skill run top_kernels --format json` and `analyze --format json` parse as JSON,
+  - `agent ask "why is this slow?"` contains `## Verify` (the deterministic
+    no-API-key answer contract),
+  - `diff healthy_1pct healthy_1pct --format json` parses.
+
+**`security`** (`security.yml`) — `bandit -r src/ -c pyproject.toml` and `pip-audit .`,
+against the core install only.
+
+**`smoke`** (`plugin-smoke.yml`) — path-gated: only runs when the PR touches
+`skills/**`, `scripts/smoke_test.sh`, `scripts/build_fixture.py`, `.claude-plugin/**`,
+or `tests/fixtures/mock.sqlite`. If your change touches any of those, run
+`bash scripts/smoke_test.sh` locally rather than discovering it on the PR. If it does
+not, the job's absence is correct, not a missing check.
+
+**`credentialed`** (`ci.yml`) — provider-backed tests. Never on `pull_request` (forks
+cannot read secrets); runs nightly and on push to `main`, with `continue-on-error` so a
+provider outage does not redden `main`. Do not expect it on your PR.
+
+## Reporting
+
+Say what ran, what it produced, and what is left:
+
+> `ruff` clean. `bandit` clean. `pytest tests/` — 812 passed, 137 skipped, 0 failed;
+> skips all pre-registered. `test_ci_coverage` passed. `smoke_test.sh` not run — this
+> change does not touch `skills/` or the CLI surface.
+
+If a check failed, report the failure and its output. If one was skipped, name it and
+say why. A claim without the run behind it is the thing this whole file is against.


### PR DESCRIPTION
## Summary

- Adds three agent skills under `.claude/skills/` covering how work gets done in this repo: research-then-build, review-then-verify, and push-then-PR.
- Each `SKILL.md` is a router under 165 lines with the bulk in `references/`, so only the relevant part loads.
- Encodes contracts that currently live only in reviewers' heads — the abstention contract, versioned Nsight table names, the stdlib-only constraint on SQL and web paths.

## Changes

**`.claude/skills/develop/`** — research before code, plan before edit, then build.
- `SKILL.md` — four phases with gates.
- `references/REPO_MAP.md` — where things already live, and the seams to extend rather than duplicate.
- `references/RESEARCH.md` — primary sources, plus settled facts so they are not re-derived (overlap accounting, diff thresholds, CUTracer pin).
- `references/PLAN.md` — task format; no `TBD`, every task ends with a command.
- `references/BUILTIN_SKILL.md` — adding a skill to `src/nsys_ai/skills/builtins/`, written against `top_kernels.py` as the reference implementation.

**`.claude/skills/review-change/`** — repo-specific review pass plus a verification gate.
- `references/CHECKLIST.md` — the contracts a general-purpose review will not know: `abstain()` rather than `[]` or raise, no hardcoded `CUPTI_ACTIVITY_KIND_*`, no `assert` as a safety guard in `src/` (bandit B101), `exposed_comm_ms` not `communication_ms`.
- `references/VERIFY.md` — which commands for which change, and what each CI job actually asserts.

Named `review-change` rather than `review`: `review` collides with a built-in skill of the same name and is shadowed by it. Verified — the project skill did not appear in the skill list until renamed.

**`.claude/skills/contribute/`** — pre-flight, identity gate, branch, PR.
- `references/IDENTITY.md` — the correct author identity and how to repair a wrong one.
- `references/PR.md` — body template, titles, labels, release flow.

## Backward compatibility

Yes. Documentation only; no code, no test, no CI change. `.claude/skills/` is inert unless an agent loads it.

## Test plan

- [x] Every repo path referenced by the skills verified to exist (only `foo.py` / `test_foo.py` are deliberate template placeholders).
- [x] Every command written into the skills executed: `skill list`, `skill run nvtx_kernel_map tests/fixtures/mock.sqlite` (prints its abstention reason and exits 0, as documented), `skill run top_kernels --format json` parsed by `json.load`, `ruff check src/ tests/` clean, `bandit -r src/ -c pyproject.toml` clean.
- [x] Identity check exercised both ways — empty range reports `OK — all 0 commit(s)`; run against `f666c64` it reports `FAIL — 1 commit(s) checked, wrong identity: rich7420 <rc910420@gmail.com>`.
- [x] Pre-flight `gh` query corrected and re-run: `select(.files[].path | test(…))` emitted one row per matching file, so a PR touching six files looked like six PRs. Now `select(any(.files[]; …))`.
- [ ] `pytest tests/` — not run. No Python changed; the suite cannot observe this PR.
- [ ] `bash scripts/smoke_test.sh` — not run. This PR does not touch `skills/`, `.claude-plugin/`, or the smoke scripts, so `plugin-smoke` is not triggered either.

## Out of scope

One stale fact was found while verifying. It is corrected inside the skills, but the source documents are left alone for a separate PR: `AGENTS.md` and `CLAUDE.md` both describe publishing as `publish.yml` via a trusted publisher, when the file is `workflow.yml` and it authenticates with `PYPI_TOKEN`.

Also deliberately not included:

- A `.mailmap`. The repo has none, and one email currently carries two author names (`rich7420` locally, `KUAN-HAO HUANG` from web-UI merges), so `git shortlog -sn` counts one person twice. The fix is written up in `references/IDENTITY.md` and should land as its own small PR.
- Evals for the skills. Worth doing, but a different scope from checking in the instructions.

## Linked issues

None.
