### PR TITLE
fix(cache): keep the stamp's mtime when the lazy map publish rewrites it

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -27,7 +27,10 @@ deferring it, and peak RSS on the 3.5 GB capture fell from 7.01 GB to 5.97 GB.
 The 13 base tables are the opposite case — 8.6s of that 93.2s, wanted by nearly
 every skill — so they stay eager and are deliberately not split up.
 
-Cache invalidation uses mtime comparison + a version stamp file. A cache with
+Cache invalidation uses mtime comparison + a version stamp file — the stamp's
+mtime dates the step 1 build, and step 3 rewrites that stamp with its timestamps
+preserved so publishing the map can never revalidate a cache that has since gone
+stale against its source. A cache with
 the map and one without are both legal, complete caches: every consumer probes
 for the map rather than assuming it, which is why deferring it does not need a
 ``_CACHE_VERSION`` bump. "Not built yet" and "built wrong" stay distinct on
@@ -169,6 +172,14 @@ def is_cache_valid(sqlite_path: str) -> bool:
       - The cache directory exists
       - The version stamp matches ``_CACHE_VERSION``
       - The cache is at least as new as the SQLite file (mtime comparison)
+
+    The freshness test reads no cache contents: ``.cache_version``'s own mtime
+    *is* the token, standing in for "when was this cache built". Every writer of
+    that file must therefore preserve its timestamps unless it is publishing a
+    genuinely new build — a writer that merely edits the JSON (see
+    :func:`_publish_stamp_map_ready`) and lets ``os.replace`` date the result
+    "now" revalidates a cache this function had correctly rejected, and the
+    stale Parquet is then served silently.
     """
     cache_dir = _cache_dir_for(sqlite_path)
     version_file = cache_dir / ".cache_version"
@@ -1648,11 +1659,22 @@ def _create_nvtx_map_views(db, cache_dir: Path) -> bool:
 def _publish_stamp_map_ready(cache_dir: Path) -> None:
     """Record in ``.cache_version`` that the map is now on disk.
 
-    Informational — nothing reads these two keys to decide behaviour, and
-    ``is_cache_valid`` does not consult them — but leaving them saying
-    "deferred" after the map exists would make the stamp lie to anyone
-    debugging. Written temp-file + ``os.replace`` because a torn stamp fails the
-    JSON parse in ``is_cache_valid`` and costs a full rebuild.
+    The two keys are informational — nothing reads them to decide behaviour.
+    The *file* they live in is not: its mtime is the cache's freshness token,
+    compared against the source SQLite's mtime by :func:`is_cache_valid`. This
+    rewrite happens at query time, arbitrarily long after the build that the
+    token is supposed to date, so an ``os.replace`` alone would stamp the token
+    "now" and revalidate a cache that had correctly gone stale — the source can
+    change while a cached connection is live (a re-capture to the same path),
+    and every later process would then be served the old Parquet. Hence the
+    ``os.utime`` restore below: the file's contents advance, its timestamps do
+    not, and a stale cache stays stale. The stat and the replace both run under
+    ``_build_lock`` (see :func:`materialize_cached_nvtx_kernel_map`), so a
+    concurrent rebuild cannot slip between them and have its fresh stamp aged
+    backwards.
+
+    Written temp-file + ``os.replace`` because a torn stamp fails the JSON parse
+    in ``is_cache_valid`` and costs a full rebuild.
 
     A failure here is not a build failure: the Parquet is already published and
     the next open finds it by glob regardless.
@@ -1660,18 +1682,38 @@ def _publish_stamp_map_ready(cache_dir: Path) -> None:
     stamp = cache_dir / ".cache_version"
     try:
         meta = json.loads(stamp.read_text())
+        before = os.stat(stamp)
     except (json.JSONDecodeError, OSError):
         return
     meta["nvtx_kernel_map_ready"] = True
     meta["deferred_nvtx_kernel_map"] = False
     tmp = cache_dir / ".cache_version.tmp"
+    replaced = False
     try:
         tmp.write_text(json.dumps(meta))
         os.replace(tmp, stamp)
+        replaced = True
     except OSError as exc:
         log.debug("could not refresh cache stamp after lazy map build (%s)", exc)
         with contextlib.suppress(OSError):
             tmp.unlink()
+
+    if replaced:
+        # Its own except, and its own message: folding this into the block
+        # above would report a silently revalidated stale cache as "could not
+        # refresh cache stamp" and would try to unlink a tmp that os.replace
+        # has already consumed. ``ns=`` rather than the float fields — the
+        # float form rounds, and the invariant is an exact one.
+        try:
+            os.utime(stamp, ns=(before.st_atime_ns, before.st_mtime_ns))
+        except OSError as exc:
+            log.warning(
+                "could not restore the freshness token on %s (%s); a cache that "
+                "is stale against its source may now pass is_cache_valid until "
+                "it is rebuilt",
+                stamp,
+                exc,
+            )
 
     # The oversized-map warning used to fire only from _build_cache_into, which
     # no longer builds the map — so without this it would never fire again. The

--- a/tests/test_nvtx_kernel_map_ondemand.py
+++ b/tests/test_nvtx_kernel_map_ondemand.py
@@ -297,6 +297,100 @@ def test_the_first_nvtx_query_publishes_the_map_into_the_cache(cached_profile):
     assert again == rows
 
 
+def _age_the_stamp(cache_dir, seconds=5.0):
+    """Move ``.cache_version``'s mtime *backwards* so the cache reads as stale.
+
+    Read this before rewriting it. The obvious alternative — pushing the source
+    SQLite's mtime forwards — produces a test that passes with the fix reverted:
+    a source dated into the future is also newer than the publish's "now", so
+    ``is_cache_valid`` stays False either way and nothing is being measured. The
+    window this test exists for is ``build < source change < publish``, and with
+    the build already done the only way to reach that ordering without sleeping
+    is to age the stamp, leaving the source's real, present-day mtime in front
+    of it and the publish's later still.
+    """
+    stamp = cache_dir / ".cache_version"
+    aged = os.stat(stamp).st_mtime_ns - int(seconds * 1e9)
+    os.utime(stamp, ns=(aged, aged))
+    return aged
+
+
+def test_a_stale_cache_is_not_resurrected_by_the_lazy_map_publish(cached_profile):
+    """Publishing the map must not re-date the cache's freshness token (#323).
+
+    ``is_cache_valid`` decides staleness from ``.cache_version``'s mtime, so the
+    query-time stamp rewrite that records "map ready" is not the inert
+    bookkeeping it looks like: an ``os.replace`` alone stamps it "now", which is
+    newer than any source change that happened while this connection was open,
+    and the cache this function had correctly rejected passes again.
+
+    The two informational keys are asserted as well, so the fix cannot be met by
+    skipping the publish — the stamp must still stop saying "deferred".
+    """
+    profile, cache_dir = cached_profile
+
+    # A connection opened while the cache was still valid — the live web/tui/
+    # chat/loop session in the issue.
+    db = parquet_cache.open_cached_db(str(profile))
+    try:
+        _age_the_stamp(cache_dir)
+        assert parquet_cache.is_cache_valid(str(profile)) is False, (
+            "the aged stamp should already read as stale before the publish"
+        )
+
+        assert ensure_nvtx_kernel_map(db) is True
+    finally:
+        db.close()
+
+    assert parquet_cache.is_cache_valid(str(profile)) is False, (
+        "publishing the lazily built map resurrected a cache that was stale "
+        "against its source; every later process is now served the old Parquet"
+    )
+
+    stamp = json.loads((cache_dir / ".cache_version").read_text())
+    assert stamp["nvtx_kernel_map_ready"] is True
+    assert stamp["deferred_nvtx_kernel_map"] is False
+
+
+def test_a_changed_source_is_reread_after_a_lazy_map_publish(cached_profile):
+    """The issue's reproduction, at the level a user feels it (#323).
+
+    Re-capturing to the same path while a cached connection is live is the
+    ordinary way a profile changes. The live connection keeps its own Parquet
+    views for its lifetime — that is unchanged and out of scope — but the *next*
+    process must see the new capture, and it does not if the map publish has
+    quietly revalidated the old cache.
+    """
+    profile, cache_dir = cached_profile
+
+    db = parquet_cache.open_cached_db(str(profile))
+    try:
+        cached_rows = db.execute("SELECT count(*) FROM nvtx").fetchone()[0]
+
+        # Re-capture: same path, twice the NVTX events.
+        con = sqlite3.connect(str(profile))
+        con.execute("INSERT INTO NVTX_EVENTS SELECT * FROM NVTX_EVENTS")
+        con.commit()
+        source_rows = con.execute("SELECT count(*) FROM NVTX_EVENTS").fetchone()[0]
+        con.close()
+        assert source_rows == 2 * cached_rows > 0
+
+        _age_the_stamp(cache_dir)
+        assert ensure_nvtx_kernel_map(db) is True
+    finally:
+        db.close()
+
+    later = parquet_cache.open_cached_db(str(profile))
+    try:
+        served = later.execute("SELECT count(*) FROM nvtx").fetchone()[0]
+    finally:
+        later.close()
+
+    assert served == source_rows, (
+        f"a later open was served {served} stale rows; the source has {source_rows}"
+    )
+
+
 def test_the_map_is_absent_from_schema_discovery_until_it_is_built(cached_profile):
     """Deferral hides the map from the catalog, not just from the cache dir.
 


### PR DESCRIPTION
Closes #323.

## The defect

`is_cache_valid` decides freshness by comparing `.cache_version`'s mtime against the source SQLite's. Until #322 that file had exactly one writer — the end of `_build_cache_into` — so its mtime dated the build.

#322 added a second writer, `_publish_stamp_map_ready`, which runs at **query** time to flip `nvtx_kernel_map_ready`. It rewrites the stamp with `os.replace`, so the new inode's mtime is "now" — arbitrarily later than the build the token is supposed to date, and later than any source change that happened while the connection was open.

The result: a cache that `is_cache_valid` had correctly rejected as stale becomes valid again the first time a skill triggers the lazy map build, and every later process is served the old Parquet with no warning. `Profile`'s "auto" mode is caught by the same thing — a large re-captured profile that would have taken the direct-SQLite branch is routed back onto the stale cache.

The window is: the source changes while a cached connection is live. `web`, `tui`, `chat` and `loop` all hold exactly that, and re-capturing to the same path is the ordinary way a profile changes.

## Evidence

The two new tests, run against `parquet_cache.py` with only the `os.utime` restore deleted. Real output, filtered to the assertion and result lines:

```
$ python3 -m pytest tests/test_nvtx_kernel_map_ondemand.py -q -k "resurrect or reread"

E   AssertionError: publishing the lazily built map resurrected a cache that was
E   stale against its source; every later process is now served the old Parquet
E   assert True is False
E    +  where True = <function is_cache_valid at 0x74952db45080>('.../p.sqlite')

E   AssertionError: a later open was served 16782 stale rows; the source has 33564
E   assert 16782 == 33564

FAILED tests/test_nvtx_kernel_map_ondemand.py::test_a_stale_cache_is_not_resurrected_by_the_lazy_map_publish
FAILED tests/test_nvtx_kernel_map_ondemand.py::test_a_changed_source_is_reread_after_a_lazy_map_publish
2 failed, 16 deselected in 1.01s
```

The second failure is the user-visible shape: a connection is opened, the source is re-captured to the same path (NVTX events doubled, 16,782 -> 33,564), the map is published, and a *later* `open_cached_db` still hands back 16,782 rows.

With the fix restored, on `tests/fixtures/h100_2gpu_1s.sqlite`:

```
$ python3 -m pytest tests/test_nvtx_kernel_map_ondemand.py -q
18 passed in 4.23s
```

## Mutation check

Deleting the `if replaced:` / `os.utime` block is the whole mutation, and it fails both new tests — output above, produced by actually reverting, running, and restoring. Restored, the file's 18 tests pass.

One trap is worth naming, because the *obvious* version of this test does not have that property. Pushing the **source** SQLite's mtime forwards yields a test that passes with the fix reverted: a source dated into the future is also newer than the publish's "now", so `is_cache_valid` stays `False` either way and nothing is being measured. The window that matters is `build < source change < publish`, and with the build already done the only way to reach that ordering without sleeping is to age the *stamp* backwards, leaving the source's real mtime in front of it and the publish's later still. That is what `_age_the_stamp` does, and the reasoning sits in its docstring so the next reader does not "simplify" it back into a tautology.

## The fix

`src/nsys_ai/parquet_cache.py` — `_publish_stamp_map_ready` stats the stamp before the rewrite and `os.utime`s its timestamps back afterwards. Contents advance; the freshness token is held still. `ns=` rather than the float fields, because the float form rounds and the invariant is an exact one.

The restore gets its own `try`/`except` and its own log line. Folding it into the write's `except OSError` would report a silently revalidated stale cache as "could not refresh cache stamp", and would try to `unlink` a tmp that `os.replace` has already consumed. A failed restore logs at `warning`, not `debug`, because its consequence is stale data rather than a stale-looking debug field.

Both the `stat` and the `replace` run inside `with _build_lock(cache_dir)` — verified by reading `materialize_cached_nvtx_kernel_map`, where the `_publish_stamp_map_ready(cache_dir)` call sits inside the `with _build_lock(cache_dir):` body — so a concurrent rebuild cannot slip between them and have its fresh stamp aged backwards.

Docstrings on `is_cache_valid`, `_publish_stamp_map_ready` and the module header now state the invariant: the stamp's mtime *is* the freshness token, so every writer of that file must preserve its timestamps unless it is publishing a genuinely new build. #322's docstring claimed publication "keeps 'not built yet' and 'built wrong' distinct"; it had in fact introduced a third state — *built from a source that has since changed* — indistinguishable from fresh. That claim is corrected in place rather than left for a follow-up, which is the failure mode #321 was opened for.

## Deliberately out of scope

- **Already-open connections.** A connection opened while the cache was valid keeps serving its own Parquet views for its lifetime. That is #322's behaviour and is unchanged here; this PR corrects *later* opens. Invalidating a live session's views mid-flight is a separate design question.
- **No `_CACHE_VERSION` bump.** Cache contents are byte-identical; only the stamp's timestamp handling changes. Existing caches stay valid — and a stale one now correctly stays stale.
- **The mtime-comparison scheme itself.** Comparing mtimes is coarse: it cannot see a same-second edit, and it trusts the clock. Replacing it with a content hash is a real improvement and a much larger change. This PR restores the invariant the existing scheme was already relying on rather than replacing the scheme.

## Verification

```
ruff check src/ tests/                  All checks passed!
bandit -q -r src/ -c pyproject.toml     exit 0 (5 pre-existing nosec notices only)
python3 -m pytest tests/ -q             1514 passed, 135 skipped in 248.12s
```

Two tests added, none skipped, so no `tests/test_ci_coverage.py` registration is needed.

Branches from `upstream/main` at ac9c3fa (#322); depends on no unmerged PR.
