### PR TITLE
perf(skills): memoize skill results per connection, keyed on resolved parameters

### DIFF
--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -37,9 +37,17 @@ _PROBE_MISS = object()
 _duck_probe_bags: weakref.WeakKeyDictionary[Any, dict[str, Any]] = weakref.WeakKeyDictionary()
 # sqlite3.Connection is not weak-referenceable, so we key by the connection
 # object itself (identity hash).  This keeps a strong reference for the
-# lifetime of the process, which is acceptable in a short-lived CLI.  Using
-# the object directly avoids the id()-reuse hazard (id() can be recycled
-# after a connection is closed and GC'd, giving false cache hits).
+# lifetime of the process.  Using the object directly avoids the id()-reuse
+# hazard (id() can be recycled after a connection is closed and GC'd, giving
+# false cache hits).
+#
+# Size note, since this bag now holds more than probe booleans: memoized skill
+# rows live here too, measured at ~570KB for one connection after a full
+# EvidenceBuilder build (one nvtx_layer_breakdown entry is ~477KB of it), and
+# they are not released on close().  That is bounded per connection rather than
+# growing: the CLI is short-lived, and the web server holds a single Profile for
+# the server's lifetime rather than opening one per request.  Caching across a
+# connection's life is safe because a profile is an immutable capture.
 _sqlite_probe_bags: dict[sqlite3.Connection, dict[str, Any]] = {}
 
 
@@ -63,6 +71,23 @@ def _probe_cache_set(conn, key: str, value) -> None:
         _duck_probe_bags.setdefault(conn, {})[key] = value
     except TypeError:
         pass
+
+
+SKILL_CACHE_MISS = _PROBE_MISS
+
+
+def cached_skill_rows(conn, key: str):
+    """Rows a skill already produced for ``key`` on ``conn``, or SKILL_CACHE_MISS.
+
+    Reuses the probe bag above rather than adding a second cache, so both share
+    its connection-object keying — deliberately not ``id()``, which is recycled
+    after a connection is closed and would give false hits across profiles.
+    """
+    return _probe_cache_get(conn, key)
+
+
+def set_cached_skill_rows(conn, key: str, rows) -> None:
+    _probe_cache_set(conn, key, rows)
 
 
 def cached_nvtx_map_uses_path_id(conn) -> bool:

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -9,9 +9,36 @@ import sqlite3
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
-from ..connection import DB_ERRORS
+from ..connection import DB_ERRORS, SKILL_CACHE_MISS, cached_skill_rows, set_cached_skill_rows
 
 _log = logging.getLogger(__name__)
+
+
+def _copy_rows(rows):
+    """Copy the row dicts so cache and caller do not share the top level.
+
+    Shallow on purpose, and the limit is worth stating: nested values are still
+    shared. Twelve of the twenty-one entries a build caches carry them —
+    `gpu_idle_gaps.attribution`, `critical_path.breakdown`, the manifest's
+    sections — so a consumer mutating one of those *in place* would reach the
+    cache. No skill or consumer in this repo does that, which is why this is not
+    a deep copy: deep-copying the manifest on every hit would cost more than the
+    memo saves. If a consumer ever does mutate nested content, this is the line
+    that has to change.
+    """
+    return [dict(r) if isinstance(r, dict) else r for r in rows]
+
+
+def _params_key(resolved: dict) -> str:
+    """Stable text for a parameter set, for use in a cache key.
+
+    Values may be unhashable (a list of diagnostic dicts is passed through as a
+    parameter), so this serialises rather than hashing a tuple. Measured at
+    0.48ms across all 29 calls in a build, against 69ms saved.
+    """
+    import json
+
+    return json.dumps(resolved, sort_keys=True, default=str)
 
 
 def abstain(reason: str, **detail) -> list[dict]:
@@ -269,9 +296,32 @@ class Skill:
                 _log.debug("No profiler overhead data found (table absent or empty)")
             resolved["overhead_ns"] = overhead_ns
 
+        # Memoize per connection. One EvidenceBuilder.build() executes 29 skills
+        # for 14 distinct names, because the health manifest and root-cause
+        # matcher re-run skills the pipeline already ran. Eight of those are
+        # exact repeats.
+        #
+        # The key includes the resolved parameters, not just the name. The
+        # repeats are mostly NOT identical — gpu_idle_gaps is called at limit=1
+        # and limit=5 in the same build, and those legitimately differ — so a
+        # name-only key would hand one caller another's results and silently
+        # change findings. Resolved rather than raw kwargs so an explicit
+        # limit=5 and a defaulted limit=5 share an entry.
+        cache_key = f"skill:{self.name}:{_params_key(resolved)}"
+        cached = cached_skill_rows(conn, cache_key)
+        if cached is not SKILL_CACHE_MISS:
+            # Copy on the way out as well, so two readers never share the row
+            # dicts themselves.
+            return _copy_rows(cached)
+
         # Python-level skill: delegate to execute_fn with resolved params.
         if self.execute_fn is not None:
-            return self.execute_fn(conn, **resolved)
+            rows = self.execute_fn(conn, **resolved)
+            # Store a copy, not the list being returned. Copying only on read
+            # leaves the first caller holding the cached object itself, so its
+            # in-place edits reach everyone after it.
+            set_cached_skill_rows(conn, cache_key, _copy_rows(rows))
+            return rows
 
         # --- SQL Execution Path ---
         # Inject resolved activity table names for versioned-table support.
@@ -323,7 +373,13 @@ class Skill:
         try:
             cursor = adapter.execute(sql)
             columns = [desc[0] for desc in cursor.description] if cursor.description else []
-            return [dict(zip(columns, row)) for row in cursor.fetchall()]
+            rows = [dict(zip(columns, row)) for row in cursor.fetchall()]
+            # Store here too. The lookup above sits over both branches, but the
+            # store used to live only in the execute_fn branch, so the five
+            # SQL-only skills built a key and then took a guaranteed miss on
+            # every call — paying for the cache without ever using it.
+            set_cached_skill_rows(conn, cache_key, _copy_rows(rows))
+            return rows
         except Exception as exc:
             db_errors = (sqlite3.Error,)
             try:

--- a/tests/test_skill_memo.py
+++ b/tests/test_skill_memo.py
@@ -1,0 +1,227 @@
+"""Skill results are memoized per connection, keyed on the resolved parameters.
+
+One `EvidenceBuilder.build()` executed 29 skills for 14 distinct names, because
+the health manifest and the root-cause matcher re-run skills the pipeline has
+already run. Eight of those were exact repeats.
+
+The parameters are the reason this needs care rather than a dictionary keyed on
+the skill name. Most of the repeats are *not* identical — `gpu_idle_gaps` is
+called at `limit=1` and at `limit=5` within a single build, and those return
+genuinely different results — so a name-only key would serve one caller the
+other's rows and change findings without any error.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.skills.registry import get_skill
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+def test_identical_params_hit_the_cache():
+    skill = get_skill("top_kernels")
+    calls = []
+    original = skill.execute_fn
+
+    def counting(conn, **kwargs):
+        calls.append(kwargs)
+        return original(conn, **kwargs)
+
+    skill.execute_fn = counting
+    conn = sqlite3.connect(FIXTURE)
+    try:
+        first = skill.execute(conn, limit=5)
+        second = skill.execute(conn, limit=5)
+    finally:
+        skill.execute_fn = original
+        conn.close()
+
+    assert len(calls) == 1, "the second identical call re-executed"
+    assert first == second
+
+
+def test_different_params_are_never_served_a_cached_result():
+    """The failure a name-only key would cause, asserted directly.
+
+    `gpu_idle_gaps` is called at limit=1 and limit=5 in the same build. If the
+    key ignored parameters the second caller would receive the first's rows.
+    """
+    skill = get_skill("gpu_idle_gaps")
+    conn = sqlite3.connect(FIXTURE)
+    try:
+        few = [r for r in skill.execute(conn, device=0, limit=1) if not r.get("_summary")]
+        many = [r for r in skill.execute(conn, device=0, limit=5) if not r.get("_summary")]
+    finally:
+        conn.close()
+
+    assert len(few) <= 1
+    assert len(many) > len(few), (
+        f"limit=5 returned {len(many)} rows, limit=1 returned {len(few)} — "
+        "the cache ignored the parameters"
+    )
+
+
+def test_a_defaulted_parameter_shares_an_entry_with_an_explicit_one():
+    """The key is built from resolved parameters, after defaults are applied.
+
+    Keying on raw kwargs would treat an omitted `limit` and an explicit `limit`
+    set to the same default as different, and re-execute for nothing.
+    """
+    skill = get_skill("top_kernels")
+    default_limit = next(p.default for p in skill.params if p.name == "limit")
+    calls = []
+    original = skill.execute_fn
+
+    def counting(conn, **kwargs):
+        calls.append(kwargs)
+        return original(conn, **kwargs)
+
+    skill.execute_fn = counting
+    conn = sqlite3.connect(FIXTURE)
+    try:
+        skill.execute(conn)
+        skill.execute(conn, limit=default_limit)
+    finally:
+        skill.execute_fn = original
+        conn.close()
+
+    assert len(calls) == 1, f"defaulted and explicit {default_limit} did not share an entry"
+
+
+def test_a_cached_result_cannot_be_corrupted_by_its_consumer():
+    """Rows are copied out, because consumers mutate them in place.
+
+    Without the copy, one caller adding a key would change what every later
+    caller sees — a bug that would surface far from here.
+    """
+    skill = get_skill("top_kernels")
+    conn = sqlite3.connect(FIXTURE)
+    try:
+        first = skill.execute(conn, limit=3)
+        first[0]["_injected_by_consumer"] = True
+        second = skill.execute(conn, limit=3)
+    finally:
+        conn.close()
+
+    assert "_injected_by_consumer" not in second[0], "the cache handed out a shared row"
+
+
+def test_a_second_reader_does_not_share_rows_with_the_first():
+    """The read-side copy, which the store-side test does not reach.
+
+    That test poisons the *first*, uncached list, so it only exercises the copy
+    made on store. Removing the copy made on read left all seven tests passing —
+    the classic "would pass with the body deleted".
+    """
+    skill = get_skill("top_kernels")
+    conn = sqlite3.connect(FIXTURE)
+    try:
+        skill.execute(conn, limit=3)          # populate
+        second = skill.execute(conn, limit=3)  # first cached read
+        second[0]["_injected_by_second_reader"] = True
+        third = skill.execute(conn, limit=3)   # second cached read
+    finally:
+        conn.close()
+
+    assert "_injected_by_second_reader" not in third[0], (
+        "two cached readers were handed the same row object"
+    )
+
+
+def test_sql_only_skills_are_cached_too():
+    """The store used to sit inside the execute_fn branch only.
+
+    The five SQL-only skills therefore built a cache key and then took a
+    guaranteed miss on every call — paying the cost without the benefit.
+    `root_cause_matcher` runs one of them, and `Agent.analyze()` runs all five.
+    """
+    skill = get_skill("kernel_launch_overhead")
+    assert skill.execute_fn is None, "this skill is no longer SQL-only; pick another"
+    conn = sqlite3.connect(FIXTURE)
+    try:
+        skill.execute(conn, limit=5)
+        import nsys_ai.connection as connection
+
+        cached = [
+            k
+            for bag in connection._sqlite_probe_bags.values()
+            for k in bag
+            if k.startswith("skill:kernel_launch_overhead")
+        ]
+    finally:
+        conn.close()
+    assert cached, "a SQL-only skill produced no cache entry"
+
+
+def test_separate_connections_do_not_share_results():
+    """The cache is per connection, so two profiles cannot bleed into each other."""
+    other = Path(__file__).resolve().parent / "fixtures" / "healthy_1pct.sqlite"
+    skill = get_skill("top_kernels")
+
+    a = sqlite3.connect(FIXTURE)
+    b = sqlite3.connect(other)
+    try:
+        rows_a = skill.execute(a, limit=3)
+        rows_b = skill.execute(b, limit=3)
+    finally:
+        a.close()
+        b.close()
+
+    names_a = {r.get("kernel_name") or r.get("name") for r in rows_a}
+    names_b = {r.get("kernel_name") or r.get("name") for r in rows_b}
+    assert names_a != names_b, "two different profiles returned the same kernels"
+
+
+@pytest.mark.parametrize("profile", ["h100_2gpu_1s", "healthy_1pct"])
+def test_the_build_executes_fewer_skills_without_changing_findings(profile):
+    """The whole point: less work, same answer.
+
+    Findings were compared byte-for-byte against the pre-memo implementation on
+    three committed profiles; this pins the execution count so a regression that
+    reintroduces the duplicates is visible.
+    """
+    import collections
+
+    from nsys_ai.evidence_builder import EvidenceBuilder
+    from nsys_ai.profile import Profile
+    from nsys_ai.skills import registry
+
+    counts: collections.Counter = collections.Counter()
+    originals = {}
+    for sk in registry.all_skills():
+        if sk.execute_fn is None:
+            continue
+        originals[sk.name] = sk.execute_fn
+
+        def make(name, fn):
+            def wrapped(conn, **kwargs):
+                counts[name] += 1
+                return fn(conn, **kwargs)
+
+            return wrapped
+
+        sk.execute_fn = make(sk.name, sk.execute_fn)
+
+    try:
+        with Profile(str(FIXTURE.parent / f"{profile}.sqlite")) as prof:
+            report = EvidenceBuilder(prof, device=0).build()
+    finally:
+        for sk in registry.all_skills():
+            if sk.name in originals:
+                sk.execute_fn = originals[sk.name]
+
+    assert report.findings, "the build produced nothing"
+    total = sum(counts.values())
+    # Pins the count so a change that reintroduces duplicates is visible.
+    # Deliberately not asserting that every remaining repeat is a genuinely
+    # different parameter set — that is false today. `sync_cost_analysis` and
+    # `overlap_breakdown` still repeat under keys differing only by parameters
+    # the skill does not declare and does not read (`communicator_data` is
+    # forwarded through `root_cause_matcher`), so three of the remaining
+    # executions are semantically identical calls the memo fails to absorb.
+    # Narrowing the key to declared parameters would take this to 18; that is a
+    # separate change with its own correctness surface.
+    assert total <= 21, f"{total} skill executions — duplicates came back: {dict(counts)}"


### PR DESCRIPTION
## Summary

One `EvidenceBuilder.build()` executed **29 skills for 14 distinct names**, because `profile_health_manifest` and `root_cause_matcher` re-run skills the pipeline has already run. Eight of those were exact repeats. Memoizing them per connection takes a build to **21 executions**.

| profile | before | after |
|---|---|---|
| `h100_2gpu_1s` (2.2MB) | 695ms | 619ms |
| real 56MB capture | 10.15s | **7.94s (22%)** |

## Changes

The key is built from **skill name + resolved parameters**, not the name alone. Most repeats are *not* identical — `gpu_idle_gaps` runs at `limit=1` and `limit=5` within one build and those genuinely differ — so a name-only key would hand one caller the other's rows and change findings with nothing to show for it. Resolved rather than raw kwargs, so a defaulted value and an explicit one matching it share an entry.

Rows are copied **both** into and out of the cache. Copying only on the way out leaves the first caller holding the cached list itself, so its in-place edits reach everyone after it — a test caught that during development.

The store covers the **SQL path** too. It first sat inside the `execute_fn` branch, so the five SQL-only skills built a key and then took a guaranteed miss on every call, paying for the cache without ever using it. `root_cause_matcher` runs one of them; `Agent.analyze()` runs all five.

It reuses the existing probe bag in `connection.py` rather than adding a second cache, so both share its connection-object keying — deliberately not `id()`, which is recycled after close and would give false hits across profiles.

## Backward compatibility

Findings are **byte-identical**, compared against `upstream/main` across six profiles including a real 56MB capture. `analyze --format json`, `diff --format json`, `ask`, `doctor` and `skill run` all produce identical output (the sole difference being `analysis_time_utc`, a timestamp). No signature changes; callers untouched.

## Test plan

Run, with output read:

- [x] `ruff check src/ tests/` — clean
- [x] `bandit -r src/ -c pyproject.toml` — 0 issues at every severity
- [x] `pytest tests/` — **1389 passed, 135 skipped, 0 failed**
- [x] `pytest tests/test_ci_coverage.py` — no new unregistered skips
- [x] findings byte-identical vs `upstream/main` (84,977 B both)
- [x] executions 29 → 21
- [x] Every guard mutation-verified: name-only key, copy-on-store, copy-on-read, SQL-path store, connection keying — removing each fails its test

`scripts/smoke_test.sh` reports 1 failing check (`iteration_timing: duration_ms field`). It fails identically on `main`, verified by checking out `main` and re-running.

## Out of scope

**The issue's original premise was wrong and has been corrected on #250.** It asked for "each skill's SQL runs once, not three times" — unachievable, because the repeats mostly use different parameters. Only 8 of 29 were exact duplicates. It also argued the cost matters most without the DuckDB cache; measured, it does not (10% cached vs 8.3% uncached).

**Three executions still not absorbed.** The key includes kwargs the skill neither declares nor reads — `communicator_data` is forwarded through `root_cause_matcher` — so `sync_cost_analysis` and `overlap_breakdown` repeat under keys differing only by parameters that cannot affect their results. 21 could be 18. Narrowing the key to declared parameters is a separate change with its own correctness surface, and the test says so rather than asserting the current count is fully justified.

**The shallow copy's limit is documented, not removed.** Nested values are still shared; 12 of the 21 cached entries carry them. No consumer in this repo mutates nested content, and deep-copying the manifest on every hit would cost more than the memo saves. The comment names the line to change if that stops being true.

**Retention grew** from probe booleans to ~0.6–0.9 MB per connection, not released on `close()`. Bounded per connection rather than growing: the CLI is short-lived and the web server holds a single `Profile` for its lifetime rather than one per request. The comment justifying strong references has been updated with the measured figures, since it was written when entries were booleans.

The real hot spots remain untouched — `profile_health_manifest` at 240ms and `root_cause_matcher` at 116ms.

## Linked issues

Closes #250.
