### PR TITLE
test: bound analysis memory, verify concurrent skill agreement, cover damaged input

### DIFF
--- a/tests/_concurrency_probe.py
+++ b/tests/_concurrency_probe.py
@@ -1,0 +1,188 @@
+"""Child process for ``test_skill_concurrency.py``. Not collected by pytest.
+
+Runs each named skill sequentially to get an oracle, then runs it again from a
+thread pool and reports how many concurrent answers disagreed. Prints one JSON
+object on stdout.
+
+It lives in a subprocess because the failure mode this guards is a *deadlock*,
+not a mismatch. Two threads sharing one DuckDB connection contend for the single
+pending result set on it; when that regression was mutation-checked the run went
+past four minutes of wall time on 2.5 seconds of CPU, and one variant dumped
+core. ``future.result(timeout=...)`` does not bound that: the TimeoutError
+propagates out of the ``with ThreadPoolExecutor(...)`` block, ``__exit__`` calls
+``shutdown(wait=True)``, and that joins the stuck workers forever. A subprocess
+with a kill timeout is the only bound that holds.
+
+The workdir is supplied by the parent rather than made here, for the same
+reason: the parent kills this process on timeout, a killed process never runs
+its ``finally``, and a deadlock probe that leaks a 2.5 MB temp directory on
+every failed run is a probe that fills /tmp during a bisect.
+
+Usage: ``python tests/_concurrency_probe.py <profile.sqlite> <workdir> <skill,skill,...>``
+"""
+
+import json
+import shutil
+import sys
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+WAVES = 3
+FUTURES_PER_WAVE = 8
+WORKERS = 4
+
+# Skills whose defaults return too much to compare cheaply get a small limit.
+_LIMITED = {"top_kernels", "gpu_idle_gaps"}
+
+
+def _clear_probe_bag(conn) -> None:
+    """Drop the per-connection memo bag so the next call really queries.
+
+    Without this the test measures the memo, not the database. #295 memoizes
+    skill results per connection keyed on resolved parameters, and #302 shares
+    one bag between a connection and every cursor derived from it — so a naive
+    concurrent run issues one statement and reads it back 39 times. Clearing the
+    bag between waves is what makes the eight racing calls actually contend.
+
+    Note what is cleared: the *whole* bag, not just the ``skill:`` entries. The
+    bag also holds schema-resolution results (``resolve_activity_tables``,
+    ``detect_nvtx_text_id``, the ``nvtx_kernel_map`` shape probe), so every wave
+    races those as well as the skill query. That is deliberate — they are read
+    on the same connection from the same threads and are part of what a
+    concurrent skill call actually does — but it means a mismatch reported here
+    is not necessarily in the skill's own SQL.
+    """
+    from nsys_ai import connection as conn_mod
+
+    owner = conn_mod._cache_owner(conn)
+    bag = conn_mod._duck_probe_bags.get(owner)
+    if bag is not None:
+        bag.clear()
+
+
+def main() -> int:
+    source = Path(sys.argv[1])
+    workdir = Path(sys.argv[2])
+    names = sys.argv[3].split(",")
+
+    work = workdir / source.name
+    shutil.copy(source, work)
+
+    from nsys_ai.profile import Profile
+    from nsys_ai.skills import base as skills_base
+    from nsys_ai.skills.registry import get_skill
+
+    # Count real executions: set_cached_skill_rows runs only on a memo miss,
+    # so it is an exact count of the calls that went to the database.
+    executions: dict[str, int] = {name: 0 for name in names}
+    exec_lock = threading.Lock()
+    original_set = skills_base.set_cached_skill_rows
+
+    def counting_set(conn, key, rows):
+        skill_name = key.split(":")[1] if key.startswith("skill:") else ""
+        if skill_name in executions:
+            with exec_lock:
+                executions[skill_name] += 1
+        return original_set(conn, key, rows)
+
+    skills_base.set_cached_skill_rows = counting_set
+
+    started = time.perf_counter()
+    with Profile(str(work)) as prof:
+        if prof.db is None:
+            print(json.dumps({"engine": "sqlite3"}))
+            return 0
+        open_s = time.perf_counter() - started
+
+        # ── Phase 1: worker threads must share the owning connection's bag ──
+        # Runs before anything clears the memo, because that is the whole point:
+        # the owner populates it, and every worker thread must find it. Keyed on
+        # the handle instead of the owning connection, each thread starts empty
+        # and re-executes — measured as four extra executions across four
+        # threads before #302.
+        #
+        # This lives in the probe rather than in-process next to the accessor
+        # tests it belongs with, because it is not memo-only work: Skill.execute
+        # calls compute_profiler_overhead_ns *before* the memo lookup, and that
+        # queries the database on every single call. Under the shared-connection
+        # regression eight of those contend for one pending result set and never
+        # return — measured hanging past 120s, with f.result(timeout=60) doing
+        # nothing about it, in a file pytest collects before this one. Only a
+        # killed subprocess bounds it.
+        share_skill = get_skill(names[0])
+        share_kwargs = {"limit": 5} if names[0] in _LIMITED else {}
+        share_skill.execute(prof.query_conn(), **share_kwargs)
+        after_owner = executions[names[0]]
+        share_pool = ThreadPoolExecutor(max_workers=WORKERS)
+        try:
+            share_futures = [
+                share_pool.submit(lambda: share_skill.execute(prof.query_conn(), **share_kwargs))
+                for _ in range(FUTURES_PER_WAVE)
+            ]
+            for future in share_futures:
+                future.result()
+        finally:
+            share_pool.shutdown(wait=True)
+        cache_sharing = {
+            "skill": names[0],
+            "owner_executions": after_owner,
+            "worker_extra_executions": executions[names[0]] - after_owner,
+        }
+
+        # ── Phase 2: concurrent answers must equal the sequential ones ──
+        # Executions are reported as a delta from here, so phase 1's run does
+        # not inflate the count the parent uses to prove phase 2 reached the
+        # database.
+        before_phase2 = dict(executions)
+        mismatches: dict[str, int] = {}
+        # Baseline shape, reported so the parent can refuse to compare [] to [].
+        # A skill that returns nothing on this fixture makes its agreement case
+        # a tautology, which is how nccl_breakdown sat in this list asserting
+        # nothing at all.
+        baseline_rows: dict[str, int] = {}
+        for name in names:
+            skill = get_skill(name)
+            kwargs = {"limit": 5} if name in _LIMITED else {}
+
+            def run():
+                return skill.execute(prof.query_conn(), **kwargs)
+
+            _clear_probe_bag(prof.query_conn())
+            baseline = run()
+            baseline_rows[name] = -1 if skills_base.is_abstention(baseline) else len(baseline)
+
+            bad = 0
+            pool = ThreadPoolExecutor(max_workers=WORKERS)
+            try:
+                for _ in range(WAVES):
+                    _clear_probe_bag(prof.query_conn())
+                    futures = [pool.submit(run) for _ in range(FUTURES_PER_WAVE)]
+                    for future in futures:
+                        if future.result() != baseline:
+                            bad += 1
+            finally:
+                pool.shutdown(wait=True)
+            mismatches[name] = bad
+
+    print(
+        json.dumps(
+            {
+                "engine": "duckdb",
+                "open_s": round(open_s, 3),
+                "total_s": round(time.perf_counter() - started, 3),
+                "mismatches": mismatches,
+                "executions": {name: executions[name] - before_phase2[name] for name in names},
+                "baseline_rows": baseline_rows,
+                "cache_sharing": cache_sharing,
+                "waves": WAVES,
+                "futures_per_wave": FUTURES_PER_WAVE,
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/_memory_probe.py
+++ b/tests/_memory_probe.py
@@ -1,0 +1,154 @@
+"""Child process for ``test_analysis_memory.py``. Not collected by pytest.
+
+Runs one fixed analysis workload under ``tracemalloc`` and prints the peak
+Python-heap allocation as JSON on stdout. Lives in its own process because the
+number is only reproducible from a fresh interpreter: inside a pytest session the
+first measurement pays for lazily-imported skill modules and DuckDB, and later
+ones do not, which was measured as 36.35 / 4.88 / 4.84 MB for three identical
+in-process repetitions.
+
+**Two windows, not one.** The peak is reported separately for opening the
+profile and for running the skills, because they are not the same measurement
+and an earlier single-number version of this probe silently conflated them.
+Measured on ``h100_2gpu_1s.sqlite``: with ``SKILLS`` emptied the single number
+was 4.99 MB against 5.00 MB with all three skills — 100% of it was the Parquet
+cache ETL inside ``Profile.__init__``, and a skill-layer memory regression was
+invisible under it. Split, and with the one-time costs below taken out, the same
+run reports 4.85 MB for the open and 0.27 MB for the skills on
+``cache_mode="auto"``, and 0.06 / 6.62 MB on ``cache_mode="direct"``. Each of the
+four has a mutation that moves it — see the test module.
+
+The workdir is supplied by the parent rather than made here. The parent kills
+this process on timeout, and a killed process does not run its ``finally``, so
+whoever can still clean up has to own the directory.
+
+Usage: ``python tests/_memory_probe.py <profile.sqlite> <workdir> <cache_mode>``
+"""
+
+import json
+import shutil
+import sys
+import time
+import tracemalloc
+from pathlib import Path
+
+# Three skills with different shapes: top_kernels aggregates, gpu_idle_gaps
+# sweeps the kernel timeline, and nvtx_kernel_map attributes kernels to NVTX
+# ranges. The last is the expensive one and it is expensive in two different
+# places depending on the cache mode, which is why both modes are measured:
+#
+#   cache_mode="auto"   — parquet_cache._build_nvtx_kernel_map already ran
+#                         during Profile.__init__, streaming the NVTX ranges;
+#                         the skill then reads a precomputed map. The streaming
+#                         is in the *open* window.
+#   cache_mode="direct" — nothing was precomputed, so the skill's first call
+#                         reaches parquet_cache.ensure_nvtx_kernel_map, which
+#                         fetchall()s the whole NVTX and kernel/runtime join
+#                         into Python. That is in the *skills* window, and it is
+#                         the largest single allocation this repo makes.
+SKILLS = ("top_kernels", "gpu_idle_gaps", "nvtx_kernel_map")
+
+
+def main() -> int:
+    source = Path(sys.argv[1])
+    workdir = Path(sys.argv[2])
+    cache_mode = sys.argv[3]
+
+    # Two copies. The cache is built fresh for each, because measuring against a
+    # cache that may or may not already exist is how this number stops being
+    # reproducible.
+    warm = workdir / f"{cache_mode}-warmup-{source.name}"
+    work = workdir / f"{cache_mode}-{source.name}"
+    shutil.copy(source, warm)
+    shutil.copy(source, work)
+
+    from nsys_ai.profile import Profile
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    # Import cost is deliberately outside the measurement, and getting it out is
+    # most of the work. Measured against a probe that only imported nsys_ai
+    # first, 23 of the 33.9 MB peak was module bytecode from duckdb and pyarrow
+    # being imported lazily during Profile construction — so the data term was a
+    # third of the number, and a doubling of it would have sat under any
+    # plausible ceiling. Importing them up front leaves a measurement that is
+    # mostly the profile.
+    skills = {name: get_skill(name) for name in SKILLS}
+    import duckdb  # noqa: F401
+    import pyarrow  # noqa: F401
+    import pyarrow.parquet  # noqa: F401
+
+    from nsys_ai import parquet_cache, sql_compat  # noqa: F401
+
+    # pandas is not a declared dependency but duckdb reaches for it, and it is
+    # 18 MB of module objects when it lands inside the window. Hoisted when
+    # present; when it is absent it never enters the window at all, so either
+    # way the measurement is of the profile and not of an import.
+    try:
+        import pandas  # noqa: F401
+    except ImportError:
+        pass
+
+    # One complete throwaway pass on a separate copy, for the same reason the
+    # imports above are hoisted: everything a first run pays once has to be paid
+    # before the window opens, or the number is a property of the machine's
+    # state rather than of the code.
+    #
+    # The explicit import list above cannot cover this on its own. Modules
+    # imported lazily *inside* skill execution — nvtx_attribution and what it
+    # reaches — were still landing in the measured window, and compiling their
+    # bytecode cost 0.61 MB: the skills window measured 1.96 MB with a cold
+    # __pycache__ and 1.35 MB with a warm one, on identical code. CI checks out
+    # clean, so without this the first number would be the CI number and the
+    # second the local one, and the difference is 46%.
+    with Profile(str(warm), cache_mode=cache_mode) as warmup_prof:
+        for name, skill in skills.items():
+            skill.execute(
+                warmup_prof.query_conn(), **({"limit": 20} if name == "top_kernels" else {})
+            )
+
+    tracemalloc.start()
+    started = time.perf_counter()
+    prof = Profile(str(work), cache_mode=cache_mode)
+    try:
+        engine = "duckdb" if prof.db is not None else "sqlite3"
+        _, open_peak = tracemalloc.get_traced_memory()
+        open_s = time.perf_counter() - started
+
+        # Second window. reset_peak leaves the live blocks in place — the open
+        # window's retained objects still count against this one, which is what
+        # a caller experiences.
+        tracemalloc.reset_peak()
+        # Nothing is swallowed here. A skill that raises or abstains would leave
+        # the measured window smaller than it looks, so the parent is told which
+        # rows each skill produced and asserts they are real.
+        rows: dict[str, int] = {}
+        for name, skill in skills.items():
+            kwargs = {"limit": 20} if name == "top_kernels" else {}
+            out = skill.execute(prof.query_conn(), **kwargs)
+            rows[name] = -1 if is_abstention(out) else len(out)
+        _, skills_peak = tracemalloc.get_traced_memory()
+    finally:
+        prof.close()
+    elapsed = time.perf_counter() - started
+    tracemalloc.stop()
+
+    print(
+        json.dumps(
+            {
+                "engine": engine,
+                "cache_mode": cache_mode,
+                "input_mb": round(source.stat().st_size / 1e6, 3),
+                "open_peak_mb": round(open_peak / 1e6, 2),
+                "skills_peak_mb": round(skills_peak / 1e6, 2),
+                "rows": rows,
+                "open_s": round(open_s, 2),
+                "workload_s": round(elapsed, 2),
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_analysis_memory.py
+++ b/tests/test_analysis_memory.py
@@ -1,0 +1,283 @@
+"""Ceilings on how much Python heap an analysis run is allowed to allocate.
+
+Nothing in this repo bounded memory anywhere. The working set of a run is
+roughly two to three times the capture size, and that ratio is what decides
+whether a tens-of-GB profile can be opened at all — but it lived in session
+notes, so a change that doubled it would have gone through CI green.
+
+What is measured, and what each number actually covers
+-----------------------------------------------------
+
+Four numbers, from two child processes. The split matters: an earlier version of
+this file reported one peak for "open plus three skills" and claimed it bounded
+both. It did not. Re-run with the skill list emptied, that single number was
+4.99 MB against 5.00 MB with all three skills — every measurable byte of it was
+the Parquet-cache ETL inside ``Profile.__init__``, and a skill-layer regression
+was invisible underneath it. Each window now carries its own ceiling and its own
+mutation:
+
+===============  ========  =======  ==================================================
+window           baseline  ceiling  mutation that moves it (all measured here)
+===============  ========  =======  ==================================================
+auto / open       4.85 MB   5.5 MB  ``list(_stream_nvtx_ranges(...))`` -> 6.09 MB
+auto / skills     0.27 MB   0.8 MB  drop the ``LIMIT`` push-down in
+                                    ``nvtx_attribution`` -> 1.53 MB
+direct / open     0.06 MB   1.0 MB  route ``cache_mode="direct"`` through
+                                    ``open_cached_db`` -> 4.85 MB
+direct / skills   6.62 MB   7.4 MB  dict instead of tuple buckets in
+                                    ``_sweep_nvtx_kernel_map`` -> 8.06 MB
+===============  ========  =======  ==================================================
+
+``cache_mode="direct"`` is the second case because it is the path a real
+tens-of-GB capture takes: ``Profile.__init__`` sends anything over 50 MB to
+``open_direct_sqlite``, which does no ETL at all. The two cases are near
+mirror images, and the shape is worth stating plainly because it is where the
+scale risk lives:
+
+* the cached path spends its memory *opening* (4.85 MB) and almost none running
+  skills (0.27 MB), because ``_build_nvtx_kernel_map`` streams and the skills
+  then read a precomputed map;
+* the direct path spends almost nothing opening (0.06 MB — the zero-ETL promise
+  of that path, in a number) and 6.62 MB running skills, because the first
+  NVTX-attribution call reaches ``ensure_nvtx_kernel_map``, which ``fetchall()``s
+  the entire NVTX table and the whole kernel/runtime join into Python tuples.
+
+So the path taken by the largest captures is the one that materialises most, at
+2.9x the input against the cached path's 2.1x. That is not asserted as good; it
+is pinned so it does not get worse silently, and so that fixing it (streaming
+the on-demand build the way the cache build already streams) shows up as a
+deliberate change to a stated number.
+
+Why tracemalloc and not peak RSS
+--------------------------------
+
+The obvious test — assert peak RSS stays under a multiple of the input size —
+was built and rejected on measurement. The reasons are recorded so it does not
+get proposed again:
+
+* Peak RSS on a fixture this size is a *floor*, not a ratio: 176.6 MB for a
+  0.057 MB profile, 212.2 MB for a 2.437 MB one. ~85% of it is interpreter and
+  DuckDB startup, so the apparent "ratio" spans 3230x to 11.4x purely because
+  the denominator moves.
+* Environment noise swamps the signal. DuckDB thread count alone moved peak RSS
+  by ±7% (185.8 MB at one thread, 212.1 MB at twelve). CI has 4 vCPU; this was
+  measured at 12.
+* The denominator is not stable either: analysing a profile in place grows the
+  .sqlite file by 71%, because it builds indices in the source database.
+* It failed its own mutation check. Materialising a 320k-row NVTX generator
+  into a list gave peak RSS of 334.7-372.8 MB against a clean 284.3-360.7 MB —
+  overlapping distributions, no threshold between them.
+
+``tracemalloc`` peak, taken from a fresh interpreter with the imports hoisted
+out of the measured window, is the instrument that works. It counts Python
+allocations only, so it is blind to DuckDB's C++ arena and to interpreter
+startup, and every one of the four numbers above reproduced to within 0.01 MB on
+five consecutive runs, under ``taskset -c 0,1``, and with eight CPU hogs
+competing for the machine. That is the axis that killed the RSS version.
+
+Being blind to the C++ arena is a real limitation and not a footnote: a
+regression that moves work into DuckDB, numpy or pyarrow buffers will not show
+up here at all. One measured example — swapping ``fetchall()`` for
+``fetchdf().to_records()`` in ``ensure_nvtx_kernel_map`` moved the direct/skills
+number by 0.01 MB while genuinely allocating more, because the data landed in
+numpy. These ceilings bound the Python heap, which is where this repo's own row
+handling lives, and nothing more.
+
+Getting one-time costs out of the window is most of the work, not a detail, and
+it took three attempts:
+
+* A first version measured 33.92 MB, of which 23 MB was module bytecode from
+  duckdb, pyarrow and pandas being imported lazily *during* ``Profile``
+  construction. Hence the explicit import block at the top of the probe.
+* Explicit imports are not enough, because the skills reach for modules the
+  probe does not name. With a cold ``__pycache__`` the skills window measured
+  1.96 MB and with a warm one 1.35 MB — 46% apart on identical code, and CI
+  always checks out cold. Hence the throwaway warm-up pass in the probe, after
+  which the same measurement is 0.27 MB either way.
+* Three identical repetitions inside one pytest session returned 36.35 / 4.88 /
+  4.84 MB, because the first pays for those imports and the rest do not. Hence
+  the subprocess.
+
+Each of those made the number smaller and the data term a larger share of it.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+PROBE = Path(__file__).resolve().parent / "_memory_probe.py"
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+# Baselines and ceilings, measured on Python 3.12.3 / DuckDB 1.5.0 /
+# pyarrow 22.0.0 / pandas 2.3.3 against the 2.269 MB fixture. Each ceiling sits
+# above its baseline and below the mutation named in the module docstring.
+#
+#   cache_mode -> (open ceiling MB, skills ceiling MB, measured open, measured skills)
+#
+# The measured pair is carried so the failure message can say how far the number
+# moved, not just that it is over. Only one interpreter was available where this
+# was set and CI runs three, so every number is printed on every run — including
+# a green one. If a CI baseline comes in materially above the measured value,
+# re-derive the ceiling from the printed numbers rather than nudging one until
+# it passes.
+#
+# Headroom is deliberately uneven, because it is set by the gap to the mutation
+# rather than by taste. direct/skills is the tightest at 12% over baseline and
+# 9% under its mutation; if that one ever flakes on another interpreter it is the
+# first to re-derive, and the honest fix is a bigger gap, not a bigger ceiling.
+CASES = {
+    "auto": (5.5, 0.8, 4.85, 0.27),
+    "direct": (1.0, 7.4, 0.06, 6.62),
+}
+
+PROBE_TIMEOUT_S = 120
+
+
+def _emit(request, message: str) -> None:
+    """Write to the terminal even when the test passes.
+
+    pytest captures stdout for a passing test, and the whole point of printing
+    the number is that a *green* build reports it. The terminal reporter writes
+    outside the capture.
+    """
+    reporter = request.config.pluginmanager.get_plugin("terminalreporter")
+    if reporter is not None:
+        reporter.write_line(message)
+    else:  # pragma: no cover - only under a stripped-down pytest
+        print(message)
+
+
+@pytest.fixture(scope="module", params=sorted(CASES))
+def measured(request):
+    """One child process per cache mode.
+
+    The working directory belongs to this fixture, not to the child. On timeout
+    the child is killed, and a killed process never reaches its own cleanup — so
+    the side that survives has to be the side that owns the directory.
+    """
+    cache_mode = request.param
+    workdir = tempfile.mkdtemp(prefix="nsys-mem-probe-")
+    try:
+        result = subprocess.run(
+            [sys.executable, str(PROBE), str(FIXTURE), workdir, cache_mode],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            timeout=PROBE_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        shutil.rmtree(workdir, ignore_errors=True)
+        pytest.fail(f"the memory probe did not finish within {PROBE_TIMEOUT_S}s")
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    if result.returncode != 0:
+        pytest.fail(
+            f"the memory probe exited {result.returncode}\n"
+            f"stdout: {result.stdout.strip()}\nstderr: {result.stderr.strip()[-2000:]}"
+        )
+
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    if payload["engine"] != "duckdb":
+        pytest.skip("requires duckdb — the ceilings were measured on the DuckDB path")
+    payload["ceilings"] = CASES[cache_mode]
+    return payload
+
+
+def test_the_measured_workload_actually_ran(measured, request):
+    """Guards the guard: an empty workload has a very low peak.
+
+    Every ceiling below is an upper bound, so anything that stops the workload
+    doing its work makes them pass harder. A skill that abstained, returned
+    nothing, or was quietly skipped would leave a comfortably green build
+    measuring almost nothing — which is the failure mode that made the previous
+    single-window version of this file measure the cache ETL while claiming to
+    measure skills.
+    """
+    rows = measured["rows"]
+    _emit(
+        request,
+        f"[memory:{measured['cache_mode']}] rows "
+        + ", ".join(f"{name}={count}" for name, count in sorted(rows.items())),
+    )
+    abstained = sorted(name for name, count in rows.items() if count < 0)
+    assert not abstained, (
+        f"{abstained} abstained on this fixture, so the measured window does not "
+        "include their work. Replace them with skills that run here, or the "
+        "ceilings below bound nothing."
+    )
+    empty = sorted(name for name, count in rows.items() if count == 0)
+    assert not empty, (
+        f"{empty} returned no rows, so the measured window is mostly the "
+        "round trip and not the data"
+    )
+
+
+def test_opening_a_profile_stays_under_the_python_heap_ceiling(measured, request):
+    """Peak Python heap for ``Profile(...)`` alone, from a cold start.
+
+    On ``cache_mode="auto"`` this is the Parquet-cache ETL, and it is the number
+    that catches a streamed scan being turned back into a materialised list:
+    reverting the NVTX generator in ``parquet_cache._build_nvtx_kernel_map``
+    takes it from 4.85 MB to 6.09 MB. That change leaves every other assertion in
+    the suite passing, because the answers are identical — only the memory
+    differs, and nothing else looks at memory.
+
+    On ``cache_mode="direct"`` this is the zero-ETL claim stated as a number:
+    0.06 MB, against 4.85 MB if the mode is ever routed through the cache build.
+    """
+    open_ceiling, _, want_open, _ = measured["ceilings"]
+    peak = measured["open_peak_mb"]
+    _emit(
+        request,
+        f"[memory:{measured['cache_mode']}] open {peak:.2f} MB "
+        f"(ceiling {open_ceiling:.1f}, measured {want_open:.2f}, "
+        f"input {measured['input_mb']:.3f} MB, {measured['open_s']:.2f}s, "
+        f"python {sys.version_info.major}.{sys.version_info.minor})",
+    )
+    assert peak < open_ceiling, (
+        f"opening a profile with cache_mode={measured['cache_mode']!r} peaked at "
+        f"{peak:.2f} MB of Python heap against a {want_open:.2f} MB baseline, over "
+        f"the {open_ceiling:.1f} MB ceiling. Either something now holds rows that "
+        "used to stream, or the ceiling needs raising with a reason. Do not raise "
+        "it without one — this number is what decides whether a tens-of-GB "
+        "capture can be opened at all."
+    )
+
+
+def test_running_skills_stays_under_the_python_heap_ceiling(measured, request):
+    """Peak Python heap for three skills on an already-open profile.
+
+    Separate from the open window because on the cached path the open dominates
+    so completely that this was invisible: with the skills removed entirely the
+    combined number moved by 0.01 MB. Measured alone it is 0.27 MB, and dropping
+    the ``LIMIT`` push-down in ``nvtx_attribution.attribute_kernels_to_nvtx`` —
+    the optimisation its own docstring describes as keeping unrelated kernels
+    out of Python — takes it to 1.53 MB.
+
+    On ``cache_mode="direct"`` this window also contains the on-demand
+    ``ensure_nvtx_kernel_map`` build, which is the largest single Python
+    allocation in the codebase at 6.62 MB for a 2.27 MB capture. Turning that
+    sweep's per-thread buckets from tuples into dicts takes it to 8.06 MB.
+    """
+    _, skills_ceiling, _, want_skills = measured["ceilings"]
+    peak = measured["skills_peak_mb"]
+    _emit(
+        request,
+        f"[memory:{measured['cache_mode']}] skills {peak:.2f} MB "
+        f"(ceiling {skills_ceiling:.1f}, measured {want_skills:.2f}, "
+        f"total {measured['workload_s']:.2f}s)",
+    )
+    assert peak < skills_ceiling, (
+        f"running skills with cache_mode={measured['cache_mode']!r} peaked at "
+        f"{peak:.2f} MB of Python heap against a {want_skills:.2f} MB baseline, "
+        f"over the {skills_ceiling:.1f} MB ceiling. Something a skill reads now "
+        "lands in Python objects that did not before — check the LIMIT push-downs "
+        "and the on-demand nvtx_kernel_map build before raising this."
+    )

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -429,6 +429,129 @@ class TestUnrecognisedKernelTable:
         ) == ["CUPTI_ACTIVITY_KIND_KERNEL_X1"]
 
 
+class TestDamagedInput:
+    """What happens when the bytes on disk are wrong.
+
+    The sibling class above covers "the cache was never published". This one
+    covers the two cases after that: a cache that *was* published and then went
+    bad on disk, and a profile that is itself truncated. Both are ordinary in
+    practice — an interrupted build, a killed capture, a full filesystem, an
+    rsync that stopped halfway — and only three or four files in the whole suite
+    touched malformed input before this.
+
+    Every assertion here is a behaviour that was measured first. Nothing in this
+    class asserts what the code *should* do; where the current behaviour is
+    wrong, it is pinned as wrong and said so.
+    """
+
+    def test_a_corrupt_kernels_parquet_falls_back_instead_of_failing(
+        self, minimal_nsys_db_path
+    ):
+        """A damaged cache file must degrade to sqlite3, not take the profile down.
+
+        Silent otherwise in the loudest possible way: the cache is an
+        optimisation the user never asked for, so a byte-level fault inside it
+        surfacing as an error on a perfectly good capture is the worst outcome
+        available. Nothing else in the suite writes garbage into a published
+        cache, so a change that let ``duckdb.Error`` escape
+        ``Profile.__init__``'s fallback would go unnoticed.
+        """
+        from nsys_ai.profile import Profile
+        from nsys_ai.skills.registry import get_skill
+
+        with Profile(minimal_nsys_db_path, cache_mode="auto") as prof:
+            if prof.db is None:
+                pytest.skip("requires duckdb")
+        cache_dir = Path(minimal_nsys_db_path).with_suffix(".nsys-cache")
+        (cache_dir / "kernels.parquet").write_bytes(b"NOTAPARQUET" * 100)
+
+        with Profile(minimal_nsys_db_path, cache_mode="auto") as prof:
+            assert prof.db is None, "a corrupt cache file was accepted as a cache"
+            rows = get_skill("top_kernels").execute(prof.query_conn(), limit=3)
+        assert rows, "falling back to sqlite3 lost the kernel data"
+
+    def test_a_corrupt_cache_is_never_repaired(self, minimal_nsys_db_path):
+        """Pinned defect, not a virtue: the damage is permanent and invisible.
+
+        ``is_cache_valid()`` checks for the cache directory and its manifest, not
+        for readable Parquet, so a corrupt cache stays "valid" forever. Every
+        subsequent open pays the fallback and gets the degraded answer — the
+        sqlite3 path returns fewer columns than the cached one (``top_kernels``
+        loses ``tc_eligible``/``uses_tc``, ``nvtx_kernel_map`` loses demangled
+        names), so the user silently gets a thinner analysis on every run until
+        someone deletes the directory by hand.
+
+        This test exists so that fixing it — discard and rebuild on the first
+        unreadable read — is a visible change to a stated behaviour rather than
+        an accidental one. When that lands, this test should fail and be
+        rewritten to assert the repair.
+        """
+        from nsys_ai.profile import Profile
+
+        with Profile(minimal_nsys_db_path, cache_mode="auto") as prof:
+            if prof.db is None:
+                pytest.skip("requires duckdb")
+        cache_dir = Path(minimal_nsys_db_path).with_suffix(".nsys-cache")
+        damaged = cache_dir / "kernels.parquet"
+        damaged.write_bytes(b"GARBAGE" * 50)
+        damaged_size = damaged.stat().st_size
+
+        for attempt in range(3):
+            with Profile(minimal_nsys_db_path, cache_mode="auto") as prof:
+                assert prof.db is None, f"open #{attempt + 1} unexpectedly used the cache"
+
+        assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is True, (
+            "is_cache_valid now rejects a corrupt cache — good, but this test "
+            "pins the old behaviour; rewrite it to assert the repair"
+        )
+        assert damaged.stat().st_size == damaged_size, (
+            "the damaged file changed size — something is rebuilding now; "
+            "rewrite this test to assert the repair"
+        )
+
+    def test_a_truncated_profile_raises_rather_than_answering(self, tmp_path):
+        """Half a capture must fail loudly, not analyse whatever survived.
+
+        The loud-fail path from #305 seen from the other end. Nothing about the
+        truncation is detected as truncation: ``sqlite3.connect`` succeeds
+        (connecting is lazy), the first read of ``sqlite_master`` raises
+        ``DatabaseError: database disk image is malformed``, and every layer
+        above swallows that on its way to concluding there is no kernel table.
+        The user gets a ``SchemaError`` — the right *outcome*, reached for
+        reasons the message gets wrong.
+
+        Both halves are asserted, and the second is pinned deliberately. The
+        message currently blames the capture ("may have been captured without
+        CUDA kernel tracing") for a file that is simply cut in half, which is a
+        wart worth fixing; pinning it means fixing it is a visible change. And
+        without the first half, a change to kernel-table detection could turn a
+        truncated profile into an empty-but-successful analysis, which reads to
+        a user exactly like a profile with no GPU work.
+        """
+        from nsys_ai.exceptions import SchemaError
+        from nsys_ai.profile import Profile
+
+        source = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+        truncated = tmp_path / "truncated.sqlite"
+        data = source.read_bytes()
+        truncated.write_bytes(data[: len(data) // 2])
+        del data
+
+        # Control: connecting is lazy and succeeds, so nothing before the first
+        # read can tell this file apart from a healthy one.
+        control = sqlite3.connect(str(truncated))
+        try:
+            with pytest.raises(sqlite3.DatabaseError):
+                control.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()
+        finally:
+            control.close()
+
+        with pytest.raises(SchemaError) as excinfo:
+            with Profile(str(truncated)) as prof:
+                prof.query_conn()
+        assert "no suitable KERNEL table found" in str(excinfo.value)
+
+
 class TestConcurrentBuild:
     """Regression: two terminals opening the same profile concurrently
     must NOT both run the full ETL.

--- a/tests/test_profile_query_conn.py
+++ b/tests/test_profile_query_conn.py
@@ -66,33 +66,80 @@ def test_worker_threads_get_their_own_reused_handle():
         assert len(seen) <= 4, f"expected at most one handle per worker, got {len(seen)}"
 
 
-def test_concurrent_skill_runs_agree_with_the_sequential_answer():
-    """The behaviour the accessor exists to protect.
+def test_repeated_memo_reads_hand_out_independent_copies():
+    """Every read of one memoized answer must get its own row dicts.
 
-    Run through a shared connection this returns wrong row counts silently; the
-    sequential baseline is the oracle.
+    This test used to claim it verified concurrent skill runs against a
+    sequential oracle, on a thread pool. It did neither, and both claims were
+    measured false. Recorded here rather than quietly deleted, because the way it
+    failed is the way any concurrency test in this repo will fail:
+
+    * Its oracle was the cache. Across all forty concurrent calls the process
+      issued exactly *one* distinct SQL statement — everything after the
+      sequential baseline was served by the per-connection skill memo (#295),
+      shared with every derived cursor (#302). It was comparing copies of the
+      baseline against the baseline.
+    * Its bound did not bind. The comment said a regression must fail the build
+      and not hang it, and ``f.result(timeout=60)`` looked like it enforced
+      that. It does not: the TimeoutError leaves the ``with
+      ThreadPoolExecutor(...)`` block, ``__exit__`` calls ``shutdown(wait=True)``
+      and joins the deadlocked workers forever. Mutated to hand every thread the
+      shared connection, this test ran past 120 seconds of wall clock on a couple
+      of seconds of CPU before being killed by hand — and pytest collects this
+      file seven files *before* the bounded probe that is supposed to catch that
+      regression, so under it CI hung to the job timeout instead of failing.
+
+    The real property — concurrent skill answers equal the sequential ones, with
+    the memo cleared so the calls reach the database, bounded by a subprocess
+    kill so a deadlock is a failure — lives in ``tests/test_skill_concurrency.py``.
+
+    What is left here needs no threads at all, and therefore cannot hang: the
+    memo's isolation is fully observable from repeated sequential reads. Both
+    halves of it are asserted, because they are two different copies guarding two
+    different directions:
+
+    * ``Skill.execute`` copies on the way *out* of the cache, so no two readers
+      hold the same dict. Without it, one reader's in-place edit is visible to
+      every later reader.
+    * It copies on the way *in* as well, so the first caller — which is handed
+      the freshly built list, not a copy of it — cannot reach the cache either.
+      That one is invisible to an identity check and only shows up if you
+      actually mutate what the first call returned, which is what the last block
+      does.
     """
     with Profile(str(FIXTURE)) as prof:
         if prof.db is None:  # pragma: no cover
             pytest.skip("DuckDB not in use")
         skill = get_skill("top_kernels")
-        baseline = skill.execute(prof.query_conn(), limit=5)
 
-        # Bounded wait on purpose. Removing the per-thread handle does not just
-        # return wrong rows — threads contending for one connection's result set
-        # deadlocked and ran past ten minutes when this was mutation-checked. A
-        # regression must fail the build, not hang it.
-        batches = []
-        with ThreadPoolExecutor(max_workers=4) as ex:
-            for _ in range(5):
-                futures = [
-                    ex.submit(lambda: skill.execute(prof.query_conn(), limit=5)) for _ in range(8)
-                ]
-                batches.append([f.result(timeout=60) for f in futures])
+        # The first call builds and stores; every later one is a memo hit. Three
+        # reads, because the copy-on-read defect only shows between two *hits* —
+        # the builder's own list is distinct from the cache either way.
+        first = skill.execute(prof.query_conn(), limit=5)
+        assert first, "the fixture returned no kernels, so nothing below is tested"
+        reads = [first] + [skill.execute(prof.query_conn(), limit=5) for _ in range(2)]
 
-    for batch in batches:
-        for rows in batch:
-            assert rows == baseline, "a concurrent run disagreed with the sequential answer"
+        for rows in reads[1:]:
+            assert rows == first, "a memoized read returned different values"
+
+        seen_ids: set[int] = set()
+        for rows in reads:
+            for row in rows:
+                assert id(row) not in seen_ids, (
+                    "two readers were handed the same row dict — the memo stopped "
+                    "copying on the way out"
+                )
+                seen_ids.add(id(row))
+
+        # Copy-on-store: poison what the *builder* was handed. If the cache kept
+        # that same list, the poison is served to everyone after it.
+        marker = "poisoned-by-the-first-caller"
+        first[0]["kernel_name"] = marker
+        after = skill.execute(prof.query_conn(), limit=5)
+        assert after[0].get("kernel_name") != marker, (
+            "the first caller's in-place edit reached the cache — the memo stopped "
+            "copying on the way in"
+        )
 
 
 def test_a_sqlite_only_profile_gets_the_sqlite_connection():
@@ -118,47 +165,24 @@ def test_the_accessor_works_during_construction():
         assert prof.query_conn() is not None
 
 
-def test_worker_threads_share_the_owning_connection_s_cache():
-    """A second handle must not mean a second cache.
-
-    The per-connection bag backs both the probe cache and the skill memo from
-    #295. Keyed on the handle, every worker thread starts empty and re-executes
-    work the owner already did — measured as four extra executions across four
-    threads. Keyed on the owning connection, the handle a thread happens to hold
-    stops mattering.
-
-    Sharing is safe because the bag stores results, not handles: one skill with
-    one set of resolved parameters over an immutable capture has one answer.
-    """
-    skill = get_skill("top_kernels")
-    executions: list[int] = []
-    original = skill.execute_fn
-
-    def counting(conn, **kwargs):
-        executions.append(threading.get_ident())
-        return original(conn, **kwargs)
-
-    skill.execute_fn = counting
-    try:
-        with Profile(str(FIXTURE)) as prof:
-            if prof.db is None:  # pragma: no cover
-                pytest.skip("DuckDB not in use")
-            skill.execute(prof.query_conn(), limit=5)  # owner populates
-            after_owner = len(executions)
-            with ThreadPoolExecutor(max_workers=4) as ex:
-                futures = [
-                    ex.submit(lambda: skill.execute(prof.query_conn(), limit=5)) for _ in range(8)
-                ]
-                for f in futures:
-                    f.result(timeout=60)
-    finally:
-        skill.execute_fn = original
-
-    assert after_owner == 1
-    assert len(executions) == after_owner, (
-        f"worker threads re-executed {len(executions) - after_owner} times — "
-        "the cache is keyed on the handle again, not the owning connection"
-    )
+# "A second handle must not mean a second cache" — the property that worker
+# threads share the owning connection's bag (#302) — used to be asserted here,
+# in-process, on a ThreadPoolExecutor with f.result(timeout=60). It has moved to
+# tests/test_skill_concurrency.py, which runs it in a killed subprocess.
+#
+# It is not memo-only work, which is what made it unsafe to keep here.
+# Skill.execute calls compute_profiler_overhead_ns *before* the memo lookup, and
+# that queries the database on every call — so eight futures issue eight real
+# concurrent statements. Under the regression this whole file exists to catch,
+# they contend for one DuckDB connection's pending result set and never return:
+# measured hanging past 120 seconds, with the result() timeout doing nothing
+# because the TimeoutError leaves the executor's with-block and
+# shutdown(wait=True) joins the stuck workers forever. pytest collects this file
+# well before the bounded probe, so the hang arrived first and CI would have run
+# to its job timeout rather than failing.
+#
+# Everything left in this file is either single-threaded or touches no database
+# from a thread, so this file cannot hang.
 
 
 def test_close_drops_the_per_thread_handles():

--- a/tests/test_skill_concurrency.py
+++ b/tests/test_skill_concurrency.py
@@ -1,0 +1,207 @@
+"""Concurrent skill runs must give the sequential answer — as a standing property.
+
+``tests/test_profile_query_conn.py`` covers the accessor that decides which
+handle a thread queries through. It does not establish agreement at the skill
+layer, and agreement is the thing that actually matters: DuckDB keeps the
+pending result set on the connection, so ``execute`` and ``fetch`` are each
+atomic but not atomic as a pair. Two threads on one handle read each other's
+rows, and nothing raises.
+
+Three design points are load-bearing and were all settled by measurement.
+
+**The memo has to be cleared, or this measures the memo.** #295 memoizes skill
+results per connection keyed on resolved parameters, and #302 shares one bag
+between a connection and every cursor derived from it. Left alone, forty
+concurrent skill calls issue *one* distinct SQL statement and read the answer
+back thirty-nine times — the concurrent calls never touch the database, so the
+oracle is being compared against copies of itself. The probe clears the bag
+before each wave and reports the resulting execution count; the test asserts on
+that count, so if the memo ever swallows the concurrency again this fails rather
+than passing vacuously.
+
+**The skills have to return rows, or agreement is a tautology.** Two of the six
+skills originally listed here did not, on this fixture: ``nccl_breakdown``
+returns 0 rows (the capture has no NCCL kernels at all — measured, despite the
+fixture's name) so its case asserted ``[] == []``, and ``thread_utilization``
+abstains for want of a ``COMPOSITE_EVENTS`` table, so its "answer" is a constant
+marker built without touching the data. Neither can disagree under any
+regression. They are replaced by two skills that do read the tables and do
+return rows, and the probe now reports each baseline's row count so a future
+fixture change turns the same vacuity into a failure instead of a green tick.
+
+**The bound has to be a process kill, not a future timeout.** The regression
+mode here is a hang, not a wrong answer. Under the mutation that hands every
+thread the shared connection, the run went past 120 seconds of wall clock on a
+couple of seconds of CPU, and one variant dumped core. Bounding it with
+``future.result(timeout=...)`` does nothing: the TimeoutError leaves the ``with
+ThreadPoolExecutor(...)`` block, ``__exit__`` calls ``shutdown(wait=True)``, and
+that joins the deadlocked workers forever. Only ``subprocess.run(timeout=...)``,
+which kills the child, turns the hang into a build failure — measured here as a
+red build in 31s under that mutation.
+
+One child process covers everything and returns per-skill counts; a
+module-scoped fixture plus parametrize gives per-skill failure attribution for
+the price of one subprocess (six separate children would cost 4.6s instead of
+1.2s for the same information).
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+PROBE = Path(__file__).resolve().parent / "_concurrency_probe.py"
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+# Every skill here reads the kernel/runtime/NVTX tables of this fixture and
+# returns rows — measured, and asserted below so it stays true. Row counts at
+# the limits the probe applies: top_kernels 5, gpu_idle_gaps 6,
+# memory_transfers 3, kernel_launch_overhead 20, nvtx_layer_breakdown 21,
+# kernel_overlap_matrix 10.
+#
+# Left out on purpose: schema_inspect reads the catalog rather than the data;
+# nvtx_kernel_map is covered by the memory probe; nccl_breakdown and
+# thread_utilization return nothing here (see the module docstring).
+SKILLS = (
+    "top_kernels",
+    "gpu_idle_gaps",
+    "memory_transfers",
+    "kernel_launch_overhead",
+    "nvtx_layer_breakdown",
+    "kernel_overlap_matrix",
+)
+
+# Generous: the clean run is ~1.2s wall including interpreter start and a cold
+# cache build. The deadlock this bounds does not resolve at any timeout, so the
+# only thing a larger number buys is a slower failure.
+PROBE_TIMEOUT_S = 30
+
+
+@pytest.fixture(scope="module")
+def probe_result():
+    """One child process, shared by every parametrized case.
+
+    The working directory belongs to this fixture. On timeout the child is
+    SIGKILLed, and a killed process never runs its own cleanup — so the 2.3 MB
+    copy it made would be left behind on exactly the runs that happen most
+    during a bisect.
+    """
+    workdir = tempfile.mkdtemp(prefix="nsys-conc-probe-")
+    try:
+        result = subprocess.run(
+            [sys.executable, str(PROBE), str(FIXTURE), workdir, ",".join(SKILLS)],
+            cwd=REPO,
+            capture_output=True,
+            text=True,
+            timeout=PROBE_TIMEOUT_S,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.fail(
+            f"the concurrent skill run did not finish within {PROBE_TIMEOUT_S}s. "
+            "This is the deadlock signature: threads contending for one DuckDB "
+            "connection's pending result set never make progress. Check that "
+            "Profile.query_conn() still hands worker threads their own cursor."
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    if result.returncode != 0:
+        pytest.fail(
+            f"the concurrency probe exited {result.returncode}\n"
+            f"stdout: {result.stdout.strip()}\nstderr: {result.stderr.strip()[-2000:]}"
+        )
+
+    payload = json.loads(result.stdout.strip().splitlines()[-1])
+    if payload.get("engine") != "duckdb":
+        pytest.skip("requires duckdb — a sqlite3 connection serialises internally")
+    return payload
+
+
+def test_worker_threads_share_the_owning_connection_s_cache(probe_result):
+    """A second handle must not mean a second cache.
+
+    The per-connection bag backs both the probe cache and the skill memo from
+    #295. Keyed on the handle, every worker thread starts empty and re-executes
+    work the owner already did — measured as four extra executions across four
+    threads. Keyed on the owning connection (#302), the handle a thread happens
+    to hold stops mattering.
+
+    Sharing is safe because the bag stores results, not handles: one skill with
+    one set of resolved parameters over an immutable capture has one answer.
+
+    Lived in ``tests/test_profile_query_conn.py`` until it was measured hanging
+    past 120s under the shared-connection regression — see the note left in that
+    file. It is here because here there is a kill timeout.
+    """
+    sharing = probe_result["cache_sharing"]
+    assert sharing["owner_executions"] == 1, (
+        f"the owner's single call to {sharing['skill']} executed "
+        f"{sharing['owner_executions']} times, so the count below measures "
+        "something other than what the workers added"
+    )
+    assert sharing["worker_extra_executions"] == 0, (
+        f"worker threads re-executed {sharing['skill']} "
+        f"{sharing['worker_extra_executions']} times — the cache is keyed on the "
+        "handle again, not the owning connection"
+    )
+
+
+@pytest.mark.parametrize("skill_name", SKILLS)
+def test_the_sequential_answer_is_worth_comparing_against(probe_result, skill_name):
+    """Guards the guard, part one: an empty oracle cannot disagree.
+
+    ``nccl_breakdown`` sat in this list for a while asserting ``[] == []``,
+    because the fixture has no NCCL kernels; ``thread_utilization`` asserted that
+    forty threads all produced the same abstention marker, which is built without
+    reading anything. Both were green under every mutation. A skill that stops
+    returning rows on this fixture — because the fixture changed, or because the
+    skill did — has to fail here rather than quietly making its agreement case
+    meaningless.
+    """
+    rows = probe_result["baseline_rows"][skill_name]
+    assert rows > 0, (
+        f"{skill_name}'s sequential baseline is "
+        + ("an abstention" if rows < 0 else "empty")
+        + " on this fixture, so comparing forty concurrent runs against it "
+        "proves nothing. Give it parameters that return rows, or drop it."
+    )
+
+
+@pytest.mark.parametrize("skill_name", SKILLS)
+def test_concurrent_runs_agree_with_the_sequential_answer(probe_result, skill_name):
+    """Eight threads asking the same question must get the sequential answer.
+
+    Fails silently otherwise: a shared result set returns short or interleaved
+    rows, so a skill reports a plausible-looking wrong number and every other
+    assertion in the suite still passes.
+    """
+    bad = probe_result["mismatches"][skill_name]
+    assert bad == 0, (
+        f"{skill_name}: {bad} of "
+        f"{probe_result['waves'] * probe_result['futures_per_wave']} concurrent "
+        "runs disagreed with the sequential answer"
+    )
+
+
+@pytest.mark.parametrize("skill_name", SKILLS)
+def test_the_concurrent_runs_actually_queried_the_database(probe_result, skill_name):
+    """Guards the guard, part two: without this the agreement test can pass vacuously.
+
+    The per-connection memo will serve every concurrent call from the sequential
+    baseline's result if nothing clears it, and then agreement is a tautology —
+    which is exactly the state the older concurrency test was in, at one distinct
+    statement for forty calls. Each wave must produce at least one real
+    execution beyond the baseline.
+    """
+    executions = probe_result["executions"][skill_name]
+    waves = probe_result["waves"]
+    assert executions >= waves + 1, (
+        f"{skill_name} executed only {executions} times for {waves} waves plus a "
+        "baseline — the concurrent calls were served from the memo, so the "
+        "agreement assertion proves nothing"
+    )


### PR DESCRIPTION
## Summary

- The suite covers data-shape edges thoroughly but has no coverage on the three axes the tens-of-GB goal actually stresses: memory, concurrency, and damaged input. Nothing anywhere bounds memory, so a regression that doubled allocation would pass CI silently.
- Worse than absent: the one test that claimed to check concurrent-vs-sequential skill agreement checked neither, and under mutation it hung instead of failing.
- This PR adds bounded, mutation-verified coverage for all three, plus the fix to the test that was lying.

## The defect

**1. No memory bound exists.** Nothing in the suite asserts an allocation ceiling on any path.

**2. `test_concurrent_skill_runs_agree_with_the_sequential_answer` verified nothing and could not fail.** Two independent problems:

- *Its oracle was the cache.* Across all forty concurrent calls the process issued exactly one distinct SQL statement — everything after the sequential baseline was served by the per-connection skill memo (#295), which derived cursors share (#302). It compared copies of the baseline against the baseline.
- *Its bound did not bind.* `f.result(timeout=60)` looks like it enforces "fail, don't hang". It does not: the `TimeoutError` leaves the `with ThreadPoolExecutor(...)` block, `__exit__` calls `shutdown(wait=True)`, and that joins the deadlocked workers forever. And pytest collects this file seven files *before* any bounded probe, so under a real regression CI would hang to the job timeout rather than report a failure.

**3. Two of the baselines being compared were constants.** `nccl_breakdown` returns no rows on `h100_2gpu_1s.sqlite` (no NCCL kernels) and `thread_utilization` abstains for want of CPU sampling. Both were asserting an empty answer against an empty answer.

## Evidence

All numbers below were produced on this machine, in this session, by the commands shown.

**Clean run** — `pytest tests/test_analysis_memory.py tests/test_skill_concurrency.py -q -rA`:

```
[memory:auto] rows gpu_idle_gaps=21, nvtx_kernel_map=50, top_kernels=20
[memory:auto] open 4.84 MB (ceiling 5.5, measured 4.85, input 2.269 MB, 0.46s, python 3.12)
[memory:auto] skills 0.27 MB (ceiling 0.8, measured 0.27, total 0.51s)
[memory:direct] rows gpu_idle_gaps=21, nvtx_kernel_map=50, top_kernels=20
[memory:direct] open 0.05 MB (ceiling 1.0, measured 0.06, input 2.269 MB, 0.13s, python 3.12)
[memory:direct] skills 6.62 MB (ceiling 7.4, measured 6.62, total 0.39s)
25 passed in 3.70s
```

Four numbers rather than one, because a single combined window turned out to measure only the Parquet-cache ETL: with the skill list emptied it moved 4.99 -> 5.00 MB, so a skill-layer regression was invisible under it.

The asymmetry is the finding. The cached path spends its memory *opening* and almost none running skills; `cache_mode="direct"` — the path `Profile.__init__` sends anything over 50 MB down, i.e. the path every large capture takes — is the reverse, because the first NVTX-attribution call `fetchall()`s the whole NVTX table to build the map on demand. That is pinned as the current shape, not endorsed.

**Full verification, this session, on this branch:**

```
ruff check src/ tests/               -> All checks passed!   (exit 0)
bandit -q -r src/ -c pyproject.toml  -> exit 0 (5 acknowledged nosec warnings, no failed tests)
python3 -m pytest tests/ -q          -> 1500 passed, 135 skipped in 264.77s
python3 -m nsys_ai --help            -> exit 0
```

## Mutation check

Each assertion was verified by mutating `src/`, running, and restoring. Two representative mutations, both re-run in this session:

*Materialise the NVTX generator* — `nvtx_rows = _stream_nvtx_ranges(db, nps)` -> `list(...)` in `parquet_cache._build_nvtx_kernel_map`:

```
E  AssertionError: opening a profile with cache_mode='auto' peaked at 6.08 MB of Python
   heap against a 4.85 MB baseline, over the 5.5 MB ceiling.
E  assert 6.08 < 5.5
1 failed, 5 passed in 2.26s
```

*Hand every thread the shared connection* — early `return self.db` in `Profile.query_conn()`:

```
1 failed, 6 passed, 19 errors in 31.41s
real  0m31.898s

E  subprocess.TimeoutExpired: ... '_concurrency_probe.py' ... timed out after 30 seconds
E  Failed: the concurrent skill run did not finish within 30s. This is the deadlock
   signature: threads contending for one DuckDB connection's pending result set never
   make progress. Check that Profile.query_conn() still hands worker threads their own cursor.
```

31 seconds and red, where the old test ran past 120 seconds of wall clock on a couple of seconds of CPU before being killed by hand. Both mutations were reverted and the affected files re-run green (`59 passed in 10.29s`) before pushing; `git diff` against the tree is empty.

The other two memory ceilings were established the same way during the work leading up to this commit: dropping the `LIMIT` push-down in NVTX attribution moves `auto/skills` 0.27 -> 1.53 MB, and dict instead of tuple buckets in `_sweep_nvtx_kernel_map` moves `direct/skills` 6.62 -> 8.06 MB.

## Changes

Memory — `tests/test_analysis_memory.py`, `tests/_memory_probe.py`
- `tracemalloc` ceilings on a fixed workload, in a subprocess from a fresh interpreter, split into an open window and a skills window, once per cache mode.
- One-time costs kept out of the window three ways, each measured: hoisted imports (a first version read 33.9 MB, 23 of it module bytecode), a throwaway warm-up pass (the skills window read 1.96 MB with a cold `__pycache__` against 1.35 MB warm, and CI always checks out cold), and the subprocess itself (three in-session repetitions gave 36.35 / 4.88 / 4.84 MB).
- Peak RSS was tried first and rejected: a 176-212 MB floor dominated by interpreter and DuckDB startup, moving +-7% with core count alone, with overlapping clean and regressed distributions.
- The probe reports each skill's row count and the test refuses an abstaining or empty workload, so a silently broken workload cannot make an upper bound pass.

Concurrency — `tests/test_skill_concurrency.py`, `tests/_concurrency_probe.py`
- Six skills run sequentially for an oracle, then in three waves of eight futures on four workers, with the per-connection memo cleared before each wave so the concurrent calls reach the database.
- A second test asserts the execution count, so the memo can never quietly become the oracle again.
- A third asserts each baseline is a real non-empty answer; `nccl_breakdown` and `thread_utilization` are replaced for the reason above.
- The probe runs in a subprocess with a kill timeout, because the regression mode is a deadlock rather than a mismatch. Both probes take their working directory from the parent, because a killed child never runs its own cleanup.

`tests/test_profile_query_conn.py`
- The broken concurrency test is reduced to the invariant it can observe with no threads at all — that memoized reads hand out independent row dicts, on the way in and on the way out — with how it failed recorded in its docstring rather than quietly deleted.
- Its neighbour, which asserted worker threads share the owning connection's cache, hung for a different reason (`Skill.execute` queries before the memo lookup, so eight futures issue eight real concurrent statements) and moves to the bounded probe.

Damaged input — `tests/test_parquet_cache.py::TestDamagedInput`
- A corrupt `kernels.parquet` degrades to sqlite3 rather than taking a good capture down.
- That corruption is never repaired — pinned as a defect rather than a virtue.
- A truncated profile raises `SchemaError`, reached by swallowing a malformed-image error, so the message blames the capture.

## Backward compatibility

Yes — tests only. No file under `src/` is modified by this PR.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -q` passes locally (1500 passed, 135 skipped, 264.77s)
- [x] `ruff check src/ tests/` clean
- [x] `bandit -q -r src/ -c pyproject.toml` clean
- [x] Every new ceiling and every new assertion verified by a mutation that crosses it, then reverted

Suite cost: 275.7s against 273.3s for 11 more tests, on a machine where the suite takes 273s.

## Out of scope

- **Scale.** No large fixture is committed and none is added here; multi-GB behaviour still is not exercised in CI. The memory ceilings are a ratio-style guard on the committed 2.269 MB fixture, which catches multiplicative regressions without needing large files — they do not substitute for a real large-profile run.
- **Fixing what the ceilings expose.** `direct/skills` at 6.62 MB against `auto/skills` at 0.27 MB is the large-capture path materialising the whole NVTX table. This PR pins that number; reducing it belongs with #300.
- **Repairing a corrupt cache.** The test asserts the current behaviour (never repaired) so a future fix has something to flip; it does not implement the repair.
- **Corrupt-cache / truncated-profile coverage seeded by #305** is only partly here — three cases, not a systematic sweep.

## Linked issues

Closes #309. Part of #304. Refs #295, #300, #302, #305.
