### PR TITLE
fix(nvtx): abstain when a profile's NVTX is only Start/End ranges

### DIFF
--- a/docs/03-nvtx-annotations.md
+++ b/docs/03-nvtx-annotations.md
@@ -142,3 +142,44 @@ This is the recommended way to profile specific training iterations.
 | 34 | Mark (instant) |
 | 59 | Push/Pop range |
 | 60 | Start/End range |
+| 70 | Push/Pop range imported from NVTXT |
+| 71 | Start/End range imported from NVTXT |
+| 75 | Domain creation |
+
+A profile that exports these lists them in its own `ENUM_NSYS_EVENT_TYPE`
+table, which is the authoritative source for the export you are holding.
+
+## What nsys-ai attributes
+
+Mapping a GPU kernel to the annotation it ran under uses **Push/Pop ranges
+(eventType 59) only**.
+
+Nsight keeps a push/pop range stack per CPU thread, so a thread's push/pop
+ranges are strictly nested by construction. That is what makes kernel
+attribution a single ordered sweep: walk one thread's ranges in start order,
+keep the open ones on a stack, and the innermost still-open range at a
+kernel's launch is that kernel's label.
+
+Start/End ranges carry no such guarantee. NVIDIA documents that they "expose
+arbitrary concurrency (not just nesting)" and that "the start of a range can
+occur on a different thread than the end" — Nsight records that as one row
+whose `globalTid` and `endGlobalTid` differ. Handing those to a nesting stack
+would produce confident, wrong parents, so nsys-ai does not attribute them.
+The same applies to the NVTXT-imported variants (70 and 71).
+
+On a profile whose NVTX is entirely Start/End, the skills that depend on
+attribution — `nvtx_kernel_map`, `nvtx_layer_breakdown`,
+`code_attribution_candidates`, `nccl_compile_context_breakdown` — abstain and
+say why, rather than returning an empty result that reads as "this profile has
+no annotation". To get attribution, annotate with `nvtxRangePush` /
+`nvtxRangePop` (`torch.cuda.nvtx.range_push` / `range_pop`, or the
+`torch.cuda.nvtx.range` context manager). PyTorch's own annotations already
+use push/pop.
+
+Region *listing* is unaffected and does see Start/End ranges: the NVTX tree,
+`region_mfu`, iteration detection, `host_sync_parent_ranges` and `gc_impact`
+all read NVTX rows as plain intervals.
+
+One limitation worth stating: on a profile that mixes both kinds, the
+attribution skills run on the push/pop ranges and the Start/End ranges are
+silently left out.

--- a/docs/03-nvtx-annotations.md
+++ b/docs/03-nvtx-annotations.md
@@ -167,14 +167,16 @@ whose `globalTid` and `endGlobalTid` differ. Handing those to a nesting stack
 would produce confident, wrong parents, so nsys-ai does not attribute them.
 The same applies to the NVTXT-imported variants (70 and 71).
 
-On a profile whose NVTX is entirely Start/End, the skills that depend on
+On a profile with no push/pop ranges at all, the skills that depend on
 attribution — `nvtx_kernel_map`, `nvtx_layer_breakdown`,
 `code_attribution_candidates`, `nccl_compile_context_breakdown` — abstain and
 say why, rather than returning an empty result that reads as "this profile has
-no annotation". To get attribution, annotate with `nvtxRangePush` /
-`nvtxRangePop` (`torch.cuda.nvtx.range_push` / `range_pop`, or the
-`torch.cuda.nvtx.range` context manager). PyTorch's own annotations already
-use push/pop.
+no annotation". An entirely Start/End profile gets a reason naming that; any
+other case, including an NVTXT import, gets a reason listing the eventTypes
+actually present, read from the profile's own `ENUM_NSYS_EVENT_TYPE`. To get
+attribution, annotate with `nvtxRangePush` / `nvtxRangePop`
+(`torch.cuda.nvtx.range_push` / `range_pop`, or the `torch.cuda.nvtx.range`
+context manager). PyTorch's own annotations already use push/pop.
 
 Region *listing* is unaffected and does see Start/End ranges: the NVTX tree,
 `region_mfu`, iteration detection, `host_sync_parent_ranges` and `gc_impact`

--- a/src/nsys_ai/nvtx_attribution.py
+++ b/src/nsys_ai/nvtx_attribution.py
@@ -70,7 +70,15 @@ def _sort_merge_attribute(
     if not kr_rows:
         return []
 
-    # Phase 2: Load NVTX ranges (eventType 59 = NVTX push/pop range)
+    # Phase 2: Load NVTX ranges (eventType 59 = NVTX push/pop range).
+    #
+    # The 59 filter is a deliberate exclusion of Start/End ranges (eventType 60),
+    # not an oversight — do not widen it. The sweep below is a per-thread nesting
+    # stack, which is sound only because NVIDIA keeps push/pop ranges on a
+    # per-thread stack and they are therefore strictly nested. Start/End ranges
+    # may overlap arbitrarily and may start and end on different threads, so
+    # feeding them to this stack would produce wrong parents, not more coverage.
+    # `skills.base.requires_pushpop_nvtx` makes that exclusion visible to users.
     has_textid = adapter.detect_nvtx_text_id()
 
     if has_textid:

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1242,6 +1242,11 @@ def _stream_nvtx_ranges(db, nvtx_parquet: str):
     Batched through Arrow so the whole result never exists as one list of
     tuples, and labels interned so repeated NVTX text costs one string object
     rather than one per row.
+
+    ``eventType = 59`` deliberately excludes Start/End ranges (eventType 60)
+    rather than merely overlooking them: the consumer is a per-thread nesting
+    stack, valid only for push/pop ranges. See
+    ``skills.base.requires_pushpop_nvtx`` for why widening this is not the fix.
     """
     result = db.execute(
         f"""

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -107,6 +107,109 @@ def requires_nvtx(conn, *, needs: str = "Region attribution") -> list[dict] | No
     )
 
 
+def requires_pushpop_nvtx(conn, *, needs: str = "Region attribution") -> list[dict] | None:
+    """Abstain unless ``conn`` carries Push/Pop NVTX ranges, else None.
+
+    Kernel attribution in this package is a per-thread nesting sweep
+    (``nvtx_attribution._sort_merge_attribute`` and the cache's equivalent in
+    ``parquet_cache``). That sweep is only valid for eventType 59
+    (``NvtxPushPopRange``): NVIDIA maintains the push/pop range stack per CPU
+    thread, so a thread's ranges are strictly nested by construction. eventType
+    60 (``NvtxStartEndRange``) carries no such guarantee — NVIDIA documents that
+    Start/End ranges "expose arbitrary concurrency (not just nesting)" and that
+    "the start of a range can occur on a different thread than the end", which
+    Nsight materialises as a single row with ``globalTid`` and ``endGlobalTid``
+    disagreeing. Widening the ``eventType = 59`` filter would therefore not fix
+    anything; it would feed non-nested intervals to a stack.
+
+    So Start/End ranges are deliberately not attributed, and this guard makes
+    that visible. Without it a 60-only profile produced an empty result and the
+    formatter asked "are NVTX annotations present?" — a question whose answer is
+    yes, and which ``profile_health_manifest`` answers with the region names on
+    the very same profile, because ``Profile.aggregate_nvtx_ranges`` does not
+    filter eventType.
+
+    Known limitation, stated rather than half-solved: on a *mixed* profile the
+    59-probe hits, this guard passes, and the 60 ranges are still dropped from
+    attribution with no signal. Rank-ordering every range kind is not worth
+    building for a case with no observed users: no committed profile fixture and
+    no real capture available here holds a single eventType-60 row — a 3.5GB
+    trace with 15.9M NVTX rows is 100% eventType 59 — and PyTorch annotates with
+    push/pop. The Start/End fixtures the tests build are synthetic on purpose.
+
+    NVTXT ranges (eventType 70/71, the text-import variants) are excluded on the
+    same grounds, so the message says "Push/Pop (eventType 59)" rather than
+    implying 59 is the only range kind Nsight records.
+
+    Fails open. Several test databases create ``NVTX_EVENTS`` with no
+    ``eventType`` column at all, and a schema surprise must not be reported to a
+    user as "your annotation is the wrong kind".
+    """
+    missing = requires_nvtx(conn, needs=needs)
+    if missing:
+        return missing
+
+    from ..connection import wrap_connection
+
+    adapter = wrap_connection(conn)
+    nvtx_table = resolve_nvtx_table(conn)
+
+    def _has(event_type: int | None) -> bool | None:
+        """Does a row of this eventType exist? None when the probe cannot run.
+
+        ``event_type=None`` probes for any row at all, which needs no
+        ``eventType`` column.
+        """
+        where = "" if event_type is None else f"WHERE eventType = {int(event_type)}"
+        try:
+            cur = adapter.execute(f"SELECT 1 FROM {nvtx_table} {where} LIMIT 1")
+            return cur.fetchone() is not None
+        except DB_ERRORS:
+            return None
+
+    # 59 first, deliberately. Measured on a 15.9M-row capture: the push/pop
+    # probe returns on the first row in 0.05ms, while a miss costs a full scan
+    # (0.48s), so probing 60 first would tax every healthy profile for nothing.
+    # A GROUP BY census costs 2.3s and tells us no more than these two probes.
+    has_pushpop = _has(59)
+    if has_pushpop is None or has_pushpop:
+        return None
+
+    has_startend = _has(60)
+    if has_startend:
+        return abstain(
+            f"This profile's NVTX annotation consists only of Start/End ranges "
+            f"(eventType 60). {needs} maps kernels to ranges with a per-thread "
+            f"nesting sweep, which is valid only for Push/Pop ranges "
+            f"(eventType 59): those are kept on a per-thread stack and so are "
+            f"strictly nested. Start/End ranges may begin and end on different "
+            f"threads and may overlap arbitrarily, so they are not attributed. "
+            f"Re-annotate with nvtxRangePush/nvtxRangePop "
+            f"(torch.cuda.nvtx.range_push/range_pop, or the "
+            f"torch.cuda.nvtx.range context manager) to use this skill.",
+            nvtx_event_types="60",
+        )
+
+    # An NVTX table with no rows at all is a different question, and not this
+    # guard's. Callers already handle it in ways an abstention would make worse:
+    # `code_attribution_candidates` returns a structured row carrying the
+    # requested window and the skill's limitations, which is more useful than a
+    # reason string. Claiming "only marks, categories or domain records" would
+    # also simply be false — there are no records. Left as it was.
+    has_rows = _has(None)
+    if has_rows is None or not has_rows:
+        return None
+
+    return abstain(
+        f"This profile's {nvtx_table} table carries no range rows that "
+        f"{needs.lower()} can use — only marks, categories or domain records, "
+        f"which are instants and so have no extent to attribute a kernel to. "
+        f"Re-capture with nvtxRangePush/nvtxRangePop ranges around the code you "
+        f"want attributed.",
+        nvtx_event_types="none",
+    )
+
+
 def is_abstention(rows: list[dict] | None) -> bool:
     """True when ``rows`` is a skill saying it could not run.
 

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -137,9 +137,11 @@ def requires_pushpop_nvtx(conn, *, needs: str = "Region attribution") -> list[di
     trace with 15.9M NVTX rows is 100% eventType 59 — and PyTorch annotates with
     push/pop. The Start/End fixtures the tests build are synthetic on purpose.
 
-    NVTXT ranges (eventType 70/71, the text-import variants) are excluded on the
-    same grounds, so the message says "Push/Pop (eventType 59)" rather than
-    implying 59 is the only range kind Nsight records.
+    NVTXT ranges (eventType 70/71, the text-import variants) are excluded too —
+    the sweep filters ``eventType = 59`` and nothing else — so every message
+    here says "Push/Pop (eventType 59)" rather than implying 59 is the only
+    range kind Nsight records. Those profiles reach the final branch, which for
+    that reason names the eventTypes it measured instead of describing them.
 
     Fails open. Several test databases create ``NVTX_EVENTS`` with no
     ``eventType`` column at all, and a schema surprise must not be reported to a
@@ -154,15 +156,12 @@ def requires_pushpop_nvtx(conn, *, needs: str = "Region attribution") -> list[di
     adapter = wrap_connection(conn)
     nvtx_table = resolve_nvtx_table(conn)
 
-    def _has(event_type: int | None) -> bool | None:
-        """Does a row of this eventType exist? None when the probe cannot run.
-
-        ``event_type=None`` probes for any row at all, which needs no
-        ``eventType`` column.
-        """
-        where = "" if event_type is None else f"WHERE eventType = {int(event_type)}"
+    def _has(event_type: int) -> bool | None:
+        """Does a row of this eventType exist? None when the probe cannot run."""
         try:
-            cur = adapter.execute(f"SELECT 1 FROM {nvtx_table} {where} LIMIT 1")
+            cur = adapter.execute(
+                f"SELECT 1 FROM {nvtx_table} WHERE eventType = {int(event_type)} LIMIT 1"
+            )
             return cur.fetchone() is not None
         except DB_ERRORS:
             return None
@@ -190,24 +189,85 @@ def requires_pushpop_nvtx(conn, *, needs: str = "Region attribution") -> list[di
             nvtx_event_types="60",
         )
 
-    # An NVTX table with no rows at all is a different question, and not this
-    # guard's. Callers already handle it in ways an abstention would make worse:
-    # `code_attribution_candidates` returns a structured row carrying the
-    # requested window and the skill's limitations, which is more useful than a
-    # reason string. Claiming "only marks, categories or domain records" would
-    # also simply be false — there are no records. Left as it was.
-    has_rows = _has(None)
-    if has_rows is None or not has_rows:
+    # Neither kind the in-process NVTX range API produces is present. What the
+    # rows actually *are* is now measured rather than asserted: an earlier
+    # version of this branch told the user the table held "only marks,
+    # categories or domain records, which are instants", having probed nothing
+    # but 59 and 60. That is false for a profile imported from an .nvtxt file,
+    # whose ranges land as eventType 70/71 and do have extent — a confident
+    # wrong claim about the user's data, which is the one thing an abstention
+    # must never be. So census the column and name what is there.
+    #
+    # The census is a third scan of a table the two misses above have already
+    # scanned twice, and it runs only on a profile that is abstaining either
+    # way, so no healthy profile pays for it: measured on the 15.9M-row capture
+    # here, DISTINCT eventType costs 0.60s, while the guard on that same
+    # profile — which hits on the first 59 row and never reaches this line —
+    # takes 0.25ms.
+    types = _distinct_event_types(adapter, nvtx_table)
+    if not types:
+        # None means the census could not run (fail open, as above). Empty means
+        # an NVTX table with no rows, which is a different question and not this
+        # guard's: callers already handle it in ways an abstention would make
+        # worse — `code_attribution_candidates` returns a structured row
+        # carrying the requested window and the skill's limitations, which is
+        # more useful than a reason string.
         return None
 
+    present = ", ".join(_describe_event_type(adapter, t) for t in types)
     return abstain(
-        f"This profile's {nvtx_table} table carries no range rows that "
-        f"{needs.lower()} can use — only marks, categories or domain records, "
-        f"which are instants and so have no extent to attribute a kernel to. "
-        f"Re-capture with nvtxRangePush/nvtxRangePop ranges around the code you "
-        f"want attributed.",
-        nvtx_event_types="none",
+        f"This profile's {nvtx_table} table holds no Push/Pop ranges "
+        f"(eventType 59) — the only kind {needs.lower()} attributes a kernel "
+        f"to — and no Start/End ranges (eventType 60) either. What it does "
+        f"hold: {present}. Annotate the code you want attributed with "
+        f"nvtxRangePush/nvtxRangePop (torch.cuda.nvtx.range_push/range_pop, or "
+        f"the torch.cuda.nvtx.range context manager) so the ranges are "
+        f"recorded as eventType 59.",
+        nvtx_event_types=",".join(str(t) for t in types),
     )
+
+
+def _distinct_event_types(adapter, nvtx_table: str) -> list[int] | None:
+    """The eventTypes present in ``nvtx_table``, or None when it cannot be read.
+
+    None and ``[]`` are different answers and both callers depend on it: None is
+    "no eventType column, or the column is not readable as numbers" and must
+    fail open, ``[]`` is "the table has no rows", which is a state this module
+    deliberately says nothing about. NULL eventTypes are dropped rather than
+    reported, so a table of nothing but NULLs reads as ``[]`` and is likewise
+    left alone.
+
+    ``ValueError``/``TypeError`` are caught alongside the driver errors because
+    SQLite columns are dynamically typed: a fixture or an unusual export can put
+    text in ``eventType``, and the whole point of this guard is that a schema
+    surprise never becomes a claim about the user's annotation.
+    """
+    try:
+        cur = adapter.execute(f"SELECT DISTINCT eventType FROM {nvtx_table}")
+        return sorted({int(r[0]) for r in cur.fetchall() if r[0] is not None})
+    except (*DB_ERRORS, ValueError, TypeError):
+        return None
+
+
+def _describe_event_type(adapter, event_type: int) -> str:
+    """``"70 (NvtxtPushPopRange)"``, or just ``"70"`` when the name is unknown.
+
+    The name comes from the profile's own ``ENUM_NSYS_EVENT_TYPE`` table, which
+    is authoritative for the export in hand — 155 rows on the fixture here, of
+    which this package hard-codes none. Missing table, missing row or a read
+    error all degrade to the bare number: a name is a convenience, and inventing
+    one from a built-in list that may not match this Nsight version would be the
+    same class of mistake this branch exists to correct.
+    """
+    try:
+        row = adapter.execute(
+            "SELECT label FROM ENUM_NSYS_EVENT_TYPE WHERE id = ?", (int(event_type),)
+        ).fetchone()
+    except DB_ERRORS:
+        return str(event_type)
+    if not row or not row[0]:
+        return str(event_type)
+    return f"{event_type} ({row[0]})"
 
 
 def is_abstention(rows: list[dict] | None) -> bool:

--- a/src/nsys_ai/skills/builtins/code_attribution_candidates.py
+++ b/src/nsys_ai/skills/builtins/code_attribution_candidates.py
@@ -7,7 +7,7 @@ model/training regions, without claiming exact source-line attribution.
 
 from collections import Counter, defaultdict
 
-from ..base import Skill, SkillParam, requires_nvtx
+from ..base import Skill, SkillParam, requires_pushpop_nvtx
 
 _LIMITATIONS = [
     "NVTX attribution is temporal context, not exact source-line attribution",
@@ -164,7 +164,7 @@ def _top_kernels(kernels: list[dict], limit: int = 3) -> list[dict]:
 
 def _execute(conn, **kwargs):
 
-    guard = requires_nvtx(conn, needs="Code attribution")
+    guard = requires_pushpop_nvtx(conn, needs="Code attribution")
     if guard:
         return guard
 

--- a/src/nsys_ai/skills/builtins/iteration_detail.py
+++ b/src/nsys_ai/skills/builtins/iteration_detail.py
@@ -12,6 +12,9 @@ from ..base import Skill, SkillParam, requires_nvtx
 
 def _execute(conn, **kwargs):
 
+    # Plain requires_nvtx, NOT requires_pushpop_nvtx, on purpose: detect_iterations
+    # reads NVTX rows as bare intervals and never filters eventType, so it works
+    # unchanged on a Start/End-only profile. See requires_pushpop_nvtx.
     guard = requires_nvtx(conn, needs="Per-iteration breakdown")
     if guard:
         return guard

--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -14,6 +14,10 @@ def _execute(conn, **kwargs):
     # removes the skill from the output with no trace that it was even asked.
     from ...overlap import detect_iterations
 
+    # Plain requires_nvtx, NOT requires_pushpop_nvtx, on purpose: detect_iterations
+    # reads NVTX rows as bare intervals and never filters eventType, so it works
+    # unchanged on a Start/End-only profile — measured, identical rows. Guarding
+    # on Push/Pop here would break profiles that work today.
     guard = requires_nvtx(conn, needs="Iteration detection")
     if guard:
         return guard

--- a/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
@@ -15,7 +15,7 @@ Classifies by **leaf** label, not ancestor-path containment. See
 containment).
 """
 
-from ..base import Skill, requires_nvtx
+from ..base import Skill, requires_pushpop_nvtx
 
 _INDUCTOR_LEAF_MARKERS = ("## Call CompiledFxGraph",)
 _EAGER_LEAF_PREFIXES = ("c10d::", "nccl")
@@ -41,7 +41,7 @@ def _execute(conn, **kwargs):
     # removes the skill from the output with no trace that it was even asked.
     from ...nvtx_attribution import attribute_kernels_to_nvtx
 
-    guard = requires_nvtx(conn, needs="Call-mode classification")
+    guard = requires_pushpop_nvtx(conn, needs="Call-mode classification")
     if guard:
         return guard
 

--- a/src/nsys_ai/skills/builtins/nvtx_kernel_map.py
+++ b/src/nsys_ai/skills/builtins/nvtx_kernel_map.py
@@ -25,7 +25,7 @@ on ``nvtx_path``. The ``nccl_compile_context_breakdown`` skill is the
 canonical example.
 """
 
-from ..base import Skill, SkillParam, requires_nvtx
+from ..base import Skill, SkillParam, requires_pushpop_nvtx
 
 
 def _execute(conn, **kwargs):
@@ -35,7 +35,7 @@ def _execute(conn, **kwargs):
     # Say so rather than raising: callers catch and log, so an exception here
     # removes the skill from the output with no trace that it was even asked.
 
-    guard = requires_nvtx(conn, needs="Region attribution")
+    guard = requires_pushpop_nvtx(conn, needs="Region attribution")
     if guard:
         return guard
 

--- a/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
@@ -22,7 +22,7 @@ from nsys_ai.connection import (
     cached_nvtx_map_uses_path_id,
 )
 
-from ..base import Skill, SkillParam, requires_nvtx
+from ..base import Skill, SkillParam, requires_pushpop_nvtx
 
 
 def _pick_nvtx_view(conn, fallback: str) -> str:
@@ -95,7 +95,7 @@ def _execute(conn, **kwargs):
     if report_err:
         return [{"error": report_err}]
 
-    guard = requires_nvtx(conn, needs="Layer attribution")
+    guard = requires_pushpop_nvtx(conn, needs="Layer attribution")
     if guard:
         return guard
 

--- a/tests/test_abstention.py
+++ b/tests/test_abstention.py
@@ -552,6 +552,285 @@ def test_the_marker_is_not_re_implemented_across_the_codebase():
     assert not offenders, "raw marker checks outside skills/base.py:\n" + "\n".join(offenders)
 
 
+# ── #307: Start/End (eventType 60) ranges are not attributed, and say so ───
+#
+# Every attribution path filters `eventType = 59`. A profile annotated only
+# with Start/End ranges therefore produced an empty result and a formatter
+# asking "are NVTX annotations present?" — while `profile_health_manifest`
+# named the very same regions on the very same profile, because
+# `Profile.aggregate_nvtx_ranges` does not filter eventType. Two skills in one
+# run disagreeing, and the wrong one phrased as a question whose answer is yes.
+#
+# The decision is NOT to widen the filter. NVIDIA keeps push/pop ranges on a
+# per-thread stack, so they nest strictly by construction — which is precisely
+# what the sweep exploits. Start/End ranges "expose arbitrary concurrency (not
+# just nesting)" and "the start of a range can occur on a different thread than
+# the end". Feeding those to a nesting stack yields wrong parents, not more
+# coverage. So the four Push/Pop-dependent skills abstain with a stated reason.
+
+# The four skills whose attribution is a per-thread nesting sweep. The two
+# iteration skills are deliberately absent: `overlap.detect_iterations` never
+# filters eventType, so they work on a Start/End profile and guarding them
+# would be a regression. `test_iteration_timing_still_runs_on_start_end_ranges`
+# pins that.
+PUSHPOP_DEPENDENT = [
+    ("nvtx_kernel_map", {}),
+    ("nvtx_layer_breakdown", {}),
+    ("code_attribution_candidates", {"start_ns": 0, "end_ns": 10**9}),
+    ("nccl_compile_context_breakdown", {}),
+]
+
+
+def _build_nvtx_profile(path: Path, rows: list[tuple]) -> Path:
+    """A minimal attributable profile whose NVTX rows are exactly ``rows``.
+
+    Kernels and their correlated runtime launches sit inside the ranges, so the
+    only reason a skill can fail to attribute is the eventType — otherwise a
+    passing abstention assertion would prove nothing.
+
+    ``endGlobalTid`` is present because that is how real exports carry a
+    Start/End pair that begins and ends on different threads: one row with two
+    thread ids. Stated plainly — no capture available here has a populated one
+    (it is NULL across all 15.9M NVTX rows of the largest trace on this
+    machine), so the cross-thread row below is a reasoned reconstruction of the
+    documented shape, not an observed sample.
+    """
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE StringIds(id INTEGER PRIMARY KEY, value TEXT);
+        CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL(globalPid INTEGER, deviceId INTEGER,
+          streamId INTEGER, correlationId INTEGER, start INTEGER,"end" INTEGER,
+          shortName INTEGER, demangledName INTEGER,
+          gridX INTEGER, gridY INTEGER, gridZ INTEGER,
+          blockX INTEGER, blockY INTEGER, blockZ INTEGER);
+        CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME(globalTid INTEGER,
+          correlationId INTEGER, start INTEGER,"end" INTEGER, nameId INTEGER);
+        CREATE TABLE NVTX_EVENTS(globalTid INTEGER, endGlobalTid INTEGER,
+          start INTEGER,"end" INTEGER, text TEXT, eventType INTEGER,
+          rangeId INTEGER, textId INTEGER);
+        """
+    )
+    conn.executemany(
+        "INSERT INTO StringIds VALUES (?,?)",
+        [(1, "gemm_nn_128x128"), (2, "ncclDevKernel_AllReduce"), (24, "cudaLaunchKernel")],
+    )
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?,?,?,?,?,?,?,?,1,1,1,128,1,1)",
+        [
+            (100, 0, 7, 1, 1_000_000, 2_000_000, 1, 1),
+            (100, 0, 7, 2, 2_200_000, 3_000_000, 2, 2),
+        ],
+    )
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (?,?,?,?,24)",
+        [(100, 1, 900_000, 950_000), (100, 2, 2_100_000, 2_150_000)],
+    )
+    conn.executemany(
+        "INSERT INTO NVTX_EVENTS(globalTid, endGlobalTid, start, [end], text, "
+        "eventType, rangeId, textId) VALUES (?,?,?,?,?,?,?,NULL)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+    return path
+
+
+# Two ranges on ONE thread that overlap without nesting — impossible under
+# push/pop, which is the whole point — plus a pair whose start and end are on
+# different threads.
+_START_END_ROWS = [
+    (100, None, 500_000, 2_500_000, "train_step", 60, 0),
+    (100, None, 2_000_000, 3_500_000, "overlapping_phase", 60, 1),
+    (100, 101, 800_000, 2_800_000, "cross_thread_span", 60, 2),
+]
+_PUSH_POP_ROWS = [
+    (100, None, 500_000, 3_500_000, "train_step", 59, 0),
+    (100, None, 900_000, 2_500_000, "forward", 59, 1),
+]
+# eventType 34 is NvtxMark in the profile's own ENUM_NSYS_EVENT_TYPE table:
+# an instant, with no duration to attribute a kernel to.
+_MARKS_ONLY_ROWS = [
+    (100, None, 900_000, -1, "step_begin", 34, 0),
+    (100, None, 2_600_000, -1, "step_end", 34, 1),
+]
+
+
+@pytest.fixture
+def start_end_profile(tmp_path):
+    return _build_nvtx_profile(tmp_path / "start_end.sqlite", _START_END_ROWS)
+
+
+@pytest.fixture
+def push_pop_profile(tmp_path):
+    return _build_nvtx_profile(tmp_path / "push_pop.sqlite", _PUSH_POP_ROWS)
+
+
+def test_the_start_end_fixture_really_is_start_end_only(start_end_profile):
+    """Guard the premise, so the abstention assertions cannot go vacuous."""
+    conn = sqlite3.connect(start_end_profile)
+    try:
+        types = {r[0] for r in conn.execute("SELECT DISTINCT eventType FROM NVTX_EVENTS")}
+        cross = conn.execute(
+            "SELECT count(*) FROM NVTX_EVENTS WHERE endGlobalTid IS NOT NULL "
+            "AND endGlobalTid != globalTid"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert types == {60}, f"the fixture is no longer Start/End-only: {types}"
+    assert cross == 1, "the cross-thread row that push/pop cannot express is gone"
+
+
+@pytest.mark.parametrize("skill_name,kwargs", PUSHPOP_DEPENDENT)
+def test_start_end_only_nvtx_abstains_instead_of_reporting_nothing(
+    skill_name, kwargs, start_end_profile
+):
+    """The bug: silence that reads as "this profile has no annotation"."""
+    from nsys_ai.skills.base import is_abstention
+
+    conn = sqlite3.connect(start_end_profile)
+    try:
+        rows = get_skill(skill_name).execute(conn, **kwargs)
+    finally:
+        conn.close()
+
+    assert is_abstention(rows), f"{skill_name} reported nothing instead of abstaining: {rows[:1]}"
+    reason = rows[0]["reason"]
+    # Name the kind and the number, so the user can check it against their own
+    # annotation calls rather than guessing what "unsupported" means.
+    assert "Start/End" in reason, reason
+    assert "60" in reason, reason
+    assert "59" in reason, reason
+    # And say what to do about it.
+    assert "nvtxRangePush" in reason, reason
+    assert rows[0].get("nvtx_event_types") == "60"
+
+
+@pytest.mark.parametrize("skill_name,kwargs", PUSHPOP_DEPENDENT)
+def test_push_pop_nvtx_is_not_swept_up_by_the_new_guard(skill_name, kwargs, push_pop_profile):
+    """A guard that is too broad is the real failure mode.
+
+    Same fixture builder, same kernels, same ranges — only eventType differs —
+    so this pins that the abstention above is caused by the event kind and not
+    by the fixture being unattributable in the first place.
+    """
+    from nsys_ai.skills.base import is_abstention
+
+    conn = sqlite3.connect(push_pop_profile)
+    try:
+        rows = get_skill(skill_name).execute(conn, **kwargs)
+    finally:
+        conn.close()
+    assert not is_abstention(rows), (
+        f"{skill_name} told a Push/Pop profile its annotation was the wrong kind: {rows[0]}"
+    )
+
+
+def test_the_push_pop_fixture_is_actually_attributable(push_pop_profile):
+    """Otherwise the test above passes on an empty result and proves nothing."""
+    conn = sqlite3.connect(push_pop_profile)
+    try:
+        rows = get_skill("nvtx_kernel_map").execute(conn)
+    finally:
+        conn.close()
+    assert rows, "the positive fixture attributes no kernels — the negative test is vacuous"
+    assert {r["nvtx_text"] for r in rows} & {"forward", "train_step"}
+
+
+def test_iteration_timing_still_runs_on_start_end_ranges(start_end_profile):
+    """Deliberate scope. `overlap.detect_iterations` is eventType-agnostic, so
+    these two skills work on Start/End ranges and must not be guarded."""
+    from nsys_ai.skills.base import is_abstention
+
+    conn = sqlite3.connect(start_end_profile)
+    try:
+        rows = get_skill("iteration_timing").execute(conn, marker="train_step")
+    finally:
+        conn.close()
+    assert not is_abstention(rows), (
+        "iteration_timing was guarded on Push/Pop; it does not need it and "
+        f"profiles that work today would stop: {rows[0]}"
+    )
+
+
+def test_marks_only_nvtx_abstains_with_its_own_reason(tmp_path):
+    """Neither 59 nor 60: the table has no ranges at all, only instants."""
+    from nsys_ai.skills.base import is_abstention
+
+    path = _build_nvtx_profile(tmp_path / "marks.sqlite", _MARKS_ONLY_ROWS)
+    conn = sqlite3.connect(path)
+    try:
+        rows = get_skill("nvtx_kernel_map").execute(conn)
+    finally:
+        conn.close()
+
+    assert is_abstention(rows), rows[:1]
+    assert rows[0].get("nvtx_event_types") == "none"
+    assert "no range rows" in rows[0]["reason"], rows[0]["reason"]
+
+
+def test_an_empty_nvtx_table_is_left_alone_by_the_push_pop_guard(tmp_path):
+    """Deliberate scope, and the one case the guard must NOT claim.
+
+    A present-but-empty NVTX_EVENTS table is a third state, distinct from
+    "Start/End only" and "marks only", and it is not what #307 is about. The
+    "only marks, categories or domain records" reason would be plainly false
+    there — the table holds no records at all — and `code_attribution_candidates`
+    already answers this case with a structured row carrying the requested
+    window and the skill's limitations, which a reason string would replace with
+    something less useful.
+    """
+    from nsys_ai.skills.base import is_abstention, requires_pushpop_nvtx
+
+    path = _build_nvtx_profile(tmp_path / "empty_nvtx.sqlite", [])
+    conn = sqlite3.connect(path)
+    try:
+        guard = requires_pushpop_nvtx(conn, needs="Region attribution")
+        rows = get_skill("nvtx_layer_breakdown").execute(conn)
+    finally:
+        conn.close()
+
+    assert guard is None, f"an empty NVTX table was claimed as the wrong kind: {guard}"
+    assert not is_abstention(rows)
+
+
+def test_the_push_pop_guard_fails_open_when_there_is_no_eventType_column(tmp_path):
+    """A schema surprise must not be reported as "your annotation is the wrong
+    kind". Five test modules build NVTX_EVENTS without an eventType column."""
+    from nsys_ai.skills.base import is_abstention, requires_pushpop_nvtx
+
+    path = tmp_path / "no_eventtype.sqlite"
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE NVTX_EVENTS(globalTid INTEGER, start INTEGER,"end" INTEGER, text TEXT);
+        INSERT INTO NVTX_EVENTS VALUES (100, 0, 9000, 'my_layer');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(path)
+    try:
+        guard = requires_pushpop_nvtx(conn, needs="Region attribution")
+    finally:
+        conn.close()
+    assert guard is None, f"a missing column was turned into a false abstention: {guard}"
+    assert not is_abstention(guard or [])
+
+
+def test_the_push_pop_guard_is_defined_once():
+    """Same reason as the NVTX guard below: an inlined eventType probe would
+    drift, and one that hard-codes NVTX_EVENTS misses NVTX_EVENTS_V2."""
+    src_root = Path(__file__).resolve().parent.parent / "src" / "nsys_ai"
+    copies = [
+        p.relative_to(src_root)
+        for p in (src_root / "skills" / "builtins").rglob("*.py")
+        if "eventType = 60" in p.read_text() or "eventType=60" in p.read_text()
+    ]
+    assert copies == [], f"an eventType-60 probe was inlined in: {copies}"
+
+
 def test_the_nvtx_guard_is_defined_once():
     """Six skills needed the same resolve-and-abstain block.
 

--- a/tests/test_abstention.py
+++ b/tests/test_abstention.py
@@ -754,7 +754,7 @@ def test_iteration_timing_still_runs_on_start_end_ranges(start_end_profile):
 
 
 def test_marks_only_nvtx_abstains_with_its_own_reason(tmp_path):
-    """Neither 59 nor 60: the table has no ranges at all, only instants."""
+    """Neither 59 nor 60: a third reason, and it reports the type it measured."""
     from nsys_ai.skills.base import is_abstention
 
     path = _build_nvtx_profile(tmp_path / "marks.sqlite", _MARKS_ONLY_ROWS)
@@ -765,8 +765,77 @@ def test_marks_only_nvtx_abstains_with_its_own_reason(tmp_path):
         conn.close()
 
     assert is_abstention(rows), rows[:1]
-    assert rows[0].get("nvtx_event_types") == "none"
-    assert "no range rows" in rows[0]["reason"], rows[0]["reason"]
+    reason = rows[0]["reason"]
+    assert rows[0].get("nvtx_event_types") == "34", reason
+    assert "34" in reason, reason
+    # It must still name what it needs, or the user cannot act on it.
+    assert "59" in reason and "nvtxRangePush" in reason, reason
+
+
+def test_nvtxt_imported_ranges_are_not_called_marks(tmp_path):
+    """The fallthrough must not describe rows it never inspected.
+
+    A profile built by `nsys import` from an .nvtxt annotation file carries its
+    ranges as eventType 70/71 (NvtxtPushPopRange / NvtxtStartEndRange in the
+    profile's own ENUM_NSYS_EVENT_TYPE). Those are not attributed here — the
+    sweep filters eventType 59 and nothing else — so an abstention is right.
+    But an earlier version of this branch probed only "does any row exist" and
+    then told the user the table held "only marks, categories or domain
+    records, which are instants": two claims about their data, both false, from
+    a branch that had inspected neither. Reporting `nvtx_event_types="none"`
+    was wrong there for the same reason.
+    """
+    from nsys_ai.skills.base import is_abstention
+
+    for event_type in (70, 71):
+        path = _build_nvtx_profile(
+            tmp_path / f"nvtxt_{event_type}.sqlite",
+            [(100, None, 500_000, 3_000_000, "imported_step", event_type, 0)],
+        )
+        conn = sqlite3.connect(path)
+        try:
+            rows = get_skill("nvtx_kernel_map").execute(conn)
+        finally:
+            conn.close()
+
+        assert is_abstention(rows), f"eventType {event_type}: {rows[:1]}"
+        reason = rows[0]["reason"]
+        # The claims that were false.
+        assert "instants" not in reason, reason
+        assert "only marks" not in reason, reason
+        assert "no range rows" not in reason, reason
+        # And the measured truth, in both the prose and the machine field.
+        assert str(event_type) in reason, reason
+        assert rows[0].get("nvtx_event_types") == str(event_type), rows[0]
+
+
+def test_the_fallthrough_names_event_types_from_the_profiles_own_enum(tmp_path):
+    """`ENUM_NSYS_EVENT_TYPE` is the authority for the export in hand.
+
+    Naming the type from a list hard-coded here would be the same mistake this
+    branch exists to correct, one Nsight release later. The bare number is the
+    documented fallback when the profile does not carry the table, which the
+    fixtures above exercise.
+    """
+    from nsys_ai.skills.base import requires_pushpop_nvtx
+
+    path = _build_nvtx_profile(
+        tmp_path / "nvtxt_named.sqlite",
+        [(100, None, 500_000, 3_000_000, "imported_step", 70, 0)],
+    )
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        "CREATE TABLE ENUM_NSYS_EVENT_TYPE(id INTEGER PRIMARY KEY, label TEXT);"
+        "INSERT INTO ENUM_NSYS_EVENT_TYPE VALUES (70, 'NvtxtPushPopRange');"
+    )
+    conn.commit()
+    try:
+        guard = requires_pushpop_nvtx(conn, needs="Region attribution")
+    finally:
+        conn.close()
+
+    assert guard is not None
+    assert "70 (NvtxtPushPopRange)" in guard[0]["reason"], guard[0]["reason"]
 
 
 def test_an_empty_nvtx_table_is_left_alone_by_the_push_pop_guard(tmp_path):
@@ -796,7 +865,14 @@ def test_an_empty_nvtx_table_is_left_alone_by_the_push_pop_guard(tmp_path):
 
 def test_the_push_pop_guard_fails_open_when_there_is_no_eventType_column(tmp_path):
     """A schema surprise must not be reported as "your annotation is the wrong
-    kind". Five test modules build NVTX_EVENTS without an eventType column."""
+    kind".
+
+    Not hypothetical: eight modules in this suite (test_baseline, test_diff,
+    test_e2e_golden_loop, test_fingerprint, test_profile_resolve,
+    test_region_mfu, test_skills, test_tools_profile) build NVTX_EVENTS with no
+    eventType column at all. The count is only there to say the shape is
+    common; if it drifts, nothing about this test does.
+    """
     from nsys_ai.skills.base import is_abstention, requires_pushpop_nvtx
 
     path = tmp_path / "no_eventtype.sqlite"
@@ -817,6 +893,35 @@ def test_the_push_pop_guard_fails_open_when_there_is_no_eventType_column(tmp_pat
         conn.close()
     assert guard is None, f"a missing column was turned into a false abstention: {guard}"
     assert not is_abstention(guard or [])
+
+
+def test_a_non_numeric_eventType_column_fails_open_too(tmp_path):
+    """SQLite columns are dynamically typed, so the census can meet text.
+
+    Same contract as the missing-column case: a schema surprise must produce no
+    claim at all, not a claim about the user's annotation, and certainly not a
+    ValueError out of a guard.
+    """
+    from nsys_ai.skills.base import requires_pushpop_nvtx
+
+    path = tmp_path / "text_eventtype.sqlite"
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE NVTX_EVENTS(globalTid INTEGER, start INTEGER,"end" INTEGER,
+          text TEXT, eventType TEXT);
+        INSERT INTO NVTX_EVENTS VALUES (100, 0, 9000, 'my_layer', 'NvtxMark');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    conn = sqlite3.connect(path)
+    try:
+        guard = requires_pushpop_nvtx(conn, needs="Region attribution")
+    finally:
+        conn.close()
+    assert guard is None, f"a text eventType was turned into a false abstention: {guard}"
 
 
 def test_the_push_pop_guard_is_defined_once():


### PR DESCRIPTION
## The defect

Every NVTX kernel-attribution path filters `WHERE eventType = 59` (Push/Pop). A profile annotated
only with Start/End ranges (`eventType = 60`) therefore got no attribution at all, silently — no
abstention, no warning, just an empty result.

Worse than silent: the empty result was rendered by a formatter that asks *"are NVTX annotations
present?"* — a question whose answer on such a profile is **yes**. `profile_health_manifest` names
the very same regions on the very same profile, because `Profile.aggregate_nvtx_ranges` does not
filter `eventType`. Two skills in one run contradicting each other, and the wrong one phrased as a
question.

## Evidence

Run on this machine against a synthetic Start/End profile — three eventType-60 ranges, with kernels
and their correlated runtime launches sitting *inside* them, so the only possible reason attribution
can fail is the eventType:

```
attribute_kernels_to_nvtx(start/end-only) -> []
NVTX_EVENTS rows present -> [('train_step', 60), ('cross_thread_span', 60), ('overlapping_phase', 60)]
```

The same profile, through the path that does not filter eventType — the contradiction, on one
profile in one process:

```
Profile.aggregate_nvtx_ranges() ->
  [{'text': 'cross_thread_span', 'total_ns': 2000000, 'count': 1, 'avg_ns': 2000000.0},
   {'text': 'train_step',        'total_ns': 2000000, 'count': 1, 'avg_ns': 2000000.0},
   {'text': 'overlapping_phase', 'total_ns': 1500000, 'count': 1, 'avg_ns': 1500000.0}]
```

After the change, the guarded skill on that same profile:

```
nvtx_kernel_map is_abstention -> True
reason -> This profile's NVTX annotation consists only of Start/End ranges (eventType 60). Region
          attribution maps kernels to ranges with a per-thread nesting sweep, which is valid only
          for Push/Pop ranges (eventType 59): those ar...
nvtx_event_types -> 60
```

The full suite after the change, on this machine:

```
$ python3 -m pytest tests/ -q
1471 passed, 135 skipped in 255.54s (0:04:15)
$ ruff check src/ tests/
All checks passed!
$ bandit -q -r src/ -c pyproject.toml
(no findings; 5 pre-existing nosec warnings only)
```

## The fix — abstain, do not widen the filter

The `eventType = 59` filter is **not** widened, and two comments now say so at the two sites that
carry it (`nvtx_attribution._sort_merge_attribute`, `parquet_cache._stream_nvtx_ranges`).

NVIDIA keeps push/pop ranges on a per-thread stack, so a thread's push/pop ranges are strictly
nested by construction — that is exactly the property the sweep exploits. Start/End ranges "expose
arbitrary concurrency (not just nesting)" and "the start of a range can occur on a different thread
than the end" (Nsight materialises that as one row whose `globalTid` and `endGlobalTid` differ).
Feeding those to a nesting stack would produce confident, *wrong* parents — not more coverage.

So a new guard `skills.base.requires_pushpop_nvtx` makes the exclusion visible, per the abstention
contract:

- **Push/Pop present** → pass through, unchanged behaviour.
- **Start/End only** → abstain naming eventType 60, why the sweep does not apply, and how to fix it
  (`nvtxRangePush`/`nvtxRangePop`, `torch.cuda.nvtx.range`). `nvtx_event_types="60"`.
- **Neither** → census `DISTINCT eventType` and report *what was measured*, naming each type from
  the profile's own `ENUM_NSYS_EVENT_TYPE` table (authoritative for the export in hand; this package
  hard-codes no such list). This matters for `nsys import` of an `.nvtxt` file, whose ranges land as
  eventType 70/71: an earlier revision of this branch told those users the table held "only marks,
  categories or domain records, which are instants" — two claims, both false, from a branch that had
  inspected neither. `nvtx_event_types` carries the measured list too.
- **Fails open** everywhere a probe cannot run. Eight test modules build `NVTX_EVENTS` with no
  `eventType` column at all, and a schema surprise must never be reported to a user as "your
  annotation is the wrong kind". A non-numeric `eventType` (SQLite types are dynamic) fails open for
  the same reason.

Applied to the four skills whose attribution *is* the per-thread sweep: `nvtx_kernel_map`,
`nvtx_layer_breakdown`, `code_attribution_candidates`, `nccl_compile_context_breakdown`.

Deliberately **not** applied to `iteration_timing` / `iteration_detail`: `overlap.detect_iterations`
reads NVTX rows as bare intervals and never filters `eventType`, so those skills already work on a
Start/End-only profile. Guarding them would have been a regression; a test pins that they still run.

Probe order is 59 first, deliberately. On the largest capture available here (15.9M NVTX rows) the
push/pop probe returns on the first row in 0.05ms while a miss costs a full scan (0.48s), so probing
60 first would tax every healthy profile for nothing. The `DISTINCT` census (0.60s there) is reached
only by a profile that is abstaining either way; on that capture the guard returns in 0.25ms without
reaching it.

## Mutation check

Ran, not assumed. Two independent reverts:

1. `requires_pushpop_nvtx` → `requires_nvtx` in `nvtx_kernel_map.py`:
   `3 failed, 49 passed` — `test_start_end_only_nvtx_abstains_instead_of_reporting_nothing[nvtx_kernel_map]`,
   `test_marks_only_nvtx_abstains_with_its_own_reason`, `test_nvtxt_imported_ranges_are_not_called_marks`
   (the last with `AssertionError: eventType 70: []` — the exact silent-empty symptom).
2. Census branch reverted to the old hardcoded `"only marks, categories or domain records"` /
   `nvtx_event_types="none"`: `5 failed, 47 passed`, including
   `test_the_fallthrough_names_event_types_from_the_profiles_own_enum`,
   `test_an_empty_nvtx_table_is_left_alone_by_the_push_pop_guard` and
   `test_a_non_numeric_eventType_column_fails_open_too`.

Both reverts restored; suite re-run green afterwards.

## Out of scope, stated rather than half-solved

- **Mixed profiles.** If a profile holds both kinds, the 59 probe hits, the guard passes, and its
  Start/End ranges are still dropped from attribution with no signal. Rank-ordering every range kind
  is not worth building for a case with no observed users: no committed fixture and no real capture
  available here holds a single eventType-60 row (the 3.5GB trace with 15.9M NVTX rows is 100%
  eventType 59), and PyTorch annotates with push/pop. Documented in `docs/03-nvtx-annotations.md`.
- **An empty-but-present `NVTX_EVENTS` table.** A distinct third state, left alone on purpose:
  `code_attribution_candidates` already answers it with a structured row carrying the requested
  window and the skill's limitations, which is more useful than a reason string. A test pins that.
- **The fixtures are synthetic, and labelled as such.** No capture on this machine has a populated
  `endGlobalTid` (NULL across all 15.9M NVTX rows of the largest one), so the cross-thread row is a
  reasoned reconstruction of the documented shape, not an observed sample. The test docstring says so.

No new runtime dependencies. No new CLI subcommand. No new skipped tests.

Closes #307.
