### PR TITLE
test(chat): pin the chat loop's per-invocation DuckDB connection

### DIFF
--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -348,10 +348,9 @@ def _prepare_session(
     private in-memory database, so concurrent sessions do not even contend on
     DuckDB's per-database query lock — and, when that cache cannot be opened,
     a read-only ``sqlite3.connect(..., uri=True)`` fallback. ``query_conn()``
-    solves a
-    different problem: the analysis path must share one database because of
-    ``CREATE TEMP TABLE`` scratch tables and the memoized skill bag, and hands
-    out per-thread cursors so that sharing stays correct.
+    solves a different problem: the analysis path must share one database
+    because of ``CREATE TEMP TABLE`` scratch tables and the memoized skill bag,
+    and hands out per-thread cursors so that sharing stays correct.
 
     The affinity is real, not incidental: this runs *inside* the
     ``stream_agent_loop`` generator body (and inside the synchronous
@@ -581,9 +580,9 @@ def stream_agent_loop(
     remains responsive during DB queries and LLM streaming.
 
     Build and drain the generator on the same thread. No connection or cursor
-    is shared between invocations — the only module-level state this path
-    touches is ``profile_db_tool._schema_cache``, which is lock-guarded and
-    holds strings — so two turns may overlap freely, and they do:
+    is shared between invocations — the only mutable module-level state this
+    path touches is ``profile_db_tool._schema_cache``, which is lock-guarded
+    and holds strings — so two turns may overlap freely, and they do:
     ``@work(thread=True, exclusive=True)`` cancels the asyncio task, not the OS
     thread, so a cancelled chat turn keeps running alongside its replacement
     (Textual's own docs: thread workers cannot be interrupted, only asked to

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -343,11 +343,13 @@ def _prepare_session(
     Raises RuntimeError on profile path resolution errors.
 
     Thread affinity — why this does not use ``Profile.query_conn()``.
-    ``open_profile_readonly`` returns a fresh ``duckdb.connect()``: a private
-    in-memory database per call, not a cursor on a shared one. So each chat
-    session is isolated by construction, and concurrent sessions do not even
-    contend on DuckDB's per-database query lock. ``query_conn()`` solves a
-    different problem — the analysis path must share one database because of
+    ``open_profile_readonly`` returns a fresh connection per call, never a
+    cursor on a shared one: ``duckdb.connect()`` on the Parquet-cache path — a
+    private in-memory database, so concurrent sessions do not even contend on
+    DuckDB's per-database query lock — and, when that cache cannot be opened,
+    a read-only ``sqlite3.connect(..., uri=True)`` fallback. ``query_conn()``
+    solves a
+    different problem: the analysis path must share one database because of
     ``CREATE TEMP TABLE`` scratch tables and the memoized skill bag, and hands
     out per-thread cursors so that sharing stays correct.
 
@@ -357,11 +359,21 @@ def _prepare_session(
     advances the generator, and it is closed on that same thread. Every caller
     builds and drains the generator on one thread — ``tui_textual.py``'s
     ``@work(thread=True)`` worker, ``tree/chat.py``'s stream worker,
-    ``cli/handlers.py``, and ``web.py``'s per-request handler thread.
+    ``cli/handlers.py``, and ``web.py``'s per-request handler thread. This is
+    the same rule ``open_profile_readonly_for_worker`` states for callers that
+    open a connection themselves; the difference is only that here the opening
+    is implicit in when the generator is first advanced.
 
-    Do not memoize this per path and do not hoist it out of the generator:
-    either turns a private database into a shared handle, which serves
-    concurrent queries wrong rows with nothing raised. Pinned by
+    Two changes would break it, for two *different* reasons — do not conflate
+    them. **Memoizing per path** collapses the private databases into one
+    shared handle, which serves concurrent queries wrong rows with nothing
+    raised. **Hoisting the setup out of the generator** shares nothing (each
+    call still opens its own connection) but creates it on the thread that
+    builds the generator and closes it on the thread that drains it. On DuckDB
+    that mismatch is merely unenforced; on the SQLite fallback it raises
+    ``sqlite3.ProgrammingError`` — ``open_profile_readonly`` leaves
+    ``check_same_thread`` at its default, so the handle is usable and closable
+    only from its creating thread. Both are pinned by
     ``tests/test_chat_connection_threading.py``.
     """
     from .profile import resolve_profile_path
@@ -568,13 +580,20 @@ def stream_agent_loop(
     thread (e.g. Textual ``@work(thread=True)``) so the main thread's UI
     remains responsive during DB queries and LLM streaming.
 
-    Build and drain the generator on the same thread. Nothing here is shared
-    between invocations, so two turns may overlap freely — and they do:
+    Build and drain the generator on the same thread. No connection or cursor
+    is shared between invocations — the only module-level state this path
+    touches is ``profile_db_tool._schema_cache``, which is lock-guarded and
+    holds strings — so two turns may overlap freely, and they do:
     ``@work(thread=True, exclusive=True)`` cancels the asyncio task, not the OS
     thread, so a cancelled chat turn keeps running alongside its replacement
     (Textual's own docs: thread workers cannot be interrupted, only asked to
     check ``is_cancelled``). That overlap is harmless only because each
-    invocation holds its own connection; see ``_prepare_session``.
+    invocation holds its own connection; see ``_prepare_session``. The
+    *diff_context* path holds no connection of its own — its ``ToolDispatcher``
+    is built with ``conn=None``, as is the one in ``diff_tools.run_diff_tool``
+    — but its ``DiffContext`` (and the two ``Profile`` objects inside it) is
+    caller-owned, so it inherits its owner's thread; today's only caller is the
+    single-threaded ``nsys-ai diff --chat`` REPL.
 
     *skill_names* — optional list of skill file paths relative to the
     ``docs/agent_skills/`` directory (e.g. ``["skills/mfu.md"]``). When

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -341,6 +341,28 @@ def _prepare_session(
 
     Returns (conn, sqlite_path, system_prompt, query_runner).
     Raises RuntimeError on profile path resolution errors.
+
+    Thread affinity — why this does not use ``Profile.query_conn()``.
+    ``open_profile_readonly`` returns a fresh ``duckdb.connect()``: a private
+    in-memory database per call, not a cursor on a shared one. So each chat
+    session is isolated by construction, and concurrent sessions do not even
+    contend on DuckDB's per-database query lock. ``query_conn()`` solves a
+    different problem — the analysis path must share one database because of
+    ``CREATE TEMP TABLE`` scratch tables and the memoized skill bag, and hands
+    out per-thread cursors so that sharing stays correct.
+
+    The affinity is real, not incidental: this runs *inside* the
+    ``stream_agent_loop`` generator body (and inside the synchronous
+    ``chat_completion``), so the connection belongs to whichever thread
+    advances the generator, and it is closed on that same thread. Every caller
+    builds and drains the generator on one thread — ``tui_textual.py``'s
+    ``@work(thread=True)`` worker, ``tree/chat.py``'s stream worker,
+    ``cli/handlers.py``, and ``web.py``'s per-request handler thread.
+
+    Do not memoize this per path and do not hoist it out of the generator:
+    either turns a private database into a shared handle, which serves
+    concurrent queries wrong rows with nothing raised. Pinned by
+    ``tests/test_chat_connection_threading.py``.
     """
     from .profile import resolve_profile_path
 
@@ -545,6 +567,14 @@ def stream_agent_loop(
     generator and closed in the ``finally`` block.  Call this from a background
     thread (e.g. Textual ``@work(thread=True)``) so the main thread's UI
     remains responsive during DB queries and LLM streaming.
+
+    Build and drain the generator on the same thread. Nothing here is shared
+    between invocations, so two turns may overlap freely — and they do:
+    ``@work(thread=True, exclusive=True)`` cancels the asyncio task, not the OS
+    thread, so a cancelled chat turn keeps running alongside its replacement
+    (Textual's own docs: thread workers cannot be interrupted, only asked to
+    check ``is_cancelled``). That overlap is harmless only because each
+    invocation holds its own connection; see ``_prepare_session``.
 
     *skill_names* — optional list of skill file paths relative to the
     ``docs/agent_skills/`` directory (e.g. ``["skills/mfu.md"]``). When

--- a/tests/test_chat_connection_threading.py
+++ b/tests/test_chat_connection_threading.py
@@ -1,0 +1,170 @@
+"""The chat path's DuckDB handle belongs to the thread that drives the generator.
+
+`Profile.query_conn()` exists because a shared DuckDB handle serves concurrent
+queries wrong rows with nothing raised. The chat path does not use it and does
+not need to: `_prepare_session` calls `open_profile_readonly`, which returns a
+fresh `duckdb.connect()` — a private in-memory database, not a cursor on a
+shared one — and `_prepare_session` runs inside the `stream_agent_loop`
+generator body, so the connection is created on whichever thread advances the
+generator and closed in that generator's `finally`.
+
+Two ways a future change could break that, both of which these tests catch:
+memoizing `open_profile_readonly` per path (one handle shared by every session),
+or hoisting the session setup out of the generator (the connection then belongs
+to the thread that *built* the generator, not the one that drains it).
+
+Neither is hypothetical protection against an imaginary caller. A cancelled
+Textual `@work(thread=True, exclusive=True)` worker keeps running — cancellation
+sets a flag, it does not stop the OS thread — so two chat turns really do
+overlap, and only the per-invocation connection makes that harmless.
+"""
+
+import shutil
+import sys
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nsys_ai import chat as chat_mod
+
+# Imported for its side effect: `stream_agent_loop` imports `tool_dispatch`
+# lazily, and six threads racing to execute that import for the first time is
+# not what these tests are measuring.
+from nsys_ai import tool_dispatch as _tool_dispatch  # noqa: F401
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+CONCURRENT_SESSIONS = 6
+
+
+@pytest.fixture(scope="module")
+def profile_copy(tmp_path_factory):
+    """A private copy of the fixture, with its Parquet cache already built.
+
+    The copy keeps `tests/fixtures/` free of `.nsys-cache` directories; the
+    pre-warm keeps cache construction out of the concurrent section.
+    """
+    dst = tmp_path_factory.mktemp("chat_conn") / "profile.sqlite"
+    shutil.copy(FIXTURE, dst)
+    path = str(dst)
+    chat_mod.open_profile_readonly(path).close()
+    return path
+
+
+@pytest.fixture
+def fake_litellm(monkeypatch):
+    """A litellm whose stream yields one text chunk and no tool calls.
+
+    Installed once, on the main thread. The `patch.dict(sys.modules, ...)`
+    idiom used elsewhere in the chat tests races with itself when entered from
+    several threads and fails with a spurious ImportError.
+    """
+    fake = MagicMock()
+
+    def completion(**_kwargs):
+        delta = MagicMock()
+        delta.content = "ok"
+        delta.tool_calls = []
+        chunk = MagicMock()
+        chunk.choices = [MagicMock(delta=delta)]
+        chunk.usage = None
+        return iter([chunk])
+
+    fake.completion = completion
+    monkeypatch.setitem(sys.modules, "litellm", fake)
+    return fake
+
+
+def _drain(profile_path):
+    for _ in chat_mod.stream_agent_loop(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        ui_context={},
+        profile_path=profile_path,
+        max_turns=1,
+    ):
+        pass
+
+
+def test_each_concurrent_session_gets_its_own_connection(
+    profile_copy, fake_litellm, monkeypatch
+):
+    """Overlapping chat sessions must not share one DuckDB handle.
+
+    Every connection is held open until all of them exist, so this measures
+    simultaneous sessions rather than sequential ones that happen to reuse an
+    address.
+    """
+    seen = []
+    lock = threading.Lock()
+    real_open = chat_mod.open_profile_readonly
+    all_open = threading.Barrier(CONCURRENT_SESSIONS)
+
+    def recording_open(path):
+        conn = real_open(path)
+        with lock:
+            seen.append((threading.get_ident(), conn))
+        try:
+            all_open.wait(timeout=60)
+        except threading.BrokenBarrierError:
+            # A session never reached this point; let the assertions below say so
+            # instead of leaking the connection this call already opened.
+            pass
+        return conn
+
+    monkeypatch.setattr(chat_mod, "open_profile_readonly", recording_open)
+
+    with ThreadPoolExecutor(max_workers=CONCURRENT_SESSIONS) as pool:
+        for fut in [pool.submit(_drain, profile_copy) for _ in range(CONCURRENT_SESSIONS)]:
+            fut.result()
+
+    assert len(seen) == CONCURRENT_SESSIONS, seen
+    assert len({id(conn) for _, conn in seen}) == CONCURRENT_SESSIONS, (
+        "connection object shared across concurrent chat sessions"
+    )
+    assert len({tid for tid, _ in seen}) == CONCURRENT_SESSIONS, (
+        "sessions did not actually run on distinct threads"
+    )
+
+
+def test_connection_opens_on_the_thread_that_iterates(profile_copy, fake_litellm, monkeypatch):
+    """The session is set up in the generator body, not when the generator is built.
+
+    Textual and the web server both construct the generator on one thread and
+    drain it on another; the connection must belong to the draining thread.
+    """
+    opened_on = []
+    real_open = chat_mod.open_profile_readonly
+
+    def recording_open(path):
+        opened_on.append(threading.get_ident())
+        return real_open(path)
+
+    monkeypatch.setattr(chat_mod, "open_profile_readonly", recording_open)
+
+    gen = chat_mod.stream_agent_loop(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        ui_context={},
+        profile_path=profile_copy,
+        max_turns=1,
+    )
+    assert opened_on == [], "generator opened a connection before it was iterated"
+
+    drained_on = []
+
+    def consume():
+        drained_on.append(threading.get_ident())
+        for _ in gen:
+            pass
+
+    thread = threading.Thread(target=consume)
+    thread.start()
+    thread.join(timeout=60)
+
+    assert not thread.is_alive()
+    assert opened_on == drained_on
+    assert opened_on[0] != threading.get_ident()

--- a/tests/test_chat_connection_threading.py
+++ b/tests/test_chat_connection_threading.py
@@ -3,15 +3,19 @@
 `Profile.query_conn()` exists because a shared DuckDB handle serves concurrent
 queries wrong rows with nothing raised. The chat path does not use it and does
 not need to: `_prepare_session` calls `open_profile_readonly`, which returns a
-fresh `duckdb.connect()` — a private in-memory database, not a cursor on a
-shared one — and `_prepare_session` runs inside the `stream_agent_loop`
+fresh connection per call — `duckdb.connect()` on the Parquet-cache path (a
+private in-memory database, not a cursor on a shared one), `sqlite3.connect()`
+on the fallback — and `_prepare_session` runs inside the `stream_agent_loop`
 generator body, so the connection is created on whichever thread advances the
 generator and closed in that generator's `finally`.
 
-Two ways a future change could break that, both of which these tests catch:
-memoizing `open_profile_readonly` per path (one handle shared by every session),
-or hoisting the session setup out of the generator (the connection then belongs
-to the thread that *built* the generator, not the one that drains it).
+Two ways a future change could break that, for two different reasons, both of
+which these tests catch. Memoizing `open_profile_readonly` per path collapses
+the private databases into one handle shared by every session. Hoisting the
+session setup out of the generator shares nothing — each call still opens its
+own connection — but binds it to the thread that *built* the generator rather
+than the one that drains it; benign-looking on DuckDB, a hard
+`sqlite3.ProgrammingError` on the fallback, which the third test pins.
 
 Neither is hypothetical protection against an imaginary caller. A cancelled
 Textual `@work(thread=True, exclusive=True)` worker keeps running — cancellation
@@ -20,6 +24,7 @@ overlap, and only the per-invocation connection makes that harmless.
 """
 
 import shutil
+import sqlite3
 import sys
 import threading
 from concurrent.futures import ThreadPoolExecutor
@@ -168,3 +173,44 @@ def test_connection_opens_on_the_thread_that_iterates(profile_copy, fake_litellm
     assert not thread.is_alive()
     assert opened_on == drained_on
     assert opened_on[0] != threading.get_ident()
+
+
+def test_sqlite_fallback_connection_is_thread_affine(profile_copy, monkeypatch):
+    """When the Parquet cache cannot open, the fallback handle is bound to its thread.
+
+    The two tests above only exercise the DuckDB path, where a
+    build-here/drain-there mismatch is unenforced. On the fallback it is a hard
+    error, and that is what makes "open it inside the generator" a rule rather
+    than a preference. This pins that ``open_profile_readonly`` leaves
+    ``check_same_thread`` at its default: passing ``False`` would silence the
+    error without making concurrent use of one ``sqlite3.Connection`` safe.
+    """
+    from nsys_ai import parquet_cache
+
+    def no_cache(_path):
+        raise RuntimeError("forced fallback")
+
+    monkeypatch.setattr(parquet_cache, "open_cached_db", no_cache)
+
+    conn = chat_mod.open_profile_readonly(profile_copy)
+    try:
+        assert isinstance(conn, sqlite3.Connection)
+        # Usable from the thread that created it.
+        assert conn.execute("SELECT count(*) FROM sqlite_master").fetchone()[0] > 0
+
+        failure = []
+
+        def query_elsewhere():
+            try:
+                conn.execute("SELECT count(*) FROM sqlite_master").fetchone()
+            except sqlite3.ProgrammingError as e:
+                failure.append(str(e))
+
+        t = threading.Thread(target=query_elsewhere)
+        t.start()
+        t.join(timeout=60)
+        assert not t.is_alive()
+        assert failure, "fallback connection was usable from a foreign thread"
+        assert "same thread" in failure[0]
+    finally:
+        conn.close()

--- a/tests/test_chat_connection_threading.py
+++ b/tests/test_chat_connection_threading.py
@@ -1,4 +1,4 @@
-"""The chat path's DuckDB handle belongs to the thread that drives the generator.
+"""The chat path's profile connection belongs to the thread that drives the generator.
 
 `Profile.query_conn()` exists because a shared DuckDB handle serves concurrent
 queries wrong rows with nothing raised. The chat path does not use it and does


### PR DESCRIPTION
Closes #302.

## Outcome: no fix needed — the issue's three questions, answered

#302 says "Not known to be broken" and offers, as one of its accepted outcomes, "if the path turns out to be single-threaded by construction, a comment saying why, so the next reader does not have to re-derive it." That is what this is. The chat path is already thread-correct; what lands is the comment plus the tests that keep it true.

The mechanism: `stream_agent_loop` opens one connection per invocation, lazily, on the thread that iterates the generator, and closes it in that generator's `finally`. `open_profile_readonly` → `parquet_cache.open_cached_db` → `duckdb.connect()` with no arguments — a new in-memory database, not a cursor on a shared one, and not memoized by path. I confirmed they are genuinely separate databases: a `CREATE TEMP TABLE` on one raises `CatalogException` on the other. So DuckDB's per-database query lock does not serialise concurrent chat sessions against each other at all.

### 1. Where `conn` at `chat.py:619` comes from

From `_prepare_session`, inside the generator body. Measured with 8 concurrent `stream_agent_loop` sessions over a copy of `h100_2gpu_1s.sqlite`: `distinct conn ids: 8 of 8`, `distinct threads: 8`, `MISMATCHES: 0 of 8` — every dispatcher received the connection its own thread opened, all 8 returning rows identical to the single-threaded ground truth.

This does correct one statement in the issue body: "Only the first [`Profile.query_conn()`] is thread-correct" is false. A per-invocation `duckdb.connect()` opened on the consuming thread is thread-correct, and is *stronger* than `query_conn()`'s cursors, which serialise on one database. `query_conn()` is the right fix for the analysis path because that path must share one database (`CREATE TEMP TABLE` scratch tables, memoized skill bag). The chat path has neither constraint.

### 2. Whether a cancelled Textual worker can still hold a handle when its replacement begins

It can — the issue raised this as an open question and the answer is yes. Textual 8.0.1 runs thread workers via `loop.run_in_executor` (`worker.py:326`), and `Worker.cancel()` (`worker.py:416`) only sets a flag and cancels the awaiting asyncio task; the OS thread is never interrupted. Reproduced with the real chat loop, A held inside a tool call while B is launched:

```
 1.512 thr=80096  open conn id=132262045516464
 1.517 thr=80096  query START conn=132262045516464 (holding 4s)
 1.935 thr= 7936  -- cancel_all() + launch B (exclusive) --
 1.870 thr=50912  open conn id=132262043678896   <- B: different thread, different conn
 5.531 thr=80096  query END   conn=132262045516464  <- A finishes later, correct rows
```

Overlap is real; sharing is not.

### 3. Whether the web chat entry point shares one connection across pool threads

It does not. Over the real `_ThreadPoolMixIn` server with 8 concurrent `POST /api/chat`, both modes: `connections opened: 8, distinct ids: 8, distinct threads: 8, disagreeing results: 0`. `do_POST`'s `/api/chat` branch never touches the shared `_ViewerHandler.prof`, and the SSE generator is drained inside the same request thread.

### The issue's other named site: `diff_tools.py:1903`

Benign, and worth stating since the issue asked. `run_diff_tool` builds `ToolDispatcher(mode="diff", diff_context=ctx)` — no `conn` argument at all, so `self._conn is None`; `stream_agent_loop`'s own diff branch sets `conn = None` before constructing its dispatcher too. What the diff path does carry is the `DiffContext`, holding two `Profile` objects, and that object is caller-owned rather than per-invocation. Today's only caller is `cli/handlers.py:936`, a synchronous single-threaded REPL that constructs the context once and reuses it turn after turn on one thread. Noted in the `stream_agent_loop` docstring so a future concurrent caller of the diff path knows the connection ownership is theirs, not the loop's.

## What this PR changes

No logic. Comments at the definition site plus the regression tests that keep the invariant from being "optimised" away.

- `src/nsys_ai/chat.py` — on `_prepare_session`: why the connection is opened here rather than taken from `query_conn()`, which thread owns it, and the two edits that would break it *and the different reason each one breaks it*. On `stream_agent_loop`'s docstring: the measured behaviour of cancelled thread workers, what module-level state the path actually touches, and the diff path's connection ownership.
- `tests/test_chat_connection_threading.py` — three tests, none skipped.

## Revert-validated, as the project requires

Each mutation applied in a throwaway `git worktree` with `PYTHONPATH` pinned to it, so the working tree was never dirtied; source restored and the worktree removed afterwards.

- Memoize `open_profile_readonly` to one connection per path (lock-guarded, so not even racy): `AssertionError: connection object shared across concurrent chat sessions`. Test 1 fails.
- Hoist session setup so it runs eagerly on the calling thread: tests 1 and 2 fail — `assert 12 == 6` and `generator opened a connection before it was iterated`.
- `sqlite3.connect(uri, uri=True, check_same_thread=False)` on the fallback: `AssertionError: fallback connection was usable from a foreign thread`. Test 3 fails.

The three are complementary — each mutation is caught by a different subset, so none of the tests is carried by the others.

## Correction to the first version of this PR body

The first version of this description, and my first comment on #302, claimed the hoist mutation "turns a private database into a shared handle." That is wrong, and my own mutation output disproved it: hoisting produced **12 opens and 12 distinct `DuckDBPyConnection` objects**. Nothing is shared. The real hazard of hoisting is thread affinity — the connection is created on the thread that builds the generator and closed on the thread that drains it — which is unenforced on DuckDB but a hard failure on the SQLite fallback, since `open_profile_readonly` leaves `check_same_thread` at its default:

```
fallback conn type: sqlite3.Connection
same-thread query OK, sqlite_master rows = 47
cross-thread result: {'err': "ProgrammingError: SQLite objects created in a thread can only be used in that same thread. ..."}
cross-thread close:  {'err': "ProgrammingError: SQLite objects created in a thread can only be used in that same thread. ..."}
```

Since the whole point of a zero-logic PR is the comment it leaves behind, a comment stating the wrong cause is the defect. Fixed, plus two smaller overstatements: the docstring said the connection is always `duckdb.connect()` (it is, unless the cache fails), and said "nothing here is shared between invocations" (`profile_db_tool._schema_cache` is module-level — lock-guarded and strings-only, so the conclusion holds, but the sentence did not).

I also framed this PR as correcting two errors in #302. Only one — "Only the first is thread-correct" — was an error. The overlap point was the issue's own question 2, which explicitly said `exclusive=True` "does not cover a cancelled worker still inside a query while its replacement starts." I answered its open question and published the answer as a correction of it. Rewritten above.

## Verification on this machine, after those edits

```
ruff check src/ tests/               -> All checks passed!
bandit -q -r src/ -c pyproject.toml  -> only the 5 pre-existing nosec warnings, no failures
python3 -m pytest tests/ -q          -> 1438 passed, 135 skipped in 248.94s
```

Baseline is 1435 passed; the three added tests account for the difference, and none is skipped, so nothing is owed to `tests/test_ci_coverage.py`. The test file copies the fixture into `tmp_path_factory`, so `tests/fixtures/` stays clean — `git status --porcelain --ignored tests/fixtures/` afterwards shows only the pre-existing `mock.nsys-rep`.

## Found while tracing, filed separately

`tui_textual.py`'s `action_cancel_generation()` calls `workers.cancel_all()` but `_run_stream_worker` never checks `get_current_worker().is_cancelled`. Given that the thread keeps running, the abandoned worker keeps calling `call_from_thread(self._on_text_chunk, ...)` so its text interleaves with the next turn's, and its `_on_stream_done` clears `_is_generating` mid-stream. `tree/chat.py` does not have this problem — it checks a `threading.Event` each iteration. That is a UI bug, not a connection bug, and is not folded in here.
