### PR TITLE
fix(cli): surface `agent` in --help, and say what `agent analyze` actually covers

### DIFF
--- a/docs/root-causes/README.md
+++ b/docs/root-causes/README.md
@@ -1,30 +1,61 @@
-# 📖 Book of Root Causes — Quick Reference
+# Book of Root Causes — Quick Reference
 
 > Performance problems that cost millions of dollars in GPU hours, distilled into a single table.
 
 | # | Root Cause | Symptom | Detection Skill | Severity |
 |---|-----------|---------|----------------|----------|
-| 1 | **GPU Bubbles** | Idle gaps between kernels on a stream | `gpu_idle_gaps` | 🔴 High |
-| 2 | **CPU Bottleneck** | Low GPU utilization despite available work | `thread_utilization` | 🔴 High |
-| 3 | **NCCL Serialization** | AllReduce not overlapping with compute | `nccl_breakdown` | 🔴 High |
-| 4 | **Excessive H2D Transfers** | Large memory copies in the critical path | `memory_transfers` | 🟠 Medium |
-| 5 | **Small Kernel Overhead** | Thousands of tiny kernels with high launch cost | `kernel_launch_overhead` | 🟠 Medium |
-| 6 | **Kernel Hotspot** | Single kernel dominates >50% of total time | `top_kernels` | 🔴 High |
-| 7 | **Missing NVTX** | Cannot attribute kernels to source code | `nvtx_kernel_map` | 🟡 Low |
-| 8 | **GC Pauses** | Python garbage collection stalls GPU pipeline | `gpu_idle_gaps` | 🟠 Medium |
-| 9 | **Module Loading** | Import/JIT compilation during forward pass | `gpu_idle_gaps` | 🟡 Low |
-| 10 | **Compute-Comm Imbalance** | Some ranks finish early, wait at barrier | `nccl_breakdown` | 🔴 High |
-| 11 | **Stream Serialization** | Streams that should overlap but run sequentially | `gpu_idle_gaps` | 🟠 Medium |
-| 12 | **Excessive Synchronization** | `cudaDeviceSynchronize` in the loop | `kernel_launch_overhead` | 🟠 Medium |
-| 13 | **FP32 Fallback** | Tensor Core eligible kernels falling back to FP32/SIMT | `tensor_core_usage` | 🔴 High |
+| 1 | **GPU Bubbles** | Idle gaps between kernels on a stream | `gpu_idle_gaps` | High |
+| 2 | **CPU Bottleneck** | Low GPU utilization despite available work | `thread_utilization` | High |
+| 3 | **NCCL Serialization** | AllReduce not overlapping with compute | `nccl_breakdown` | High |
+| 4 | **Excessive H2D Transfers** | Large memory copies in the critical path | `memory_transfers` | Medium |
+| 5 | **Small Kernel Overhead** | Thousands of tiny kernels with high launch cost | `kernel_launch_overhead` | Medium |
+| 6 | **Kernel Hotspot** | Single kernel dominates >50% of total time | `top_kernels` | High |
+| 7 | **Missing NVTX** | Cannot attribute kernels to source code | `nvtx_kernel_map` | Low |
+| 8 | **GC Pauses** | Python garbage collection stalls GPU pipeline | `gpu_idle_gaps` | Medium |
+| 9 | **Module Loading** | Import/JIT compilation during forward pass | `gpu_idle_gaps` | Low |
+| 10 | **Compute-Comm Imbalance** | Some ranks finish early, wait at barrier | `nccl_breakdown` | High |
+| 11 | **Stream Serialization** | Streams that should overlap but run sequentially | `gpu_idle_gaps` | Medium |
+| 12 | **Excessive Synchronization** | `cudaDeviceSynchronize` in the loop | `kernel_launch_overhead` | Medium |
+| 13 | **FP32 Fallback** | Tensor Core eligible kernels falling back to FP32/SIMT | `tensor_core_usage` | High |
 
 ---
 
 ## How to Use This
 
-1. **Run `nsys-ai agent analyze <profile>`** — the agent checks for all of these automatically
-2. **Check the top hits** — focus on 🔴 High severity items first
-3. **Drill down** — run the specific detection skill for more detail
-4. **Read the [full writeup](book.md)** for remediation guidance
+1. **Run `nsys-ai agent analyze <profile>`.** It runs a fixed set of skills and prints one
+   report. Adding `--evidence` also runs the evidence pipeline and writes a findings JSON.
+2. **Check the top hits** — start with the High severity rows.
+3. **Drill down** with `nsys-ai skill run <skill> <profile>` for the detail behind a hit,
+   or ask a question directly with `nsys-ai ask <profile> "..."`.
+4. **Read the [full writeup](book.md)** for remediation guidance.
+
+## What `agent analyze` covers
+
+Five of the detection skills named above run on every `agent analyze`: `gpu_idle_gaps`,
+`top_kernels`, `nccl_breakdown`, `memory_transfers`, and `kernel_launch_overhead`. Rows 1,
+3, 4, 5, 6, 8, 9, 10, 11 and 12 are therefore reported without any extra command.
+
+The other three named skills are not part of that run. Two of the three root causes are
+still surfaced in the report anyway, by a different skill; the third needs one explicit
+command:
+
+- **Row 13, FP32 Fallback.** `tensor_core_usage` does not run, but `top_kernels` carries
+  Tensor Core columns: the report marks each kernel that is TC eligible but not using
+  Tensor Cores, and the evidence pipeline emits a `tc_eligible_inactive` finding for it.
+  This signal comes from the Parquet cache; on the pure-SQLite fallback path TC
+  eligibility is unknown and no such finding is emitted.
+- **Row 7, Missing NVTX.** `nvtx_kernel_map` does not run, but a profile without usable
+  NVTX is reported anyway: `iteration_timing` and `nvtx_layer_breakdown` abstain with an
+  explicit "no NVTX annotation — re-capture with NVTX enabled" message, and the evidence
+  pipeline emits `profile_insufficient_nvtx_coverage`.
+- **Row 2, CPU Bottleneck.** Not covered by a plain `agent analyze`. The skill the table
+  names, `thread_utilization`, needs CPU sampling in the capture (a `COMPOSITE_EVENTS`
+  table); without it it abstains and says so. Per-thread attribution does not require that
+  capture option, though: `nsys-ai skill run cpu_gpu_pipeline <profile>` derives it from
+  the CUDA runtime trace joined to kernels by `correlationId`, and reports per-thread
+  dispatch counts, launch-queue depth and GPU starvation events on a profile with no CPU
+  sampling at all. `agent analyze --evidence` reaches that data too — `critical_path` runs
+  there and folds the starvation count into its CPU attribution line alongside a bound
+  verdict — but neither `critical_path` nor `cpu_gpu_pipeline` runs without `--evidence`.
 
 See also: [veteran-questions.md](veteran-questions.md) — diagnostic questions a performance expert would ask.

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -122,7 +122,6 @@ def main():
         "perfetto",
         "tui",
         "timeline",
-        "agent",
     }
     use_legacy_skill_mgmt = (
         len(sys.argv) > 2 and sys.argv[1] == "skill" and sys.argv[2] in {"add", "remove", "save"}

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -257,6 +257,41 @@ def _register_root_cause_parser(sub):
     return p
 
 
+def _register_agent_parser(sub):
+    """Register the ``agent`` subcommand tree on *sub*.
+
+    Lives on the public parser only. ``agent`` is not in ``app.main``'s
+    ``legacy_commands`` set, so ``nsys-ai agent ...`` always builds the public
+    parser and a second registration on the legacy parser would be dead.
+    """
+    p = sub.add_parser("agent", help="AI agent for profile analysis")
+    agent_sub = p.add_subparsers(dest="agent_action")
+    sp_analyze = agent_sub.add_parser("analyze", help="Full auto-analysis report")
+    sp_analyze.add_argument("profile", help="Path to .sqlite file")
+    sp_analyze.add_argument(
+        "--trim",
+        nargs=2,
+        type=float,
+        metavar=("START_S", "END_S"),
+        default=None,
+        help="Time window in seconds (recommended for large profiles)",
+    )
+    sp_analyze.add_argument(
+        "--evidence", action="store_true", help="Also output evidence findings JSON"
+    )
+    sp_analyze.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Output path for findings JSON (default: findings.json)",
+    )
+    sp_ask = agent_sub.add_parser("ask", help="Ask a question about a profile")
+    sp_ask.add_argument("profile", help="Path to .sqlite file")
+    sp_ask.add_argument("question", help="Natural language question")
+    p.set_defaults(handler=_cmd_agent)
+    return p
+
+
 # ---------------------------------------------------------------------------
 # Main parser — public CLI surface visible to ``nsys-ai --help``
 # ---------------------------------------------------------------------------
@@ -270,8 +305,9 @@ def _build_parser():
     sub = parser.add_subparsers(
         dest="command",
         metavar=(
-            "{open,web,timeline-web,loop,chat,ask,agent-guide,"
-            "info,doctor,skill,evidence,report,diff,diff-web,export,cutracer,root-cause,help}"
+            "{open,web,timeline-web,loop,chat,ask,agent,agent-guide,"
+            "info,doctor,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
+            "root-cause,help}"
         ),
     )
 
@@ -773,6 +809,7 @@ def _build_parser():
     _register_info_parser(sub)
     _register_doctor_parser(sub)
     _register_skill_parser(sub, include_management=False)
+    _register_agent_parser(sub)
     _register_evidence_parser(sub)
     _register_root_cause_parser(sub)
 
@@ -900,32 +937,6 @@ def _register_legacy_commands(sub):
     p.set_defaults(handler=_cmd_timeline)
 
     _register_skill_parser(sub, include_management=True)
-
-    p = sub.add_parser("agent", help="AI agent for profile analysis")
-    agent_sub = p.add_subparsers(dest="agent_action")
-    sp_analyze = agent_sub.add_parser("analyze", help="Full auto-analysis report")
-    sp_analyze.add_argument("profile", help="Path to .sqlite file")
-    sp_analyze.add_argument(
-        "--trim",
-        nargs=2,
-        type=float,
-        metavar=("START_S", "END_S"),
-        default=None,
-        help="Time window in seconds (recommended for large profiles)",
-    )
-    sp_analyze.add_argument(
-        "--evidence", action="store_true", help="Also output evidence findings JSON"
-    )
-    sp_analyze.add_argument(
-        "-o",
-        "--output",
-        default=None,
-        help="Output path for findings JSON (default: findings.json)",
-    )
-    sp_ask = agent_sub.add_parser("ask", help="Ask a question about a profile")
-    sp_ask.add_argument("profile", help="Path to .sqlite file")
-    sp_ask.add_argument("question", help="Natural language question")
-    p.set_defaults(handler=_cmd_agent)
 
     # ── evidence ──────────────────────────────────────────────────
     _register_evidence_parser(sub)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,7 @@ def test_subcommands():
         "diff-web",
         "loop",
         "export",
+        "agent",
         "agent-guide",
         "info",
         "skill",
@@ -52,9 +53,43 @@ def test_subcommands():
     for hidden in ["summary", "overlap", "analyze"]:
         assert hidden not in usage_text
 
-    # 'agent-guide' is public, but 'agent' should be hidden
-    assert ",agent," not in usage_text
-    assert ",agent}" not in usage_text
+    # 'agent' is public. The zero-arg banner tells the reader that
+    # `nsys-ai agent analyze` exists, and that report has no other entry point
+    # (`report`/`analyze` run a different pipeline), so --help must confirm it.
+    assert ",agent," in usage_text
+
+    # The usage metavar is hand-maintained; keep it honest about what is
+    # actually registered so machine consumers can trust it.
+    import argparse
+
+    from nsys_ai.cli.parsers import _build_parser
+
+    registered = set()
+    for action in _build_parser()._actions:
+        if isinstance(action, argparse._SubParsersAction):
+            registered = set(action.choices)
+    assert registered, "could not find the subparsers action on the public parser"
+    advertised = set(usage_text.split("{", 1)[1].split("}", 1)[0].split(","))
+    assert registered == advertised, (
+        f"usage metavar out of sync: missing {sorted(registered - advertised)}, "
+        f"stale {sorted(advertised - registered)}"
+    )
+
+
+def test_agent_subcommand_is_reachable():
+    """`nsys-ai agent` must parse the same whether or not it is in --help."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "agent", "--help"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "{analyze,ask}" in result.stdout
+
+    # Bare `agent` still prints its usage line and exits non-zero (unchanged).
+    bare = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "agent"], capture_output=True, text=True
+    )
+    assert bare.returncode == 1
+    assert "Usage: nsys-ai agent {analyze,ask}" in bare.stdout
 
 
 def test_custom_help_mentions_default_profile_shortcut():

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1038,3 +1038,91 @@ def test_run_skill_name_param_does_not_collide(minimal_nsys_conn):
     )
     # Returns formatted text (an error string is fine) — the point is no raise.
     assert isinstance(result, str)
+
+
+def test_root_cause_readme_coverage_claim_matches_wiring():
+    """Pin the coverage claim in docs/root-causes/README.md to the actual wiring.
+
+    Read off the two statically declared skill lists: ``Agent.analyze``'s
+    ``core_skills`` (what a plain ``agent analyze`` runs) and
+    ``EvidenceBuilder._SKILL_PIPELINE`` (what ``--evidence`` adds). Each
+    assertion below is tied to the sentence it guards, and the two lists are
+    kept separate on purpose: the README distinguishes "runs on every
+    ``agent analyze``" from "runs under ``--evidence``", so a claim about the
+    former must be checked against ``core_skills`` alone. Checking it against
+    the union would let a skill silently drop out of the plain run while this
+    test stayed green.
+
+    Scope, deliberately narrow: this reads those two lists only. It does NOT
+    model runtime fan-out (``critical_path`` -> ``cpu_gpu_pipeline``,
+    ``profile_health_manifest`` -> ``root_cause_matcher`` -> ``sync_cost_analysis``),
+    so it under-reports the skills that actually execute — a skill absent from
+    both lists may still run as fan-out. Every claim asserted here is one that
+    membership in these lists is sufficient to settle. Do not "fix" it into a
+    general reachability check; that framing was tried and rejected because it
+    cannot see fan-out.
+
+    If this fails, docs/root-causes/README.md and the pipeline have diverged;
+    update both together.
+    """
+    import inspect
+    import re
+
+    from nsys_ai.agent.loop import Agent
+    from nsys_ai.evidence_builder import EvidenceBuilder
+
+    src = inspect.getsource(Agent.analyze)
+    body = src.split("core_skills = [", 1)[1].split("]", 1)[0]
+    core_skills = set(re.findall(r'"([a-z0-9_]+)"', body))
+    assert len(core_skills) >= 10, f"core_skills parse looks wrong: {core_skills}"
+
+    pipeline = {skill for skill, _params in EvidenceBuilder._SKILL_PIPELINE.values()}
+    declared = core_skills | pipeline
+
+    # "Five of the detection skills named above run on every `agent analyze`."
+    # Checked against core_skills only — see the docstring.
+    automatic = {
+        "gpu_idle_gaps",
+        "top_kernels",
+        "nccl_breakdown",
+        "memory_transfers",
+        "kernel_launch_overhead",
+    }
+    assert automatic <= core_skills, (
+        "README says these run on every `agent analyze` but they are no longer in "
+        f"Agent.analyze's core_skills: {sorted(automatic - core_skills)}"
+    )
+
+    # "The other three named skills are not part of that run" — and are not in
+    # the evidence pipeline either, so `skill run` really is the only route.
+    manual = {"thread_utilization", "nvtx_kernel_map", "tensor_core_usage"}
+    assert not (manual & declared), (
+        "README says these need an explicit `skill run` but they are now wired "
+        f"into the pipeline: {sorted(manual & declared)}"
+    )
+
+    # Row 7: the NVTX abstention the README quotes comes from these two, and
+    # the README says it is reported without an extra command.
+    assert {"iteration_timing", "nvtx_layer_breakdown"} <= core_skills, (
+        "README's Row 7 claim relies on iteration_timing and nvtx_layer_breakdown "
+        "running on a plain `agent analyze`"
+    )
+
+    # Row 13: the `tc_eligible_inactive` finding is emitted by top_kernels'
+    # to_findings, which only runs from the evidence pipeline.
+    assert "top_kernels" in pipeline, (
+        "README's Row 13 claim relies on top_kernels being in the evidence pipeline"
+    )
+
+    # Row 2: the README says critical_path runs under `--evidence` and not on a
+    # plain `agent analyze`, and that cpu_gpu_pipeline needs an explicit
+    # `skill run`. cpu_gpu_pipeline is reached at runtime only as fan-out from
+    # critical_path, so its absence from core_skills is what makes the "not
+    # covered by a plain `agent analyze`" half true.
+    assert "critical_path" in pipeline and "critical_path" not in core_skills, (
+        "README's Row 2 claim relies on critical_path being evidence-only"
+    )
+    assert "cpu_gpu_pipeline" not in declared, (
+        "README says cpu_gpu_pipeline needs an explicit `skill run`, but it is now "
+        "declared in core_skills or the evidence pipeline"
+    )


### PR DESCRIPTION
Closes #308.

Two discoverability defects: `agent` was reachable but undocumented, and the root-causes README overstated what `agent analyze` covers.

## Defect 1 — `agent` was absent from the modern `--help`

`agent` was registered only on the legacy parser (`_register_legacy_commands`) and listed in `app.main`'s `legacy_commands` set, so it never appeared in the modern `--help`. It was not broken, just invisible — and the zero-arg banner advertised it anyway, so the CLI contradicted itself.

On `upstream/main`:

```
$ python3 -m nsys_ai --help
usage: nsys-ai [-h]
               {open,web,timeline-web,loop,chat,ask,agent-guide,info,doctor,skill,evidence,report,diff,diff-web,export,cutracer,root-cause,help}
               ...

$ python3 -m nsys_ai | grep -i "agent analyze"
    nsys-ai agent analyze <profile>           Full auto-analysis

$ python3 -m nsys_ai agent --help
usage: nsys-ai agent [-h] {analyze,ask} ...
```

The banner tells the reader `agent analyze` exists, `agent --help` works, but `--help` does not list it. That report has no other entry point — `report` and `analyze` run a different pipeline — so `--help` should confirm it rather than hide it.

Note the same output: `baseline` was also missing from the usage metavar, which is hand-maintained and had drifted.

### Fix

Moved the `agent` parser out of `_register_legacy_commands` into its own `_register_agent_parser`, registered on the public parser, and dropped `"agent"` from `legacy_commands`. Registration is deliberately on the public parser only — with `agent` out of `legacy_commands`, `nsys-ai agent ...` always builds the public parser, so a second registration on the legacy parser would be dead code. Added the two missing entries to the metavar.

After:

```
$ python3 -m nsys_ai --help
usage: nsys-ai [-h]
               {open,web,timeline-web,loop,chat,ask,agent,agent-guide,info,doctor,skill,evidence,report,diff,diff-web,baseline,export,cutracer,root-cause,help}
               ...
```

Argument parsing is unchanged: `agent --help` and bare `agent` (usage line, exit 1) behave exactly as before, which `test_agent_subcommand_is_reachable` pins.

`test_subcommands` now also asserts the hand-maintained metavar equals the actually-registered subparser choices, so the next drift fails the build instead of shipping.

## Defect 2 — the README overstated automatic coverage

`docs/root-causes/README.md` claimed `agent analyze` "checks for all of these automatically" across its 13 root causes. It does not. Rewritten to state what actually runs, per the wiring in `Agent.analyze`'s `core_skills` and `EvidenceBuilder._SKILL_PIPELINE`:

- Five of the named detection skills run on every `agent analyze`, covering rows 1, 3, 4, 5, 6, 8, 9, 10, 11 and 12.
- **Row 13 (FP32 Fallback):** `tensor_core_usage` does not run, but `top_kernels` carries the TC columns and the evidence pipeline emits `tc_eligible_inactive`. Documented as Parquet-cache-dependent — on the pure-SQLite fallback path TC eligibility is unknown and no such finding is emitted.
- **Row 7 (Missing NVTX):** `nvtx_kernel_map` does not run, but `iteration_timing` / `nvtx_layer_breakdown` abstain with an explicit message and the evidence pipeline emits `profile_insufficient_nvtx_coverage`.
- **Row 2 (CPU Bottleneck):** genuinely not covered by a plain `agent analyze`. `thread_utilization` needs CPU sampling (`COMPOSITE_EVENTS`) and abstains without it; `cpu_gpu_pipeline` derives per-thread attribution from the runtime trace via `correlationId` without that capture option, and `critical_path` reaches it under `--evidence`. Both routes are now named explicitly.

Also dropped the decorative emoji from the file to match the repo's doc style.

`test_root_cause_readme_coverage_claim_matches_wiring` pins each of those sentences to the two statically declared skill lists, so the doc and the pipeline cannot drift apart silently.

## Mutation check

Both new guards were verified to fail when the thing they guard is undone, then restored.

1. Reverted `cli/app.py` + `cli/parsers.py` to `upstream/main`, keeping the new tests:

```
FAILED tests/test_cli.py::test_subcommands - AssertionError: assert ',agent,' in 'usage: nsys-ai [-h]\n               {open,web,timeline-web,loop,chat,ask,agent-guide,...
1 failed, 1 passed in 0.35s
```

`test_agent_subcommand_is_reachable` passes in both directions by design — it asserts parsing was *not* changed, so it is a regression guard, not a mutation target.

2. Dropped `"memory_transfers"` from `Agent.analyze`'s `core_skills`:

```
FAILED tests/test_skills.py::test_root_cause_readme_coverage_claim_matches_wiring
AssertionError: README says these run on every `agent analyze` but they are no longer in Agent.analyze's core_skills: ['memory_transfers']
1 failed in 0.08s
```

## Deliberately out of scope

- **Making the uncovered root causes covered.** This PR corrects the claim; it does not add `thread_utilization`, `nvtx_kernel_map` or `tensor_core_usage` to any pipeline. Widening `agent analyze` is a behaviour change with its own cost and belongs in a separate issue.
- **The coverage test does not model runtime fan-out.** It reads `core_skills` and `_SKILL_PIPELINE` only, so it under-reports what actually executes (`critical_path` -> `cpu_gpu_pipeline`, `profile_health_manifest` -> `root_cause_matcher` -> `sync_cost_analysis`). Every claim it asserts is one that membership in those two lists is sufficient to settle. A general reachability framing was tried and rejected — it cannot see fan-out. This is documented in the test docstring so it is not "fixed" into something weaker.
- **No change to `agent`'s behaviour, arguments, or output** — help visibility only.

## Verification

Run locally on this branch:

```
ruff check src/ tests/        All checks passed!
bandit -q -r src/ -c pyproject.toml    exit 0
python3 -m pytest tests/ -q   1473 passed, 135 skipped in 254.72s
```
