### PR TITLE
feat(profile): one thread-safe accessor for the query connection

### DIFF
--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -134,16 +134,32 @@ class Agent:
             # Fallback: open as a raw SQLite connection so the agent can still
             # run generic SQL queries even if schema detection fails.
             self.profile = None  # type: ignore[assignment]
-            self.conn = _sqlite3.connect(profile_path, check_same_thread=False)
-            self.conn.row_factory = _sqlite3.Row
+            self._fallback_conn = _sqlite3.connect(profile_path, check_same_thread=False)
+            self._fallback_conn.row_factory = _sqlite3.Row
             return
-        self.conn = self.profile.query_conn()
+        self._fallback_conn = None
+
+    @property
+    def conn(self):
+        """Resolved per access, never cached on the instance.
+
+        ``Profile.query_conn()`` hands a worker thread its own DuckDB cursor,
+        which only works if it is asked at the point of use. Caching the result
+        in ``__init__`` pins whichever handle the constructing thread got, so an
+        Agent built on one thread and run on another would share a handle and
+        silently return wrong rows — the very failure the accessor exists to
+        prevent. That is not hypothetical here: the chat TUI runs the agent from
+        a ``@work(thread=True)`` worker.
+        """
+        if self.profile is not None:
+            return self.profile.query_conn()
+        return self._fallback_conn
 
     def close(self):
         if self.profile is not None:
             self.profile.close()
-        elif hasattr(self, "conn"):
-            self.conn.close()
+        elif self._fallback_conn is not None:
+            self._fallback_conn.close()
 
     def analyze(self) -> str:
         """Run a full auto-analysis of the profile.

--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -137,7 +137,7 @@ class Agent:
             self.conn = _sqlite3.connect(profile_path, check_same_thread=False)
             self.conn.row_factory = _sqlite3.Row
             return
-        self.conn = self.profile.db if self.profile.db is not None else self.profile.conn
+        self.conn = self.profile.query_conn()
 
     def close(self):
         if self.profile is not None:

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -784,7 +784,7 @@ def _cmd_diff(args, _profile):
             sol_specs = [parse_sol_gate(s) for s in sol_specs_raw]
             sol_flops = resolve_theoretical_flops(getattr(args, "theoretical_flops", None))
             with _profile.open(args.after) as sol_after:
-                sol_conn = sol_after.db if sol_after.db is not None else sol_after.conn
+                sol_conn = sol_after.query_conn()
                 sol_results = evaluate_sol_gates(
                     sol_conn,
                     sol_specs,

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -50,6 +50,40 @@ _duck_probe_bags: weakref.WeakKeyDictionary[Any, dict[str, Any]] = weakref.WeakK
 # connection's life is safe because a profile is an immutable capture.
 _sqlite_probe_bags: dict[sqlite3.Connection, dict[str, Any]] = {}
 
+# A DuckDB cursor is a second handle on the same database, and a thread that
+# queries through one must not lose the cache the owning connection filled.
+# Keying the bag on the handle would give each worker thread its own empty bag
+# and re-execute every memoized skill once per thread -- measured as four extra
+# executions across four threads for a skill the owner had already run.
+#
+# Sharing the bag is safe because it stores *results*, not handles: the same
+# skill with the same resolved parameters over the same immutable capture has
+# one answer whichever handle asks. Two threads can still both miss and both
+# compute, which costs duplicate work and never correctness.
+#
+# DuckDB exposes no parent pointer on a cursor, and duckdb_databases() names
+# every in-memory database "memory", so neither can identify the owner. The
+# registry is populated where cursors are created, in Profile.query_conn().
+_handle_owner: weakref.WeakKeyDictionary[Any, Any] = weakref.WeakKeyDictionary()
+
+
+def register_derived_handle(handle, owner) -> None:
+    """Record that ``handle`` is a second handle on ``owner``'s database.
+
+    Both are held weakly, so neither outlives its natural lifetime.
+    """
+    if handle is owner:
+        return
+    try:
+        _handle_owner[handle] = owner
+    except TypeError:  # not weak-referenceable; fall back to a private bag
+        pass
+
+
+def _cache_owner(conn):
+    """The object whose bag ``conn`` should read and write."""
+    return _handle_owner.get(conn, conn)
+
 
 def _probe_cache_get(conn, key: str):
     if isinstance(conn, sqlite3.Connection):
@@ -57,7 +91,7 @@ def _probe_cache_get(conn, key: str):
         if bag is None:
             return _PROBE_MISS
         return bag.get(key, _PROBE_MISS)
-    bag = _duck_probe_bags.get(conn)
+    bag = _duck_probe_bags.get(_cache_owner(conn))
     if bag is None:
         return _PROBE_MISS
     return bag.get(key, _PROBE_MISS)
@@ -68,7 +102,7 @@ def _probe_cache_set(conn, key: str, value) -> None:
         _sqlite_probe_bags.setdefault(conn, {})[key] = value
         return
     try:
-        _duck_probe_bags.setdefault(conn, {})[key] = value
+        _duck_probe_bags.setdefault(_cache_owner(conn), {})[key] = value
     except TypeError:
         pass
 

--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -159,7 +159,7 @@ def _producer_version() -> str:
 
 def _skill_conn(prof: Any) -> Any:
     """The connection a skill should run against (DuckDB cache if present)."""
-    return prof.db if getattr(prof, "db", None) is not None else prof.conn
+    return prof.query_conn()
 
 
 # ---------------------------------------------------------------------------

--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -148,7 +148,7 @@ class EvidenceBuilder:
                     kwargs["trim_end_ns"] = self.trim[1]
 
                 # Use DuckDB if available, fallback to SQLite
-                conn = self.prof.db if self.prof.db is not None else self.prof.conn
+                conn = self.prof.query_conn()
                 rows = skill.execute(conn, **kwargs)
                 if skill.to_findings_fn:
                     findings.extend(_invoke_to_findings(skill.to_findings_fn, rows, context))

--- a/src/nsys_ai/nccl_communicator.py
+++ b/src/nsys_ai/nccl_communicator.py
@@ -738,7 +738,7 @@ def _estimate_peak_bandwidth_gbps(prof: Profile) -> tuple[float | None, str | No
         except Exception:
             pass
 
-    gpu_name = get_first_gpu_name(prof.conn if prof.db is None else prof.db)
+    gpu_name = get_first_gpu_name(prof.query_conn())
     normalized = (gpu_name or "").upper()
     for key, gbps in sorted(_NVLINK_PEAK_GBPS.items(), key=lambda item: len(item[0]), reverse=True):
         if key in normalized:

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -183,7 +183,11 @@ def launch_overhead_ms(
 def _has_duckdb(prof: Profile) -> bool:
     from .connection import DuckDBAdapter, wrap_connection
 
-    conn = prof.query_conn()
+    # Asks the engine question of ``prof.db`` rather than ``query_conn()``:
+    # this is a type check, and going through the accessor would materialise a
+    # thread-local cursor as a side effect of answering it. Both handles are on
+    # the same database, so the answer is identical either way.
+    conn = prof.db if prof.db is not None else prof.conn
     return isinstance(wrap_connection(conn), DuckDBAdapter)
 
 

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -63,7 +63,7 @@ def overlap_analysis(prof: Profile, device: int, trim: tuple[int, int] | None = 
     """
     from .connection import _PROBE_MISS, _probe_cache_get, _probe_cache_set
 
-    conn = prof.db if prof.db is not None else prof.conn
+    conn = prof.query_conn()
     cache_key = f"overlap_analysis:{device}:{trim}"
     cached = _probe_cache_get(conn, cache_key)
     if cached is not _PROBE_MISS:
@@ -183,7 +183,7 @@ def launch_overhead_ms(
 def _has_duckdb(prof: Profile) -> bool:
     from .connection import DuckDBAdapter, wrap_connection
 
-    conn = prof.db if prof.db is not None else prof.conn
+    conn = prof.query_conn()
     return isinstance(wrap_connection(conn), DuckDBAdapter)
 
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1377,7 +1377,7 @@ def _build_nvtx_kernel_map_python(
 
 
 def _materialize_nvtx_kernel_map(db, results: list[dict]) -> None:
-    """Create the ``nvtx_kernel_map`` + ``nvtx_path_dict`` temp tables on a
+    """Create the ``nvtx_kernel_map`` + ``nvtx_path_dict`` tables on a
     DuckDB connection from sweep ``results``. Emits the full 9-column
     cache-built schema, including the embedded ``is_tc_eligible``/``uses_tc``,
     so consumers take their map-only fast path (a TC-less map would force
@@ -1411,16 +1411,23 @@ def _materialize_nvtx_kernel_map(db, results: list[dict]) -> None:
     db.register("_odm_nkm", map_tbl)
     db.register("_odm_npd", dict_tbl)
     try:
-        db.execute("CREATE TEMP TABLE nvtx_kernel_map AS SELECT * FROM _odm_nkm")
-        db.execute("CREATE TEMP TABLE nvtx_path_dict AS SELECT * FROM _odm_npd")
+        # Deliberately not TEMP. A temp table is visible only to the connection
+        # that created it, and DuckDB requires each thread to work through its
+        # own ``.cursor()`` handle — so a temp table here leaves every worker
+        # thread unable to see the map and silently falling back to the slower
+        # on-the-fly attribution. These two are the shared artifacts other code
+        # reads; the scratch tables above stay TEMP because they never escape
+        # the function that builds them.
+        db.execute("CREATE TABLE nvtx_kernel_map AS SELECT * FROM _odm_nkm")
+        db.execute("CREATE TABLE nvtx_path_dict AS SELECT * FROM _odm_npd")
     finally:
         db.unregister("_odm_nkm")
         db.unregister("_odm_npd")
 
 
 def ensure_nvtx_kernel_map(conn) -> bool:
-    """Materialize ``nvtx_kernel_map`` + ``nvtx_path_dict`` as temp tables on a
-    DuckDB connection when they are absent, so NVTX-attribution skills take their
+    """Materialize ``nvtx_kernel_map`` + ``nvtx_path_dict`` as ordinary tables on
+    a DuckDB connection when they are absent, so NVTX-attribution skills take their
     fast map-backed path instead of an in-file IEJoin that hangs DuckDB's
     ``sqlite_scanner`` on a direct-attached profile with no parquet cache (#257).
 

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -351,6 +351,8 @@ class Profile:
         )
         self.meta = self._discover()
         self._nvtx_has_text_id = self.adapter.detect_nvtx_text_id()
+        self._owner_thread = threading.get_ident()
+        self._thread_handles = threading.local()
 
     @classmethod
     def _from_conn(cls, conn: sqlite3.Connection) -> "Profile":
@@ -376,6 +378,8 @@ class Profile:
         obj.schema = NsightSchema(conn)
         obj.meta = obj._discover()
         obj._nvtx_has_text_id = obj.adapter.detect_nvtx_text_id()
+        obj._owner_thread = threading.get_ident()
+        obj._thread_handles = threading.local()
         return obj
 
     def _discover(self) -> ProfileMeta:
@@ -436,6 +440,46 @@ class Profile:
             tables=tables,
             gpu_info=self._gpu_info(devices, streams, tables, kcounts),
         )
+
+    def query_conn(self):
+        """The connection this thread should run queries through.
+
+        Two things in one accessor, because they are the same decision.
+
+        Which connection: DuckDB when a cache or direct attach is in use, the
+        SQLite connection when it is not. That choice was spelled out in eleven
+        places across eight modules, in three different spellings including an
+        inverted one, while ``__init__`` had already made it.
+
+        Which handle: DuckDB keeps the pending result set on the connection, so
+        ``execute`` and ``fetch`` are individually atomic but not atomic as a
+        pair. Two threads sharing one handle therefore clobber each other and
+        return wrong rows with nothing raised — measured wrong in 6 of 6 trials
+        against a plain DuckDB connection. The documented remedy is one
+        ``.cursor()`` per thread, so worker threads get a thread-local cursor,
+        reused across calls rather than created per query.
+
+        The thread that opened the profile keeps the connection object itself.
+        That leaves every existing single-threaded caller on exactly the path it
+        was on, and confines the new behaviour to threads that did not exist
+        before. It also matters for correctness: scratch tables created with
+        ``CREATE TEMP TABLE`` are visible only to the handle that made them.
+
+        SQLite needs none of this — the connection is opened with
+        ``check_same_thread=False`` and serialises internally.
+        """
+        if self.db is None:
+            return self.conn
+        # During __init__ the owner is not recorded yet, and _discover() queries
+        # through here. Construction is single-threaded, so the raw handle is
+        # the right answer and there is nothing to guard.
+        owner = getattr(self, "_owner_thread", None)
+        if owner is None or threading.get_ident() == owner:
+            return self.db
+        handle = getattr(self._thread_handles, "conn", None)
+        if handle is None:
+            handle = self._thread_handles.conn = self.db.cursor()
+        return handle
 
     def _gpu_info(self, devices, streams, tables, kcounts) -> dict[int, GpuInfo]:
         """Build per-GPU metadata. Per-device kernel counts come from the

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -479,6 +479,12 @@ class Profile:
         handle = getattr(self._thread_handles, "conn", None)
         if handle is None:
             handle = self._thread_handles.conn = self.db.cursor()
+            # Point the per-connection caches at the owning connection's bag.
+            # Without this each worker thread starts with an empty bag and
+            # re-executes every memoized skill once per thread.
+            from .connection import register_derived_handle
+
+            register_derived_handle(handle, self.db)
         return handle
 
     def _gpu_info(self, devices, streams, tables, kcounts) -> dict[int, GpuInfo]:
@@ -878,6 +884,15 @@ class Profile:
                 return [dict(r) for r in cur.fetchall()]
 
     def close(self):
+        # Drop the per-thread cursors first. They are handles on self.db, so
+        # after it closes they raise "Connection already closed" — and being
+        # held in a thread-local, a worker thread that outlives the profile
+        # would be handed the dead one instead of an error or a fresh handle.
+        # Replacing the container clears every thread's slot, not just this
+        # thread's, which is the point: the owner is usually the one closing.
+        if getattr(self, "_thread_handles", None) is not None:
+            self._thread_handles = threading.local()
+
         # Close the primary connection only if we own it.
         if getattr(self, "_owns_conn", True):
             try:

--- a/tests/test_nvtx_kernel_map_ondemand.py
+++ b/tests/test_nvtx_kernel_map_ondemand.py
@@ -161,3 +161,29 @@ def test_ensure_is_noop_when_map_present():
 def test_ensure_returns_false_for_sqlite_connection():
     # Non-DuckDB connection: unchanged, caller keeps its own path.
     assert ensure_nvtx_kernel_map(sqlite3.connect(":memory:")) is False
+
+
+def test_the_map_is_visible_to_a_thread_local_cursor():
+    """The on-demand map must not be a TEMP table.
+
+    DuckDB requires each thread to work through its own ``.cursor()`` handle —
+    a shared connection serves concurrent queries wrong results, silently. A
+    TEMP table is visible only to the connection that created it, so building
+    the map as one left every worker thread unable to see it and quietly
+    falling back to the slower on-the-fly attribution. The fallback returns
+    rows, so nothing raised and nothing looked broken; only the source of the
+    numbers changed.
+
+    This bites specifically on the direct-attach path a large profile takes,
+    where there is no ``nvtx_kernel_map.parquet`` to expose as a view.
+    """
+    con = _duckdb_profile()
+    assert ensure_nvtx_kernel_map(con) is True
+    expected = con.execute("SELECT COUNT(*) FROM nvtx_kernel_map").fetchone()[0]
+
+    for name in ("nvtx_kernel_map", "nvtx_path_dict"):
+        cur = con.cursor()
+        got = cur.execute(f"SELECT COUNT(*) FROM {name}").fetchone()
+        assert got is not None, f"{name} is invisible to a cursor — is it TEMP again?"
+
+    assert con.cursor().execute("SELECT COUNT(*) FROM nvtx_kernel_map").fetchone()[0] == expected

--- a/tests/test_profile_query_conn.py
+++ b/tests/test_profile_query_conn.py
@@ -1,0 +1,118 @@
+"""`Profile.query_conn()` — one accessor for two decisions that were one.
+
+Which connection to query was spelled out in eleven places across eight modules,
+in three spellings, while `Profile.__init__` had already decided it. Which
+*handle* to query through was decided nowhere, and the default was wrong under
+threads: DuckDB keeps the pending result set on the connection, so `execute`
+and `fetch` are individually atomic but not atomic as a pair. Two threads on one
+handle clobber each other and return wrong rows with nothing raised.
+
+Measured against a plain DuckDB connection, outside this repo entirely: a shared
+connection was wrong in 6 of 6 trials, per-thread cursors in 0 of 6. The failure
+mode includes `fetchone()` returning None because another thread had already
+consumed the result.
+"""
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.profile import Profile
+from nsys_ai.skills.registry import get_skill
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+def test_the_owning_thread_keeps_the_connection_itself():
+    """Existing single-threaded callers must stay on exactly the path they were on.
+
+    This is not cosmetic. Scratch tables made with `CREATE TEMP TABLE` are
+    visible only to the handle that created them, so handing the owning thread a
+    cursor would change behaviour for code that has always worked.
+    """
+    with Profile(str(FIXTURE)) as prof:
+        if prof.db is None:  # pragma: no cover - cache unavailable
+            pytest.skip("DuckDB not in use")
+        assert prof.query_conn() is prof.db
+
+
+def test_worker_threads_get_their_own_reused_handle():
+    """One cursor per thread, reused — not one per call.
+
+    Per-call cursors would work too, but every cursor is a distinct key in the
+    per-connection memo from #295, so churning them churns the cache. Bound to
+    the pool size, the fragmentation is bounded too.
+    """
+    with Profile(str(FIXTURE)) as prof:
+        if prof.db is None:  # pragma: no cover
+            pytest.skip("DuckDB not in use")
+        seen: set[int] = set()
+        lock = threading.Lock()
+
+        def grab(_):
+            handle = prof.query_conn()
+            with lock:
+                seen.add(id(handle))
+            return handle is prof.db
+
+        with ThreadPoolExecutor(max_workers=4) as ex:
+            for _ in range(10):  # ten waves over one persistent pool
+                results = list(ex.map(grab, range(8)))
+
+        assert not any(results), "a worker thread was handed the shared connection"
+        assert len(seen) <= 4, f"expected at most one handle per worker, got {len(seen)}"
+
+
+def test_concurrent_skill_runs_agree_with_the_sequential_answer():
+    """The behaviour the accessor exists to protect.
+
+    Run through a shared connection this returns wrong row counts silently; the
+    sequential baseline is the oracle.
+    """
+    with Profile(str(FIXTURE)) as prof:
+        if prof.db is None:  # pragma: no cover
+            pytest.skip("DuckDB not in use")
+        skill = get_skill("top_kernels")
+        baseline = skill.execute(prof.query_conn(), limit=5)
+
+        # Bounded wait on purpose. Removing the per-thread handle does not just
+        # return wrong rows — threads contending for one connection's result set
+        # deadlocked and ran past ten minutes when this was mutation-checked. A
+        # regression must fail the build, not hang it.
+        batches = []
+        with ThreadPoolExecutor(max_workers=4) as ex:
+            for _ in range(5):
+                futures = [
+                    ex.submit(lambda: skill.execute(prof.query_conn(), limit=5)) for _ in range(8)
+                ]
+                batches.append([f.result(timeout=60) for f in futures])
+
+    for batch in batches:
+        for rows in batch:
+            assert rows == baseline, "a concurrent run disagreed with the sequential answer"
+
+
+def test_a_sqlite_only_profile_gets_the_sqlite_connection():
+    """No cursor games where none are needed — sqlite3 is opened with
+    `check_same_thread=False` and serialises internally."""
+    conn = sqlite3.connect(FIXTURE, check_same_thread=False)
+    try:
+        prof = Profile._from_conn(conn)
+        assert prof.db is None
+        assert prof.query_conn() is conn
+    finally:
+        conn.close()
+
+
+def test_the_accessor_works_during_construction():
+    """`_discover()` queries through this before the owning thread is recorded.
+
+    Constructing a Profile at all is the assertion; an ordering mistake here
+    raises AttributeError from deep inside __init__.
+    """
+    with Profile(str(FIXTURE)) as prof:
+        assert prof.meta is not None
+        assert prof.query_conn() is not None

--- a/tests/test_profile_query_conn.py
+++ b/tests/test_profile_query_conn.py
@@ -116,3 +116,91 @@ def test_the_accessor_works_during_construction():
     with Profile(str(FIXTURE)) as prof:
         assert prof.meta is not None
         assert prof.query_conn() is not None
+
+
+def test_worker_threads_share_the_owning_connection_s_cache():
+    """A second handle must not mean a second cache.
+
+    The per-connection bag backs both the probe cache and the skill memo from
+    #295. Keyed on the handle, every worker thread starts empty and re-executes
+    work the owner already did — measured as four extra executions across four
+    threads. Keyed on the owning connection, the handle a thread happens to hold
+    stops mattering.
+
+    Sharing is safe because the bag stores results, not handles: one skill with
+    one set of resolved parameters over an immutable capture has one answer.
+    """
+    skill = get_skill("top_kernels")
+    executions: list[int] = []
+    original = skill.execute_fn
+
+    def counting(conn, **kwargs):
+        executions.append(threading.get_ident())
+        return original(conn, **kwargs)
+
+    skill.execute_fn = counting
+    try:
+        with Profile(str(FIXTURE)) as prof:
+            if prof.db is None:  # pragma: no cover
+                pytest.skip("DuckDB not in use")
+            skill.execute(prof.query_conn(), limit=5)  # owner populates
+            after_owner = len(executions)
+            with ThreadPoolExecutor(max_workers=4) as ex:
+                futures = [
+                    ex.submit(lambda: skill.execute(prof.query_conn(), limit=5)) for _ in range(8)
+                ]
+                for f in futures:
+                    f.result(timeout=60)
+    finally:
+        skill.execute_fn = original
+
+    assert after_owner == 1
+    assert len(executions) == after_owner, (
+        f"worker threads re-executed {len(executions) - after_owner} times — "
+        "the cache is keyed on the handle again, not the owning connection"
+    )
+
+
+def test_close_drops_the_per_thread_handles():
+    """Cursors are handles on the connection being closed.
+
+    Left in the thread-local, a worker thread outliving the profile would be
+    handed a dead cursor rather than an error or a fresh one.
+    """
+    prof = Profile(str(FIXTURE))
+    if prof.db is None:  # pragma: no cover
+        prof.close()
+        pytest.skip("DuckDB not in use")
+
+    def touch():
+        prof.query_conn()
+
+    worker = threading.Thread(target=touch)
+    worker.start()
+    worker.join()
+
+    prof.close()
+    assert getattr(prof._thread_handles, "conn", None) is None, (
+        "close() left a cursor in the thread-local"
+    )
+
+
+def test_a_type_check_does_not_materialise_a_cursor():
+    """`_has_duckdb` asks which engine is in use; answering it should not
+    allocate a handle as a side effect."""
+    from nsys_ai.overlap import _has_duckdb
+
+    with Profile(str(FIXTURE)) as prof:
+        if prof.db is None:  # pragma: no cover
+            pytest.skip("DuckDB not in use")
+        seen = {}
+
+        def probe():
+            _has_duckdb(prof)
+            seen["handle"] = getattr(prof._thread_handles, "conn", None)
+
+        worker = threading.Thread(target=probe)
+        worker.start()
+        worker.join()
+
+    assert seen["handle"] is None, "a type check created a thread-local cursor"


### PR DESCRIPTION
First step of #300. Two commits: a prerequisite, then the accessor it unblocks.

## The defect

DuckDB keeps the pending result set on the connection, so `execute` and `fetch` are each atomic but not atomic **as a pair**. Two threads sharing one handle clobber each other. Isolated against a plain DuckDB connection, with none of this repo's code involved:

```
sequential baseline: [548444, 548444, 548444, 548444]
  shared connection      wrong in 6 of 6 trials
  per-thread .cursor()   wrong in 0 of 6 trials
```

The failure mode includes wrong values and `TypeError: 'NoneType' object is not subscriptable`, when one thread's `fetchone()` finds the result set already consumed. Under mutation it also **deadlocked past ten minutes**, which is why the concurrency test uses a bounded `f.result(timeout=...)` — a regression should fail the build, not hang it.

DuckDB documents the remedy: one `.cursor()` per thread.

## Why the accessor, and not a patch at the call site

Which connection to query was written out in **eleven places across eight modules**, in three spellings — inverted in `nccl_communicator.py:741`, a defensive `getattr` in `doctor.py:162` — while `__init__` had already made the choice. `Profile` exposed no accessor at all.

Which *handle* to use was decided nowhere. Both are the same decision, so they get one accessor: `Profile.query_conn()`.

The owning thread keeps the connection object itself, so every existing caller stays on exactly the path it was on and `CREATE TEMP TABLE` scratch state stays visible to the handle that made it. Only threads that did not previously exist get a cursor — thread-local and reused, not per call, because each cursor is a distinct key in the memo from #295. Verified over a persistent pool: **160 calls across 20 waves, 0 disagreements, exactly 4 cursors for `max_workers=4`**.

A second handle must not mean a second cache. The per-connection bag backs both the probe cache and the memo from #295, and keying it on the handle made every worker thread start empty and re-execute what the owner had already done — **four extra executions across four threads**, at 5–11 s per skill on a 3.5 GB profile. A registry maps a derived handle back to its owning connection, so the bag a thread reads no longer depends on which handle it holds. (An earlier revision of this description called the fragmentation "self-limiting" on the grounds that the bag is a `WeakKeyDictionary`. That is true of *memory* and says nothing about *hit rate*; the claim was wrong and the cost was real.)

## The prerequisite

Adopting cursors is blocked while `nvtx_kernel_map` and `nvtx_path_dict` are `TEMP`, because a temp table is visible only to the connection that created it. On the direct-attach path a profile over 50 MB takes — where there is no `nvtx_kernel_map.parquet` to expose as a view — a cursor got `Catalog Error: Table with name nvtx_kernel_map does not exist`. After the change every cursor sees the same 1,643 rows. The scratch tables in the SQL builder stay `TEMP`; they never escape the function that builds them.

## What this does not do

**It does not correct a wrong number.** The four skills that read the map — `nvtx_kernel_map`, `nvtx_layer_breakdown`, `nccl_compile_context_breakdown`, `profile_health_manifest` — were run through a cursor with the map visible and with it absent, and returned identical results either way, because each falls back to computing attribution on the fly. This removes a silent downgrade to the slower path and unblocks cursors. (The one flagged difference was `profile_health_manifest`'s `analysis_time_utc`.)

**It does not fix a demonstrated live bug.** The only place concurrency is known to occur is the timeline tile path — `timeline.js:218` fires tile fetches through `Promise.all` — and that path goes through `_duckdb_query`, which already holds `self._lock`. The skill path has no such lock, but its concurrency has not been demonstrated. So this is a latent-risk fix and an architectural convergence, not a hotfix. An earlier draft of this description claimed otherwise; the lock is why that was wrong.

## Test plan

- [x] `pytest tests/` — **1429 passed, 135 skipped, 0 failed**
- [x] `ruff check src/ tests/` — clean
- [x] Root cause isolated with pure DuckDB, outside this repo's code (6/6 vs 0/6)
- [x] Thread-local reuse verified over a persistent pool (160 calls, 4 cursors)
- [x] Cursor visibility of the map verified before and after on the direct-attach path
- [x] Both changes mutation-verified: reverting the temp-table fix fails its test; removing the owner check fails the handle-identity test

`_duckdb_query` and the two `__init__` sites keep the inline form deliberately — two run before the owning thread is recorded, and `_duckdb_query` already has its lock. Narrowing those is separate work.

## Next in #300

The 20-minute `nvtx_kernel_map` IEJoin, where the sweep already in this repo measured 19.0 s against 20+ minutes with byte-identical output at full scale.

Refs #300.
