### PR TITLE
fix(cli): read the NVTX table by resolved name, and survive its absence

### DIFF
--- a/src/nsys_ai/nvtx_tree.py
+++ b/src/nsys_ai/nvtx_tree.py
@@ -78,11 +78,15 @@ def _build_single_thread_tree(
     """
     # Load NVTX for this thread only.
     # Support both schemas: (1) only NVTX_EVENTS.text, (2) textId -> StringIds (COALESCE text, s.value).
+    # The table is resolved, not named: newer exports suffix it _V2/_V3, and a
+    # hardcoded name here raised "no such table" on an annotated profile — the
+    # very symptom this change set out to remove, from the file it edited.
+    nvtx_table = profile.adapter.resolve_activity_tables().get("nvtx", "NVTX_EVENTS")
     if profile._nvtx_has_text_id:
         nvtx_rows = profile._duckdb_query(
-            """
+            f"""
             SELECT COALESCE(n.text, s.value) AS text, n.start, n.[end]
-            FROM NVTX_EVENTS n
+            FROM {nvtx_table} n
             LEFT JOIN StringIds s ON n.textId = s.id
             WHERE (n.text IS NOT NULL OR s.value IS NOT NULL) AND n.[end] > n.start
               AND n.globalTid = ?
@@ -96,9 +100,9 @@ def _build_single_thread_tree(
         )
     else:
         nvtx_rows = profile._duckdb_query(
-            """
+            f"""
             SELECT text, start, [end]
-            FROM NVTX_EVENTS
+            FROM {nvtx_table}
             WHERE text IS NOT NULL AND [end] > start
               AND globalTid = ?
               AND [end] >= ? AND start <= ?
@@ -221,6 +225,14 @@ def build_nvtx_tree(profile, device: int, trim: tuple[int, int], pad: int = int(
 
     Each node: {name, start, end, type: "nvtx"|"kernel", stream?, children: [...]}
     """
+    # A capture taken without NVTX has no table to read. Both callers — the
+    # analyze report's hierarchy summary and export-csv's per-kernel NVTX path —
+    # previously reached the query and died with a raw SQL error naming the
+    # table, on a profile that is perfectly valid. There is simply no hierarchy
+    # to build.
+    if not profile.adapter.resolve_activity_tables().get("nvtx"):
+        return []
+
     kmap = profile.kernel_map(device)
     if not kmap:
         return []

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -513,6 +513,7 @@ def detect_iterations(
             if t.startswith("NVTX_EVENTS"):
                 nvtx_table = t
                 break
+    has_nvtx = nvtx_table in tables
 
     runtime_table = "CUPTI_ACTIVITY_KIND_RUNTIME"
     if runtime_table not in tables:
@@ -532,7 +533,10 @@ def detect_iterations(
         text_expr = "n.text"
         text_join = ""
 
-    pri_nvtx = prof._duckdb_query(
+    # Without the table there is nothing to match, but the gap-based heuristic
+    # below needs no annotation — returning early here withheld a result the
+    # profile can genuinely support.
+    pri_nvtx = [] if not has_nvtx else prof._duckdb_query(
         f"""
             SELECT {text_expr} AS text, n.start, n.[end] FROM {nvtx_table} n
             {text_join}

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -420,9 +420,10 @@ class Profile:
             if mx is not None:
                 max_end = mx if max_end is None else max(max_end, mx)
 
+        _meta_nvtx = self.adapter.resolve_activity_tables().get("nvtx")
         nc = (
-            self.adapter.execute("SELECT COUNT(*) FROM NVTX_EVENTS").fetchone()[0]
-            if "NVTX_EVENTS" in tables
+            self.adapter.execute(f"SELECT COUNT(*) FROM {_meta_nvtx}").fetchone()[0]  # noqa: S608
+            if _meta_nvtx
             else 0
         )
 
@@ -558,29 +559,35 @@ class Profile:
         Returns rows sorted by total_ns descending:
           {text, total_ns, count, avg_ns}
         """
-        if "NVTX_EVENTS" not in self.schema.tables:
+        # Resolve rather than hardcode: Nsight suffixes this table _V2/_V3 on
+        # newer exports, and it is absent entirely from a capture taken without
+        # NVTX. Both cases used to reach the query and fail with a raw SQL error
+        # naming the table. A profile with no annotation is valid, and the
+        # truthful answer at this layer is that there are no ranges.
+        nvtx_table = self.adapter.resolve_activity_tables().get("nvtx")
+        if not nvtx_table:
             return []
 
         if self._nvtx_has_text_id:
-            sql = """
+            sql = f"""
                 SELECT
                     COALESCE(n.text, s.value) AS text,
                     SUM(n.[end] - n.start) AS total_ns,
                     COUNT(*) AS count,
                     AVG(n.[end] - n.start) AS avg_ns
-                FROM NVTX_EVENTS n
+                FROM {nvtx_table} n
                 LEFT JOIN StringIds s ON n.textId = s.id
                 WHERE (n.text IS NOT NULL OR s.value IS NOT NULL)
                   AND n.[end] > n.start
             """
         else:
-            sql = """
+            sql = f"""
                 SELECT
                     n.text AS text,
                     SUM(n.[end] - n.start) AS total_ns,
                     COUNT(*) AS count,
                     AVG(n.[end] - n.start) AS avg_ns
-                FROM NVTX_EVENTS n
+                FROM {nvtx_table} n
                 WHERE n.text IS NOT NULL
                   AND n.[end] > n.start
             """
@@ -610,7 +617,13 @@ class Profile:
         pattern: substring to match; for LIKE we wrap with %; for GLOB pass a full pattern.
         Returns rows: {text, total_ns, count} sorted by total_ns descending.
         """
-        if "NVTX_EVENTS" not in self.schema.tables:
+        # Resolve rather than hardcode: Nsight suffixes this table _V2/_V3 on
+        # newer exports, and it is absent entirely from a capture taken without
+        # NVTX. Both cases used to reach the query and fail with a raw SQL error
+        # naming the table. A profile with no annotation is valid, and the
+        # truthful answer at this layer is that there are no ranges.
+        nvtx_table = self.adapter.resolve_activity_tables().get("nvtx")
+        if not nvtx_table:
             return []
         match_val = (
             pattern
@@ -620,12 +633,12 @@ class Profile:
             else f"*{pattern}*"
         )
         if self._nvtx_has_text_id:
-            sql = """
+            sql = f"""
                 SELECT
                     COALESCE(n.text, s.value) AS text,
                     SUM(n.[end] - n.start) AS total_ns,
                     COUNT(*) AS count
-                FROM NVTX_EVENTS n
+                FROM {nvtx_table} n
                 LEFT JOIN StringIds s ON n.textId = s.id
                 WHERE (n.text IS NOT NULL OR s.value IS NOT NULL)
                   AND n.[end] > n.start
@@ -633,12 +646,12 @@ class Profile:
             sql += "GLOB ?" if use_glob else "LIKE ?"
             params: list = [match_val]
         else:
-            sql = """
+            sql = f"""
                 SELECT
                     n.text AS text,
                     SUM(n.[end] - n.start) AS total_ns,
                     COUNT(*) AS count
-                FROM NVTX_EVENTS n
+                FROM {nvtx_table} n
                 WHERE n.text IS NOT NULL AND n.[end] > n.start
                   AND n.text """
             sql += "GLOB ?" if use_glob else "LIKE ?"
@@ -747,7 +760,13 @@ class Profile:
           - Legacy: NVTX_EVENTS.text holds the annotation string inline.
           - Newer:  NVTX_EVENTS.textId references StringIds; text may be NULL.
         """
-        if "NVTX_EVENTS" not in self.schema.tables or not threads:
+        # Resolve rather than hardcode: Nsight suffixes this table _V2/_V3 on
+        # newer exports, and it is absent entirely from a capture taken without
+        # NVTX. Both cases used to reach the query and fail with a raw SQL error
+        # naming the table. A profile with no annotation is valid, and the
+        # truthful answer at this layer is that there are no ranges.
+        nvtx_table = self.adapter.resolve_activity_tables().get("nvtx")
+        if not nvtx_table or not threads:
             return []
         tids = ",".join(map(str, threads))
         if self._nvtx_has_text_id:
@@ -755,7 +774,7 @@ class Profile:
                 f"""
                 SELECT COALESCE(n.text, s.value) AS text,
                        n.globalTid, n.start, n.[end]
-                FROM NVTX_EVENTS n
+                FROM {nvtx_table} n
                 LEFT JOIN StringIds s ON n.textId = s.id
                 WHERE (n.text IS NOT NULL OR s.value IS NOT NULL)
                   AND n.[end] > n.start
@@ -768,7 +787,7 @@ class Profile:
         else:
             return self._duckdb_query(
                 f"""
-                SELECT text, globalTid, start, [end] FROM NVTX_EVENTS
+                SELECT text, globalTid, start, [end] FROM {nvtx_table}
                 WHERE text IS NOT NULL AND [end] > start
                   AND start >= ? AND start <= ?
                   AND globalTid IN ({tids})

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -560,10 +560,10 @@ class Profile:
           {text, total_ns, count, avg_ns}
         """
         # Resolve rather than hardcode: Nsight suffixes this table _V2/_V3 on
-        # newer exports, and it is absent entirely from a capture taken without
-        # NVTX. Both cases used to reach the query and fail with a raw SQL error
-        # naming the table. A profile with no annotation is valid, and the
-        # truthful answer at this layer is that there are no ranges.
+        # newer exports. The check this replaced named the table literally, so a
+        # _V2 export reported no ranges on a fully annotated profile — silence
+        # rather than an error, and the harder failure to notice. An absent
+        # table is the other case, and there the empty answer is the true one.
         nvtx_table = self.adapter.resolve_activity_tables().get("nvtx")
         if not nvtx_table:
             return []
@@ -618,10 +618,10 @@ class Profile:
         Returns rows: {text, total_ns, count} sorted by total_ns descending.
         """
         # Resolve rather than hardcode: Nsight suffixes this table _V2/_V3 on
-        # newer exports, and it is absent entirely from a capture taken without
-        # NVTX. Both cases used to reach the query and fail with a raw SQL error
-        # naming the table. A profile with no annotation is valid, and the
-        # truthful answer at this layer is that there are no ranges.
+        # newer exports. The check this replaced named the table literally, so a
+        # _V2 export reported no ranges on a fully annotated profile — silence
+        # rather than an error, and the harder failure to notice. An absent
+        # table is the other case, and there the empty answer is the true one.
         nvtx_table = self.adapter.resolve_activity_tables().get("nvtx")
         if not nvtx_table:
             return []
@@ -761,10 +761,10 @@ class Profile:
           - Newer:  NVTX_EVENTS.textId references StringIds; text may be NULL.
         """
         # Resolve rather than hardcode: Nsight suffixes this table _V2/_V3 on
-        # newer exports, and it is absent entirely from a capture taken without
-        # NVTX. Both cases used to reach the query and fail with a raw SQL error
-        # naming the table. A profile with no annotation is valid, and the
-        # truthful answer at this layer is that there are no ranges.
+        # newer exports. The check this replaced named the table literally, so a
+        # _V2 export reported no ranges on a fully annotated profile — silence
+        # rather than an error, and the harder failure to notice. An absent
+        # table is the other case, and there the empty answer is the true one.
         nvtx_table = self.adapter.resolve_activity_tables().get("nvtx")
         if not nvtx_table or not threads:
             return []

--- a/tests/test_no_nvtx_profile.py
+++ b/tests/test_no_nvtx_profile.py
@@ -1,0 +1,165 @@
+"""A capture taken without NVTX is valid, and must not crash the commands.
+
+`analyze` and `export-csv` exited 1 with a raw SQL error naming NVTX_EVENTS on
+any profile lacking that table. Nothing about such a profile is wrong — NVTX
+annotation is optional, and everything else in it is analysable — so the correct
+behaviour is to produce the rest of the report and leave out the part that needs
+annotation. `analyze` already reports the absence through the health manifest's
+"Insufficient NVTX coverage" finding, so once the crash is gone the user is told.
+
+The same code also hardcoded the table name, which would fail on the _V2 and _V3
+suffixed variants newer Nsight exports use even when NVTX is present. Resolving
+the table fixes both, which is why the tests below check resolution as well as
+absence.
+"""
+
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+NO_NVTX = REPO / "tests" / "fixtures" / "healthy_1pct.sqlite"
+WITH_NVTX = REPO / "tests" / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+def _run(*args) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-m", "nsys_ai", *args],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_the_fixture_really_has_no_nvtx():
+    """Guard the premise, so these cannot go vacuous."""
+    conn = sqlite3.connect(NO_NVTX)
+    try:
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    finally:
+        conn.close()
+    assert not any(t.startswith("NVTX_EVENTS") for t in tables)
+
+
+def test_analyze_succeeds_without_nvtx():
+    r = _run("analyze", str(NO_NVTX), "--gpu", "0", "--trim", "0.0", "0.4")
+    assert r.returncode == 0, f"analyze failed:\n{r.stderr[-600:]}"
+    assert "NVTX_EVENTS" not in r.stderr, "leaked a database error naming the table"
+    # It must still analyse everything that does not need annotation.
+    assert "Kernels:" in r.stdout
+
+
+def test_export_csv_succeeds_without_nvtx(tmp_path):
+    out = tmp_path / "k.csv"
+    r = _run("export-csv", str(NO_NVTX), "--gpu", "0", "--trim", "0.0", "0.4", "-o", str(out))
+    assert r.returncode == 0, f"export-csv failed:\n{r.stderr[-600:]}"
+    assert out.exists() and out.read_text().count("\n") > 1, "wrote no rows"
+
+
+def test_iteration_detection_falls_back_to_the_heuristic():
+    """Without markers there is nothing to match, but the gap-based heuristic
+    needs no annotation.
+
+    This crashed before. An intermediate fix returned early instead, which
+    withheld a result the profile can genuinely support — the issue asked for
+    everything that does not require annotation, and this qualifies.
+    """
+    from nsys_ai.overlap import detect_iterations
+    from nsys_ai.profile import Profile
+
+    with Profile(str(NO_NVTX)) as prof:
+        iters = detect_iterations(prof, 0, (0, 400_000_000))
+    assert iters, "the heuristic fallback was skipped"
+    assert all(i.get("heuristic") for i in iters), "claimed real iterations without NVTX"
+
+
+def test_nvtx_tree_returns_nothing_rather_than_raising():
+    """The shared entry point for both commands' NVTX work."""
+    from nsys_ai.nvtx_tree import build_nvtx_tree
+    from nsys_ai.profile import Profile
+
+    with Profile(str(NO_NVTX)) as prof:
+        assert build_nvtx_tree(prof, 0, (0, 400_000_000)) == []
+
+
+@pytest.mark.parametrize(
+    "method,args",
+    [
+        ("aggregate_nvtx_ranges", ()),
+        ("search_nvtx_names", ("anything",)),
+    ],
+)
+def test_profile_nvtx_accessors_return_empty(method, args):
+    """`[]` deliberately, not an abstention row.
+
+    `Profile` is a data accessor, where "there are no NVTX ranges" is the
+    truthful answer. Abstention is a skill-layer concept; pushing it here would
+    force all six callers to handle a sentinel row.
+
+    This behaviour predates the change — it is pinned, not claimed as new.
+    """
+    from nsys_ai.profile import Profile
+
+    with Profile(str(NO_NVTX)) as prof:
+        assert getattr(prof, method)(*args) == []
+
+
+# ── The other half: a resolved table name, not a hardcoded one ──────────────
+
+
+@pytest.fixture
+def v2_profile(tmp_path):
+    """An annotated profile whose table carries the _V2 suffix newer exports use."""
+    import shutil
+
+    dst = tmp_path / "v2.sqlite"
+    shutil.copy(WITH_NVTX, dst)
+    conn = sqlite3.connect(dst)
+    try:
+        conn.execute("ALTER TABLE NVTX_EVENTS RENAME TO NVTX_EVENTS_V2")
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+def test_a_versioned_nvtx_table_is_still_read(v2_profile):
+    """The half of this change that a source-text check could not verify.
+
+    An earlier version asserted that a literal table name was absent from one
+    file. It passed while the fix was inert — a redundant guard sat above the
+    hardcoded one that actually short-circuited — and while sibling files kept
+    their own literals. Renaming the table on a real annotated profile is the
+    only check that distinguishes "resolved" from "looks resolved": the wrong
+    answer here is silence, not a crash.
+    """
+    from nsys_ai.nvtx_tree import build_nvtx_tree
+    from nsys_ai.profile import Profile
+
+    # Pure-SQLite path: the fallback users on older exports actually hit.
+    conn = sqlite3.connect(v2_profile)
+    try:
+        prof = Profile._from_conn(conn)
+        assert prof.aggregate_nvtx_ranges(limit=5), "annotated _V2 profile reported no ranges"
+        assert prof.search_nvtx_names("a", limit=5) is not None
+        assert build_nvtx_tree(prof, 0, prof.meta.time_range), "_V2 tree came back empty"
+        assert prof.meta.nvtx_count > 0, "_V2 export reported nvtx_count=0"
+    finally:
+        conn.close()
+
+
+def test_a_profile_with_nvtx_is_unaffected():
+    """The guards must not short-circuit a profile that does have annotation."""
+    from nsys_ai.nvtx_tree import build_nvtx_tree
+    from nsys_ai.profile import Profile
+
+    if not WITH_NVTX.exists():  # pragma: no cover - fixture is committed
+        pytest.skip("two-GPU fixture not available")
+
+    with Profile(str(WITH_NVTX)) as prof:
+        assert prof.aggregate_nvtx_ranges(limit=5), "NVTX ranges vanished"
+        tree = build_nvtx_tree(prof, 0, prof.meta.time_range)
+    assert tree, "the NVTX tree came back empty on an annotated profile"


### PR DESCRIPTION
## Summary

`analyze` and `export-csv` exited 1 with a raw database error naming `NVTX_EVENTS` on any capture taken without annotation. Such a capture is valid — everything not depending on NVTX is still analysable — so both now produce the rest of the report and omit the part that needs it.

A second, quieter defect surfaced while fixing it: the table name was written literally, so an export using the `_V2`/`_V3` suffix reported **no ranges on a fully annotated profile**. That is silence rather than a crash, and the harder failure to notice.

## Changes

**The first attempt was inert, which is worth recording.** Two accessors already returned empty via a check against the schema table list, so they never crashed; the guard I added above that check changed nothing. What the existing check *did* do was name the table literally. The literal check is gone and the name is resolved — in every query in both files, not just the ones adjacent to the fix.

- `profile.py` — three accessors resolve the table; the dead literal guards are deleted rather than shadowed; the metadata probe resolves too, so a `_V2` export no longer reports `nvtx_count=0` and trigger a false "Insufficient NVTX coverage" finding.
- `nvtx_tree.py` — both queries resolve the table. This is the shared entry point for `analyze`'s hierarchy summary and `export-csv`'s per-kernel NVTX path, so one guard covers both commands. It resolves against `profile.adapter`, matching where the queries actually run, rather than the raw SQLite connection.
- `overlap.py` — `detect_iterations` no longer returns early when the table is absent. It falls through to the gap-based heuristic, which needs no annotation and does produce a result; withholding it dropped something the capture can genuinely support.

## Backward compatibility

No signature or output-shape changes. Six callers of the accessors are untouched. Profiles with NVTX behave identically — verified against two committed annotated fixtures and a `_V2` variant.

`Profile` accessors return `[]`, not `abstain()`. `Profile` is a data accessor where "there are no NVTX ranges" is the truthful answer; abstention is a skill-layer concept, and pushing a sentinel row here would force all six callers to handle it. The skill layer above already calls `requires_nvtx()` and abstains before reaching these.

## Test plan

Run, with output read:

- [x] `ruff check src/ tests/` — clean
- [x] `bandit -r src/ -c pyproject.toml` — 0 issues at every severity
- [x] `pytest tests/` with `NSYS_TEST_PROFILE` set — **1380 passed, 135 skipped, 0 failed**
- [x] `pytest tests/test_ci_coverage.py` — no new unregistered skips
- [x] `analyze` and `export-csv` exit 0 on all three shapes: no-NVTX (397 CSV rows), annotated (104), `_V2` variant (104)
- [x] New tests fail on `main` — 5 of 9, including the `_V2` case, so they catch real defects
- [x] Guards mutation-verified: removing the `nvtx_tree` guard fails 3 tests, the `overlap` guard 2

`scripts/smoke_test.sh` reports 1 failing check (`iteration_timing: duration_ms field`). It fails identically on `main` — same check, same message — so it is pre-existing and unrelated; verified by checking out `main` and re-running rather than assuming.

The `_V2` test replaces an earlier source-text assertion. That version asserted a literal string was absent from one file: it passed while the fix did nothing, and while sibling files kept their own literals. Renaming the table on a real annotated profile is the only check that separates *resolved* from *looks resolved*, because the wrong answer there is an empty result rather than an exception.

## Out of scope

`nccl_communicator.py:286,409` and `region_mfu.py:193,202` still name the table literally. Neither is reachable from `analyze` or `export-csv`: the first degrades to an empty result behind `_safe_skill_run` (silent, and worse for it), the second only via `mfu`/`tool_dispatch`. Both are real and both deserve fixing — expanding this PR to cover them would bury the change it exists to make. Filed separately.

## Linked issues

Closes #288.
