### PR TITLE
fix(skills): collapse abstention to no-evidence in root_cause_matcher

### DIFF
--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -970,8 +970,22 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
 
 
 def _safe_execute(skill_name, conn: sqlite3.Connection, **kwargs):
-    """Execute a skill, returning [] on DB or skill execution errors."""
+    """Execute a skill, returning [] on DB errors, skill errors, or abstention.
+
+    Abstention collapses to [] here rather than at each call site. A skill that
+    could not run is not evidence for any pattern, and every consumer below
+    guards with ``if <rows>:`` — which a one-row abstention passes, because it
+    is a non-empty list.
+
+    Nothing currently misreads one, and the reason is an accident rather than a
+    design: the only sub-skill that can abstain is ``nvtx_layer_breakdown``, and
+    the analysers it feeds sit behind ``len(layer_data) >= 2`` while abstention
+    is exactly one row. Adding a second abstaining skill to a ``len >= 1`` path
+    would end that silently. ``evidence_builder`` filters at its own boundary
+    for the same reason.
+    """
     from ...exceptions import SkillExecutionError
+    from ...skills.base import is_abstention
     from ...skills.registry import get_skill
 
     _safe_errors = DB_ERRORS + (SkillExecutionError,)
@@ -980,10 +994,19 @@ def _safe_execute(skill_name, conn: sqlite3.Connection, **kwargs):
         skill = get_skill(skill_name)
         if skill is None:
             return []
-        return skill.execute(conn, **kwargs)
+        rows = skill.execute(conn, **kwargs)
     except _safe_errors as e:
         _log.debug("root_cause_matcher (%s): %s", skill_name, e, exc_info=True)
         return []
+
+    if is_abstention(rows):
+        _log.debug(
+            "root_cause_matcher (%s): abstained — %s",
+            skill_name,
+            rows[0].get("reason", ""),
+        )
+        return []
+    return rows
 
 
 def _format(rows):

--- a/tests/test_root_cause_abstention.py
+++ b/tests/test_root_cause_abstention.py
@@ -27,7 +27,13 @@ NO_NVTX = REPO / "tests" / "fixtures" / "healthy_1pct.sqlite"
 
 @pytest.fixture
 def conn():
-    c = sqlite3.connect(NO_NVTX)
+    """Read-only, so the run cannot modify the checked-in fixture.
+
+    `Skill.execute` calls `ensure_performance_indexes`, which writes `_nsysai_*`
+    indexes into whatever profile it is handed. Against a committed fixture that
+    leaves the working tree dirty and changes the file for every later run.
+    """
+    c = sqlite3.connect(f"file:{NO_NVTX}?mode=ro", uri=True)
     try:
         yield c
     finally:
@@ -61,6 +67,21 @@ def test_safe_execute_does_not_pass_abstention_through(conn):
         f"_safe_execute returned an abstention row as if it were data; every "
         f"consumer guards with `if rows:` and a non-empty list passes that: {rows}"
     )
+
+
+def test_safe_execute_still_returns_real_rows(conn):
+    """The other half of the contract: a skill that ran must pass its data through.
+
+    The change restructured the return, so guard the path it moved: without this
+    a `return rows` lost in the edit would only surface as some unrelated
+    matcher test going quiet.
+    """
+    from nsys_ai.skills.builtins.root_cause_matcher import _safe_execute
+
+    rows = _safe_execute("top_kernels", conn, limit=5)
+
+    assert rows, "top_kernels ran against a profile with kernels and returned nothing"
+    assert "kernel_name" in rows[0], f"rows came back reshaped: {rows[0]}"
 
 
 def test_matcher_reports_no_layer_findings_without_annotation(conn):

--- a/tests/test_root_cause_abstention.py
+++ b/tests/test_root_cause_abstention.py
@@ -1,0 +1,78 @@
+"""`root_cause_matcher` must not treat "could not run" as evidence.
+
+`_safe_execute` returns whatever the sub-skill returned, and every consumer
+guards with `if <rows>:`. An abstention row is a non-empty list, so it passes
+that guard and is read as data.
+
+Nothing goes wrong today, and the reason is worth stating because it is not a
+design: the only sub-skill that can abstain is `nvtx_layer_breakdown`, abstention
+is exactly one row, and the layer analysers happen to sit behind
+`len(layer_data) >= 2`. Add a second abstaining skill to a `len >= 1` path, or
+give `abstain()` a detail row, and the accident stops holding.
+
+`evidence_builder` already filters for this reason — its docstring names the same
+hazard, that the safe skills are "safe only through unrelated guards ... which a
+refactor could remove without anyone noticing". This puts `root_cause_matcher` on
+the same footing.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+NO_NVTX = REPO / "tests" / "fixtures" / "healthy_1pct.sqlite"
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(NO_NVTX)
+    try:
+        yield c
+    finally:
+        c.close()
+
+
+def test_the_fixture_really_has_no_nvtx(conn):
+    """Guard the premise: without this the assertions below go vacuous."""
+    tables = {
+        r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    }
+    assert not any(t.startswith("NVTX_EVENTS") for t in tables)
+
+
+def test_the_subskill_really_abstains(conn):
+    """The other half of the premise: the skill must abstain, not return []."""
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    rows = get_skill("nvtx_layer_breakdown").execute(conn)
+    assert is_abstention(rows), f"expected an abstention row, got {rows[:1]}"
+
+
+def test_safe_execute_does_not_pass_abstention_through(conn):
+    """The assertion that fails without the guard."""
+    from nsys_ai.skills.builtins.root_cause_matcher import _safe_execute
+
+    rows = _safe_execute("nvtx_layer_breakdown", conn)
+
+    assert rows == [], (
+        f"_safe_execute returned an abstention row as if it were data; every "
+        f"consumer guards with `if rows:` and a non-empty list passes that: {rows}"
+    )
+
+
+def test_matcher_reports_no_layer_findings_without_annotation(conn):
+    """End to end: an unannotated profile must not yield layer-attributed causes."""
+    from nsys_ai.skills.registry import get_skill
+
+    findings = get_skill("root_cause_matcher").execute(conn)
+
+    for f in findings:
+        assert "_abstained" not in f, f"an abstention row was emitted as a finding: {f}"
+        # Layer findings are the ones nvtx_layer_breakdown feeds; none can be
+        # justified on a profile that carries no annotation at all.
+        assert "layer" not in str(f.get("pattern", "")).lower(), (
+            f"layer-attributed cause on an unannotated profile: {f}"
+        )


### PR DESCRIPTION
## Summary

- `root_cause_matcher._safe_execute` returned abstention rows to its callers, all of which guard with `if <rows>:` — a guard a one-row abstention passes, because it is a non-empty list.
- Collapses abstention to `[]` at that boundary, matching what `evidence_builder` already does at its own.

## Changes

- `src/nsys_ai/skills/builtins/root_cause_matcher.py` — `_safe_execute` returns `[]` on abstention as well as on DB and skill errors, and logs the reason at debug.
- `tests/test_root_cause_abstention.py` — new.

## Why this is worth fixing while nothing is broken

Nothing misreads an abstention row today. The reason is not a design:

- the only sub-skill here that can abstain is `nvtx_layer_breakdown`,
- `abstain()` returns exactly one row,
- and the layer analysers sit behind `if layer_data and len(layer_data) >= 2`.

Three unrelated facts line up. Add a second abstaining skill to a `len >= 1` path, or give `abstain()` a detail row, and the accident stops holding with nothing to notice — a "could not run" would be counted as evidence for a pattern, which is the failure the abstention contract exists to prevent.

`evidence_builder` filters for exactly this reason, and its docstring already says so: the safe skills are *"safe only through unrelated guards (an early return on a row count, a length check), which a refactor could remove without anyone noticing."* This applies the same reasoning one module over.

## Backward compatibility

Yes. On every profile the suite covers, the matcher's output is unchanged — the abstention row was already being excluded downstream, just incidentally.

## Test plan

- [x] `pytest tests/ -v --tb=short -rs` with `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite` — 1394 passed, 140 skipped, 0 failed.
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` 0 medium / 0 high; `python -m nsys_ai --help` exits 0.
- [x] Regression proof: neutering the guard turns `test_safe_execute_does_not_pass_abstention_through` red; restoring it turns it green.
- [ ] Manual CLI/GUI exercise — n/a, no user-facing surface changed.

## A note on where the test asserts

The test targets `_safe_execute` directly rather than the matcher's output. End to end the matcher already behaves correctly, thanks to the length check described above, so an output-level test would pass with or without this change and would be evidence of nothing. Asserting at the boundary being changed is what makes it fail before and pass after.

## Linked issues

Refs #283. That issue also covers `evidence_builder`, which already has the guard — this closes the remaining half; leaving it open in case the reporter reads the scope differently.
