### PR TITLE
fix: resolve the NVTX table name in the two readers that open their own connection

### DIFF
--- a/src/nsys_ai/nccl_communicator.py
+++ b/src/nsys_ai/nccl_communicator.py
@@ -272,6 +272,15 @@ def _load_nccl_payload_events(
         trim_clause = "AND n.[end] >= ? AND n.start <= ?"
         params.extend([int(trim[0]), int(trim[1])])
 
+    # parquet_cache aliases the unversioned name over whatever versioned table it
+    # finds, in cached and direct mode alike, so the literal answers correctly
+    # here today. Resolving anyway: the alias is a property of how the profile
+    # was opened, not something this reader is entitled to assume, and line 461
+    # of this module already resolves for the same reason.
+    nvtx_table = prof.adapter.resolve_activity_tables().get("nvtx")
+    if not nvtx_table:
+        return [], ["Profile has no NVTX_EVENTS table, so it carries no NCCL payloads."]
+
     try:
         rows = prof._duckdb_query(
             f"""
@@ -283,7 +292,7 @@ def _load_nccl_payload_events(
                 n.globalTid,
                 n.domainId,
                 n.binaryData
-            FROM NVTX_EVENTS n
+            FROM {nvtx_table} n
             LEFT JOIN StringIds s ON n.textId = s.id
             WHERE n.binaryData IS NOT NULL
               AND n.eventType = {_NVTX_RANGE_EVENT}
@@ -393,6 +402,20 @@ def _load_nvtx_payload_rows_sqlite(
     try:
         conn = sqlite3.connect(sqlite_path)
         conn.row_factory = sqlite3.Row
+
+        # This side-connection is opened here rather than taken from the Profile,
+        # so it gets none of the alias views parquet_cache creates for the
+        # unversioned name. On an export that suffixes the table _V2 / _V3 a
+        # literal fails outright, and the failure surfaces only as a diagnostic
+        # string — the caller reports no NCCL payloads on a profile that has them.
+        from .connection import wrap_connection
+
+        nvtx_table = wrap_connection(conn).resolve_activity_tables().get("nvtx")
+        if not nvtx_table:
+            conn.close()
+            diagnostics.append("SQLite fallback: profile has no NVTX_EVENTS table.")
+            return [], diagnostics
+
         cur = conn.cursor()
         result = [
             dict(row)
@@ -406,7 +429,7 @@ def _load_nvtx_payload_rows_sqlite(
                     n.globalTid,
                     n.domainId,
                     n.binaryData
-                FROM NVTX_EVENTS n
+                FROM {nvtx_table} n
                 LEFT JOIN StringIds s ON n.textId = s.id
                 WHERE n.binaryData IS NOT NULL
                   AND n.eventType = {_NVTX_RANGE_EVENT}

--- a/src/nsys_ai/nccl_communicator.py
+++ b/src/nsys_ai/nccl_communicator.py
@@ -277,8 +277,10 @@ def _load_nccl_payload_events(
     # here today. Resolving anyway: the alias is a property of how the profile
     # was opened, not something this reader is entitled to assume, and line 461
     # of this module already resolves for the same reason.
+    from .connection import is_safe_identifier
+
     nvtx_table = prof.adapter.resolve_activity_tables().get("nvtx")
-    if not nvtx_table:
+    if not nvtx_table or not is_safe_identifier(nvtx_table):
         return [], ["Profile has no NVTX_EVENTS table, so it carries no NCCL payloads."]
 
     try:
@@ -408,10 +410,10 @@ def _load_nvtx_payload_rows_sqlite(
         # unversioned name. On an export that suffixes the table _V2 / _V3 a
         # literal fails outright, and the failure surfaces only as a diagnostic
         # string — the caller reports no NCCL payloads on a profile that has them.
-        from .connection import wrap_connection
+        from .connection import is_safe_identifier, wrap_connection
 
         nvtx_table = wrap_connection(conn).resolve_activity_tables().get("nvtx")
-        if not nvtx_table:
+        if not nvtx_table or not is_safe_identifier(nvtx_table):
             conn.close()
             diagnostics.append("SQLite fallback: profile has no NVTX_EVENTS table.")
             return [], diagnostics

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -179,16 +179,21 @@ def find_nvtx_ranges(
     if not nvtx_name:
         return []
 
-    from .connection import wrap_connection
+    from .connection import is_safe_identifier, wrap_connection
 
     adapter = wrap_connection(conn)
 
     # Newer Nsight exports suffix the table NVTX_EVENTS_V2 / _V3. This reader is
     # handed a plain connection, so nothing upstream aliases the unversioned name
-    # for it, and a literal here returns no ranges on such an export rather than
-    # raising — an MFU region that silently cannot be found.
+    # for it, and a literal here finds no ranges on such an export — an MFU
+    # region that silently cannot be located.
+    #
+    # The absent-table case is the caller's to report, not this function's:
+    # `region_mfu` checks for the table and returns a NO_NVTX error before
+    # calling here, so the `[]` below is a guard for direct callers rather than
+    # an abstention. Returning it does not mean "this profile has no NVTX".
     nvtx_table = adapter.resolve_activity_tables().get("nvtx")
-    if not nvtx_table:
+    if not nvtx_table or not is_safe_identifier(nvtx_table):
         return []
 
     has_text_id = adapter.detect_nvtx_text_id()

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -182,6 +182,15 @@ def find_nvtx_ranges(
     from .connection import wrap_connection
 
     adapter = wrap_connection(conn)
+
+    # Newer Nsight exports suffix the table NVTX_EVENTS_V2 / _V3. This reader is
+    # handed a plain connection, so nothing upstream aliases the unversioned name
+    # for it, and a literal here returns no ranges on such an export rather than
+    # raising — an MFU region that silently cannot be found.
+    nvtx_table = adapter.resolve_activity_tables().get("nvtx")
+    if not nvtx_table:
+        return []
+
     has_text_id = adapter.detect_nvtx_text_id()
     if match_mode not in ("contains", "exact"):
         match_mode = "contains"
@@ -190,7 +199,7 @@ def find_nvtx_ranges(
         base_sql = (
             "SELECT COALESCE(n.text, s.value) AS text, "
             "n.start AS start_ns, n.[end] AS end_ns, n.globalTid AS global_tid "
-            "FROM NVTX_EVENTS n "
+            f"FROM {nvtx_table} n "
             "LEFT JOIN StringIds s ON n.textId = s.id "
             "WHERE (n.text IS NOT NULL OR s.value IS NOT NULL) "
             "AND n.[end] > n.start "
@@ -199,7 +208,7 @@ def find_nvtx_ranges(
         base_sql = (
             "SELECT n.text AS text, n.start AS start_ns, n.[end] AS end_ns, "
             "n.globalTid AS global_tid "
-            "FROM NVTX_EVENTS n "
+            f"FROM {nvtx_table} n "
             "WHERE n.text IS NOT NULL AND n.[end] > n.start "
         )
 

--- a/tests/test_nvtx_table_resolution.py
+++ b/tests/test_nvtx_table_resolution.py
@@ -90,13 +90,20 @@ def test_renamed_copy_has_only_the_versioned_table(versioned_profile):
 
 
 def _sample_range_name(path: Path) -> str:
-    """A range name that really occurs, so a miss means resolution, not a typo."""
+    """A range name that really occurs, so a miss means resolution, not a typo.
+
+    Ordered because LIMIT without ORDER BY picks whatever row the scan reaches
+    first, which is stable on this fixture today and guaranteed by nothing. A
+    test that quietly changes what it searches for is one that stops testing
+    what it claims to.
+    """
     conn = sqlite3.connect(path)
     try:
         row = conn.execute(
-            "SELECT COALESCE(n.text, s.value) FROM NVTX_EVENTS n "
+            "SELECT COALESCE(n.text, s.value) AS t FROM NVTX_EVENTS n "
             "LEFT JOIN StringIds s ON n.textId = s.id "
-            "WHERE COALESCE(n.text, s.value) IS NOT NULL AND n.[end] > n.start LIMIT 1"
+            "WHERE COALESCE(n.text, s.value) IS NOT NULL AND n.[end] > n.start "
+            "ORDER BY n.start, n.globalTid, t LIMIT 1"
         ).fetchone()
     finally:
         conn.close()

--- a/tests/test_nvtx_table_resolution.py
+++ b/tests/test_nvtx_table_resolution.py
@@ -1,0 +1,182 @@
+"""The NVTX table name is versioned, and two more readers still named it literally.
+
+Newer Nsight exports call the table NVTX_EVENTS_V2 or NVTX_EVENTS_V3. #285, #288
+and #291 resolved it in the skills layer, `profile.py`, `nvtx_tree.py` and
+`overlap.py`; `nccl_communicator.py` and `region_mfu.py` kept the literal.
+
+The failure is quiet rather than loud. `region_mfu` returns no ranges, and
+`nccl_communicator` is reached through `profile_health_manifest`'s
+`_safe_skill_run`, which turns any database error into `[]`. A profile that has
+NCCL communicator data is reported as having none.
+
+That is what these tests are shaped around. #288 shipped a source-text assertion
+that kept passing while the fix was inert and while these two files kept their
+literals, so checking the code reads a resolved name proves nothing. Each test
+below renames the table on a real annotated fixture and asserts on what the
+reader returns, which is the only thing that separates resolved from
+looks-resolved.
+"""
+
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+ANNOTATED = REPO / "tests" / "fixtures" / "h100_2gpu_1s.sqlite"
+
+# The suffix newer exports use. _V2 and _V3 both occur; resolution is by prefix,
+# so exercising one covers both.
+RENAMED = "NVTX_EVENTS_V3"
+
+
+def _nvtx_tables(path: Path) -> set[str]:
+    conn = sqlite3.connect(path)
+    try:
+        return {
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name LIKE 'NVTX_EVENTS%'"
+            )
+        }
+    finally:
+        conn.close()
+
+
+@pytest.fixture(scope="module")
+def versioned_profile(tmp_path_factory) -> Path:
+    """A copy of the annotated fixture with NVTX_EVENTS renamed to NVTX_EVENTS_V3.
+
+    Renaming rather than hand-building keeps the row content real: 16k annotated
+    ranges with the text/textId split an actual PyTorch capture produces.
+    """
+    dst = tmp_path_factory.mktemp("versioned") / "nvtx_v3.sqlite"
+    shutil.copy(ANNOTATED, dst)
+    conn = sqlite3.connect(dst)
+    try:
+        conn.execute(f"ALTER TABLE NVTX_EVENTS RENAME TO {RENAMED}")
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+# ── Premises ────────────────────────────────────────────────────────────────
+# Without these the tests below can pass vacuously: an empty fixture would make
+# "no rows" the correct answer under both the literal and the resolved name.
+
+
+def test_source_fixture_is_annotated():
+    assert ANNOTATED.exists(), f"fixture missing: {ANNOTATED}"
+    assert _nvtx_tables(ANNOTATED) == {"NVTX_EVENTS"}
+    conn = sqlite3.connect(ANNOTATED)
+    try:
+        named = conn.execute(
+            "SELECT COUNT(*) FROM NVTX_EVENTS n LEFT JOIN StringIds s ON n.textId = s.id "
+            "WHERE COALESCE(n.text, s.value) IS NOT NULL AND n.[end] > n.start"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert named > 0, "fixture has no named NVTX ranges — the tests below prove nothing"
+
+
+def test_renamed_copy_has_only_the_versioned_table(versioned_profile):
+    """The literal name must be genuinely absent, or resolution is untested."""
+    assert _nvtx_tables(versioned_profile) == {RENAMED}
+
+
+# ── region_mfu ──────────────────────────────────────────────────────────────
+
+
+def _sample_range_name(path: Path) -> str:
+    """A range name that really occurs, so a miss means resolution, not a typo."""
+    conn = sqlite3.connect(path)
+    try:
+        row = conn.execute(
+            "SELECT COALESCE(n.text, s.value) FROM NVTX_EVENTS n "
+            "LEFT JOIN StringIds s ON n.textId = s.id "
+            "WHERE COALESCE(n.text, s.value) IS NOT NULL AND n.[end] > n.start LIMIT 1"
+        ).fetchone()
+    finally:
+        conn.close()
+    # Range texts look like "aten::view, op_id = 314290"; match the stable head.
+    return row[0].split(",")[0]
+
+
+def test_find_nvtx_ranges_reads_the_versioned_table(versioned_profile):
+    """The assertion that fails while the table name is a literal."""
+    from nsys_ai.region_mfu import find_nvtx_ranges
+
+    name = _sample_range_name(ANNOTATED)
+    conn = sqlite3.connect(versioned_profile)
+    try:
+        rows = find_nvtx_ranges(conn, name)
+    finally:
+        conn.close()
+
+    assert rows, (
+        f"find_nvtx_ranges returned nothing for {name!r} on a profile whose NVTX "
+        f"table is {RENAMED} — the table name is not being resolved"
+    )
+
+
+def test_find_nvtx_ranges_agrees_across_both_table_names(versioned_profile):
+    """Resolution must not change the answer, only where it is read from."""
+    from nsys_ai.region_mfu import find_nvtx_ranges
+
+    name = _sample_range_name(ANNOTATED)
+
+    original = sqlite3.connect(ANNOTATED)
+    renamed = sqlite3.connect(versioned_profile)
+    try:
+        before = find_nvtx_ranges(original, name)
+        after = find_nvtx_ranges(renamed, name)
+    finally:
+        original.close()
+        renamed.close()
+
+    assert before, "premise: the unrenamed profile must return ranges"
+    assert len(after) == len(before)
+
+
+# ── nccl_communicator ───────────────────────────────────────────────────────
+# Only one of this module's two readers is reachable with the literal name.
+#
+# The primary reader goes through ``Profile._duckdb_query``, and
+# ``parquet_cache`` creates an alias view named NVTX_EVENTS over whatever
+# versioned table it finds — in cached and in direct-SQLite mode both. So that
+# query answers correctly today despite the literal, and no test written against
+# it can fail. It is still resolved below, because the alias layer is a
+# coincidence of how the profile happens to be opened rather than a guarantee
+# this module is entitled to.
+#
+# The blob fallback opens its own ``sqlite3`` connection, which has no alias
+# layer. That one is genuinely broken, and it is what the test asserts on.
+
+
+def test_duckdb_reader_is_not_the_broken_one(versioned_profile):
+    """Records why the primary reader has no failing test: it cannot fail.
+
+    If parquet_cache ever stops aliasing the unversioned name, this starts
+    failing and points at the reader that would then be exposed.
+    """
+    from nsys_ai import profile as profile_mod
+
+    with profile_mod.open(str(versioned_profile), cache_mode="direct") as prof:
+        via_literal = prof._duckdb_query("SELECT COUNT(*) AS n FROM NVTX_EVENTS")
+        via_actual = prof._duckdb_query(f"SELECT COUNT(*) AS n FROM {RENAMED}")
+
+    assert via_literal[0]["n"] == via_actual[0]["n"] > 0
+
+
+def test_sqlite_blob_fallback_reads_the_versioned_table(versioned_profile):
+    """The assertion that fails while the fallback's table name is a literal."""
+    from nsys_ai.nccl_communicator import _load_nvtx_payload_rows_sqlite
+
+    _rows, diagnostics = _load_nvtx_payload_rows_sqlite(str(versioned_profile))
+
+    assert not diagnostics, (
+        f"the SQLite blob fallback failed against a profile whose NVTX table is "
+        f"{RENAMED} — the table name is not being resolved: {diagnostics}"
+    )


### PR DESCRIPTION
## Summary

- Resolves the NVTX table name in `region_mfu.find_nvtx_ranges` and `nccl_communicator`'s two readers, so they work on exports that suffix it `_V2` / `_V3`.
- Adds behavioural tests that rename the table on a real annotated fixture and assert on what each reader returns.
- Corrects part of the issue's diagnosis: only two of the three sites are reachable with the wrong name. Detail below.

## Changes

- `src/nsys_ai/region_mfu.py` — `find_nvtx_ranges` resolves via `adapter.resolve_activity_tables().get("nvtx")` and returns `[]` when the table is absent. Both the `textId` and the legacy `text` branch were literal.
- `src/nsys_ai/nccl_communicator.py` — the SQLite blob fallback resolves against its own connection; the primary reader resolves via `prof.adapter`.
- `tests/test_nvtx_table_resolution.py` — new.

## What is actually broken, and what is not

The issue lists `nccl_communicator.py:286`, `:409` and `region_mfu.py:193`, `:202`. Checked each against a renamed fixture:

| Site | Path it takes | Reachable with the literal? |
|---|---|---|
| `region_mfu.py:193` / `:202` | plain `sqlite3.Connection` | **Yes** — returns no ranges |
| `nccl_communicator.py:409` | its own `sqlite3.connect()` | **Yes** — `no such table: NVTX_EVENTS` |
| `nccl_communicator.py:286` | `Profile._duckdb_query` | **No** |

`parquet_cache` creates an alias view named `NVTX_EVENTS` over whatever versioned table it finds — `_ALIASES["nvtx"] == ["NVTX_EVENTS"]`, matched by prefix — and it does so in cached *and* direct-SQLite mode. Confirmed empirically: on a profile whose only NVTX table is `NVTX_EVENTS_V3`, `_duckdb_query` returns 16782 rows for both names.

So the primary reader answers correctly today, and the issue's description of it degrading to an empty result through `_safe_skill_run` does not reproduce. It is resolved anyway, because the alias depends on how the profile was opened rather than on anything that reader controls, and line 461 of the same module already resolves for that reason. The test suite records this rather than leaving a passing test that proves nothing.

## Backward compatibility

Yes. Same results on unversioned exports — one test asserts the row count is identical across both table names.

## Test plan

- [x] `pytest tests/ -v --tb=short -rs` with `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite` — 1381 passed, 140 skipped, 0 failed. All skips pre-existing (absent API keys, local-only profiles).
- [x] `pytest tests/test_ci_coverage.py` — 5 passed, no unregistered skips.
- [x] `ruff check src/ tests/` clean.
- [x] `bandit -r src/ -c pyproject.toml` — 0 medium, 0 high.
- [x] `python -m nsys_ai --help` exits 0.
- [x] Regression proof: reverting either resolved name turns the new tests red; restoring turns them green. Verified rather than assumed, since #288 shipped a check that passed while its fix was inert.
- [ ] Manual CLI/GUI exercise — n/a, no user-facing surface changed.

## Out of scope

- **`src/nsys_ai/ai/backend/profile_db_tool.py:22`** — `NVTX_TABLE = "NVTX_EVENTS"`, with the comment "NVTX table name is stable". That comment is the assumption #285, #288, #291 and this issue have each disproved. It is used at `:234` to decide which tables' schema is shown to the model, so the impact differs from the readers here and it is outside this issue's scope. Worth its own issue; happy to open one.
- **`_safe_skill_run` distinguishing "raised" from "returned nothing"** — the issue's third suggestion. It is a real gap, but it changes manifest behaviour broadly and does not belong in a fix this size.

## Linked issues

Closes #292.
