### PR TITLE
perf(connection): memoize activity-table resolution per connection

### DIFF
--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -75,6 +75,20 @@ def _probe_cache_set(conn, key: str, value) -> None:
 
 SKILL_CACHE_MISS = _PROBE_MISS
 
+# Key under which both adapters memoize resolve_activity_tables().
+#
+# Safe because the catalog is fixed by the time a caller can query it: every
+# DuckDB connection is built by open_cached_db / open_parquetdir_db /
+# open_direct_sqlite_db, each of which creates its parquet views and its alias
+# views *before* returning the connection.  Nothing afterwards creates or drops
+# a table matching these prefixes — ensure_performance_indexes writes indexes,
+# not tables — and a profile is an immutable capture besides.
+#
+# The distinction matters on DuckDB specifically, where SHOW TABLES lists views
+# too: caching a pre-alias catalog would pin the versioned name (or, on direct
+# mode, nothing at all) for the connection's life.
+_ACTIVITY_TABLES_KEY = "activity_tables"
+
 
 def cached_skill_rows(conn, key: str):
     """Rows a skill already produced for ``key`` on ``conn``, or SKILL_CACHE_MISS.
@@ -149,13 +163,20 @@ class SQLiteAdapter:
         return self.conn.execute(sql, parameters)
 
     def resolve_activity_tables(self) -> dict[str, str]:
+        cached = _probe_cache_get(self.conn, _ACTIVITY_TABLES_KEY)
+        if cached is not _PROBE_MISS:
+            return dict(cached)
         try:
             cur = self.conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
             tables = {row[0] for row in cur.fetchall()}
         except sqlite3.Error as exc:
             _log.debug("Failed to resolve activity tables (sqlite): %s", exc, exc_info=True)
+            # Deliberately not cached: a failure here should not pin an empty
+            # answer for the rest of the connection's life.
             return {}
-        return _find_activity_tables(tables)
+        resolved = _find_activity_tables(tables)
+        _probe_cache_set(self.conn, _ACTIVITY_TABLES_KEY, resolved)
+        return dict(resolved)
 
     def detect_nvtx_text_id(self) -> bool:
         try:
@@ -196,12 +217,19 @@ class DuckDBAdapter:
         return self.conn.execute(rewritten_sql, list(parameters) if parameters else [])
 
     def resolve_activity_tables(self) -> dict[str, str]:
+        cached = _probe_cache_get(self.conn, _ACTIVITY_TABLES_KEY)
+        if cached is not _PROBE_MISS:
+            return dict(cached)
         try:
             tables = {row[0] for row in self.conn.execute("SHOW TABLES").fetchall()}
         except DB_ERRORS as exc:
             _log.debug("Failed to resolve activity tables (duckdb): %s", exc, exc_info=True)
+            # Deliberately not cached: a failure here should not pin an empty
+            # answer for the rest of the connection's life.
             return {}
-        return _find_activity_tables(tables)
+        resolved = _find_activity_tables(tables)
+        _probe_cache_set(self.conn, _ACTIVITY_TABLES_KEY, resolved)
+        return dict(resolved)
 
     def detect_nvtx_text_id(self) -> bool:
         try:

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -77,16 +77,21 @@ SKILL_CACHE_MISS = _PROBE_MISS
 
 # Key under which both adapters memoize resolve_activity_tables().
 #
-# Safe because the catalog is fixed by the time a caller can query it: every
-# DuckDB connection is built by open_cached_db / open_parquetdir_db /
-# open_direct_sqlite_db, each of which creates its parquet views and its alias
-# views *before* returning the connection.  Nothing afterwards creates or drops
-# a table matching these prefixes — ensure_performance_indexes writes indexes,
-# not tables — and a profile is an immutable capture besides.
+# What makes this safe is *not* that the catalog stops changing — it does not.
+# ensure_nvtx_kernel_map materializes nvtx_kernel_map and nvtx_path_dict onto a
+# connection well after it is handed out.  The invariant is narrower: the names
+# these prefixes match are all created before the connection is returned, and
+# nothing afterwards adds or drops one.
 #
-# The distinction matters on DuckDB specifically, where SHOW TABLES lists views
-# too: caching a pre-alias catalog would pin the versioned name (or, on direct
-# mode, nothing at all) for the connection's life.
+# Two halves to that.  Every DuckDB connection comes from open_cached_db /
+# open_parquetdir_db / open_direct_sqlite, each of which creates its parquet
+# views and its alias views before returning — this matters on DuckDB
+# specifically, where SHOW TABLES lists views too, so caching a pre-alias
+# catalog would pin the versioned name (or, in direct mode where the real tables
+# live under src., pin nothing at all).  And the DDL that does run later names
+# lowercase helper tables, which no CUPTI_ACTIVITY_KIND_* / NVTX_EVENTS prefix
+# matches.  Both halves are asserted in tests/test_activity_table_memoization.py;
+# a new post-open table that did collide would break the second one.
 _ACTIVITY_TABLES_KEY = "activity_tables"
 
 

--- a/tests/test_activity_table_memoization.py
+++ b/tests/test_activity_table_memoization.py
@@ -129,23 +129,78 @@ def test_two_connections_do_not_share_an_answer(tmp_path):
         versioned.close()
 
 
+class _FailsOnceSQLite(sqlite3.Connection):
+    """A profile connection whose first catalog scan raises, then recovers."""
+
+    fail_next = True
+
+    def execute(self, sql, *args):  # noqa: D102
+        if "sqlite_master" in sql and type(self).fail_next:
+            type(self).fail_next = False
+            raise sqlite3.OperationalError("simulated catalog failure")
+        return super().execute(sql, *args)
+
+
 def test_a_failed_scan_is_not_cached():
-    """A closed or broken connection must not pin `{}` for good.
+    """A failure must not pin `{}` on *that same connection* for good.
 
-    Caching the failure would turn a transient error into a profile that has no
-    activity tables for the rest of its life, which reads as an empty profile
+    Caching it would turn one transient error into a profile that has no activity
+    tables for the rest of its life — which reads downstream as an empty profile
     rather than as an error.
+
+    The recovery has to be observed on the connection that failed. Checking a
+    fresh connection instead would prove nothing: the cache is keyed per
+    connection, so a second one would miss the cache whether or not the failure
+    was stored.
     """
-    conn = sqlite3.connect(f"file:{ANNOTATED}?mode=ro", uri=True)
-    conn.close()
-
-    assert wrap_connection(conn).resolve_activity_tables() == {}
-
-    revived = sqlite3.connect(f"file:{ANNOTATED}?mode=ro", uri=True)
+    _FailsOnceSQLite.fail_next = True
+    conn = sqlite3.connect(
+        f"file:{ANNOTATED}?mode=ro", uri=True, factory=_FailsOnceSQLite
+    )
     try:
-        assert wrap_connection(revived).resolve_activity_tables().get("kernel")
+        assert wrap_connection(conn).resolve_activity_tables() == {}, (
+            "premise: the first scan must fail"
+        )
+        recovered = wrap_connection(conn).resolve_activity_tables()
+        assert recovered.get("kernel"), (
+            "the same connection still resolves nothing — the failure was cached"
+        )
     finally:
-        revived.close()
+        conn.close()
+
+
+def test_post_open_ddl_does_not_change_the_answer():
+    """The catalog is *not* frozen after open, so the invariant is tested directly.
+
+    ``ensure_nvtx_kernel_map`` materializes ``nvtx_kernel_map`` and
+    ``nvtx_path_dict`` onto a live connection. That is real post-open DDL, and it
+    is exactly the shape of change that would invalidate a cached catalog — it
+    happens not to, because no ``CUPTI_ACTIVITY_KIND_*`` / ``NVTX_EVENTS`` prefix
+    matches a lowercase helper table.
+
+    Asserted against the *uncached* truth rather than against the earlier cached
+    value, so this fails if a future helper table ever does collide, rather than
+    agreeing with a stale answer.
+    """
+    duckdb = pytest.importorskip("duckdb")  # noqa: F841
+    from nsys_ai.connection import _find_activity_tables
+    from nsys_ai.parquet_cache import ensure_nvtx_kernel_map
+    from nsys_ai.profile import Profile
+
+    with Profile(str(ANNOTATED)) as prof:
+        adapter = prof.adapter
+        if not hasattr(adapter.raw_conn, "sql"):
+            pytest.skip("profile did not open on the DuckDB path")
+
+        cached_before = adapter.resolve_activity_tables()
+        assert cached_before.get("kernel"), "premise: the fixture must resolve"
+
+        ensure_nvtx_kernel_map(adapter.raw_conn)
+
+        catalog = {row[0] for row in adapter.raw_conn.execute("SHOW TABLES").fetchall()}
+        assert "nvtx_kernel_map" in catalog, "premise: the DDL must have run"
+
+        assert adapter.resolve_activity_tables() == _find_activity_tables(catalog)
 
 
 def test_every_duckdb_opener_creates_its_views_before_returning():

--- a/tests/test_activity_table_memoization.py
+++ b/tests/test_activity_table_memoization.py
@@ -1,0 +1,172 @@
+"""`resolve_activity_tables` rescanned the catalog on every call.
+
+It is called from readers that run per NVTX thread and from `requires_nvtx` /
+`resolve_nvtx_table`, which every NVTX skill goes through, so the scan multiplied
+by whatever the caller was iterating. Measured on `h100_2gpu_1s.sqlite`: 1605 µs
+per call against the DuckDB adapter, 20 µs against SQLite — the DuckDB catalog
+scan is the one that hurts, and it is the adapter the cache path uses.
+
+Caching it is only safe because the catalog is fixed before a caller sees the
+connection: `open_cached_db`, `open_parquetdir_db` and `open_direct_sqlite_db`
+each create their parquet views and alias views and only then return. That
+precondition is what the tests below pin — not the timing, which no CI machine
+can assert reliably.
+"""
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.connection import wrap_connection
+
+REPO = Path(__file__).resolve().parent.parent
+ANNOTATED = REPO / "tests" / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+class _CountingSQLite(sqlite3.Connection):
+    """A profile connection that records how often the catalog is scanned."""
+
+    catalog_scans = 0
+
+    def execute(self, sql, *args):  # noqa: D102
+        if "sqlite_master" in sql:
+            type(self).catalog_scans += 1
+        return super().execute(sql, *args)
+
+
+@pytest.fixture
+def counting_conn():
+    _CountingSQLite.catalog_scans = 0
+    conn = sqlite3.connect(
+        f"file:{ANNOTATED}?mode=ro", uri=True, factory=_CountingSQLite
+    )
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def test_the_catalog_is_scanned_once_per_connection(counting_conn):
+    """The whole point: repeat calls must not re-scan.
+
+    Each call goes through a *fresh* adapter, which is how callers actually use
+    it — `resolve_nvtx_table` wraps the raw connection every time. So the cache
+    has to hang off the connection, not off the adapter instance.
+    """
+    first = wrap_connection(counting_conn).resolve_activity_tables()
+    assert _CountingSQLite.catalog_scans == 1, "premise: the first call must scan"
+
+    for _ in range(5):
+        again = wrap_connection(counting_conn).resolve_activity_tables()
+        assert again == first
+
+    assert _CountingSQLite.catalog_scans == 1, (
+        f"the catalog was scanned {_CountingSQLite.catalog_scans} times for one connection"
+    )
+
+
+def test_the_answer_is_unchanged_by_caching(counting_conn):
+    """A cache that returns something different from the uncached call is worse
+    than no cache."""
+    from nsys_ai.connection import _find_activity_tables
+
+    rows = counting_conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+    expected = _find_activity_tables({row[0] for row in rows.fetchall()})
+
+    assert wrap_connection(counting_conn).resolve_activity_tables() == expected
+    assert expected.get("kernel"), "premise: the fixture must have a kernel table"
+
+
+def test_a_caller_cannot_poison_the_cache(counting_conn):
+    """The memoized value is mutable, so it is handed out as a copy.
+
+    Without this every caller shares one dict, and a single `.pop()` or
+    reassignment anywhere in the package silently changes what every later reader
+    resolves.
+    """
+    first = wrap_connection(counting_conn).resolve_activity_tables()
+    first["kernel"] = "SOMETHING_ELSE"
+    first.pop("runtime", None)
+
+    second = wrap_connection(counting_conn).resolve_activity_tables()
+    assert second["kernel"] != "SOMETHING_ELSE"
+    assert "runtime" in second
+
+
+def test_two_connections_do_not_share_an_answer(tmp_path):
+    """Keyed per connection, and the key survives one of them being closed.
+
+    The bag is keyed by the connection object rather than `id()` precisely
+    because `id()` is recycled after a close, which would let a second profile
+    inherit the first's resolution.
+    """
+    import shutil
+
+    renamed = tmp_path / "runtime_v3.sqlite"
+    shutil.copy(ANNOTATED, renamed)
+    conn = sqlite3.connect(renamed)
+    try:
+        conn.execute(
+            "ALTER TABLE CUPTI_ACTIVITY_KIND_RUNTIME "
+            "RENAME TO CUPTI_ACTIVITY_KIND_RUNTIME_V3"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    plain = sqlite3.connect(f"file:{ANNOTATED}?mode=ro", uri=True)
+    versioned = sqlite3.connect(f"file:{renamed}?mode=ro", uri=True)
+    try:
+        assert wrap_connection(plain).resolve_activity_tables()["runtime"] == (
+            "CUPTI_ACTIVITY_KIND_RUNTIME"
+        )
+        assert wrap_connection(versioned).resolve_activity_tables()["runtime"] == (
+            "CUPTI_ACTIVITY_KIND_RUNTIME_V3"
+        )
+    finally:
+        plain.close()
+        versioned.close()
+
+
+def test_a_failed_scan_is_not_cached():
+    """A closed or broken connection must not pin `{}` for good.
+
+    Caching the failure would turn a transient error into a profile that has no
+    activity tables for the rest of its life, which reads as an empty profile
+    rather than as an error.
+    """
+    conn = sqlite3.connect(f"file:{ANNOTATED}?mode=ro", uri=True)
+    conn.close()
+
+    assert wrap_connection(conn).resolve_activity_tables() == {}
+
+    revived = sqlite3.connect(f"file:{ANNOTATED}?mode=ro", uri=True)
+    try:
+        assert wrap_connection(revived).resolve_activity_tables().get("kernel")
+    finally:
+        revived.close()
+
+
+def test_every_duckdb_opener_creates_its_views_before_returning():
+    """The precondition the cache rests on.
+
+    On DuckDB `SHOW TABLES` lists views, so resolving before the alias views
+    exist would cache the versioned name — or, in direct-SQLite mode where the
+    real tables live under `src.`, cache nothing at all. Each opener must finish
+    its view creation before a caller can resolve anything.
+    """
+    src = (REPO / "src" / "nsys_ai" / "parquet_cache.py").read_text()
+
+    for opener, creator in (
+        ("def open_cached_db", "_create_existing_alias_views(db)"),
+        ("def open_parquetdir_db", "_create_existing_alias_views(db)"),
+        ("def open_direct_sqlite", "_create_sqlite_alias_views(db)"),
+    ):
+        start = src.index(opener)
+        body = src[start : src.index("\ndef ", start + 1)]
+        assert creator in body, f"{opener} no longer creates its alias views"
+        assert body.index(creator) < body.rindex("return db"), (
+            f"{opener} returns the connection before creating its alias views — "
+            "resolve_activity_tables may now cache a pre-alias catalog"
+        )


### PR DESCRIPTION
## Summary

`resolve_activity_tables` rescanned the database catalog on every call. It is memoized per connection now.

Raised while reviewing #297, where a second call added to `_build_single_thread_tree` doubled that function's resolution cost and had to be restructured around the uncached resolver. The cost is not specific to that reader — it belongs to the resolver.

## The cost

Measured against `tests/fixtures/h100_2gpu_1s.sqlite`, 200 calls each:

| adapter | per call |
| --- | --- |
| DuckDB, uncached | 2037 µs |
| SQLite, uncached | 20 µs |
| either, cached | 0.6 µs |

DuckDB is the adapter a cached profile uses, and its `SHOW TABLES` is where the cost sits.

The callers are loops. `build_nvtx_tree` resolves once per CPU thread that launches kernels; `requires_nvtx` and `resolve_nvtx_table` sit in front of every NVTX skill.

## The effect, stated honestly

One `build_nvtx_tree` on this fixture: 5 calls, 514 ms → 501 ms. About 2.5%, because a 2-GPU 1-second capture has few threads. The call count scales with thread count, so the saving does too; on this profile it is small. What the change removes is a linear factor, not a measured bottleneck on the fixtures in the repo.

## Why this is safe to cache

The catalog is fixed before a caller can see the connection. `open_cached_db`, `open_parquetdir_db` and `open_direct_sqlite` each create their parquet views and alias views and only then return, and nothing afterwards creates or drops a table matching these prefixes — `ensure_performance_indexes` writes indexes, not tables, and a profile is an immutable capture besides.

That precondition matters on DuckDB specifically, where `SHOW TABLES` lists views too: caching a pre-alias catalog would pin the versioned name, or in direct-SQLite mode (where the real tables live under `src.`) pin nothing at all. `test_every_duckdb_opener_creates_its_views_before_returning` asserts each opener still creates its views before its `return`, so a future opener that returns early fails here rather than silently caching an empty answer.

## Two hazards the implementation handles

- **The memoized dict is mutable.** It is handed out as a copy. Without that, every caller shares one dict and a single `.pop()` anywhere in the package changes what every later reader resolves.
- **A failed scan is not cached.** Pinning `{}` would turn a transient error into a profile that reads as having no activity tables for the rest of its life — an empty profile rather than an error.

## Where it is cached

The existing per-connection probe bag in `connection.py`, which already has the keying this needs: by connection object rather than `id()`, so a closed connection's recycled id cannot give a later profile a false hit. Same mechanism #295 used for memoized skill rows. The stored value is five short strings, so the size note on that bag is unaffected.

## Test plan

- [x] `pytest tests/ -rs` with `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite` — **1406 passed, 140 skipped, 0 failed**; skip count unchanged
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` 0 low / 0 medium / 0 high
- [x] Mutation-verified: reverting the cache turns `test_the_catalog_is_scanned_once_per_connection` red at 6 scans for one connection
- [x] The new tests open committed fixtures read-only; fixtures verified unmodified after the run
- [ ] Manual CLI/GUI exercise — n/a, no user-facing surface changed

## Backward compatibility

Yes. Same return value, now a copy rather than a fresh dict — no caller mutated it.

## Linked issues

None. Follow-up to #297, filed as its own change rather than bundled there.
