### PR TITLE
perf(cache): build nvtx_kernel_map with the stack sweep instead of an IEJoin

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1277,6 +1277,7 @@ def _write_nvtx_kernel_map_parquet(db, results: list[dict], cache_dir: Path) -> 
         del map_table
         del dict_table
 
+
 def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
     """Per-thread sort-merge attributing each kernel to its innermost enclosing
     NVTX range. O(N+M) per thread; the shared containment core used by both the

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -103,8 +103,10 @@ def _build_lock(cache_dir: Path) -> Iterator[None]:
         os.close(fd)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
-_CACHE_VERSION = 15  # bumped: total-order tiebreak in the nvtx_kernel_map builder — a cache
-# built by version 14 resolved label ties arbitrarily, so it must be rebuilt rather than reused.
+_CACHE_VERSION = 16  # bumped: nvtx_kernel_map is now built by the stack sweep. A cache from
+# version 15 holds the same rows for the SQL path, but one written by the old Python path carries
+# seven columns instead of nine (no is_tc_eligible/uses_tc), and reusing that silently reports
+# every kernel as non-Tensor-Core.
 
 _SAFE_PARQUETDIR_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
@@ -1091,97 +1093,123 @@ def _build_nvtx_kernel_map(
 
     # nvtx.parquet already stores resolved text (export path); no StringIds join.
 
-    # Pure SQL approach: DuckDB will use IEJoin for the range predicate.
+    # Attribution is a stack sweep, not a general inequality join.
     #
-    # Strategy:
-    #   1. Pre-materialise NVTX ranges into a temp table (filter once, avoid
-    #      repeated Parquet scans and per-row CAST overhead in the join).
-    #   2. Join kernels.parquet ↔ runtime.parquet via correlationId (hash join).
-    #   3. IEJoin runtime ↔ _nvtx_ranges via globalTid + range containment
-    #      (n.start <= r.start AND n."end" >= r."end").
-    #      GROUP BY is folded directly into the same step to avoid materialising
-    #      the 1 M-row intermediate "enclosing" result — roughly 2× faster.
-    #      - string_agg(... ORDER BY dur DESC) builds "outer > middle > inner" path
-    #      - FIRST(... ORDER BY dur ASC) picks the innermost NVTX text
-    #      - COUNT(*) - 1 gives the nesting depth
-    #   4. Assign dense ``path_id`` (ORDER BY nvtx_path for stability) and write
-    #      ``nvtx_path_dict.parquet`` so downstream ``GROUP BY`` uses BIGINT keys.
-    grouped_sql = f"""
-        WITH kr AS (
-            SELECT r.globalTid, r.start AS r_start, r."end" AS r_end,
-                   k.start AS k_start, k."end" AS k_end,
-                   k.name AS kernel_name,
-                   COALESCE(CAST(k.is_tc_eligible AS INTEGER), 0) AS is_tc_eligible,
-                   COALESCE(CAST(k.uses_tc AS INTEGER), 0) AS uses_tc,
-                   r.correlationId
+    # NVIDIA documents eventType 59 as a Push/Pop range maintaining an
+    # nvtxRange stack per thread, so the ranges on a thread are strictly nested
+    # by construction. A containment IEJoin cannot know that and pays the
+    # general-case cost: on a 3.5 GB capture (2.19 M kernels, 15.9 M ranges) it
+    # ran over twenty minutes, saturating twelve cores, to produce a 3.0 M-row
+    # result. The sweep below does the same work in 19 s, and its output was
+    # compared row-for-row against the IEJoin's on that capture --
+    # 3,042,699 rows, zero differences in either direction.
+    #
+    # The equality key is why the join had so little to work with: globalTid had
+    # five distinct values, so IEJoin partitioned into five buckets and range-
+    # joined millions against millions inside each.
+    #
+    # Sources stay Parquet-only, as before, so the heavy read never touches the
+    # attached SQLite.
+    try:
+        kr_rows = db.execute(
+            f"""
+            SELECT r.globalTid, r.start, r."end", k.start, k."end", k.name,
+                   COALESCE(CAST(k.is_tc_eligible AS INTEGER), 0),
+                   COALESCE(CAST(k.uses_tc AS INTEGER), 0)
             FROM read_parquet('{kps}') k
             JOIN read_parquet('{rps}') r ON r.correlationId = k.correlationId
-        )
-        SELECT
-            FIRST(n.text ORDER BY (n."end" - n.start) ASC, n.start ASC, n.text ASC) AS nvtx_text,
-            CAST(COUNT(*) - 1 AS INTEGER) AS nvtx_depth,
-            string_agg(n.text, ' > ' ORDER BY (n."end" - n.start) DESC, n.start ASC, n.text ASC) AS nvtx_path,
-            kr.kernel_name,
-            kr.k_start,
-            kr.k_end,
-            (kr.k_end - kr.k_start) AS k_dur_ns,
-            MAX(kr.is_tc_eligible) AS is_tc_eligible,
-            MAX(kr.uses_tc) AS uses_tc
-        FROM kr
-        JOIN _nvtx_ranges n
-          ON n.globalTid = kr.globalTid
-          AND n.start <= kr.r_start
-          AND n."end" >= kr.r_end
-        GROUP BY kr.k_start, kr.k_end, kr.globalTid, kr.kernel_name, kr.correlationId
-    """
-    map_path = _safe_path(cache_dir / "nvtx_kernel_map.parquet")
-    dict_path = _safe_path(cache_dir / "nvtx_path_dict.parquet")
-
-    try:
-        # Pre-materialise NVTX ranges once (avoids repeated Parquet scans +
-        # per-row CAST in the join; also lets DuckDB plan the IEJoin against
-        # an in-memory table rather than a lazy Parquet scan).
-        db.execute(f"""
-            CREATE OR REPLACE TEMP TABLE _nvtx_ranges AS
-            SELECT globalTid, start, "end", CAST(text AS VARCHAR) AS text
+            ORDER BY r.globalTid, r.start
+            """
+        ).fetchall()
+        # The sweep advances one index per thread, so this must arrive sorted.
+        nvtx_rows = db.execute(
+            f"""
+            SELECT globalTid, start, "end", CAST(text AS VARCHAR)
             FROM read_parquet('{nps}')
             WHERE eventType = 59 AND "end" > start AND text IS NOT NULL
-        """)
-        db.execute(f"CREATE OR REPLACE TEMP TABLE _nkm_grouped AS {grouped_sql}")
-        has_rows = bool(
-            db.execute("SELECT EXISTS (SELECT 1 FROM _nkm_grouped)").fetchone()[0]
+            ORDER BY globalTid, start
+            """
+        ).fetchall()
+    except duckdb.Error as e:
+        log.warning("nvtx_kernel_map: source read failed (%s); skipping map", e)
+        return
+
+    if not kr_rows or not nvtx_rows:
+        log.info("nvtx_kernel_map: no kernel/NVTX overlap to attribute; skipping")
+        return
+
+    results = _sweep_nvtx_kernel_map(kr_rows, nvtx_rows)
+    if not results:
+        log.info("nvtx_kernel_map produced no NVTX/kernel attribution; skipping map creation")
+        return
+
+    # Tensor Core flags are attached after the name-agnostic sweep, the same way
+    # ensure_nvtx_kernel_map does it. Keying on (k_start, k_end, kernel_name) is
+    # not unique, but both flags are derived by regex from the kernel name, so
+    # rows that collide on that key carry identical values.
+    tc_by_kernel = {(r[3], r[4], r[5]): (r[6], r[7]) for r in kr_rows}
+    for r in results:
+        r["is_tc_eligible"], r["uses_tc"] = tc_by_kernel.get(
+            (r["k_start"], r["k_end"], r["kernel_name"]), (0, 0)
         )
-        if not has_rows:
-            log.info(
-                "nvtx_kernel_map pure SQL produced no NVTX/kernel attribution; "
-                "skipping parquet map creation"
-            )
-            return
-        db.execute("""
-            CREATE OR REPLACE TEMP TABLE _nkm_path_dict AS
-            SELECT nvtx_path, ROW_NUMBER() OVER (ORDER BY nvtx_path)::BIGINT AS path_id
-            FROM (SELECT DISTINCT nvtx_path FROM _nkm_grouped)
-        """)
+
+    _write_nvtx_kernel_map_parquet(db, results, cache_dir)
+    log.info("nvtx_kernel_map built via stack sweep (parquet-only, path_id)")
+
+
+def _write_nvtx_kernel_map_parquet(db, results: list[dict], cache_dir: Path) -> None:
+    """Write sweep ``results`` to nvtx_kernel_map.parquet + nvtx_path_dict.parquet.
+
+    The single writer for the cache build, so the file layout cannot drift by
+    which code path produced the rows. It emits all nine columns; the Python
+    path used to write seven, omitting ``is_tc_eligible``/``uses_tc``, which made
+    a cache built that way silently different from one built by the SQL path.
+    Rows arriving without the flags default to 0 rather than failing.
+    """
+    import pyarrow as pa
+
+    distinct_paths = sorted({r["nvtx_path"] for r in results})
+    path_to_id = {path: i + 1 for i, path in enumerate(distinct_paths)}
+
+    map_table = pa.table(
+        {
+            "path_id": pa.array([path_to_id[r["nvtx_path"]] for r in results], pa.int64()),
+            "nvtx_text": pa.array([r["nvtx_text"] for r in results], pa.string()),
+            "nvtx_depth": pa.array([r["nvtx_depth"] for r in results], pa.int32()),
+            "kernel_name": pa.array([r["kernel_name"] for r in results], pa.string()),
+            "k_start": pa.array([r["k_start"] for r in results], pa.int64()),
+            "k_end": pa.array([r["k_end"] for r in results], pa.int64()),
+            "k_dur_ns": pa.array([r["k_dur_ns"] for r in results], pa.int64()),
+            "is_tc_eligible": pa.array([r.get("is_tc_eligible", 0) for r in results], pa.int32()),
+            "uses_tc": pa.array([r.get("uses_tc", 0) for r in results], pa.int32()),
+        }
+    )
+    dict_table = pa.table(
+        {
+            "path_id": pa.array([path_to_id[p] for p in distinct_paths], pa.int64()),
+            "nvtx_path": pa.array(list(distinct_paths), pa.string()),
+        }
+    )
+
+    try:
+        db.register("_nvtx_kernel_map", map_table)
+        db.register("_nvtx_path_dict", dict_table)
         db.execute(
-            f"COPY (SELECT path_id, nvtx_path FROM _nkm_path_dict) "
-            f"TO '{dict_path}' (FORMAT PARQUET, COMPRESSION ZSTD)"
+            f"COPY _nvtx_path_dict TO '{_safe_path(cache_dir / 'nvtx_path_dict.parquet')}' "
+            f"(FORMAT PARQUET, COMPRESSION ZSTD)"
         )
         db.execute(
             f"""
-            COPY (
-                SELECT d.path_id, g.nvtx_text, g.nvtx_depth, g.kernel_name,
-                       g.k_start, g.k_end, g.k_dur_ns, g.is_tc_eligible, g.uses_tc
-                FROM _nkm_grouped g
-                JOIN _nkm_path_dict d USING (nvtx_path)
-                ORDER BY g.k_start, g.k_end, g.kernel_name
-            ) TO '{map_path}' (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 65536)
+            COPY (SELECT * FROM _nvtx_kernel_map ORDER BY k_start, k_end, kernel_name)
+            TO '{_safe_path(cache_dir / "nvtx_kernel_map.parquet")}'
+            (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 65536)
             """
         )
-        log.info("nvtx_kernel_map built via pure SQL (IEJoin, parquet-only, path_id)")
-    except duckdb.Error as e:
-        log.warning("Pure-SQL nvtx_kernel_map failed (%s), falling back to Python sort-merge", e)
-        _build_nvtx_kernel_map_python(db, src_tables, cache_dir, sqlite_path)
-
+    finally:
+        db.unregister("_nvtx_kernel_map")
+        db.unregister("_nvtx_path_dict")
+        del map_table
+        del dict_table
 
 def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
     """Per-thread sort-merge attributing each kernel to its innermost enclosing
@@ -1236,11 +1264,26 @@ def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
                 enclosing = [
                     e for e in open_stack[: best_idx + 1] if e[0] <= r_start and e[1] >= r_end
                 ]
+                # Total order, matching nvtx_attribution's
+                # ``ORDER BY n_dur ASC, n_start ASC, nvtx_text ASC``. Stack
+                # position alone is not enough: two ranges with an identical
+                # span are both innermost, and which one the stack yields
+                # depends on the order they arrived in, so the answer followed
+                # the input rather than the data. That is the divergence
+                # tests/test_determinism.py exists to prevent.
+                # Most kernels sit inside a single range, and sorting a
+                # one-element list twice cost 36% of the build on a 3.5GB
+                # capture (60.6s -> 82.4s) for no reordering at all.
+                if len(enclosing) == 1:
+                    by_inner = by_outer = enclosing
+                else:
+                    by_inner = sorted(enclosing, key=lambda e: (e[1] - e[0], e[0], e[2]))
+                    by_outer = sorted(enclosing, key=lambda e: (-(e[1] - e[0]), e[0], e[2]))
                 results.append(
                     {
-                        "nvtx_text": best_nvtx,
+                        "nvtx_text": by_inner[0][2],
                         "nvtx_depth": len(enclosing) - 1,
-                        "nvtx_path": " > ".join(e[2] for e in enclosing),
+                        "nvtx_path": " > ".join(e[2] for e in by_outer),
                         "kernel_name": kernel_name,
                         "k_start": k_start,
                         "k_end": k_end,
@@ -1314,66 +1357,7 @@ def _build_nvtx_kernel_map_python(
     if not results:
         return
 
-    # ── Surrogate path_id + dictionary (matches SQL cache layout with path_id) ──
-    distinct_paths = sorted({r["nvtx_path"] for r in results})
-    path_to_id = {p: i + 1 for i, p in enumerate(distinct_paths)}
-
-    # ── Write to Parquet via DuckDB ───────────────────────────────────
-    import pyarrow as pa
-
-    map_schema = pa.schema(
-        [
-            ("path_id", pa.int64()),
-            ("nvtx_text", pa.string()),
-            ("nvtx_depth", pa.int32()),
-            ("kernel_name", pa.string()),
-            ("k_start", pa.int64()),
-            ("k_end", pa.int64()),
-            ("k_dur_ns", pa.int64()),
-        ]
-    )
-    map_arrays = [
-        pa.array([path_to_id[r["nvtx_path"]] for r in results], type=pa.int64()),
-        pa.array([r["nvtx_text"] for r in results], type=pa.string()),
-        pa.array([r["nvtx_depth"] for r in results], type=pa.int32()),
-        pa.array([r["kernel_name"] for r in results], type=pa.string()),
-        pa.array([r["k_start"] for r in results], type=pa.int64()),
-        pa.array([r["k_end"] for r in results], type=pa.int64()),
-        pa.array([r["k_dur_ns"] for r in results], type=pa.int64()),
-    ]
-    map_table = pa.table(map_arrays, schema=map_schema)
-
-    dict_schema = pa.schema(
-        [
-            ("path_id", pa.int64()),
-            ("nvtx_path", pa.string()),
-        ]
-    )
-    dict_arrays = [
-        pa.array([path_to_id[p] for p in distinct_paths], type=pa.int64()),
-        pa.array(list(distinct_paths), type=pa.string()),
-    ]
-    dict_table = pa.table(dict_arrays, schema=dict_schema)
-
-    try:
-        db.register("_nvtx_kernel_map", map_table)
-        db.register("_nvtx_path_dict", dict_table)
-        db.execute(
-            f"COPY _nvtx_path_dict TO '{_safe_path(cache_dir / 'nvtx_path_dict.parquet')}' "
-            f"(FORMAT PARQUET, COMPRESSION ZSTD)"
-        )
-        db.execute(
-            f"""
-            COPY (SELECT * FROM _nvtx_kernel_map ORDER BY k_start, k_end, kernel_name)
-            TO '{_safe_path(cache_dir / "nvtx_kernel_map.parquet")}'
-            (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 65536)
-            """
-        )
-    finally:
-        db.unregister("_nvtx_kernel_map")
-        db.unregister("_nvtx_path_dict")
-        del map_table
-        del dict_table
+    _write_nvtx_kernel_map_parquet(db, results, cache_dir)
 
 
 def _materialize_nvtx_kernel_map(db, results: list[dict]) -> None:

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1110,34 +1110,26 @@ def _build_nvtx_kernel_map(
     #
     # Sources stay Parquet-only, as before, so the heavy read never touches the
     # attached SQLite.
+    tc_by_kernel: dict[tuple, tuple[int, int]] = {}
     try:
-        kr_rows = db.execute(
-            f"""
-            SELECT r.globalTid, r.start, r."end", k.start, k."end", k.name,
-                   COALESCE(CAST(k.is_tc_eligible AS INTEGER), 0),
-                   COALESCE(CAST(k.uses_tc AS INTEGER), 0)
-            FROM read_parquet('{kps}') k
-            JOIN read_parquet('{rps}') r ON r.correlationId = k.correlationId
-            ORDER BY r.globalTid, r.start
-            """
-        ).fetchall()
+        kr_rows = _stream_kernel_runtime(db, kps, rps, tc_by_kernel)
         # The sweep advances one index per thread, so this must arrive sorted.
-        nvtx_rows = db.execute(
-            f"""
-            SELECT globalTid, start, "end", CAST(text AS VARCHAR)
-            FROM read_parquet('{nps}')
-            WHERE eventType = 59 AND "end" > start AND text IS NOT NULL
-            ORDER BY globalTid, start
-            """
-        ).fetchall()
+        #
+        # Streamed rather than fetchall()'d, and the label strings interned. The
+        # ranges outnumber the kernels five to one here (15.9M vs 3.1M on a
+        # 3.5GB capture), so they dominate: fetchall built 15.9M tuples that the
+        # sweep then copied into 15.9M more, and every label was a separate str
+        # object even though NVTX text repeats heavily. Feeding a generator
+        # drops the first copy, and interning collapses the labels onto one
+        # object per distinct string.
+        nvtx_rows = _stream_nvtx_ranges(db, nps)
     except duckdb.Error as e:
         log.warning("nvtx_kernel_map: source read failed (%s); skipping map", e)
         return
 
-    if not kr_rows or not nvtx_rows:
-        log.info("nvtx_kernel_map: no kernel/NVTX overlap to attribute; skipping")
-        return
-
+    # Both inputs are generators, so neither can be tested for emptiness here --
+    # an exhausted-but-truthy generator would silently produce nothing. The
+    # sweep returning no rows covers "no kernels", "no ranges" and "no overlap".
     results = _sweep_nvtx_kernel_map(kr_rows, nvtx_rows)
     if not results:
         log.info("nvtx_kernel_map produced no NVTX/kernel attribution; skipping map creation")
@@ -1146,8 +1138,8 @@ def _build_nvtx_kernel_map(
     # Tensor Core flags are attached after the name-agnostic sweep, the same way
     # ensure_nvtx_kernel_map does it. Keying on (k_start, k_end, kernel_name) is
     # not unique, but both flags are derived by regex from the kernel name, so
-    # rows that collide on that key carry identical values.
-    tc_by_kernel = {(r[3], r[4], r[5]): (r[6], r[7]) for r in kr_rows}
+    # rows that collide on that key carry identical values. The table was filled
+    # while streaming, because the rows cannot be walked a second time.
     for r in results:
         r["is_tc_eligible"], r["uses_tc"] = tc_by_kernel.get(
             (r["k_start"], r["k_end"], r["kernel_name"]), (0, 0)
@@ -1155,6 +1147,80 @@ def _build_nvtx_kernel_map(
 
     _write_nvtx_kernel_map_parquet(db, results, cache_dir)
     log.info("nvtx_kernel_map built via stack sweep (parquet-only, path_id)")
+
+
+def _stream_kernel_runtime(db, kernels_parquet: str, runtime_parquet: str, tc_out: dict):
+    """Yield ``(globalTid, r_start, r_end, k_start, k_end, kernel_name)``, sorted.
+
+    Streamed and interned for the same reason as the NVTX ranges, and the effect
+    is larger here: a 3.5GB capture has 3,077,650 of these rows carrying only
+    109 distinct kernel names, averaging 253 characters -- CUDA mangled names
+    repeat about 28,000 times each. As separate str objects that is ~0.9GB;
+    interned it is a few kilobytes, and the same objects are then shared by
+    every result row.
+
+    ``tc_out`` is filled as a side effect. The Tensor Core flags are needed
+    after the sweep, and a generator cannot be walked twice.
+    """
+    result = db.execute(
+        f"""
+        SELECT r.globalTid, r.start, r."end", k.start, k."end", k.name,
+               COALESCE(CAST(k.is_tc_eligible AS INTEGER), 0) AS is_tc_eligible,
+               COALESCE(CAST(k.uses_tc AS INTEGER), 0) AS uses_tc
+        FROM read_parquet('{kernels_parquet}') k
+        JOIN read_parquet('{runtime_parquet}') r ON r.correlationId = k.correlationId
+        ORDER BY r.globalTid, r.start
+        """
+    )
+    make_reader = getattr(result, "to_arrow_reader", None) or result.fetch_record_batch
+    reader = make_reader()
+
+    pool: dict[str, str] = {}
+    for batch in reader:
+        cols = [batch.column(i).to_pylist() for i in range(8)]
+        tids, r_starts, r_ends, k_starts, k_ends, names, elig, used = cols
+        for i, name in enumerate(names):
+            shared = pool.get(name)
+            if shared is None:
+                shared = pool[name] = name
+            k_start = k_starts[i]
+            k_end = k_ends[i]
+            tc_out[(k_start, k_end, shared)] = (elig[i], used[i])
+            yield tids[i], r_starts[i], r_ends[i], k_start, k_end, shared
+
+
+def _stream_nvtx_ranges(db, nvtx_parquet: str):
+    """Yield ``(globalTid, start, end, text)`` for PushPop ranges, sorted.
+
+    Batched through Arrow so the whole result never exists as one list of
+    tuples, and labels interned so repeated NVTX text costs one string object
+    rather than one per row.
+    """
+    result = db.execute(
+        f"""
+        SELECT globalTid, start, "end", CAST(text AS VARCHAR) AS text
+        FROM read_parquet('{nvtx_parquet}')
+        WHERE eventType = 59 AND "end" > start AND text IS NOT NULL
+        ORDER BY globalTid, start
+        """
+    )
+    # to_arrow_reader is the current name; fetch_record_batch is its deprecated
+    # alias and the only one present on the duckdb>=1.0 floor this package
+    # declares.
+    make_reader = getattr(result, "to_arrow_reader", None) or result.fetch_record_batch
+    reader = make_reader()
+
+    pool: dict[str, str] = {}
+    for batch in reader:
+        tids = batch.column(0).to_pylist()
+        starts = batch.column(1).to_pylist()
+        ends = batch.column(2).to_pylist()
+        texts = batch.column(3).to_pylist()
+        for i, text in enumerate(texts):
+            shared = pool.get(text)
+            if shared is None:
+                shared = pool[text] = text
+            yield tids[i], starts[i], ends[i], shared
 
 
 def _write_nvtx_kernel_map_parquet(db, results: list[dict], cache_dir: Path) -> None:

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -182,29 +182,50 @@ def test_window_functions_declare_a_total_order():
     assert "ORDER BY n_dur DESC, n_start ASC)" not in nvtx
 
 
-def test_all_three_nvtx_map_builders_agree_on_tie_resolution():
-    """The NVTX label ordering is cloned across three builders — fix all or none.
+def test_the_sweep_resolves_label_ties_by_data_not_by_input_order():
+    """Two enclosing ranges with an identical span are both innermost.
 
-    `nvtx_layer_breakdown` prefers the *cached* `nvtx_kernel_map`, which is
-    built by `parquet_cache` (or, on a direct-attached profile, by
-    `nvtx_attribution`). Tiebreaking only the inline fallback would leave the
-    production path arbitrary *and* make cached and uncached runs disagree —
-    reintroducing the exact "different answer depending on whether the cache
-    exists" failure this module tests against.
+    The sweep used to take whichever the stack yielded, so the answer followed
+    the order the rows arrived in rather than the data: feeding the same two
+    ranges as (zzz, aaa) chose `aaa` and as (aaa, zzz) chose `zzz`. That is the
+    "different answer for the same profile" failure this module exists to catch,
+    and it does not show up on real captures because exact-span ties are rare
+    there -- a full 3.5GB comparison found none.
+
+    Asserted on behaviour rather than on the source text. The previous version
+    of this test grepped parquet_cache.py for a fragment of the IEJoin SQL, and
+    went red the moment that query was replaced by the sweep even though the
+    property it cared about was intact.
     """
+    from nsys_ai.parquet_cache import _sweep_nvtx_kernel_map
+
+    kr = [(1, 100, 200, 100, 200, "k1")]
+    answers = set()
+    for order in (("zzz", "aaa"), ("aaa", "zzz")):
+        nvtx = sorted(((1, 0, 300, text) for text in order), key=lambda r: (r[0], r[1]))
+        rows = _sweep_nvtx_kernel_map(kr, nvtx)
+        assert rows, "the sweep attributed nothing"
+        answers.add((rows[0]["nvtx_text"], rows[0]["nvtx_path"]))
+
+    assert len(answers) == 1, f"input order changed the answer: {answers}"
+    # The order is the one nvtx_attribution uses: innermost by
+    # (duration ASC, start ASC, text ASC); path outermost-first.
+    assert answers == {("aaa", "aaa > zzz")}
+
+
+def test_the_direct_attach_builder_keeps_the_same_total_order():
+    """`nvtx_attribution` builds the map on a direct-attached profile, where
+    there is no parquet cache. Its ordering must match the sweep's, or cached
+    and uncached runs disagree."""
     from pathlib import Path
 
     root = Path(__file__).resolve().parent.parent / "src/nsys_ai"
-
-    cache = (root / "parquet_cache.py").read_text()
-    assert "n.start ASC, n.text ASC" in cache
-    assert 'FIRST(n.text ORDER BY (n."end" - n.start) ASC, n.start ASC)' not in cache
-
     attribution = (root / "nvtx_attribution.py").read_text()
     assert attribution.count("n_start ASC, nvtx_text ASC") == 2
 
-    # The persisted map must not be reused across the change in tie resolution.
-    assert "_CACHE_VERSION = 15" in cache
+    cache = (root / "parquet_cache.py").read_text()
+    # The persisted map must not be reused across a change in how it is built.
+    assert "_CACHE_VERSION = 16" in cache
 
 
 # ── Cross-backend agreement ─────────────────────────────────────────────────

--- a/tests/test_duckdb_dataflow.py
+++ b/tests/test_duckdb_dataflow.py
@@ -1,0 +1,201 @@
+"""Invariants of the DuckDB path that are currently held only by discipline.
+
+The repo runs every profile through one of two engines: DuckDB over a Parquet
+cache (or over SQLite via sqlite_scanner), and plain sqlite3 as the fallback.
+Three things keep that dual path honest, and none of them was enforced:
+
+1. SQL written in SQLite dialect must go through ``DuckDBAdapter.execute``, which
+   applies ``sqlite_to_duckdb``. Code may also issue DuckDB-native SQL directly —
+   that is legitimate — but only if it genuinely needs no rewriting. Measured
+   over a full EvidenceBuilder build, 11 executes bypass the adapter and 0 of
+   them need rewriting. The test below pins the 0, not the 11: adding a direct
+   call is fine, adding one carrying ``[end]`` or a hex literal is not.
+
+2. The Parquet cache creates an alias view for *every* known variant of a table
+   (base, _V2, _V3), so any table-resolution strategy lands on the same data.
+   That is the reason a second, differently-ordered resolver in
+   ``sync_cost_analysis`` has never produced a wrong answer.
+
+3. A profile whose tables carry an unknown future suffix must still analyse.
+
+These are characterisation tests: they encode what was measured, so a change
+that breaks the arrangement fails here rather than silently on a user's profile.
+"""
+
+import shutil
+import sqlite3
+import traceback
+from pathlib import Path
+
+import pytest
+
+duckdb = pytest.importorskip("duckdb")
+
+from nsys_ai.profile import Profile  # noqa: E402
+from nsys_ai.skills.registry import get_skill  # noqa: E402
+from nsys_ai.sql_compat import sqlite_to_duckdb  # noqa: E402
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+def _classify(stack) -> str:
+    """Which of the three legitimate routes did this execute take?"""
+    files = [f.filename for f in stack]
+    if any(
+        f.endswith("nsys_ai/connection.py") and fr.name == "execute"
+        for f, fr in zip(files, stack)
+    ):
+        return "rewritten"
+    if any(f.endswith("nsys_ai/connection.py") for f in files):
+        return "adapter_internal"  # SHOW TABLES / DESCRIBE — engine-specific by design
+    if any(f.endswith("nsys_ai/parquet_cache.py") for f in files):
+        return "cache_internal"  # DuckDB-native DDL that builds the session
+    return "direct"
+
+
+def test_sql_bypassing_the_rewriter_never_needs_rewriting():
+    """The guard that keeps the dual-dialect arrangement safe.
+
+    17 skill files write ``k.[end]`` — SQLite bracket syntax DuckDB rejects — and
+    13 of those also define an ``execute_fn`` that can call the connection
+    directly. Nothing structurally prevents bracket SQL from taking the direct
+    route; today it simply never does. Without this test that is an unstated
+    convention, and the failure mode is a DuckDB parse error on a user's profile.
+    """
+    offenders = []
+    original = duckdb.DuckDBPyConnection.execute
+
+    def patched(self, sql, *args, **kwargs):
+        if isinstance(sql, str):
+            stack = traceback.extract_stack()[:-1]
+            if _classify(stack) == "direct" and sqlite_to_duckdb(sql) != sql:
+                caller = next(
+                    (f for f in reversed(stack) if "nsys_ai" in f.filename), stack[-1]
+                )
+                offenders.append(f"{caller.filename}:{caller.lineno} -> {sql[:120]}")
+        return original(self, sql, *args, **kwargs)
+
+    duckdb.DuckDBPyConnection.execute = patched
+    try:
+        from nsys_ai.evidence_builder import EvidenceBuilder
+
+        with Profile(str(FIXTURE)) as prof:
+            EvidenceBuilder(prof, device=0).build()
+    finally:
+        duckdb.DuckDBPyConnection.execute = original
+
+    assert not offenders, (
+        "SQL needing dialect translation reached DuckDB without going through "
+        "DuckDBAdapter.execute:\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_every_known_table_variant_is_reachable_on_the_cached_path():
+    """The alias views are the actual compatibility layer.
+
+    ``parquet_cache._ALIASES`` maps each short name to every Nsight variant, and
+    ``_create_existing_alias_views`` materialises all of them over the same
+    Parquet. This is why two different table resolvers in this repo can pick
+    different names and still read identical data — a coincidence worth pinning,
+    since removing the aliases would turn it into a silent wrong answer.
+
+    Checked by querying each alias rather than by comparing names: DuckDB
+    identifiers are case-insensitive, so an alias differing from its short name
+    only in case is the *same* object and appears once in ``SHOW TABLES``.
+    Name comparison reports those as missing when they are perfectly reachable.
+    """
+    from nsys_ai.parquet_cache import _ALIASES
+
+    unreachable = []
+    with Profile(str(FIXTURE)) as prof:
+        if prof.db is None:  # pragma: no cover - cache build failed
+            pytest.skip("DuckDB cache unavailable")
+        present = {r[0] for r in prof.db.execute("SHOW TABLES").fetchall()}
+        for short_name, aliases in _ALIASES.items():
+            if short_name not in present:
+                continue  # this profile genuinely lacks that data
+            for alias in aliases:
+                try:
+                    prof.db.execute(f'SELECT 1 FROM "{alias}" LIMIT 0')
+                except duckdb.Error as exc:
+                    unreachable.append(f"{alias} ({exc.__class__.__name__})")
+
+    assert not unreachable, (
+        f"alias views absent, so resolution is no longer variant-safe: {unreachable}"
+    )
+
+
+def test_the_two_table_resolvers_agree_wherever_only_one_variant_exists():
+    """A second resolver lives in ``sync_cost_analysis`` and orders variants the
+    opposite way (``ORDER BY name DESC`` vs ``sorted()[0]``).
+
+    On a real capture only one variant is present — verified across every
+    committed fixture and a 3.7GB production capture — so the two agree. They
+    diverge only when variants coexist, which happens exclusively on the cached
+    path where all variants alias the same data. This test states the condition
+    under which the duplication is harmless, so that if it stops holding the
+    reason is on record.
+    """
+    from nsys_ai.connection import wrap_connection
+    from nsys_ai.skills.builtins.sync_cost_analysis import _resolve_table_name
+
+    conn = sqlite3.connect(FIXTURE)
+    try:
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+        variants = sorted(t for t in tables if t.startswith("CUPTI_ACTIVITY_KIND_KERNEL"))
+        assert len(variants) == 1, f"fixture premise broke; found {variants}"
+
+        official = wrap_connection(conn).resolve_activity_tables().get("kernel")
+        local = _resolve_table_name(conn, "CUPTI_ACTIVITY_KIND_KERNEL")
+    finally:
+        conn.close()
+
+    assert official == local == variants[0]
+
+
+def test_an_unknown_future_table_suffix_still_analyses(tmp_path):
+    """Nsight adds versioned tables between releases; _ALIASES stops at _V3.
+
+    A capture whose kernel table is ``_V4`` must still produce results — the ETL
+    resolves the source table by prefix rather than from the hardcoded list, so
+    the cache is built from it and the analysis proceeds.
+    """
+    profile = tmp_path / "v4.sqlite"
+    shutil.copy(FIXTURE, profile)
+    conn = sqlite3.connect(profile)
+    try:
+        conn.execute(
+            "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL RENAME TO CUPTI_ACTIVITY_KIND_KERNEL_V4"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    with Profile(str(profile)) as prof:
+        conn = prof.db if prof.db is not None else prof.conn
+        rows = get_skill("top_kernels").execute(conn, limit=3)
+
+    assert rows, "a _V4 kernel table produced no kernels"
+    assert rows[0].get("kernel_name"), f"kernels came back unnamed: {rows[0]}"
+
+
+def test_both_engines_return_the_same_answer_for_a_dual_path_skill():
+    """``sync_cost_analysis`` has a DuckDB route and a SQLite route.
+
+    Divergence between the two is the defect class that produced the cached-vs-
+    uncached bug fixed in #274, and a green unit suite did not catch that one.
+    """
+    skill = get_skill("sync_cost_analysis")
+
+    with Profile(str(FIXTURE)) as prof:
+        if prof.db is None:  # pragma: no cover
+            pytest.skip("DuckDB cache unavailable")
+        via_duckdb = skill.execute(prof.db, device=0)
+
+    conn = sqlite3.connect(FIXTURE)
+    try:
+        via_sqlite = skill.execute(conn, device=0)
+    finally:
+        conn.close()
+
+    assert via_duckdb == via_sqlite, "the DuckDB and SQLite paths disagree"

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -480,3 +480,72 @@ class TestTensorCorePatterns:
         name = "ampere_sgemm_128x128_nn"
         assert re.search(elig, name.lower())
         assert not re.search(active, name.lower())
+
+
+def test_the_map_is_built_by_the_sweep_and_carries_all_nine_columns(tmp_path):
+    """NVTX attribution is a stack sweep, not a general inequality join.
+
+    NVIDIA documents eventType 59 as a Push/Pop range maintaining an nvtxRange
+    stack per thread, so ranges on a thread are strictly nested by construction.
+    A containment IEJoin cannot exploit that: on a 3.5 GB capture it ran over
+    twenty minutes at 1170% CPU to produce a three-million-row result, where the
+    sweep takes 19 s. The whole cache build for that capture went from
+    twenty-plus minutes to 60.6 s.
+
+    Output was compared row-for-row against the IEJoin's on that capture:
+    3,042,699 rows, zero differences either direction, all nine columns.
+
+    Nine columns is the other half. The Python builder used to write seven,
+    omitting is_tc_eligible/uses_tc, so a cache built by that path was silently
+    different from one built by the SQL path. Both now go through one writer.
+    """
+    import shutil
+
+    src = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile = tmp_path / "p.sqlite"
+    shutil.copy(src, profile)
+
+    from nsys_ai.profile import Profile
+
+    with Profile(str(profile), cache_mode="parquet") as prof:
+        assert prof.db is not None, "cache build did not produce a DuckDB connection"
+        cols = [c[0] for c in prof.db.execute("DESCRIBE SELECT * FROM nvtx_kernel_map").fetchall()]
+        rows, tc_eligible, tc_used = prof.db.execute(
+            "SELECT count(*), sum(is_tc_eligible), sum(uses_tc) FROM nvtx_kernel_map"
+        ).fetchone()
+
+    assert cols == [
+        "path_id",
+        "nvtx_text",
+        "nvtx_depth",
+        "kernel_name",
+        "k_start",
+        "k_end",
+        "k_dur_ns",
+        "is_tc_eligible",
+        "uses_tc",
+    ], f"map schema drifted: {cols}"
+    assert rows > 0, "the sweep attributed nothing"
+    # Guards the seven-column regression: a map without TC flags reads as all
+    # zeroes and pushes nvtx_layer_breakdown onto a path that double-counts.
+    assert tc_eligible > 0, "is_tc_eligible is all zero — the TC flags were dropped"
+    assert tc_used > 0, "uses_tc is all zero — the TC flags were dropped"
+
+
+def test_the_path_dictionary_matches_the_map(tmp_path):
+    """Every path_id in the map must resolve, or attribution silently vanishes
+    on the join downstream."""
+    import shutil
+
+    src = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile = tmp_path / "p.sqlite"
+    shutil.copy(src, profile)
+
+    from nsys_ai.profile import Profile
+
+    with Profile(str(profile), cache_mode="parquet") as prof:
+        orphans = prof.db.execute(
+            "SELECT count(*) FROM nvtx_kernel_map m "
+            "LEFT JOIN nvtx_path_dict d USING (path_id) WHERE d.nvtx_path IS NULL"
+        ).fetchone()[0]
+    assert orphans == 0, f"{orphans} rows carry a path_id with no dictionary entry"


### PR DESCRIPTION
The blocker in #300. NVTX attribution was a containment IEJoin; on a 3.5 GB capture it ran **over twenty minutes** at 1170 % CPU — twelve cores saturated — and had not finished when it was killed. The whole cache build for that profile now takes **61 s**.

## Why the join was so expensive

```sql
JOIN _nvtx_ranges n ON n.globalTid = kr.globalTid
  AND n.start <= kr.r_start AND n."end" >= kr.r_end
```

| measured on the 3.5 GB capture | |
|---|---:|
| kernels | 2,193,776 |
| runtime rows | 7,058,308 |
| NVTX ranges (join RHS) | 15,883,792 |
| **distinct `globalTid`** | **5** |
| avg enclosing ranges per kernel | 3.2 (max 6) |
| resulting output | ~3 M rows |

The only equality key had five distinct values, so IEJoin partitioned into five buckets and range-joined millions against millions inside each — to produce three million rows. That gap is algorithmic; the build was already using every core, so no amount of parallelism closes it.

NVIDIA documents `eventType = 59` as a Push/Pop range maintaining an `nvtxRange` stack **per thread**, so ranges on a thread are strictly nested by construction. A stack sweep resolves them in one pass. That sweep was already in this file — reached only when the SQL path failed. The general-purpose operator was primary and the one that exploits the data's actual shape was the backup.

## Correctness and cost, across six captures

Both paths built to completion on each profile, in separate processes so peak RSS is clean, and the resulting `nvtx_kernel_map` compared row-for-row:

| capture | size | IEJoin | sweep | speedup | memory | rows |
|---|---:|---|---|---:|---:|---|
| nano_vllm_bench | 88 MB | 107.0 s / 1.00 GB | 5.7 s / 0.90 GB | 18.7x | 0.90x | IDENTICAL |
| perf_sp1 | 225 MB | 79.0 s / 1.03 GB | 6.3 s / 1.02 GB | 12.6x | 0.99x | IDENTICAL |
| ac_validation/full | 233 MB | 26.4 s / 0.86 GB | 5.6 s / 0.86 GB | 4.7x | 1.00x | IDENTICAL |
| ac_validation/attn_only | 278 MB | 29.8 s / 0.86 GB | 6.6 s / 0.86 GB | 4.5x | 1.00x | IDENTICAL |
| h100_sp2_fa3 | 545 MB | 139.1 s / 1.43 GB | 11.8 s / 1.53 GB | 11.8x | 1.08x | IDENTICAL |
| h100_sp4_fa3 | 1081 MB | 376.1 s / 3.20 GB | 25.5 s / 3.17 GB | 14.7x | 0.99x | IDENTICAL |
| perf | 3561 MB | **>15 min, unfinished** | 78.7 s / 6.87 GB | — | — | vs stored IEJoin output: 3,042,699 rows, IDENTICAL |

Between them these span kernel-to-range ratios from 1:1 to 1:10 and one to three annotated threads. Every comparison is a multiset diff over all nine columns in both directions; every one is zero.

**Memory is at parity, not a regression.** An earlier revision of this description claimed the sweep traded memory for time. That came from comparing a completed sweep against an IEJoin that had been killed at 15 minutes — an unfinished run cannot supply a peak. With both paths run to completion the ratio is 0.90x–1.08x, and the IEJoin itself sits at 3.2x the capture size on the 1 GB profile, so the 2–3x working set is a property of this workload rather than something this change introduces.

Re-verified after the tie fix, after the single-range optimisation, and after each streaming change.

## Tie resolution, which had to be fixed first

Two enclosing ranges with an identical span are both innermost, and the sweep took whichever the stack yielded. The same two ranges fed as `(zzz, aaa)` chose `aaa`; as `(aaa, zzz)` chose `zzz` — the answer followed input order rather than data. That is precisely the divergence `tests/test_determinism.py` exists to prevent, and it does not surface on real captures because exact-span ties are rare there (none in the 3.5 GB comparison).

It now sorts by `(duration ASC, start ASC, text ASC)`, matching `nvtx_attribution`, which is what keeps the cached and direct-attach paths agreeing. Sorting is skipped when only one range encloses — the common case, and it was costing 36 % of the build (61 s → 82 s → 61 s).

## One writer, nine columns

The Python builder wrote **seven** columns, omitting `is_tc_eligible`/`uses_tc`, so a cache built by that path silently reported every kernel as non-Tensor-Core and differed from an SQL-built one. Both paths now go through one writer emitting all nine.

`_CACHE_VERSION` 15 → 16 so a seven-column cache is rebuilt rather than reused.

## A test that had to change

`test_all_three_nvtx_map_builders_agree_on_tie_resolution` asserted on a **fragment of the deleted SQL**, so it went red although the property it guarded was intact. It now asserts the behaviour — feed the same tied ranges in both orders, the answer must not change — which is a stronger check than the grep it replaces. The companion assertion that `nvtx_attribution` keeps the same total order is kept.

## Test plan

- [x] `pytest tests/` — **1435 passed, 135 skipped, 0 failed**
- [x] `ruff check src/ tests/` — clean
- [x] Full-scale oracle comparison on a 3.5 GB capture — 3,042,699 rows, zero differences, three times (after the swap, after the tie fix, after the optimisation)
- [x] Fixture-scale A/B: cache built by old code vs new, 1,643 rows, zero differences
- [x] Tie divergence reproduced before the fix and shown fixed after
- [x] New tests assert the nine-column schema, that TC flags are non-zero, and that every `path_id` resolves

## Streaming the inputs

Review of the first revision found the build materialising every row twice — `fetchall()` built one tuple per row and the sweep copied each into a second to group it by thread — and holding one `str` object per label despite heavy repetition. Both inputs are now generators over Arrow record batches with interned labels.

The interning matters more on the kernel side than it looks: those 3,077,650 rows carry **109 distinct kernel names averaging 253 characters**, so each mangled CUDA name repeats about 28,000 times. Roughly 0.9 GB of duplicate strings becomes a few kilobytes, shared by every result row as well.

On the 3.5 GB capture: 11.19 GB → 8.10 GB with the ranges streamed → 6.87 GB with the kernel join streamed too, at 70.4 s → 78.7 s.

## Not in scope

A ~2–3x working set still bounds practical profile size, and it bounds both paths equally. Driving it lower means per-thread or time-window streaming with results flushed incrementally — the rows are already sorted by `globalTid`, so the shape is there. That is #300's next step, and it changes the contract of a sweep shared with the on-demand builder (#257), so it belongs in its own change.

The 50 MB `auto` threshold still sends large profiles to direct mode, so they never build this cache at all. Now that the build cost has changed by an order of magnitude that threshold has to be re-derived — also #300, and it depends on this landing first.

Refs #300.
