### PR TITLE
fix(schema): resolve the sync tables, and unify three variant resolvers

### DIFF
--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -296,12 +296,54 @@ class DuckDBAdapter:
             return set()
 
 
+_VERSION_SUFFIX_RE = re.compile(r"_V(\d+)")
+
+
+def resolve_table_variant(
+    tables: set[str] | frozenset[str],
+    prefix: str,
+    *,
+    allow_other_suffixes: bool = False,
+) -> str | None:
+    """Pick which of ``prefix``'s name variants a profile actually carries.
+
+    Nsight Systems documents only unversioned ``CUPTI_ACTIVITY_KIND_*`` names,
+    but exports in the wild have carried ``_V2``/``_V3`` suffixes, so the choice
+    has to be made somewhere. The order is:
+
+    1. the exact ``prefix``, when present — an unversioned table is the name the
+       exporter documents, so it wins outright;
+    2. otherwise the highest ``_V<n>``, compared as an *integer* so ``_V10``
+       beats ``_V3`` (lexicographic order gets that backwards);
+    3. otherwise, only when ``allow_other_suffixes``, the alphabetically first
+       remaining name that starts with ``prefix``, so an unforeseen future
+       suffix still resolves to something rather than to nothing.
+
+    The ``_V<n>`` match is anchored (``fullmatch``) rather than a bare
+    ``startswith``: ``CUPTI_ACTIVITY_KIND_MEMCPY2`` is a real CUPTI activity
+    kind (peer-to-peer memcpy) and must never be mistaken for a newer variant
+    of ``CUPTI_ACTIVITY_KIND_MEMCPY``.
+    """
+    if prefix in tables:
+        return prefix
+    versioned: list[tuple[int, str]] = []
+    others: list[str] = []
+    for name in tables:
+        if not name.startswith(prefix):
+            continue
+        match = _VERSION_SUFFIX_RE.fullmatch(name[len(prefix) :])
+        if match:
+            versioned.append((int(match.group(1)), name))
+        elif allow_other_suffixes:
+            others.append(name)
+    if versioned:
+        return max(versioned)[1]
+    return sorted(others)[0] if others else None
+
+
 def _find_activity_tables(tables: set[str]) -> dict[str, str]:
     def _find_by_prefix(prefix: str) -> str | None:
-        if prefix in tables:
-            return prefix
-        candidates = sorted(t for t in tables if t.startswith(prefix))
-        return candidates[0] if candidates else None
+        return resolve_table_variant(tables, prefix, allow_other_suffixes=True)
 
     resolved: dict[str, str] = {}
 
@@ -327,6 +369,14 @@ def _find_activity_tables(tables: set[str]) -> dict[str, str]:
         nvtx_table = _find_by_prefix("NVTX_EVENTS")
     if nvtx_table:
         resolved["nvtx"] = nvtx_table
+
+    sync_table = _find_by_prefix("CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
+    if sync_table:
+        resolved["sync"] = sync_table
+
+    sync_type_table = _find_by_prefix("ENUM_CUPTI_SYNC_TYPE")
+    if sync_type_table:
+        resolved["sync_type"] = sync_type_table
 
     return resolved
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -48,6 +48,7 @@ from pathlib import Path
 
 import duckdb
 
+from nsys_ai.connection import resolve_table_variant
 from nsys_ai.exceptions import ProfileNotFoundError
 
 # fcntl is POSIX-only. On Windows we degrade to no-locking — concurrent
@@ -742,11 +743,16 @@ def open_parquetdir_db(parquetdir_path: str) -> duckdb.DuckDBPyConnection:
 
 
 def _find_table(tables: set[str], prefix: str) -> str | None:
-    """Find the actual table name, handling versioned variants (e.g., _V2)."""
-    if prefix in tables:
-        return prefix
-    candidates = sorted(t for t in tables if t.startswith(prefix + "_V"))
-    return candidates[0] if candidates else None
+    """Find the actual table name, handling versioned variants (e.g., _V2).
+
+    Shares ``resolve_table_variant``'s ordering with the query-side resolver in
+    ``connection.py`` so the cached and uncached engines cannot pick different
+    source tables on a profile that carries several variants. Unlike that
+    resolver this one stays strict about ``_V<n>``: it decides which table the
+    ETL *copies*, and a looser match would let an unrelated activity kind
+    (``CUPTI_ACTIVITY_KIND_MEMCPY2``) be cached as the memcpy table.
+    """
+    return resolve_table_variant(tables, prefix)
 
 
 def _kernel_like_tables(tables: set[str]) -> list[str]:

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -11,61 +11,6 @@ from ...connection import DB_ERRORS, is_safe_identifier, wrap_connection
 from ..base import Skill, SkillParam, _compute_interval_union
 
 
-def _resolve_table_name(conn, candidate: str) -> str:
-    """Resolve an Nsight table name, allowing for version-suffixed variants."""
-    try:
-        cursor = conn.cursor()
-        cursor.execute(
-            """
-            SELECT name FROM sqlite_master
-            WHERE type='table' AND name LIKE ?
-            ORDER BY name DESC LIMIT 1
-            """,
-            (candidate + "%",),
-        )
-        row = cursor.fetchone()
-        if row:
-            return row[0]
-    except Exception:
-        pass
-    return candidate
-
-
-_sync_result_cache: dict[tuple, list[dict]] = {}
-_CACHE_MAX_SIZE = 8  # bounded to prevent unbounded growth / id() reuse
-
-
-def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
-    # Module-level cache keyed by (connection identity, trim window, device).
-    # Avoids redundant re-execution when called by multiple consumer skills
-    # (manifest, root_cause, overlap, bubble) within the same profile session.
-    # Normalize `device` before caching so `device=1` and `device='1'` — which
-    # _impl coerces to the same int — share the cache entry. Invalid values
-    # pass through unchanged so _impl still emits its own error.
-    raw_device = kwargs.get("device")
-    if raw_device is not None:
-        try:
-            raw_device = int(raw_device)
-        except (TypeError, ValueError):
-            pass
-    cache_key = (
-        id(conn),
-        kwargs.get("trim_start_ns"),
-        kwargs.get("trim_end_ns"),
-        raw_device,
-    )
-    cached = _sync_result_cache.get(cache_key)
-    if cached is not None:
-        return cached
-
-    result = _execute_sync_analysis_impl(conn, **kwargs)
-
-    if len(_sync_result_cache) >= _CACHE_MAX_SIZE:
-        _sync_result_cache.clear()
-    _sync_result_cache[cache_key] = result
-    return result
-
-
 def _has_device_id(adapter, sync_table: str) -> bool:
     """Probe whether the sync table has a `deviceId` column.
 
@@ -81,10 +26,15 @@ def _has_device_id(adapter, sync_table: str) -> bool:
         return False
 
 
-def _execute_sync_analysis_impl(conn, **kwargs) -> list[dict]:
+def _execute_sync_analysis(conn, **kwargs) -> list[dict]:
     adapter = wrap_connection(conn)
-    sync_table = _resolve_table_name(conn, "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
-    type_table = _resolve_table_name(conn, "ENUM_CUPTI_SYNC_TYPE")
+    # Resolve through the shared, per-connection-memoized resolver rather than a
+    # private one: it is the only resolver that works on the Parquet-cache
+    # connection (where every catalog entry is a view) and it agrees with the
+    # names the cache builder copied.
+    tables = adapter.resolve_activity_tables()
+    sync_table = tables.get("sync", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION")
+    type_table = tables.get("sync_type", "ENUM_CUPTI_SYNC_TYPE")
 
     # Guard against SQL injection from maliciously crafted table names
     if not is_safe_identifier(sync_table) or not is_safe_identifier(type_table):

--- a/tests/test_duckdb_dataflow.py
+++ b/tests/test_duckdb_dataflow.py
@@ -12,9 +12,11 @@ Three things keep that dual path honest, and none of them was enforced:
    call is fine, adding one carrying ``[end]`` or a hex literal is not.
 
 2. The Parquet cache creates an alias view for *every* known variant of a table
-   (base, _V2, _V3), so any table-resolution strategy lands on the same data.
-   That is the reason a second, differently-ordered resolver in
-   ``sync_cost_analysis`` has never produced a wrong answer.
+   (base, _V2, _V3), so a caller that asks for the unversioned name on a
+   versioned capture still lands on the data. Table resolution itself now goes
+   through a single shared rule (``connection.resolve_table_variant``, used by
+   both the query side and the cache builder); the alias views remain the safety
+   net for callers that never resolve at all.
 
 3. A profile whose tables carry an unknown future suffix must still analyse.
 
@@ -123,34 +125,6 @@ def test_every_known_table_variant_is_reachable_on_the_cached_path():
     assert not unreachable, (
         f"alias views absent, so resolution is no longer variant-safe: {unreachable}"
     )
-
-
-def test_the_two_table_resolvers_agree_wherever_only_one_variant_exists():
-    """A second resolver lives in ``sync_cost_analysis`` and orders variants the
-    opposite way (``ORDER BY name DESC`` vs ``sorted()[0]``).
-
-    On a real capture only one variant is present — verified across every
-    committed fixture and a 3.7GB production capture — so the two agree. They
-    diverge only when variants coexist, which happens exclusively on the cached
-    path where all variants alias the same data. This test states the condition
-    under which the duplication is harmless, so that if it stops holding the
-    reason is on record.
-    """
-    from nsys_ai.connection import wrap_connection
-    from nsys_ai.skills.builtins.sync_cost_analysis import _resolve_table_name
-
-    conn = sqlite3.connect(FIXTURE)
-    try:
-        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
-        variants = sorted(t for t in tables if t.startswith("CUPTI_ACTIVITY_KIND_KERNEL"))
-        assert len(variants) == 1, f"fixture premise broke; found {variants}"
-
-        official = wrap_connection(conn).resolve_activity_tables().get("kernel")
-        local = _resolve_table_name(conn, "CUPTI_ACTIVITY_KIND_KERNEL")
-    finally:
-        conn.close()
-
-    assert official == local == variants[0]
 
 
 def test_an_unknown_future_table_suffix_still_analyses(tmp_path):

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -2,14 +2,7 @@ import sqlite3
 
 import pytest
 
-from nsys_ai.skills.builtins.sync_cost_analysis import _sync_result_cache
 from nsys_ai.skills.registry import get_skill
-
-
-@pytest.fixture(autouse=True)
-def _clear_sync_cache():
-    """Prevent id(conn) reuse of in-memory connections from poisoning results."""
-    _sync_result_cache.clear()
 
 
 @pytest.fixture
@@ -191,23 +184,19 @@ def test_sync_analysis_invalid_device_param(sync_skill):
     assert "device" in rows[0]["error"].lower()
 
 
-def test_sync_analysis_cache_key_normalizes_device_type(sync_skill):
-    """Regression: `device=1` and `device='1'` must share a cache entry.
-    _impl coerces both to int, so if the wrapper keyed the cache on the raw
-    kwarg, the string call would miss and re-run the query — defeating the
-    cross-skill cache reuse."""
+def test_sync_analysis_device_accepts_int_or_numeric_string(sync_skill):
+    """`device=1` and `device='1'` must produce the same answer.
+
+    The skill coerces the parameter with ``int()``, so a numeric string is a
+    legal spelling of the same request. (This replaces a test that asserted the
+    two calls shared an entry in a module-level result cache; that cache is
+    gone, and ``Skill.execute``'s per-connection memo keys on the JSON dump of
+    the resolved params, so the two spellings are now two memo entries and the
+    query simply runs twice. Same answer, no correctness change.)"""
     conn = sqlite3.connect(":memory:")
     _seed_multi_device(conn)
 
-    sync_skill.execute(conn, device=1)
-    size_after_int = len(_sync_result_cache)
-    sync_skill.execute(conn, device="1")
-    size_after_str = len(_sync_result_cache)
-
-    assert size_after_str == size_after_int, (
-        "device=1 and device='1' must share the cache entry "
-        f"(size grew {size_after_int} → {size_after_str})"
-    )
+    assert sync_skill.execute(conn, device=1) == sync_skill.execute(conn, device="1")
 
 
 def test_sync_analysis_device_filter_on_missing_tables_reports_not_found(sync_skill):

--- a/tests/test_sync_table_resolution.py
+++ b/tests/test_sync_table_resolution.py
@@ -1,0 +1,299 @@
+"""One rule for choosing which variant of an Nsight table a profile carries.
+
+Nsight Systems documents only unversioned ``CUPTI_ACTIVITY_KIND_*`` names — the
+export as a whole is versioned through ``EXPORT_META_DATA.EXPORT_SCHEMA_VERSION``
+— but this repo has met ``_V2``/``_V3`` suffixed exports, so it resolves names by
+prefix. Until now it did so in three places with two different orderings:
+
+* ``connection._find_activity_tables`` took ``sorted(...)[0]`` — the *oldest*
+  variant — and never emitted a ``sync``/``sync_type`` key at all, so the
+  ``{sync_table}`` placeholder that ``skills/base.py`` advertises always fell
+  through to its unversioned literal;
+* ``parquet_cache._find_table`` also took the oldest, deciding which table the
+  cache builder copies;
+* ``sync_cost_analysis`` had a private resolver taking ``ORDER BY name DESC`` —
+  the *newest* — whose ``WHERE type='table'`` filter matched nothing on the
+  Parquet-cache connection, where every catalog entry is a view.
+
+These tests pin the single rule that replaced them (exact name first, then the
+highest ``_V<n>`` by integer), the two newly-emitted keys, and the property that
+made the three changes inseparable: with the resolvers unified but the ordering
+left alone, the two engines pick different tables on a profile that carries
+both variants.
+"""
+
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.connection import _find_activity_tables, wrap_connection
+from nsys_ai.skills.base import Skill
+from nsys_ai.skills.registry import get_skill
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+SYNC = "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"
+
+
+# ── The ordering rule, in isolation ─────────────────────────────────────────
+
+
+def test_the_unversioned_name_wins_over_any_suffixed_variant():
+    """The documented name is the exporter's own answer; a suffixed table
+    alongside it is a leftover, not an upgrade."""
+    resolved = _find_activity_tables(
+        {
+            "CUPTI_ACTIVITY_KIND_KERNEL",
+            "CUPTI_ACTIVITY_KIND_KERNEL_V2",
+            "CUPTI_ACTIVITY_KIND_KERNEL_V3",
+        }
+    )
+    assert resolved["kernel"] == "CUPTI_ACTIVITY_KIND_KERNEL"
+
+
+def test_versions_are_ordered_as_integers_not_as_strings():
+    """``_V10`` is newer than ``_V3``. Lexicographic order says the opposite,
+    and plain ``max()`` over the names would pick ``_V3``.
+
+    Both sets are needed. The three-variant set alone does not discriminate
+    against the ``sorted(...)[0]`` rule this replaced: ``_V10`` sorts first
+    lexicographically, so the old rule returned the right answer here for the
+    wrong reason. The two-variant set is where the old rule visibly picks the
+    older table.
+    """
+    resolved = _find_activity_tables(
+        {
+            "CUPTI_ACTIVITY_KIND_KERNEL_V2",
+            "CUPTI_ACTIVITY_KIND_KERNEL_V3",
+            "CUPTI_ACTIVITY_KIND_KERNEL_V10",
+        }
+    )
+    assert resolved["kernel"] == "CUPTI_ACTIVITY_KIND_KERNEL_V10"
+
+    resolved = _find_activity_tables(
+        {"CUPTI_ACTIVITY_KIND_KERNEL_V2", "CUPTI_ACTIVITY_KIND_KERNEL_V3"}
+    )
+    assert resolved["kernel"] == "CUPTI_ACTIVITY_KIND_KERNEL_V3"
+
+
+def test_a_peer_to_peer_memcpy_table_is_not_mistaken_for_a_memcpy_variant():
+    """``CUPTI_ACTIVITY_KIND_MEMCPY2`` is a real CUPTI activity kind (P2P
+    memcpy), not a version of ``..._MEMCPY``. Anchoring the ``_V<n>`` match is
+    what keeps the two apart."""
+    resolved = _find_activity_tables(
+        {"CUPTI_ACTIVITY_KIND_MEMCPY_V3", "CUPTI_ACTIVITY_KIND_MEMCPY2"}
+    )
+    assert resolved["memcpy"] == "CUPTI_ACTIVITY_KIND_MEMCPY_V3"
+
+
+def test_an_unrecognised_suffix_still_resolves_to_something():
+    """The query-side resolver keeps a permissive last resort so a future
+    suffix shape degrades to "reads the odd table" rather than "reads nothing"."""
+    resolved = _find_activity_tables({"CUPTI_ACTIVITY_KIND_KERNEL_NEXTGEN"})
+    assert resolved["kernel"] == "CUPTI_ACTIVITY_KIND_KERNEL_NEXTGEN"
+
+
+def test_the_sync_tables_are_resolved_at_all():
+    """``skills/base.py`` offers ``{sync_table}`` and ``{sync_type_table}``;
+    without these keys both placeholders always took the literal fallback."""
+    resolved = _find_activity_tables({SYNC + "_V2", "ENUM_CUPTI_SYNC_TYPE_V2"})
+    assert resolved["sync"] == SYNC + "_V2"
+    assert resolved["sync_type"] == "ENUM_CUPTI_SYNC_TYPE_V2"
+
+
+# ── The placeholder, against a real versioned profile ───────────────────────
+
+
+@pytest.fixture(scope="module")
+def sync_v2(tmp_path_factory) -> Path:
+    """The annotated fixture with its synchronization table renamed to _V2."""
+    dst = tmp_path_factory.mktemp("sync_v2") / "sync_v2.sqlite"
+    shutil.copy(FIXTURE, dst)
+    conn = sqlite3.connect(dst)
+    try:
+        conn.execute(f"ALTER TABLE {SYNC} RENAME TO {SYNC}_V2")
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+def _counting_skill() -> Skill:
+    """A skill whose whole body is the placeholder under test."""
+    return Skill(
+        name="_sync_table_placeholder_probe",
+        title="probe",
+        description="probe",
+        category="system",
+        sql="SELECT COUNT(*) AS n FROM {sync_table}",
+    )
+
+
+def test_the_fixture_has_sync_rows():
+    """Premise: without sync rows the assertions below pass vacuously."""
+    conn = sqlite3.connect(f"file:{FIXTURE}?mode=ro", uri=True)
+    try:
+        n = conn.execute(f"SELECT COUNT(*) FROM {SYNC}").fetchone()[0]
+    finally:
+        conn.close()
+    assert n > 0
+
+
+def test_sync_table_placeholder_reads_a_versioned_table_over_sqlite3(sync_v2):
+    """The failure this PR removes: a plain ``sqlite3`` connection has no alias
+    views, so an unresolved ``{sync_table}`` raises "no such table"."""
+    conn = sqlite3.connect(sync_v2)
+    try:
+        rows = _counting_skill().execute(conn)
+    finally:
+        conn.close()
+
+    assert rows and rows[0]["n"] > 0, f"{SYNC}_V2 produced no rows: {rows}"
+
+
+def test_sync_table_placeholder_agrees_across_engines(sync_v2):
+    """The cached path answered correctly all along, via the alias view for the
+    unversioned name. Both engines must now give the same count."""
+    from nsys_ai.profile import Profile
+
+    pytest.importorskip("duckdb", reason="requires duckdb")
+
+    conn = sqlite3.connect(sync_v2)
+    try:
+        via_sqlite = _counting_skill().execute(conn)
+    finally:
+        conn.close()
+
+    with Profile(str(sync_v2)) as prof:
+        if prof.db is None:  # pragma: no cover
+            pytest.skip("requires duckdb")
+        via_duckdb = _counting_skill().execute(prof.db)
+
+    assert via_sqlite == via_duckdb
+
+
+def test_sync_cost_analysis_reads_a_versioned_table_over_sqlite3(sync_v2):
+    """The shipped skill, on the path with no alias layer."""
+    conn = sqlite3.connect(sync_v2)
+    try:
+        rows = get_skill("sync_cost_analysis").execute(conn)
+    finally:
+        conn.close()
+
+    assert "error" not in rows[0], rows[0]["error"]
+    assert rows[0]["total_sync_wall_ms"] > 0
+
+
+# ── The coupling: ordering and deduplication must land together ─────────────
+
+
+@pytest.fixture(scope="module")
+def dual_variant(tmp_path_factory) -> Path:
+    """A profile carrying both ``_V2`` (truncated) and ``_V3`` (complete).
+
+    Not something nsys emits — the exporter documents no table-name versioning
+    at all — but it is the only shape in which the resolvers' orderings are
+    distinguishable, so it is what pins them together. The two tables carry
+    *different* row counts on purpose: picking the wrong one is then visible in
+    the analysis result, not just in the resolved name.
+    """
+    dst = tmp_path_factory.mktemp("dual") / "dual.sqlite"
+    shutil.copy(FIXTURE, dst)
+    conn = sqlite3.connect(dst)
+    try:
+        conn.execute(f"ALTER TABLE {SYNC} RENAME TO {SYNC}_V3")
+        total = conn.execute(f"SELECT COUNT(*) FROM {SYNC}_V3").fetchone()[0]
+        conn.execute(
+            f"CREATE TABLE {SYNC}_V2 AS SELECT * FROM {SYNC}_V3 LIMIT {total // 2}"
+        )
+        conn.commit()
+        kept = conn.execute(f"SELECT COUNT(*) FROM {SYNC}_V2").fetchone()[0]
+    finally:
+        conn.close()
+    if not 0 < kept < total:
+        raise ValueError(f"dual-variant fixture is not distinguishable: {kept}/{total}")
+    return dst
+
+
+def test_the_newest_variant_is_the_one_resolved(dual_variant):
+    conn = sqlite3.connect(dual_variant)
+    try:
+        tables = wrap_connection(conn).resolve_activity_tables()
+    finally:
+        conn.close()
+
+    assert tables["sync"] == SYNC + "_V3"
+
+
+def test_both_engines_pick_the_same_variant(dual_variant):
+    """The reason the three fixes are one PR.
+
+    Deleting ``sync_cost_analysis``'s private resolver moves the skill onto
+    ``_find_activity_tables``. Left with its old ``sorted()[0]`` ordering that
+    silently changes the skill's answer from the newest table to the oldest one;
+    and if only the query-side ordering is fixed, the cache builder still copies
+    the oldest, so the two engines disagree. This asserts the state in which
+    neither is true.
+    """
+    from nsys_ai.profile import Profile
+
+    pytest.importorskip("duckdb", reason="requires duckdb")
+
+    skill = get_skill("sync_cost_analysis")
+
+    conn = sqlite3.connect(dual_variant)
+    try:
+        via_sqlite = skill.execute(conn)
+    finally:
+        conn.close()
+
+    with Profile(str(dual_variant)) as prof:
+        if prof.db is None:  # pragma: no cover
+            pytest.skip("requires duckdb")
+        via_duckdb = skill.execute(prof.db)
+
+    assert "error" not in via_sqlite[0], via_sqlite[0]["error"]
+    assert via_sqlite == via_duckdb, "the two engines resolved different sync tables"
+
+
+# ── The duplicate cache must not come back ──────────────────────────────────
+
+
+def test_sync_cost_analysis_keeps_no_module_level_result_cache():
+    """It used to hold a dict keyed on ``id(conn)`` that ``Profile.close()``
+    never cleared, and it was the only skill cache handing out its stored list
+    uncopied — ``profile_health_manifest`` embedded that dict by reference.
+    ``Skill.execute``'s per-connection memo already does this job, with
+    copy-on-store and copy-on-read.
+
+    Asserted behaviourally rather than by attribute name: any per-connection
+    memo, whatever it is called, has to grow a module-level container as it
+    sees new connections. Two connections are held open at once so the second
+    cannot reuse the first's ``id()``.
+    """
+    from nsys_ai.skills.builtins import sync_cost_analysis
+
+    def container_sizes() -> dict[str, int]:
+        return {
+            name: len(value)
+            for name, value in vars(sync_cost_analysis).items()
+            if isinstance(value, (dict, list, set))
+        }
+
+    conn_a = sqlite3.connect(FIXTURE)
+    conn_b = sqlite3.connect(FIXTURE)
+    try:
+        # Call the execute function directly: Skill.execute has its own
+        # per-connection memo, which would mask a module-level one.
+        sync_cost_analysis._execute_sync_analysis(conn_a)
+        before = container_sizes()
+        sync_cost_analysis._execute_sync_analysis(conn_b)
+        after = container_sizes()
+    finally:
+        conn_a.close()
+        conn_b.close()
+
+    grew = {k: (before.get(k), v) for k, v in after.items() if before.get(k) != v}
+    assert not grew, f"module-level result cache reintroduced: {grew}"


### PR DESCRIPTION
Closes #306. Part of #304.

## The defect

Three related problems around `sync_cost_analysis`, all on the same call path.

**1. `{sync_table}` / `{sync_type_table}` resolved to nothing.** `skills/base.py` exposes both
placeholders, but `connection._find_activity_tables` only ever emitted `kernel`, `runtime`,
`memcpy`, `memset` and `nvtx` keys. The `sync` / `sync_type` keys were never produced, so the
fallback literal fired 100% of the time and any skill using `{sync_table}` broke on a profile whose
synchronization table carries a `_V2` suffix. No shipped skill uses the placeholders yet — this was
a trap for the next skill author.

**2. `sync_cost_analysis` carried a private second resolver.** `_resolve_table_name` queried
`sqlite_master WHERE type='table'`, which matches nothing on the Parquet-cache engine (every catalog
entry there is a view), so it returned its input unchanged and the right answer arrived from the
alias views instead. It also ordered variants opposite to `_find_activity_tables` (`ORDER BY name
DESC` = newest, versus `sorted()[0]` = oldest), and interpolated an unescaped SQLite `LIKE` pattern
over names full of `_`, which is a single-character wildcard there.

**3. `_sync_result_cache` was a duplicate cache handing out shared state.** Keyed on `id(conn)`,
never invalidated, never cleared by `Profile.close()`, and the only skill cache that returned its
stored list uncopied — `profile_health_manifest` does `sync_summary = sync_data[0]` and embeds that
dict by reference into the manifest, so one mutable dict was shared between the module cache, five
consumers and the manifest output. All five call sites read with `.get()` today, so no output is
wrong now; one ordinary future mutation corrupts four consumers. The per-connection probe bag from
 #295 already provides that memoization, with copy-on-store/copy-on-read and derived-cursor
resolution (#301).

## Evidence

Reverting only the `sync` / `sync_type` resolution — that is, the state of `main` — and running the
new test file reproduces the defect:

```
$ python3 -m pytest tests/test_sync_table_resolution.py -q
E       AssertionError: Synchronization tables not found in profile
E       assert 'error' not in {'error': 'Synchronization tables not found in profile', ...}
FAILED tests/test_sync_table_resolution.py::test_the_sync_tables_are_resolved_at_all
FAILED tests/test_sync_table_resolution.py::test_sync_table_placeholder_reads_a_versioned_table_over_sqlite3
FAILED tests/test_sync_table_resolution.py::test_sync_table_placeholder_agrees_across_engines
FAILED tests/test_sync_table_resolution.py::test_sync_cost_analysis_reads_a_versioned_table_over_sqlite3
FAILED tests/test_sync_table_resolution.py::test_the_newest_variant_is_the_one_resolved
FAILED tests/test_sync_table_resolution.py::test_both_engines_pick_the_same_variant
6 failed, 6 passed in 0.86s
```

With the fix in place the resolver emits the keys and picks the versioned table:

```
$ python3 -c "from nsys_ai.connection import _find_activity_tables, resolve_table_variant; ..."
resolved keys: ['kernel', 'sync', 'sync_type']
sync -> CUPTI_ACTIVITY_KIND_SYNCHRONIZATION_V2
variant order: X_V10
```

That last line is the integer-versus-string ordering: given `{X_V2, X_V3, X_V10}`, lexicographic
sorting puts `X_V10` below `X_V3`.

## The fix

- New `connection.resolve_table_variant(tables, prefix, *, allow_other_suffixes=False)` — one
  resolver with one documented order: the exact unversioned name first (it is the name the exporter
  documents), then the highest `_V<n>` compared as an **integer**, then, opt-in only, the
  alphabetically first other suffix so an unforeseen future name still resolves to something rather
  than to nothing. The `_V<n>` match is a `fullmatch`, not a `startswith`, so
  `CUPTI_ACTIVITY_KIND_MEMCPY2` — peer-to-peer memcpy, a real activity kind — can never be mistaken
  for a newer variant of `CUPTI_ACTIVITY_KIND_MEMCPY`.
- `_find_activity_tables` now also emits `sync` and `sync_type`, so `{sync_table}` and
  `{sync_type_table}` work on both engines.
- `parquet_cache._find_table` delegates to the same function (strict mode), so the cache builder
  cannot copy a different table than the query side later resolves.
- `_resolve_table_name` and `_sync_result_cache` are deleted; `sync_cost_analysis` reads the table
  names from `adapter.resolve_activity_tables()`, which is already memoized per connection.

Per the constraint in the issue, the ordering fix and the resolver deletion land together: deleting
the resolver alone would have flipped the chosen table on a dual-variant profile from newest to
oldest.

## Mutation check (performed, not assumed)

Both halves of the fix were reverted in the working tree, the tests re-run, and the source restored:

- Removing the `sync` / `sync_type` keys from `_find_activity_tables` — **6 failed, 6 passed**
  (output above).
- Reverting the variant ordering to oldest-lexicographic — **2 failed, 10 passed**
  (`test_versions_are_ordered_as_integers_not_as_strings`,
  `test_the_newest_variant_is_the_one_resolved`).
- Source restored (`git diff --stat` empty), file green again: **12 passed**.

## Verification

Run on this branch, on this machine:

- `ruff check src/ tests/` — All checks passed
- `bandit -q -r src/ -c pyproject.toml` — no findings (only the pre-existing `nosec` notices)
- `python3 -m pytest tests/ -q` — **1453 passed, 135 skipped**, 0 failed (baseline 1435 passed; the
  18 new tests are the delta)

## Deliberately out of scope

- No shipped skill is changed to consume `{sync_table}`. The placeholders are fixed, not exercised
  by new product surface; the test file uses a synthetic skill to prove they work on both engines.
- `parquet_cache._kernel_like_tables` keeps its own broader prefix scan — it answers a different
  question (which kernel-shaped tables exist at all) and was not touched.
- No performance claim is made for removing `_sync_result_cache`. The issue quotes ~3.5 ms of a
  ~311 ms build from the audit; that number was not re-measured here and nothing in this PR depends
  on it.
