### PR TITLE
fix(diff): always emit decision in diff.json, and name the doctor's own schema version

### DIFF
--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -564,6 +564,10 @@ def to_diff_dict(data: ProfileDiffSummary) -> dict:
     # Keep this relatively stable; tests can snapshot it.
     return {
         "schema_version": SCHEMA_VERSION,
+        # Always present, null until decided. The decided record is this same
+        # object plus a populated `decision`, so omitting the key here forced
+        # every consumer to .get() and made one artifact look like two shapes.
+        "decision": None,
         "producer": PRODUCER,
         "producer_version": _producer_version(),
         "diff_id": data.diff_id,

--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -29,7 +29,11 @@ import shutil
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
-SCHEMA_VERSION = "0.1"
+# The doctor report's own envelope version. Deliberately NOT
+# annotation.SCHEMA_VERSION: that versions the evidence/diff envelope, and these
+# are independent formats that merely happen to share a value today. Merging
+# them would make a breaking change to one falsely bump the other.
+DOCTOR_SCHEMA_VERSION = "0.1"
 
 # Profiler-overhead thresholds (percent of profile span).
 _OVERHEAD_WARN_PCT = 10.0
@@ -699,7 +703,7 @@ def run_doctor(
                         pass
 
     return DoctorReport(
-        schema_version=SCHEMA_VERSION,
+        schema_version=DOCTOR_SCHEMA_VERSION,
         producer="nsys-ai",
         producer_version=_producer_version(),
         profile_path=profile_path,

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1117,8 +1117,10 @@ def test_diff_decision_dict_path_matches_summary_path(tmp_path):
     )
 
     assert cli_path.read_bytes() == gui_path.read_bytes()
-    # The stored dict must not be mutated by the writer.
-    assert "decision" not in stored_dict
+    # The stored dict must not be mutated by the writer. The key is now always
+    # present and `null` until decided, so "undecided" is `is None` rather than
+    # absent — the writer leaving it None is the same guarantee as before.
+    assert stored_dict["decision"] is None
 
 
 def test_compute_verdict_custom_regression_pct():

--- a/tests/test_diff_json_shape.py
+++ b/tests/test_diff_json_shape.py
@@ -1,0 +1,139 @@
+"""One shape for `diff.json`, decided or not, and a versioned envelope.
+
+The decided record was never a different *shape* from the undecided one — it is
+the same object plus a populated `decision`. What differed is that the undecided
+payload omitted the key entirely, so every consumer had to `.get()` it and the
+one artifact read as two. It is now always present, `null` until decided.
+
+On versioning: nothing in this repo reads a stored `diff.json` back. `diff_web`
+regenerates it, and every use of `decision_path` stores or prints the path. So
+there is no load path on which to enforce a compatibility check, and adding one
+would invent a consumer that does not exist. The protection that does apply to a
+write-only artifact is pinning the envelope here, so a change to it has to be
+deliberate.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+BEFORE = REPO / "tests" / "fixtures" / "mfu_2gpu_before.sqlite"
+AFTER = REPO / "tests" / "fixtures" / "mfu_2gpu_after.sqlite"
+
+
+@pytest.fixture(scope="module")
+def undecided() -> dict:
+    """The payload the CLI and the web view emit before a decision."""
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.diff_render import to_diff_dict
+    from nsys_ai.profile import Profile
+
+    with Profile(str(BEFORE)) as b, Profile(str(AFTER)) as a:
+        summary = diff_profiles(b, a, gpu=0)
+    return to_diff_dict(summary)
+
+
+def test_the_decision_key_is_always_present(undecided):
+    """`null` until decided, rather than absent.
+
+    Omitting it is what made one artifact look like two: a consumer reading the
+    undecided payload had to know the key might not be there, while the same
+    consumer reading a decided one could index it directly.
+    """
+    assert "decision" in undecided, "the undecided payload omits the key again"
+    assert undecided["decision"] is None
+
+
+def test_deciding_adds_only_the_decision(undecided):
+    """The decided record is the undecided one plus a populated decision.
+
+    Asserted directly, because the issue behind this change claimed the two were
+    structurally different envelopes. They are not, and a future change that
+    made them diverge would be the actual defect.
+    """
+    from nsys_ai.diff_decision import build_diff_decision_record_from_diff_dict
+
+    decided, _warnings = build_diff_decision_record_from_diff_dict(
+        undecided, decision="accepted", reason="shape test"
+    )
+    assert set(decided) == set(undecided), (
+        f"deciding changed the key set: "
+        f"added {sorted(set(decided) - set(undecided))}, "
+        f"dropped {sorted(set(undecided) - set(decided))}"
+    )
+    assert decided["decision"] is not None
+    assert decided["decision"]["status"] == "accepted"
+
+
+def test_the_envelope_is_pinned(undecided):
+    """A write-only artifact has no reader to reject a bad version, so the
+    envelope is pinned here instead.
+
+    These are the fields a consumer outside this repo would key off. Adding an
+    optional field is fine and does not bump the version; removing or renaming
+    one of these is the breaking change the version exists to signal.
+    """
+    from nsys_ai.annotation import PRODUCER, SCHEMA_VERSION
+
+    required = {
+        "schema_version",
+        "producer",
+        "producer_version",
+        "diff_id",
+        "before",
+        "after",
+        "verdict",
+        "comparability_confidence",
+        "decision",
+    }
+    missing = required - set(undecided)
+    assert not missing, f"the diff.json envelope lost required fields: {sorted(missing)}"
+    assert undecided["schema_version"] == SCHEMA_VERSION
+    assert undecided["producer"] == PRODUCER
+    for side in ("before", "after"):
+        assert "profile_id" in undecided[side]
+        assert "path" in undecided[side]
+
+
+def test_it_is_json_serialisable(undecided):
+    """The artifact is written to disk; a value that cannot serialise is a bug
+    that would only surface at write time."""
+    assert json.loads(json.dumps(undecided, default=str))["decision"] is None
+
+
+# ── The two version constants are separate on purpose ───────────────────────
+
+
+def test_the_doctor_version_is_not_the_evidence_version():
+    """They version different artifacts and merely share a value today.
+
+    The issue behind this change asked for a single definition. That would be
+    wrong: `annotation.SCHEMA_VERSION` versions the evidence and diff envelope,
+    the doctor constant versions the doctor report. Merging them would make a
+    breaking change to one falsely bump the other. The rename makes the
+    separation intentional rather than a duplicate that invites merging.
+    """
+    import nsys_ai.doctor as doctor
+
+    assert hasattr(doctor, "DOCTOR_SCHEMA_VERSION")
+    assert not hasattr(doctor, "SCHEMA_VERSION"), (
+        "the bare name is back, which is what made this look like a duplicate"
+    )
+
+    src = (REPO / "src" / "nsys_ai" / "doctor.py").read_text()
+    assert "annotation.SCHEMA_VERSION" in src, "the reason for the split is undocumented"
+
+
+def test_the_evidence_version_documents_when_it_bumps():
+    """The version is a breaking-change counter, not semver.
+
+    Semver would let a 0.y differ freely — 'anything MAY change at any time' —
+    but this repo's own rule is narrower: bumped only on breaking envelope
+    changes, with backward-compatible additions not bumping it. That is what
+    makes the pin above meaningful, so the rule has to stay written down.
+    """
+    src = (REPO / "src" / "nsys_ai" / "annotation.py").read_text()
+    assert "Bumped on breaking changes" in src
+    assert "do not bump this" in src


### PR DESCRIPTION
## Summary

`diff.json` is the handoff artifact between the CLI, the browser and the agent. The undecided payload **omitted** `decision` while the decided record carried it, so every consumer had to `.get()` the key and one artifact read as two. It is now always present, `null` until decided.

## Changes

**`decision` is always emitted.** The decided record was never a different *shape* — measured key-for-key, its key set is the undecided one plus a populated `decision`, with nothing dropped or renamed. `test_deciding_adds_only_the_decision` asserts that directly, because a future change that made the two diverge would be the actual defect.

**`doctor.SCHEMA_VERSION` → `DOCTOR_SCHEMA_VERSION`.** It versions the doctor report; `annotation.SCHEMA_VERSION` versions the evidence/diff envelope. They share the value `"0.1"` today by coincidence, and the shared bare name read as a duplicate inviting a merge — which would make a breaking change to one falsely bump the other. A third unrelated concept, `schema.schema_version` (the Nsight export's own), shares the name too.

**The envelope is pinned in a test.** Nothing in this repo reads a stored `diff.json` back, so there is no reader to reject a bad version; pinning the required fields is the protection that applies to a write-only artifact.

## Backward compatibility

Additive. `schema_version` stays `"0.1"`: the repo's own rule is `Bumped on breaking changes… Backward-compatible additions do not bump this`, and adding a key that was previously absent is exactly that. Narrower than semver, which would let a `0.y` change freely under Rule 4 — the repo's rule is the one that applies, so it is now asserted rather than assumed.

One existing assertion changed meaning rather than intent: `test_diff_decision_dict_path_matches_summary_path` checked non-mutation of the caller's dict as `"decision" not in stored_dict`. Undecided is now `is None` rather than absent, so the same guarantee is asserted that way.

## Test plan

Run, with output read:

- [x] `pytest tests/ -rs` — **1401 passed, 135 skipped, 0 failed**; skip count unchanged, no new unregistered skips
- [x] `ruff check src/ tests/` — clean
- [x] `bandit -r src/ -c pyproject.toml` — 0 issues
- [x] End-to-end on committed real profiles: `diff … --format json` emits `"decision": null`; `doctor … --format json` still emits its own `schema_version`
- [x] Both guards mutation-verified — deleting the `decision: None` emission fails 4 tests; reverting the rename fails its test

## Out of scope

**Three of the issue's claims did not survive a second pass and are struck on #266 rather than built.** "Two shapes for one artifact" was overstated — the shapes match, only the key was missing. "A single definition of `SCHEMA_VERSION`" would have been wrong, for the reason above. "A round-trip test proving an older stored record loads" is not implementable: the artifact is write-only, and adding a reader to test against would invent a consumer nobody has asked for. If one arrives — the agent loop, or an external tool — the compatibility check belongs with it.

## Linked issues

Closes #266.
