### PR TITLE
fix(cache): refuse to publish a cache when the kernel table is unrecognised

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -534,7 +534,36 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
         # TRY_CAST guards against the `sqlite_all_varchar=true` attach
         # fallback, which would otherwise give lexicographic ordering.
         kernel_table = _find_table(src_tables, "CUPTI_ACTIVITY_KIND_KERNEL")
-        if kernel_table:
+        if kernel_table is None:
+            # The source may carry kernel activity under a name this builder
+            # cannot address. kernels.parquet would then be missing while the
+            # stamp still claimed a complete cache — and every later open would
+            # revalidate that poisoned cache and fail in NsightSchema. Raise
+            # instead: build_cache discards the temp dir on any exception, so
+            # nothing is published and the caller's except-clause falls back to
+            # direct SQLite. That fallback is degraded, not at parity — it loses
+            # the tensor-core flags and the demangled kernel names the cache
+            # precomputes — but it reads the profile.
+            #
+            # RuntimeError, not SchemaError: callers that fall back catch
+            # (duckdb.Error, RuntimeError, OSError), and SchemaError descends
+            # from Exception, not from RuntimeError.
+            #
+            # This guard only stops a *new* poisoned cache from being published.
+            # build_cache's is_cache_valid fast-path returns before we get here,
+            # so an already-poisoned cache dir is never repaired. _CACHE_VERSION
+            # is deliberately not bumped for that: poisoning requires a kernel
+            # table name outside the exact/`_V` forms _find_table matches, which
+            # no shipped Nsight export uses, so no cache in the field can be in
+            # that state. Deleting the .nsys-cache directory recovers one.
+            unrecognised = _kernel_like_tables(src_tables)
+            if unrecognised:
+                raise RuntimeError(
+                    "cache build aborted: the profile carries a kernel activity table "
+                    f"({', '.join(unrecognised)}) that this build does not recognise, "
+                    "so kernels.parquet cannot be produced"
+                )
+        else:
             _progress("kernels.parquet")
             db.execute(f"""
                 COPY (
@@ -718,6 +747,18 @@ def _find_table(tables: set[str], prefix: str) -> str | None:
         return prefix
     candidates = sorted(t for t in tables if t.startswith(prefix + "_V"))
     return candidates[0] if candidates else None
+
+
+def _kernel_like_tables(tables: set[str]) -> list[str]:
+    """Source tables ``NsightSchema`` would accept as the kernel activity table.
+
+    Mirrors ``NsightSchema._detect_kernel_table``: any non-``ENUM_`` table with
+    ``KERNEL`` in its name. Used to tell "this profile has no kernel data at all"
+    (a legitimate state — Nsight creates tables lazily) from "this profile has
+    kernel data under a name ``_find_table`` did not match", which must not be
+    cached.
+    """
+    return sorted(t for t in tables if "KERNEL" in t.upper() and not t.upper().startswith("ENUM_"))
 
 
 def _table_has_column(db: duckdb.DuckDBPyConnection, table: str, column: str) -> bool:

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -328,6 +328,107 @@ class TestBuildAndOpen:
         assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is True
 
 
+class TestUnrecognisedKernelTable:
+    """A kernel table the builder cannot address must abort the build, not
+    publish a cache without kernels.parquet that keeps on validating."""
+
+    def test_unrecognised_kernel_table_falls_back_instead_of_poisoning_cache(
+        self, minimal_nsys_db_path
+    ):
+        """A non-`_V` kernel suffix must leave no cache and open via sqlite3."""
+        from nsys_ai.profile import Profile
+
+        conn = sqlite3.connect(minimal_nsys_db_path)
+        conn.execute(
+            "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL RENAME TO CUPTI_ACTIVITY_KIND_KERNEL_X1"
+        )
+        conn.commit()
+        conn.close()
+
+        # Twice: the second open proves the first left nothing poisoned behind.
+        for _ in range(2):
+            prof = Profile(minimal_nsys_db_path, cache_mode="auto")
+            try:
+                assert prof.db is None  # sqlite3 fallback engaged
+                assert prof.schema.kernel_table == "CUPTI_ACTIVITY_KIND_KERNEL_X1"
+                assert prof.meta.kernel_count > 0
+            finally:
+                prof.close()
+
+        # Assert on the cache dir + validity, not on a listing of the parent:
+        # `_build_lock` leaves a <name>.nsys-cache.build.lock file behind on
+        # every path, which is pre-existing and does not affect validity.
+        cache_dir = Path(minimal_nsys_db_path).with_suffix(".nsys-cache")
+        assert not cache_dir.exists()
+        assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is False
+
+    def test_unrecognised_kernel_table_raises_runtimeerror_not_schemaerror(
+        self, minimal_nsys_db_path
+    ):
+        """The exception type is load-bearing and must stay a RuntimeError.
+
+        Every caller that falls back to direct SQLite keys on
+        ``(duckdb.Error, RuntimeError, OSError)`` — ``Profile.__init__`` and the
+        skill-run handler both do. ``SchemaError`` does not inherit from
+        ``RuntimeError``, so raising one here would turn a working degraded read
+        into a hard "Error [SCHEMA_ERROR]" for the user. The Profile-level test
+        above cannot see this: ``Profile.__init__`` catches bare ``Exception``
+        around the cache attempt, so it falls back either way.
+        """
+        from nsys_ai.exceptions import SchemaError
+
+        conn = sqlite3.connect(minimal_nsys_db_path)
+        conn.execute(
+            "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL RENAME TO CUPTI_ACTIVITY_KIND_KERNEL_X1"
+        )
+        conn.commit()
+        conn.close()
+
+        with pytest.raises(RuntimeError) as excinfo:
+            parquet_cache.build_cache(minimal_nsys_db_path)
+        assert "CUPTI_ACTIVITY_KIND_KERNEL_X1" in str(excinfo.value)
+        # Stated explicitly: SchemaError descends from Exception, not from
+        # RuntimeError, so it would slip past every fallback except-clause.
+        assert not issubclass(SchemaError, RuntimeError)
+
+    def test_profile_without_any_kernel_table_still_caches(self, minimal_nsys_db_path):
+        """Guard must not fire on a capture that simply has no kernel data.
+
+        Nsight creates tables lazily, so "no kernel table at all" is a legitimate
+        state that must keep its existing behaviour (cache builds, SchemaError
+        surfaces from NsightSchema).
+
+        The ENUM_ table is not decoration. Every real capture carries
+        ``ENUM_CUDA_KERNEL_LAUNCH_TYPE`` — h100_2gpu_1s.sqlite and
+        mfu_2gpu_before.sqlite both do — and its name contains "KERNEL". Without
+        the ``ENUM_`` exclusion in ``_kernel_like_tables`` the guard would fire on
+        it and strip the cache from every genuinely kernel-less real profile. The
+        minimal conftest schema has no ENUM_ table, so this test creates one.
+        """
+        conn = sqlite3.connect(minimal_nsys_db_path)
+        conn.execute("CREATE TABLE ENUM_CUDA_KERNEL_LAUNCH_TYPE (id INTEGER, label TEXT)")
+        conn.execute("DROP TABLE CUPTI_ACTIVITY_KIND_KERNEL")
+        conn.commit()
+        conn.close()
+
+        cache_dir = parquet_cache.build_cache(minimal_nsys_db_path)
+        assert cache_dir.exists()
+        assert not (cache_dir / "kernels.parquet").exists()
+        assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is True
+
+    def test_enum_tables_are_not_kernel_activity_tables(self):
+        """Unit-level companion: `_kernel_like_tables` must skip ENUM_ tables.
+
+        Mirrors ``NsightSchema._detect_kernel_table``, which applies the same
+        exclusion. Pinned separately from the build-level test so the intent
+        survives even if the fixture schema changes.
+        """
+        assert parquet_cache._kernel_like_tables({"ENUM_CUDA_KERNEL_LAUNCH_TYPE"}) == []
+        assert parquet_cache._kernel_like_tables(
+            {"ENUM_CUDA_KERNEL_LAUNCH_TYPE", "CUPTI_ACTIVITY_KIND_KERNEL_X1"}
+        ) == ["CUPTI_ACTIVITY_KIND_KERNEL_X1"]
+
+
 class TestConcurrentBuild:
     """Regression: two terminals opening the same profile concurrently
     must NOT both run the full ETL.


### PR DESCRIPTION
Closes #305.

## The defect

`_build_cache_into` resolves the kernel activity table with `_find_table`, which matches only the exact name or a `prefix + "_V"` suffix. Any other name resolves to `None`, and the build simply skipped `kernels.parquet` — then stamped the cache `{"version": ..., "empty": false}` and returned success. `is_cache_valid()` accepted that stamp, so every subsequent open reattached the same incomplete cache.

The failure then surfaced in `NsightSchema`, which is constructed *after* the `try/except` in `Profile.__init__` whose whole job is to fall back to sqlite3. The fallback never engaged, and the profile stayed unopenable on every later open, because the poisoned cache kept validating.

## Evidence

Reproduced on `tests/fixtures/`-shaped input by renaming the kernel table to a non-`_V` suffix and opening with `cache_mode="auto"`. With the guard removed, the build reports success and the open dies:

```
[nsys-ai] Building cache [1/7] nvtx.parquet (0s)[nsys-ai] Building cache [2/7] runtime.parquet (0s)
[nsys-ai] Building cache [3/7] memcpy.parquet (0s)[nsys-ai] Building cache [4/7] memset.parquet (0s)
[nsys-ai] Building cache [5/7] string_ids.parquet (0s)[nsys-ai] Building cache [6/7] gpu_info.parquet (0s)
[nsys-ai] Building cache [7/7] cuda_device.parquet (0s)[nsys-ai] Cache ready (0.1s)

>       prof = Profile(minimal_nsys_db_path, cache_mode="auto")
E       nsys_ai.exceptions.SchemaError: This profile does not contain GPU kernel activity
        (no suitable KERNEL table found) (Nsight version: 2026.1.1.204). It may have been
        captured without CUDA kernel tracing, or exported with a schema layout this version
        of nsys-ai does not yet understand.
```

Note the seven-step progress line: the build ran to completion and declared "Cache ready" without ever writing `kernels.parquet`.

## The fix

When `_find_table` returns `None` but the source database does carry a kernel-like table, abort the build with a `RuntimeError` instead of publishing. `build_cache` discards its temp directory on any exception, so nothing is published, no cache directory is left validating, and the caller's existing `except` converts the failure into the already-working direct-SQLite path.

Two details are load-bearing:

- **`RuntimeError`, not `SchemaError`.** Both fallback sites — `Profile.__init__` and the skill-run handler — key on `(duckdb.Error, RuntimeError, OSError)`, and `SchemaError` descends from `Exception`, not `RuntimeError`. A `SchemaError` here would slip past both and turn a working degraded read into a hard error. There is a test asserting the type directly, because `Profile.__init__` catches bare `Exception` and would fall back either way, hiding the distinction from a Profile-level test.
- **The guard is conditional on kernel-like tables being present.** Nsight creates tables lazily, so "no kernel table at all" is a legitimate capture state and keeps its existing behaviour. `_kernel_like_tables` mirrors `NsightSchema._detect_kernel_table` (any non-`ENUM_` table with `KERNEL` in the name); the `ENUM_` exclusion matters because every real capture carries `ENUM_CUDA_KERNEL_LAUNCH_TYPE`, and without it the guard would strip the cache from every genuinely kernel-less real profile.

## The fallback is degraded, not at parity

The issue text claimed full parity based on an earlier audit. That is not what measurement showed here, so recording it plainly: on `h100_2gpu_1s.sqlite` with the kernel table renamed, comparing seven skills cache-vs-fallback, five are byte-identical (`gpu_idle_gaps`, `memory_transfers`, `nccl_breakdown`, `kernel_launch_overhead`, `thread_utilization`), but `top_kernels` returns `tc_eligible`/`tc_active` as null where the cache returns true, and `nvtx_kernel_map` returns `vectorized_elementwise_kernel` where the cache returns the full demangled signature. Both fields survive under `--no-cache`, so the loss is specific to the raw-sqlite3 reader, not to bypassing the cache. A degraded read still beats the hard failure the poisoned cache produced, which is why the fix stands — but the parity claim in the issue is overstated.

## Mutation check

Ran on this machine. Replacing the `if unrecognised:` condition with `if False:` (keeping everything else) and running the new class:

```
FAILED tests/test_parquet_cache.py::TestUnrecognisedKernelTable::test_unrecognised_kernel_table_falls_back_instead_of_poisoning_cache
FAILED tests/test_parquet_cache.py::TestUnrecognisedKernelTable::test_unrecognised_kernel_table_raises_runtimeerror_not_schemaerror
2 failed, 2 passed, 20 deselected in 0.73s
```

The two passing ones are the negative controls (no kernel table at all still caches; a normal `_V` table still caches) and correctly do not move. Source restored, tests green again: `4 passed, 20 deselected`.

## Out of scope

- **Existing poisoned caches are not repaired.** `build_cache`'s `is_cache_valid` fast-path returns before the guard runs, so a directory already in that state stays. `_CACHE_VERSION` is deliberately not bumped to force one: poisoning requires a kernel table name outside the exact/`_V` forms `_find_table` matches, which no shipped Nsight export uses, so no cache in the field can be in this state. Deleting the `.nsys-cache` directory recovers one.
- **`_find_table`'s matching rules are unchanged.** Teaching the builder to address more table-name shapes is a separate change; this one only stops it from claiming success when it cannot.
- **The `<name>.nsys-cache.build.lock` file left behind by `_build_lock` on every path** is pre-existing and untouched. The test asserts on the cache directory and `is_cache_valid()` rather than on a directory listing, for that reason.

## Verification

```
ruff check src/ tests/          All checks passed!
bandit -q -r src/ -c pyproject.toml    (no issues; only pre-existing nosec notices)
python3 -m pytest tests/ -q     1442 passed, 135 skipped in 250.40s
```
