### PR TITLE
refactor(cache): stop asking the on-demand kernel query for an order the sweep redoes

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1923,11 +1923,12 @@ def _ensure_nvtx_kernel_map_in_memory(adapter, db) -> bool:
             f"JOIN {runtime_table} r ON r.correlationId = k.correlationId "
             f"LEFT JOIN StringIds sd ON k.demangledName = sd.id "
             f"LEFT JOIN StringIds ss ON k.shortName = ss.id "
-            f"ORDER BY r.globalTid, r.start"
         ).fetchall()
-        # nvtx must arrive sorted by start: the sweep advances a single index
-        # over it per thread without re-sorting. The kernel side above needs no
-        # such guarantee — the sweep sorts that one itself.
+        # Only the NVTX side has to arrive sorted. The sweep advances a single
+        # index over the ranges per thread without re-sorting them, but it does
+        # sort the kernel side itself (``kr_by_tid[tid].sort(...)``), so asking
+        # the kernel query above for an order it will redo buys nothing. That
+        # asymmetry is what tests/test_determinism.py pins.
         nvtx_rows = db.execute(
             f'SELECT n.globalTid, n.start, n."end", {text_expr} AS text '
             f"FROM {nvtx_table} n {text_join} "

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -223,7 +223,9 @@ def test_the_sweep_does_not_depend_on_the_order_kernels_arrive_in():
     (`kr_by_tid[tid].sort(...)`), so the SQL order was being redone in Python.
     The ORDER BY is gone; this test is what stops the self-sort from being
     dropped as "redundant" later, which would silently make the map's contents
-    depend on DuckDB's join order.
+    depend on DuckDB's join order. It now guards *both* builders: the on-demand
+    `_ensure_nvtx_kernel_map_in_memory` carried the same redundant ORDER BY and
+    no longer does, so neither caller hands the sweep a pre-sorted kernel side.
 
     Asserted on *content*, canonically ordered, not on the returned list order.
     The sweep visits threads in the order they first appear in its input, so


### PR DESCRIPTION
Closes #320.

## The defect

`_ensure_nvtx_kernel_map_in_memory` (the on-demand NVTX→kernel map builder used
by direct-attach and `parquetdir` connections) fetched its kernel/runtime rows
with `ORDER BY r.globalTid, r.start`, four lines above a comment stating that
only the NVTX side needs to arrive sorted. Both halves of that were in the same
`try` block. The comment was right: `_sweep_nvtx_kernel_map` buckets kernel rows
by thread and calls `kr_by_tid[tid].sort(key=lambda x: x[0])` on each bucket, so
the SQL order was computed and then immediately redone in Python.

The sibling cache-side builder `_stream_kernel_runtime` lost the same clause in
#318, which deliberately left this second copy alone to keep its diff to the
builder it was filed about. This is that second copy.

## Evidence

The changed function is the one exercised by `ensure_nvtx_kernel_map` over
`open_direct_sqlite` — confirmed by spying on it rather than assuming:

```
$ python3 - <<'EOF'
from nsys_ai import parquet_cache as pc
orig = pc._ensure_nvtx_kernel_map_in_memory
calls = []
def spy(adapter, db):
    calls.append(1); return orig(adapter, db)
pc._ensure_nvtx_kernel_map_in_memory = spy
conn = pc.open_direct_sqlite("c88.sqlite")
print("ok=", pc.ensure_nvtx_kernel_map(conn), "in_memory_builder_calls=", len(calls))
EOF
ok= True in_memory_builder_calls= 1
```

Content equivalence, measured on two captures larger than the test fixture, by
digesting the whole map canonically ordered (all 9 columns, `path_id` resolved
through `nvtx_path_dict` so the digest does not depend on dict numbering), with
the cache wiped before every run:

88MB capture (`nano_vllm_bench_baseline.sqlite`):

```
=== WITHOUT ORDER BY (this branch), 3 runs ===
rows=434577 digest=184b7b9cf0c858708bc7 build=3.74s
rows=434577 digest=184b7b9cf0c858708bc7 build=3.75s
rows=434577 digest=184b7b9cf0c858708bc7 build=3.76s
=== WITH ORDER BY (fix reverted), 3 runs ===
rows=434577 digest=184b7b9cf0c858708bc7 build=3.74s
rows=434577 digest=184b7b9cf0c858708bc7 build=3.75s
rows=434577 digest=184b7b9cf0c858708bc7 build=3.83s
```

881MB capture (`mfu_l40s2_nsys.sqlite`):

```
=== 881MB, WITHOUT ORDER BY (this branch), 3 runs ===
rows=598400 digest=18d46a96363fba561898 build=13.40s
rows=598400 digest=18d46a96363fba561898 build=13.47s
rows=598400 digest=18d46a96363fba561898 build=13.14s
=== 881MB, WITH ORDER BY (fix reverted), 3 runs ===
rows=598400 digest=18d46a96363fba561898 build=13.12s
rows=598400 digest=18d46a96363fba561898 build=13.17s
rows=598400 digest=18d46a96363fba561898 build=13.20s
```

No ordering guarantee is lost, because there was none to lose: the key is
partial, so the sort was already unstable over its tie groups. Counted on the
881MB capture, straight from SQLite:

```
tie_groups, rows_in_ties = (29534, 59068)
threads = 13
```

No speed claim is made. Build time was indistinguishable in both directions on
both captures (numbers above); six runs per capture is not a measurement of a
performance effect, and none is being claimed.

## The fix

Delete the `ORDER BY r.globalTid, r.start` from that one query, and reword the
comment below it to match the wording `_build_nvtx_kernel_map` already carries,
so both builders explain the asymmetry the same way. The docstring above the
function was re-read and is unaffected — it describes the `fetchall` memory cost,
not row order.

## Mutation check

Per #320 the precondition is already pinned, so no new test was added. Verified
that the pin is real rather than assumed — deleting the sweep's own per-thread
sort (`kr_by_tid[tid].sort(key=lambda x: x[0])` → `pass`) turns it red:

```
$ python3 -m pytest tests/test_determinism.py -q
E           AssertionError: kernel arrival order changed the sweep's answer (seed 0)
E             At index 0 diff: (1600, 2400, 'kA', 'step', 'step') != (1600, 2400, 'kA', 'attn', 'step > fwd > attn')
tests/test_determinism.py:291: AssertionError
FAILED tests/test_determinism.py::test_the_sweep_does_not_depend_on_the_order_kernels_arrive_in
1 failed, 8 passed in 0.65s
```

The source was restored afterwards.

Reverting *this* PR's own change does not turn any test red, and that is the
honest description of what it is: the SQL clause was doing nothing observable,
which is precisely the claim the digests above support. The test-side change
here is a docstring update recording that the test now guards both builders.

## Local verification

```
ruff check src/ tests/                 -> All checks passed!
bandit -q -r src/ -c pyproject.toml    -> exit 0 (5 pre-existing nosec notices)
python3 -m pytest tests/ -q            -> 1514 passed, 135 skipped in 248.74s
```

Fixtures restored and `.nsys-cache` directories removed after every run; the
large captures were copied to a scratch directory, analysed there, and deleted.

## Out of scope

- No change to the cache-side builder `_stream_kernel_runtime` (#318 did that
  one) or to `_build_nvtx_kernel_map`.
- No change to the sweep, to `_materialize_nvtx_kernel_map`, or to the map schema.
- No `_CACHE_VERSION` bump: this path materializes DuckDB tables on the live
  connection and writes nothing into the Parquet cache, and the content is
  unchanged in any case.
- No performance work. The clause is removed because the file should not ask for
  an order it documents as unnecessary, not because it was measured to cost
  anything.

Branches from `upstream/main` at c168f63; depends on no unmerged PR.
