### PR TITLE
fix: resolve the versioned Nsight table names left literal, and keep them out

### DIFF
--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -193,10 +193,11 @@ def get_fingerprint(conn: typing.Any) -> ProfileFingerprint:
     # (observed on some PyTorch versions where NCCL skips the typed-payload
     # path). Multi-device kernel activity is a robust signal for single-node
     # multi-rank training.
-    if not distributed and "CUPTI_ACTIVITY_KIND_KERNEL" in tables:
+    kernel_table = adapter.resolve_activity_tables().get("kernel")
+    if not distributed and kernel_table:
         try:
             cur = adapter.execute(
-                "SELECT COUNT(DISTINCT deviceId) FROM CUPTI_ACTIVITY_KIND_KERNEL"
+                f"SELECT COUNT(DISTINCT deviceId) FROM {kernel_table}"  # noqa: S608
             )
             row = cur.fetchone()
             if row and row[0] is not None and int(row[0]) > 1:
@@ -415,6 +416,11 @@ def get_profile_id(
                 "ORDER BY globalPid NULLS LAST"
             ),
         ),
+        # literal-table-ok: this is a hash input, not a reader. Resolving the
+        # name would make a _V2 / _V3 export hash differently than it does
+        # today, and get_profile_id is a stable content identifier — that is an
+        # algorithm change, which the _PROFILE_ID_ALGO tag exists to version.
+        # Tracked separately; do not "fix" this without bumping the tag.
         ("kernel_count", _scalar("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_KERNEL")),
     ]
 

--- a/src/nsys_ai/nvtx_tree.py
+++ b/src/nsys_ai/nvtx_tree.py
@@ -92,10 +92,17 @@ def _build_single_thread_tree(
     """
     # Load NVTX for this thread only.
     # Support both schemas: (1) only NVTX_EVENTS.text, (2) textId -> StringIds (COALESCE text, s.value).
-    # The table is resolved, not named: newer exports suffix it _V2/_V3, and a
-    # hardcoded name here raised "no such table" on an annotated profile — the
+    # The tables are resolved, not named: newer exports suffix them _V2/_V3, and
+    # a hardcoded name here raised "no such table" on an annotated profile — the
     # very symptom this change set out to remove, from the file it edited.
-    nvtx_table = profile.adapter.resolve_activity_tables().get("nvtx", "NVTX_EVENTS")
+    #
+    # Resolved once, for both names. resolve_activity_tables() is not memoised
+    # and rescans the schema on every call — 1.6 ms against the DuckDB adapter,
+    # measured — and this function runs per thread, so a second call here would
+    # double a cost the tree build already pays N times.
+    _tables = profile.adapter.resolve_activity_tables()
+    nvtx_table = _tables.get("nvtx", "NVTX_EVENTS")
+    runtime_table = _tables.get("runtime")
     if profile._nvtx_has_text_id:
         nvtx_rows = profile._duckdb_query(
             f"""
@@ -130,11 +137,10 @@ def _build_single_thread_tree(
     # Load runtime calls for this thread covering the discovered NVTX span set.
     # Using NVTX-derived bounds keeps GPU projection (start/end/depth/path)
     # stable across adjacent timeline tiles near boundaries.
-    rt_lo = min(int(n["start"]) for n in nvtx_rows)
-    rt_hi = max(int(n["end"]) for n in nvtx_rows) + int(2e9)
-    runtime_table = _runtime_table(profile)
     if not runtime_table:
         return []
+    rt_lo = min(int(n["start"]) for n in nvtx_rows)
+    rt_hi = max(int(n["end"]) for n in nvtx_rows) + int(2e9)
     rt_rows = profile._duckdb_query(
         f"""
             SELECT start, [end], correlationId FROM {runtime_table}

--- a/src/nsys_ai/nvtx_tree.py
+++ b/src/nsys_ai/nvtx_tree.py
@@ -15,6 +15,17 @@ import logging
 _log = logging.getLogger(__name__)
 
 
+def _runtime_table(profile) -> str | None:
+    """Resolve the CUDA runtime table, which newer exports suffix _V2 / _V3.
+
+    The NVTX table beside it is already resolved at every use, and so is the
+    kernel table; the runtime table was the one left literal. Returns None when
+    the profile has no runtime activity at all, which callers treat as "no
+    launches to attribute" rather than an error.
+    """
+    return profile.adapter.resolve_activity_tables().get("runtime")
+
+
 def _find_kernel_threads(profile, device: int, min_pct: float = 0.5) -> list[int]:
     """Find CPU threads that are significant kernel launchers on this device.
 
@@ -22,10 +33,13 @@ def _find_kernel_threads(profile, device: int, min_pct: float = 0.5) -> list[int
     count.  This filters out cross-GPU NCCL threads that launch a few
     collectives on this device but bring unrelated NVTX context.
     """
+    runtime_table = _runtime_table(profile)
+    if not runtime_table:
+        return []
     rows = profile._duckdb_query(
         f"""
             SELECT r.globalTid, COUNT(*) as cnt
-            FROM CUPTI_ACTIVITY_KIND_RUNTIME r
+            FROM {runtime_table} r
             JOIN {profile.schema.kernel_table} k ON r.correlationId = k.correlationId
             WHERE k.deviceId = ?
             -- globalTid breaks the tie: _find_primary_thread takes rows[0], so equal
@@ -118,9 +132,12 @@ def _build_single_thread_tree(
     # stable across adjacent timeline tiles near boundaries.
     rt_lo = min(int(n["start"]) for n in nvtx_rows)
     rt_hi = max(int(n["end"]) for n in nvtx_rows) + int(2e9)
+    runtime_table = _runtime_table(profile)
+    if not runtime_table:
+        return []
     rt_rows = profile._duckdb_query(
-        """
-            SELECT start, [end], correlationId FROM CUPTI_ACTIVITY_KIND_RUNTIME
+        f"""
+            SELECT start, [end], correlationId FROM {runtime_table}
             WHERE globalTid = ? AND start >= ? AND [end] <= ?  ORDER BY start
         """,
         (tid, rt_lo, rt_hi),

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -677,11 +677,12 @@ class Profile:
         Returns {h2d_ns, d2h_ns, d2d_ns, total_ns}; 0 when table or window empty.
         """
         out = {"h2d_ns": 0, "d2h_ns": 0, "d2d_ns": 0, "total_ns": 0}
-        if "CUPTI_ACTIVITY_KIND_MEMCPY" not in self.schema.tables:
+        memcpy_table = self.adapter.resolve_activity_tables().get("memcpy")
+        if not memcpy_table:
             return out
-        sql = """
+        sql = f"""
             SELECT copyKind, SUM([end] - start) AS total_ns
-            FROM CUPTI_ACTIVITY_KIND_MEMCPY
+            FROM {memcpy_table}
             WHERE start >= ? AND [end] <= ?
         """
         params: list = [trim[0], trim[1]]
@@ -727,12 +728,15 @@ class Profile:
 
     def gpu_threads(self, device: int) -> set[int]:
         """Find all CPU threads (globalTid) that launch kernels on this device."""
+        runtime_table = self.adapter.resolve_activity_tables().get("runtime")
+        if not runtime_table:
+            return set()
         return {
             r["globalTid"]
             for r in self._duckdb_query(
                 f"""
             SELECT DISTINCT r.globalTid
-            FROM CUPTI_ACTIVITY_KIND_RUNTIME r
+            FROM {runtime_table} r
             JOIN {self.schema.kernel_table} k ON r.correlationId = k.correlationId
             WHERE k.deviceId = ?
         """,
@@ -742,11 +746,14 @@ class Profile:
 
     def runtime_index(self, threads: set[int], window: tuple[int, int]) -> dict[int, list]:
         """Load CUDA runtime calls for threads, indexed by globalTid."""
+        runtime_table = self.adapter.resolve_activity_tables().get("runtime")
+        if not runtime_table:
+            return {}
         idx = {}
         for tid in threads:
             idx[tid] = self._duckdb_query(
-                """
-                SELECT start, [end], correlationId FROM CUPTI_ACTIVITY_KIND_RUNTIME
+                f"""
+                SELECT start, [end], correlationId FROM {runtime_table}
                 WHERE globalTid = ? AND start >= ? AND [end] <= ?  ORDER BY start
             """,
                 [tid, window[0], window[1]],

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -403,6 +403,15 @@ def get_region_kernels(
 
     kernel_table = schema.kernel_table
 
+    # The kernel table was already resolved; the runtime table beside it in the
+    # same query was not. This reader takes a plain connection, so there is no
+    # alias view to cover a literal — on a _V2 / _V3 export it raised.
+    from .connection import is_safe_identifier, wrap_connection
+
+    runtime_table = wrap_connection(conn).resolve_activity_tables().get("runtime")
+    if not runtime_table or not is_safe_identifier(runtime_table):
+        return []
+
     where_clauses = ["r.start >= ?", "r.[end] <= ?"]
     params: list[Any] = [int(nvtx_start_ns), int(nvtx_end_ns)]
 
@@ -422,7 +431,7 @@ def get_region_kernels(
         "k.start AS start_ns, k.[end] AS end_ns, "
         "(k.[end] - k.start) AS duration_ns, "
         "s.value AS kernel_name "
-        "FROM CUPTI_ACTIVITY_KIND_RUNTIME r "
+        f"FROM {runtime_table} r "
         f"JOIN {kernel_table} k ON r.correlationId = k.correlationId "
         "LEFT JOIN StringIds s ON k.shortName = s.id "
         "WHERE " + " AND ".join(where_clauses) + f" {dev_filter} "

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -73,6 +73,20 @@ def is_abstention_row(row) -> bool:
     return isinstance(row, dict) and row.get("_abstained") is True
 
 
+def resolve_nvtx_table(conn) -> str | None:
+    """The profile's NVTX table name, or None when it has none.
+
+    Companion to :func:`requires_nvtx` for the skills that need the *name* and
+    not only the guard — the payload decoders query the table directly. Both
+    resolve through here so ``skills/builtins`` never re-inlines the lookup,
+    which is what ``test_the_nvtx_guard_is_defined_once`` enforces: an earlier
+    inlined copy used an exact name match and missed ``NVTX_EVENTS_V2``.
+    """
+    from ..connection import wrap_connection
+
+    return wrap_connection(conn).resolve_activity_tables().get("nvtx")
+
+
 def requires_nvtx(conn, *, needs: str = "Region attribution") -> list[dict] | None:
     """Abstain if ``conn`` has no NVTX table, else None so the caller proceeds.
 
@@ -84,9 +98,7 @@ def requires_nvtx(conn, *, needs: str = "Region attribution") -> list[dict] | No
     ``needs`` names what the caller cannot do, so the message says something
     true for that skill rather than a copy of a sibling's wording.
     """
-    from ..connection import wrap_connection
-
-    if wrap_connection(conn).resolve_activity_tables().get("nvtx"):
+    if resolve_nvtx_table(conn):
         return None
     return abstain(
         f"This profile has no NVTX_EVENTS table, so it carries no NVTX "

--- a/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_payload_breakdown.py
@@ -33,7 +33,7 @@ from collections import defaultdict
 
 from nsys_ai.connection import DB_ERRORS, wrap_connection
 
-from ..base import Skill, abstain
+from ..base import Skill, abstain, resolve_nvtx_table
 
 _log = logging.getLogger(__name__)
 
@@ -198,9 +198,18 @@ def _execute(conn, **kwargs) -> list[dict]:
     #       profile that DOES have binaryData. Without this branch we'd
     #       misreport (b) as (a) and tell the user to re-profile when the
     #       fix is "use the parquet cache instead".
+    # The name, not just the guard — the decoder below queries the table. Both
+    # come from skills.base so this module never re-inlines the lookup.
+    nvtx_table = resolve_nvtx_table(conn)
+    if not nvtx_table:
+        return abstain(
+            "This profile has no NVTX_EVENTS table, so it carries no NCCL "
+            "typed payloads. Re-capture with NVTX enabled to use this skill."
+        )
+
     try:
         (has_any,) = adapter.execute(
-            "SELECT EXISTS(SELECT 1 FROM NVTX_EVENTS WHERE binaryData IS NOT NULL)"
+            f"SELECT EXISTS(SELECT 1 FROM {nvtx_table} WHERE binaryData IS NOT NULL)"  # noqa: S608
         ).fetchone()
         probe_failed = False
     except DB_ERRORS as exc:
@@ -210,7 +219,9 @@ def _execute(conn, **kwargs) -> list[dict]:
         # backend — not actually empty.
         probe_failed = False
         try:
-            (nvtx_rows,) = adapter.execute("SELECT COUNT(*) FROM NVTX_EVENTS").fetchone()
+            (nvtx_rows,) = adapter.execute(
+                f"SELECT COUNT(*) FROM {nvtx_table}"  # noqa: S608
+            ).fetchone()
             if nvtx_rows > 0:
                 probe_failed = True
                 probe_error_msg = str(exc)
@@ -284,7 +295,8 @@ def _execute(conn, **kwargs) -> list[dict]:
     skipped = 0
 
     for (bd,) in adapter.execute(
-        f"SELECT binaryData FROM NVTX_EVENTS WHERE binaryData IS NOT NULL{trim_clause}",
+        f"SELECT binaryData FROM {nvtx_table} "  # noqa: S608
+        f"WHERE binaryData IS NOT NULL{trim_clause}",
         trim_params,
     ).fetchall():
         row = _decode_row(bd, schemas)

--- a/src/nsys_ai/viewer.py
+++ b/src/nsys_ai/viewer.py
@@ -187,13 +187,14 @@ def build_timeline_gpu_data(
                     }
                 )
 
-            if "CUPTI_ACTIVITY_KIND_MEMCPY" in prof.schema.tables:
-                memcpy_sql = """
+            memcpy_table = prof.adapter.resolve_activity_tables().get("memcpy")
+            if memcpy_table:
+                memcpy_sql = f"""
                     SELECT m.start AS start_ns,
                            m.[end] AS end_ns,
                            m.streamId AS stream,
                            m.copyKind AS copy_kind
-                    FROM CUPTI_ACTIVITY_KIND_MEMCPY m
+                    FROM {memcpy_table} m
                     WHERE m.deviceId = ? AND m.[end] >= ? AND m.start <= ?
                     ORDER BY m.start
                 """
@@ -216,12 +217,13 @@ def build_timeline_gpu_data(
                         }
                     )
 
-            if "CUPTI_ACTIVITY_KIND_MEMSET" in prof.schema.tables:
-                memset_sql = """
+            memset_table = prof.adapter.resolve_activity_tables().get("memset")
+            if memset_table:
+                memset_sql = f"""
                     SELECT m.start AS start_ns,
                            m.[end] AS end_ns,
                            m.streamId AS stream
-                    FROM CUPTI_ACTIVITY_KIND_MEMSET m
+                    FROM {memset_table} m
                     WHERE m.deviceId = ? AND m.[end] >= ? AND m.start <= ?
                     ORDER BY m.start
                 """

--- a/tests/test_versioned_table_names.py
+++ b/tests/test_versioned_table_names.py
@@ -188,7 +188,14 @@ def test_no_query_names_a_versioned_table_literally():
 
 
 def test_the_check_can_actually_fail():
-    """Guard the guard: a regex that matches nothing would pass silently."""
+    """Guard the guard: a regex that matches nothing would pass silently.
+
+    Known limit: the scan is line-by-line, so `FROM` at the end of one line with
+    the table on the next would slip through. No query in the package is written
+    that way, and widening it to multi-line would cost more false positives than
+    the case is worth — but a literal that reappears in that shape will not be
+    caught here.
+    """
     probe = "            FROM CUPTI_ACTIVITY_KIND_RUNTIME r\n"
     assert _LITERAL_IN_SQL.search(probe), "the detector stopped detecting"
     assert not _LITERAL_IN_SQL.search("FROM {runtime_table} r")

--- a/tests/test_versioned_table_names.py
+++ b/tests/test_versioned_table_names.py
@@ -1,0 +1,195 @@
+"""Nsight versions its activity tables, and thirteen queries still named them literally.
+
+`resolve_activity_tables` exists because newer exports suffix these tables `_V2`
+or `_V3`. Most readers go through `Profile._duckdb_query`, and `parquet_cache`
+creates an alias view for the unversioned name over whichever versioned table it
+finds, so a literal answers correctly there and no test written against those
+readers can fail. `region_mfu.get_region_kernels` takes a plain `sqlite3`
+connection, gets no alias layer, and raises.
+
+That asymmetry is the whole problem with this defect class: it has now been found
+six times — #285, #288, #291, #292, and twice here — always by reading, never by
+a failing test, because whichever path someone happens to exercise is usually the
+aliased one.
+
+So this file has two jobs. The first tests the reader that genuinely breaks. The
+second is a source check over every query in the package, which is the only thing
+that catches a literal on a path no test exercises. A source check is a poor
+substitute for a behavioural test of a fix — #288 shipped one that passed while
+its fix was inert — but it is the right tool for "this must not reappear", which
+is a different job from "this is fixed".
+"""
+
+import re
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SRC = REPO / "src" / "nsys_ai"
+ANNOTATED = REPO / "tests" / "fixtures" / "h100_2gpu_1s.sqlite"
+
+# The tables resolve_activity_tables() resolves by prefix — the repo's own answer
+# to which names carry a version suffix. StringIds, ThreadNames and the
+# TARGET_INFO_* tables are not versioned and are deliberately absent.
+VERSIONED = (
+    "CUPTI_ACTIVITY_KIND_KERNEL",
+    "CUPTI_ACTIVITY_KIND_RUNTIME",
+    "CUPTI_ACTIVITY_KIND_MEMCPY",
+    "CUPTI_ACTIVITY_KIND_MEMSET",
+    "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION",
+    "ENUM_CUPTI_SYNC_TYPE",
+    "NVTX_EVENTS",
+)
+
+# The modules that do the resolving, and so must name the tables literally.
+RESOLVERS = {"connection.py", "parquet_cache.py"}
+
+_LITERAL_IN_SQL = re.compile(r"\b(?:FROM|JOIN)\s+(" + "|".join(VERSIONED) + r")\b")
+
+
+def _readonly(path: Path) -> sqlite3.Connection:
+    """Open a committed fixture without letting the run modify it.
+
+    Several readers call ``ensure_performance_indexes``, which writes
+    ``_nsysai_*`` indexes into whatever profile it is handed. Against a checked-in
+    fixture that leaves the working tree dirty and the file changed for every
+    later run — a test that edits its own input is not reproducible.
+    """
+    return sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+
+
+# ── The reader that actually breaks ─────────────────────────────────────────
+
+
+@pytest.fixture(scope="module")
+def runtime_v3(tmp_path_factory) -> Path:
+    """The annotated fixture with CUPTI_ACTIVITY_KIND_RUNTIME renamed to _V3."""
+    dst = tmp_path_factory.mktemp("versioned") / "runtime_v3.sqlite"
+    shutil.copy(ANNOTATED, dst)
+    conn = sqlite3.connect(dst)
+    try:
+        conn.execute(
+            "ALTER TABLE CUPTI_ACTIVITY_KIND_RUNTIME "
+            "RENAME TO CUPTI_ACTIVITY_KIND_RUNTIME_V3"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+def test_the_fixture_has_runtime_rows():
+    """Premise: without runtime rows the assertions below pass vacuously."""
+    conn = _readonly(ANNOTATED)
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME").fetchone()[0]
+    finally:
+        conn.close()
+    assert n > 0
+
+
+def test_get_region_kernels_reads_the_versioned_runtime_table(runtime_v3):
+    """The assertion that fails while the table name is a literal.
+
+    This one raises rather than returning nothing: it is handed a plain
+    connection, so there is no alias view to fall back on.
+    """
+    from nsys_ai.region_mfu import get_region_kernels
+
+    conn = sqlite3.connect(runtime_v3)
+    try:
+        rows = get_region_kernels(
+            conn, nvtx_start_ns=0, nvtx_end_ns=10**18, global_tid=None, device_id=None
+        )
+    finally:
+        conn.close()
+
+    assert rows, "no kernels resolved from a profile whose runtime table is _V3"
+
+
+def test_get_region_kernels_agrees_across_both_table_names(runtime_v3):
+    """Resolution must change where the rows come from, not how many."""
+    from nsys_ai.region_mfu import get_region_kernels
+
+    kw = dict(nvtx_start_ns=0, nvtx_end_ns=10**18, global_tid=None, device_id=None)
+    original = _readonly(ANNOTATED)
+    renamed = sqlite3.connect(runtime_v3)
+    try:
+        before = get_region_kernels(original, **kw)
+        after = get_region_kernels(renamed, **kw)
+    finally:
+        original.close()
+        renamed.close()
+
+    assert before, "premise: the unrenamed profile must return kernels"
+    assert len(after) == len(before)
+
+
+# ── The check that stops it coming back ─────────────────────────────────────
+
+
+# An escape hatch for the rare query that must keep the literal. It suppresses
+# the line that follows it, and it costs a written reason — see fingerprint.py,
+# where resolving the name would silently change a stable content hash.
+EXEMPTION = "literal-table-ok:"
+
+
+def _sql_literals() -> list[str]:
+    """Every `FROM`/`JOIN <versioned table>` outside the resolver modules."""
+    found = []
+    for path in sorted(SRC.rglob("*.py")):
+        if path.name in RESOLVERS:
+            continue
+        lines = path.read_text().splitlines()
+        exempt_until = -1
+        for lineno, line in enumerate(lines, 1):
+            stripped = line.strip()
+            if stripped.startswith("#"):
+                if EXEMPTION in stripped:
+                    # Suppress the next non-comment line.
+                    exempt_until = lineno
+                    for ahead in range(lineno, len(lines)):
+                        if not lines[ahead].strip().startswith("#"):
+                            exempt_until = ahead + 1
+                            break
+                continue
+            if lineno == exempt_until:
+                continue
+            match = _LITERAL_IN_SQL.search(line)
+            if match:
+                found.append(f"{path.relative_to(SRC.parent)}:{lineno}  {match.group(1)}")
+    return found
+
+
+def test_no_query_names_a_versioned_table_literally():
+    """A literal here reads the wrong table on a _V2 / _V3 export.
+
+    Resolve it instead:
+
+        tables = wrap_connection(conn).resolve_activity_tables()
+        runtime_table = tables.get("runtime")
+
+    or, in a Skill SQL template, use the `{runtime_table}` placeholder that
+    `Skill.execute` substitutes.
+
+    Whether a given site is currently broken depends on whether its connection
+    has parquet_cache's alias views, which is a property of how the profile was
+    opened rather than anything the reader controls. That is why this check does
+    not try to distinguish them.
+    """
+    offenders = _sql_literals()
+    assert not offenders, (
+        "queries naming a versioned Nsight table literally:\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_the_check_can_actually_fail():
+    """Guard the guard: a regex that matches nothing would pass silently."""
+    probe = "            FROM CUPTI_ACTIVITY_KIND_RUNTIME r\n"
+    assert _LITERAL_IN_SQL.search(probe), "the detector stopped detecting"
+    assert not _LITERAL_IN_SQL.search("FROM {runtime_table} r")
+    assert not _LITERAL_IN_SQL.search("FROM StringIds s")


### PR DESCRIPTION
## Summary

- One live bug: `region_mfu.get_region_kernels` raised `no such table: CUPTI_ACTIVITY_KIND_RUNTIME` on a `_V2` / `_V3` export where it had returned 1643 rows.
- Eleven latent siblings resolved alongside it.
- A source check that rejects a literal versioned table name, because no behavioural test can catch one on a path the alias views cover.

## The live one

`get_region_kernels` resolved the kernel table and named the runtime table beside it in the same query:

```python
kernel_table = schema.kernel_table
...
"FROM CUPTI_ACTIVITY_KIND_RUNTIME r "
f"JOIN {kernel_table} k ON r.correlationId = k.correlationId "
```

It takes a plain `sqlite3` connection, so `parquet_cache`'s alias views never reach it. Measured against `tests/fixtures/h100_2gpu_1s.sqlite` with the runtime table renamed to `_V3`: 1643 rows → `OperationalError`.

## The latent ones

`nvtx_tree.py` ×2, `profile.py` ×3, `viewer.py` ×2, `nccl_payload_breakdown.py` ×3, `fingerprint.py` ×1. These read through `Profile._duckdb_query`, and `parquet_cache` creates an alias view for the unversioned name over whichever versioned table `_find_table` locates — in cached and direct-SQLite mode both. Verified: with `CUPTI_ACTIVITY_KIND_RUNTIME` renamed to `_V3`, a query naming the literal still returns 5796 rows.

They are resolved anyway. The alias is a property of how the profile was opened, not something a reader controls, and `nvtx_tree.py` had reached the state of resolving its kernel table and its NVTX table while leaving the runtime table between them literal.

## Why a source check, given #292's objection to one

#292 was right that a source assertion is a poor test of a fix — #288 shipped one that passed while its fix was inert. That is a different job from this one. "This must not come back" cannot be tested behaviourally when the alias layer makes the broken and the correct code indistinguishable on every path a test can reach. So both are here: behavioural tests for the reader that genuinely breaks, and a source check for the class.

The check covers the seven tables `resolve_activity_tables` resolves by prefix — the repo's own answer to which names are versioned. `StringIds`, `ThreadNames` and `TARGET_INFO_*` are not versioned and are deliberately out of scope; including them would have made this a 104-site change for no defect. It also asserts its own detector still detects, so a regex that stopped matching cannot pass silently.

## The one literal kept

`fingerprint.py:418` feeds `get_profile_id`, a content-derived stable identifier. Resolving the name would make a versioned export hash differently than it does today — an algorithm change, which `_PROFILE_ID_ALGO` exists to version. It carries a `literal-table-ok:` marker and the reason. The escape hatch suppresses exactly one line and costs a written justification.

## A guard that caught me

`test_the_nvtx_guard_is_defined_once` forbids `resolve_activity_tables().get("nvtx")` inside `skills/builtins` — the lookup belongs to `skills.base`, after an inlined copy once shipped with an exact match that missed `NVTX_EVENTS_V2`. My first attempt re-inlined it and the test failed. `resolve_nvtx_table` now sits beside `requires_nvtx` for the callers that need the name rather than only the guard, and `requires_nvtx` routes through it.

## Backward compatibility

Yes. Unversioned exports are unaffected — one test asserts the row count is identical across both table names.

## Test plan

- [x] `pytest tests/ -v --tb=short -rs` with `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite` — 1395 passed, 140 skipped, 0 failed.
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` 0 medium / 0 high; `python -m nsys_ai --help` exits 0.
- [x] Regression proof: reverting the resolved runtime name turns both behavioural tests red.
- [x] The new tests open committed fixtures read-only, so a run cannot modify them.
- [ ] Manual CLI/GUI exercise — n/a, no user-facing surface changed.

## Out of scope

Running the suite leaves `tests/fixtures/*.sqlite` modified: `ensure_performance_indexes` writes `_nsysai_*` indexes into any profile handed to it, including checked-in ones. Pre-existing and repo-wide — the tests added here avoid it by opening read-only, but the rest of the suite does not. Worth its own issue rather than a fix bundled here.

## Linked issues

None — found while sweeping for the class after #292 and #294.
