### PR TITLE
fix(schema): resolve overlap.py's table variants through the shared resolver

### DIFF
--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -374,13 +374,27 @@ def resolve_table_variant(
     2. otherwise the highest ``_V<n>``, compared as an *integer* so ``_V10``
        beats ``_V3`` (lexicographic order gets that backwards);
     3. otherwise, only when ``allow_other_suffixes``, the alphabetically first
-       remaining name that starts with ``prefix``, so an unforeseen future
-       suffix still resolves to something rather than to nothing.
+       remaining name that starts with ``prefix`` *whose remainder is not a bare
+       number*, so an unforeseen future suffix still resolves to something rather
+       than to nothing.
 
     The ``_V<n>`` match is anchored (``fullmatch``) rather than a bare
     ``startswith``: ``CUPTI_ACTIVITY_KIND_MEMCPY2`` is a real CUPTI activity
     kind (peer-to-peer memcpy) and must never be mistaken for a newer variant
-    of ``CUPTI_ACTIVITY_KIND_MEMCPY``.
+    of ``CUPTI_ACTIVITY_KIND_MEMCPY``. Anchoring tier 2 alone did not deliver
+    that: on a profile carrying only ``..._MEMCPY2`` the permissive tier 3
+    returned it anyway. So tier 3 excludes an all-digit remainder too — every
+    versioning shape this repo has met is ``_V<n>``, and a bare trailing digit
+    is CUPTI's way of naming a *sibling* activity kind, not a version.
+
+    The consequence is deliberate: a MEMCPY2-only profile resolves ``memcpy`` to
+    ``None`` rather than reporting P2P copies (a different ``copyKind`` domain)
+    as ordinary memcpy traffic. It puts such a profile in the same class as one
+    that carries no memcpy table at all, and each reader answers that the way it
+    already did — ``memory_transfers`` and ``memory_bandwidth`` abstain naming
+    the missing table, ``kernel_overlap_matrix`` reports a matrix with no
+    ``memcpy_*`` category. This function does not itself decide any of that; do
+    not read a guarantee about caller behaviour out of it.
     """
     if prefix in tables:
         return prefix
@@ -392,7 +406,7 @@ def resolve_table_variant(
         match = _VERSION_SUFFIX_RE.fullmatch(name[len(prefix) :])
         if match:
             versioned.append((int(match.group(1)), name))
-        elif allow_other_suffixes:
+        elif allow_other_suffixes and not name[len(prefix) :].isdigit():
             others.append(name)
     if versioned:
         return max(versioned)[1]

--- a/src/nsys_ai/connection.py
+++ b/src/nsys_ai/connection.py
@@ -383,9 +383,14 @@ def resolve_table_variant(
     kind (peer-to-peer memcpy) and must never be mistaken for a newer variant
     of ``CUPTI_ACTIVITY_KIND_MEMCPY``. Anchoring tier 2 alone did not deliver
     that: on a profile carrying only ``..._MEMCPY2`` the permissive tier 3
-    returned it anyway. So tier 3 excludes an all-digit remainder too — every
-    versioning shape this repo has met is ``_V<n>``, and a bare trailing digit
-    is CUPTI's way of naming a *sibling* activity kind, not a version.
+    returned it anyway. So tier 3 excludes any remainder that *begins* with a
+    digit — every versioning shape this repo has met is ``_V<n>``, which starts
+    with an underscore, while a trailing digit is CUPTI's way of naming a
+    *sibling* activity kind. Testing the whole remainder rather than its first
+    character was not enough: it rejected ``..._MEMCPY2`` but not the versioned
+    peer-to-peer table ``..._MEMCPY2_V2``, whose remainder ``2_V2`` is not all
+    digits — so a P2P-only export that carried the suffix still had its copies
+    counted as ordinary memcpy traffic.
 
     The consequence is deliberate: a MEMCPY2-only profile resolves ``memcpy`` to
     ``None`` rather than reporting P2P copies (a different ``copyKind`` domain)
@@ -406,7 +411,7 @@ def resolve_table_variant(
         match = _VERSION_SUFFIX_RE.fullmatch(name[len(prefix) :])
         if match:
             versioned.append((int(match.group(1)), name))
-        elif allow_other_suffixes and not name[len(prefix) :].isdigit():
+        elif allow_other_suffixes and not name[len(prefix) :][:1].isdigit():
             others.append(name)
     if versioned:
         return max(versioned)[1]

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -120,13 +120,11 @@ def launch_overhead_ms(
     kernel_table = prof.schema.kernel_table
     if not kernel_table:
         return 0.0
-    tables = prof.schema.tables
-    runtime_table: str | None = "CUPTI_ACTIVITY_KIND_RUNTIME"
-    if runtime_table not in tables:
-        runtime_table = next(
-            (t for t in sorted(tables) if t.startswith("CUPTI_ACTIVITY_KIND_RUNTIME")),
-            None,
-        )
+    # Via the shared resolver, never a local prefix scan: this used to take
+    # sorted(...)[0] — the *oldest* variant — and so disagreed with every other
+    # reader on a profile carrying both _V2 and _V3. ``prof`` must therefore
+    # carry a real ConnectionAdapter (wrap_connection), not a bare connection.
+    runtime_table = prof.adapter.resolve_activity_tables().get("runtime")
     if not runtime_table:
         return 0.0
 
@@ -506,25 +504,18 @@ def detect_iterations(
 
     primary_tid = _find_primary_thread(prof, device)
 
-    # Resolve table names dynamically (versioned-table support)
-    # Prefer exact canonical name first, then sorted prefix fallback
-    # (consistent with base._resolve_activity_tables).
-    tables = prof.schema.tables
-
-    nvtx_table = "NVTX_EVENTS"
-    if nvtx_table not in tables:
-        for t in sorted(tables):
-            if t.startswith("NVTX_EVENTS"):
-                nvtx_table = t
-                break
-    has_nvtx = nvtx_table in tables
-
-    runtime_table = "CUPTI_ACTIVITY_KIND_RUNTIME"
-    if runtime_table not in tables:
-        for t in sorted(tables):
-            if t.startswith("CUPTI_ACTIVITY_KIND_RUNTIME"):
-                runtime_table = t
-                break
+    # Resolve table names through the shared resolver (versioned-table support).
+    # These two sites used to scan prefixes locally and take sorted(...)[0] — the
+    # *oldest* variant — which is the opposite of what every other reader picks.
+    # The literal fallbacks keep the pre-existing shape for an absent table:
+    # ``has_nvtx`` gates the NVTX query away entirely, and a missing runtime
+    # table still surfaces as "no such table CUPTI_ACTIVITY_KIND_RUNTIME" rather
+    # than as a query reading ``FROM None``.
+    resolved = prof.adapter.resolve_activity_tables()
+    resolved_nvtx = resolved.get("nvtx")
+    has_nvtx = resolved_nvtx is not None
+    nvtx_table = resolved_nvtx or "NVTX_EVENTS"
+    runtime_table = resolved.get("runtime") or "CUPTI_ACTIVITY_KIND_RUNTIME"
 
     # Filter to primary thread's top-level iterations
     # Use COALESCE to handle newer schemas where text is NULL and textId is used

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -809,8 +809,11 @@ def _find_table(tables: set[str], prefix: str) -> str | None:
     ``connection.py`` so the cached and uncached engines cannot pick different
     source tables on a profile that carries several variants. Unlike that
     resolver this one stays strict about ``_V<n>``: it decides which table the
-    ETL *copies*, and a looser match would let an unrelated activity kind
-    (``CUPTI_ACTIVITY_KIND_MEMCPY2``) be cached as the memcpy table.
+    ETL *copies*, so an unrecognised suffix should leave the entry uncached
+    rather than cache a guess under the canonical name. (Both sides now reject a
+    bare trailing digit — ``CUPTI_ACTIVITY_KIND_MEMCPY2`` is peer-to-peer
+    memcpy, not a memcpy version — so the two differ only on suffixes neither
+    has met, such as a hypothetical ``..._NEXTGEN``.)
     """
     return resolve_table_variant(tables, prefix)
 
@@ -818,11 +821,15 @@ def _find_table(tables: set[str], prefix: str) -> str | None:
 def _kernel_like_tables(tables: set[str]) -> list[str]:
     """Source tables ``NsightSchema`` would accept as the kernel activity table.
 
-    Mirrors ``NsightSchema._detect_kernel_table``: any non-``ENUM_`` table with
-    ``KERNEL`` in its name. Used to tell "this profile has no kernel data at all"
-    (a legitimate state — Nsight creates tables lazily) from "this profile has
-    kernel data under a name ``_find_table`` did not match", which must not be
-    cached.
+    Mirrors the *set* ``NsightSchema._detect_kernel_table`` will accept: any
+    non-``ENUM_`` table with ``KERNEL`` in its name. Which one of them that
+    function picks is the shared resolver's business and not mirrored here —
+    every name the resolver can return starts with
+    ``CUPTI_ACTIVITY_KIND_KERNEL``, so it is a subset of this list either way.
+
+    Used to tell "this profile has no kernel data at all" (a legitimate state —
+    Nsight creates tables lazily) from "this profile has kernel data under a
+    name ``_find_table`` did not match", which must not be cached.
     """
     return sorted(t for t in tables if "KERNEL" in t.upper() and not t.upper().startswith("ENUM_"))
 

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -172,10 +172,30 @@ class NsightSchema:
 
         Today this is usually CUPTI_ACTIVITY_KIND_KERNEL, but we keep
         the detection logic resilient to future renames.
+
+        Variants of the canonical name are chosen by the shared resolver, never
+        here. This used to be its own "exact name, else sorted(candidates)[0]"
+        scan, which picks the *oldest* variant: on a profile carrying both
+        ``..._KERNEL_V2`` and ``..._KERNEL_V3`` it returned ``_V2`` while
+        ``resolve_activity_tables()["kernel"]`` returned ``_V3``, so
+        ``launch_overhead_ms`` — whose SQL joins ``kernel_table`` against the
+        resolved runtime table — read two tables that did not describe the same
+        window. Measured on a fixture with all three activity tables doubled and
+        the ``_V2`` copies truncated to a quarter: 0.0 ms / 0 iterations against
+        the ``_V3``-only control's 0.05 ms / 28.
+
+        The substring sweep below stays as a last resort for a rename the
+        resolver cannot see (a name that does not start with the canonical
+        prefix at all). Its ``sorted`` is only for determinism between such
+        unrelated names — by then there is no version ordering left to get wrong.
         """
-        # Preferred legacy/known name
-        if "CUPTI_ACTIVITY_KIND_KERNEL" in self.tables:
-            return "CUPTI_ACTIVITY_KIND_KERNEL"
+        from .connection import resolve_table_variant
+
+        resolved = resolve_table_variant(
+            set(self.tables), "CUPTI_ACTIVITY_KIND_KERNEL", allow_other_suffixes=True
+        )
+        if resolved:
+            return resolved
 
         # Fallback: any non-enum table with KERNEL in the name
         candidates = [

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -41,6 +41,23 @@ def _params_key(resolved: dict) -> str:
     return json.dumps(resolved, sort_keys=True, default=str)
 
 
+# The activity-table placeholders a SQL template may use, mapped to the key
+# ``ConnectionAdapter.resolve_activity_tables`` files the resolved name under
+# and to the canonical (unversioned) name. Declared once here so the injection
+# in ``Skill.execute`` and the "cannot run" check over it read the same list;
+# they used to be one hand-written ``setdefault`` per entry, which made it easy
+# to add a placeholder to the injection and forget the guard.
+ACTIVITY_TABLE_PLACEHOLDERS: dict[str, tuple[str, str]] = {
+    "kernel_table": ("kernel", "CUPTI_ACTIVITY_KIND_KERNEL"),
+    "runtime_table": ("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME"),
+    "nvtx_table": ("nvtx", "NVTX_EVENTS"),
+    "memcpy_table": ("memcpy", "CUPTI_ACTIVITY_KIND_MEMCPY"),
+    "memset_table": ("memset", "CUPTI_ACTIVITY_KIND_MEMSET"),
+    "sync_table": ("sync", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"),
+    "sync_type_table": ("sync_type", "ENUM_CUPTI_SYNC_TYPE"),
+}
+
+
 def abstain(reason: str, **detail) -> list[dict]:
     """Return the row a skill emits when it *cannot run*, with the reason why.
 
@@ -416,7 +433,9 @@ class Skill:
         """Run the skill against a connection.
 
         If ``execute_fn`` is set, delegates to it.  Otherwise runs the
-        skill's SQL query against *conn*.
+        skill's SQL query against *conn* — unless one of the activity tables
+        that query reads cannot be resolved on this profile, in which case it
+        abstains instead of running a query that is certain to fail.
 
         Args:
             conn: SQLite connection to an Nsight profile database
@@ -426,7 +445,9 @@ class Skill:
                       in the SQL template.
 
         Returns:
-            List of result rows as dicts
+            List of result rows as dicts, or the single-row abstention marker
+            :func:`abstain` builds. Callers that treat rows as data must test
+            for it with :func:`is_abstention`.
         """
         # Auto-create performance indexes (one-time per connection).
         ensure_indexes(conn)
@@ -504,34 +525,33 @@ class Skill:
         # CUPTI_ACTIVITY_KIND_KERNEL which may be _KERNEL_V2/_V3 in
         # newer Nsight Systems versions.
         tables = adapter.resolve_activity_tables()
-        resolved.setdefault(
-            "kernel_table",
-            tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL"),
-        )
-        resolved.setdefault(
-            "runtime_table",
-            tables.get("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME"),
-        )
-        resolved.setdefault(
-            "nvtx_table",
-            tables.get("nvtx", "NVTX_EVENTS"),
-        )
-        resolved.setdefault(
-            "memcpy_table",
-            tables.get("memcpy", "CUPTI_ACTIVITY_KIND_MEMCPY"),
-        )
-        resolved.setdefault(
-            "memset_table",
-            tables.get("memset", "CUPTI_ACTIVITY_KIND_MEMSET"),
-        )
-        resolved.setdefault(
-            "sync_table",
-            tables.get("sync", "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"),
-        )
-        resolved.setdefault(
-            "sync_type_table",
-            tables.get("sync_type", "ENUM_CUPTI_SYNC_TYPE"),
-        )
+        unresolved: list[str] = []
+        for placeholder, (key, canonical) in ACTIVITY_TABLE_PLACEHOLDERS.items():
+            if placeholder in resolved:
+                # Caller named the table explicitly; that is their business.
+                continue
+            resolved[placeholder] = tables.get(key, canonical)
+            if tables.get(key) is None and "{" + placeholder + "}" in self.sql:
+                unresolved.append(canonical)
+        if unresolved:
+            # The template reads a table this profile does not have. Substituting
+            # the canonical literal anyway (which is what the ``.get`` fallback
+            # above does, and all this branch used to do) sends the skill into
+            # ``sqlite3.OperationalError: no such table`` — and ``EvidenceBuilder``
+            # catches that, so the skill vanishes from the findings with no trace.
+            # ``abstain`` is the contract for "cannot run"; see its docstring.
+            #
+            # Only a placeholder the template actually uses counts: the fallbacks
+            # are still written into ``resolved`` because ``str.format`` needs a
+            # value for every key it is given, not only the ones in this template.
+            names = ", ".join(sorted(set(unresolved)))
+            return abstain(
+                f"This profile has no {names} table, so '{self.name}' has "
+                f"nothing to read. Either the capture did not trace that "
+                f"activity kind, or the export names it something this version "
+                f"does not recognise as a variant.",
+                missing_tables=sorted(set(unresolved)),
+            )
 
         # NVTX text resolution: handle both legacy (text column only)
         # and modern schemas (textId → StringIds lookup).

--- a/src/nsys_ai/skills/builtins/kernel_overlap_matrix.py
+++ b/src/nsys_ai/skills/builtins/kernel_overlap_matrix.py
@@ -21,13 +21,24 @@ _COPY_KINDS = {
 
 
 def _query_memcpy(prof, device, trim):
-    """Query memcpy intervals from CUPTI_ACTIVITY_KIND_MEMCPY."""
-    memcpy_table = None
-    for t in prof.schema.tables:
-        if t == "CUPTI_ACTIVITY_KIND_MEMCPY" or t.startswith("CUPTI_ACTIVITY_KIND_MEMCPY"):
-            memcpy_table = t
-            break
+    """Memcpy intervals for ``device``, or ``[]`` when the profile has none.
+
+    Empty here does not mean the skill could not run, so it is not an
+    abstention: memcpy is one input among several and the matrix is still
+    answerable from the kernel categories alone. A profile with no
+    CUPTI_ACTIVITY_KIND_MEMCPY — including one carrying only
+    CUPTI_ACTIVITY_KIND_MEMCPY2, which is peer-to-peer copy, a different
+    activity kind — simply produces a matrix with no ``memcpy_*`` category in
+    it, exactly as a capture that moved no memory does.
+    """
     import re
+
+    # Through the adapter, like every other memcpy reader (profile.py,
+    # viewer.py, indexing.py), not a local prefix scan: the scan this replaces
+    # walked ``prof.schema.tables``, which is ``list(<set>)``, so on a profile
+    # carrying both CUPTI_ACTIVITY_KIND_MEMCPY and CUPTI_ACTIVITY_KIND_MEMCPY2
+    # which one it read was set-hash order.
+    memcpy_table = prof.adapter.resolve_activity_tables().get("memcpy")
 
     if memcpy_table is None or not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", memcpy_table):
         return []

--- a/src/nsys_ai/skills/builtins/memory_bandwidth.py
+++ b/src/nsys_ai/skills/builtins/memory_bandwidth.py
@@ -9,7 +9,7 @@ Analyzes CUDA memory copy operations to compute:
 Goes beyond the basic memory_transfers skill which only does direction aggregation.
 """
 
-from ..base import Skill, SkillParam
+from ..base import Skill, SkillParam, abstain
 
 _COPY_KIND_NAMES = {
     0: "Unknown",
@@ -32,13 +32,23 @@ def _execute(conn, **kwargs):
     device = int(kwargs.get("device", 0))
     limit = int(kwargs.get("limit", 5))
 
-    memcpy_table = None
-    for t in prof.schema.tables:
-        if t == "CUPTI_ACTIVITY_KIND_MEMCPY" or t.startswith("CUPTI_ACTIVITY_KIND_MEMCPY"):
-            memcpy_table = '"' + t.replace('"', '""') + '"'
-            break
-    if not memcpy_table:
-        return []
+    # Through the adapter, like every other memcpy reader (profile.py,
+    # viewer.py, indexing.py), not a local prefix scan: the scan this replaces
+    # walked ``prof.schema.tables``, which is ``list(<set>)``, so on a profile
+    # carrying both CUPTI_ACTIVITY_KIND_MEMCPY and CUPTI_ACTIVITY_KIND_MEMCPY2
+    # (peer-to-peer copies, a different activity kind) which one it read was
+    # set-hash order. Going through the adapter also picks up the cache's
+    # unversioned alias view on the DuckDB engines.
+    resolved = prof.adapter.resolve_activity_tables().get("memcpy")
+    if not resolved:
+        return abstain(
+            "This profile has no CUPTI_ACTIVITY_KIND_MEMCPY table, so it "
+            "records no host/device copies. Bandwidth analysis needs them — a "
+            "capture traced with --trace=cuda has them; a profile carrying "
+            "only CUPTI_ACTIVITY_KIND_MEMCPY2 has peer-to-peer copies, which "
+            "are a different activity kind and are not read here."
+        )
+    memcpy_table = '"' + resolved.replace('"', '""') + '"'
 
     trim_clause = ""
     trim = None

--- a/src/nsys_ai/skills/builtins/memory_transfers.py
+++ b/src/nsys_ai/skills/builtins/memory_transfers.py
@@ -1,6 +1,6 @@
 """Memory transfer summary — H2D, D2H, D2D, P2P breakdown."""
 
-from ..base import Skill, SkillParam
+from ..base import Skill, SkillParam, is_abstention
 
 _COPY_KINDS = {1: "H2D", 2: "D2H", 8: "D2D", 10: "P2P"}
 
@@ -210,11 +210,16 @@ H2D_DIST_SKILL.to_findings_fn = _to_findings_dist
 
 # Replace the direct SQL with a safe execute_fn for the module
 def _execute_h2d_dist(conn, **kwargs):
-    """Execute the H2D distribution query safely with pattern classification.
+    """Execute the H2D distribution query, then classify the pattern it shows.
 
     This function is assigned as ``H2D_DIST_SKILL.execute_fn`` and wraps the
-    underlying SQL execution so that if the memcpy table does not exist, it
-    returns an empty result instead of propagating a ``SkillExecutionError``.
+    underlying SQL execution. A profile with no memcpy table now abstains
+    inside ``Skill.execute`` rather than reaching the database at all, and that
+    abstention is returned untouched: classifying it would read ``total_mb``
+    off the marker row and raise ``KeyError``. The ``SkillExecutionError``
+    branch below stays for the errors the guard does not cover — a table that
+    resolves but cannot be read, for instance — and returns ``[]`` there as it
+    always has.
 
     After executing the SQL, appends a pattern classification dict as the
     last element of the result list.
@@ -241,6 +246,9 @@ def _execute_h2d_dist(conn, **kwargs):
         if "no such table" in err_msg or "does not exist" in err_msg:
             return []
         raise
+
+    if is_abstention(rows):
+        return rows
 
     # Append pattern classification as metadata
     if rows:

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -104,17 +104,20 @@ def _resolve_nvtx_table_for_auto_trim(prof) -> str | None:
     Preference order:
       * ``nvtx_high`` view — DuckDB cache, aten::* already filtered.
       * ``nvtx`` view — DuckDB cache, full NVTX with resolved text.
-      * Versioned canonical table — ``NVTX_EVENTS`` / ``NVTX_EVENTS_V2`` /
-        ``NVTX_EVENTS_V3`` (the actual nsys export schema for the version
-        we attached). Resolved via ``prof.schema.tables`` rather than
-        hardcoded so newer Nsight exports without an unversioned alias
-        still work.
+      * Versioned canonical table — ``NVTX_EVENTS``, else the highest
+        ``NVTX_EVENTS_V<n>`` (the actual nsys export schema for the version
+        we attached). Resolved from ``prof.schema.tables`` through the shared
+        ``resolve_table_variant`` rather than hardcoded, so newer Nsight
+        exports without an unversioned alias still work and this site cannot
+        drift from the ordering every other reader uses.
 
     Returns the chosen name or ``None`` when no NVTX source can be opened.
     """
     import sqlite3
 
     import duckdb
+
+    from ...connection import resolve_table_variant
 
     # Cache-view candidates always have resolved text (no StringIds join
     # needed by the caller). Probe each; pick the first that can be
@@ -131,12 +134,7 @@ def _resolve_nvtx_table_for_auto_trim(prof) -> str | None:
         tables = set(prof.schema.tables)
     except Exception:
         tables = set()
-    if "NVTX_EVENTS" in tables:
-        return "NVTX_EVENTS"
-    for t in sorted(tables):
-        if t.startswith("NVTX_EVENTS"):
-            return t
-    return None
+    return resolve_table_variant(tables, "NVTX_EVENTS", allow_other_suffixes=True)
 
 
 def _build_auto_trim_nvtx_sql(prof, nvtx_table: str) -> str:

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -2253,6 +2253,7 @@ def test_launch_overhead_ms_counts_only_exposed_idle():
     """launch_overhead_ms = GPU-idle time overlapping a kernel-launch API call."""
     import sqlite3
 
+    from nsys_ai.connection import wrap_connection
     from nsys_ai.overlap import launch_overhead_ms
 
     conn = sqlite3.connect(":memory:")
@@ -2293,7 +2294,10 @@ def test_launch_overhead_ms_counts_only_exposed_idle():
 
     class _Prof:
         schema = _Schema()
-        adapter = conn
+        # A real Profile always wraps its connection; launch_overhead_ms resolves
+        # the runtime table through the adapter, so a bare sqlite3.Connection
+        # (which happens to satisfy .execute) is not a faithful stub.
+        adapter = wrap_connection(conn)
 
     assert launch_overhead_ms(_Prof(), device=0) == 2.0  # 0.5 + 1.5
     assert launch_overhead_ms(_Prof(), device=99) == 0.0  # no kernels on device
@@ -2303,6 +2307,7 @@ def test_launch_overhead_ms_without_runtime_table_is_zero():
     """No runtime table → launch overhead is 0.0 (best-effort enrichment)."""
     import sqlite3
 
+    from nsys_ai.connection import wrap_connection
     from nsys_ai.overlap import launch_overhead_ms
 
     conn = sqlite3.connect(":memory:")
@@ -2319,7 +2324,7 @@ def test_launch_overhead_ms_without_runtime_table_is_zero():
 
     class _Prof:
         schema = _Schema()
-        adapter = conn
+        adapter = wrap_connection(conn)
 
     assert launch_overhead_ms(_Prof(), device=0) == 0.0
 

--- a/tests/test_duckdb_path.py
+++ b/tests/test_duckdb_path.py
@@ -234,18 +234,27 @@ class TestDuckDBCompatibilityFixes:
         assert type(p.meta).__name__ == "ProfileMeta"
 
     def test_memory_transfers_duckdb_error(self, duckdb_conn):
-        """memory_transfers H2D distribution should catch duckdb.Error on missing table."""
+        """h2d_distribution must not raise duckdb.Error when the memcpy table is absent.
+
+        It now says so rather than going quiet: ``Skill.execute`` abstains when
+        a table the template reads cannot be resolved, and the H2D wrapper
+        passes that abstention through instead of trying to classify a pattern
+        out of the marker row. The original assertion here was ``rows == []``,
+        which ``abstain``'s docstring defines as "ran, nothing to report" —
+        the wrong answer for an empty database.
+        """
         import duckdb
 
+        from nsys_ai.skills.base import is_abstention
         from nsys_ai.skills.registry import get_skill
 
         skill = get_skill("h2d_distribution")
 
         # Create a fresh DuckDB connection without the memcpy table
         bad_conn = duckdb.connect()
-        # Should quietly return [] instead of raising duckdb.Error
         rows = skill.execute(bad_conn)
-        assert rows == []
+        assert is_abstention(rows)
+        assert "CUPTI_ACTIVITY_KIND_MEMCPY" in rows[0]["reason"]
 
     def _make_textid_db(self, nvtx_rows: list[tuple], string_rows: list[tuple]):
         """Return a minimal DuckDB connection with textId-based NVTX schema."""

--- a/tests/test_overlap_table_resolution.py
+++ b/tests/test_overlap_table_resolution.py
@@ -1,0 +1,444 @@
+"""``overlap.py`` must resolve Nsight table variants the way everyone else does.
+
+Three sites in ``overlap.py`` scanned ``prof.schema.tables`` themselves and took
+``sorted(...)[0]`` — the *oldest* variant — which is the ordering the shared
+resolver was introduced to replace. On a profile carrying both ``_V2`` and
+``_V3`` the two engines then answered differently for the same skill on the same
+profile:
+
+* ``launch_overhead_ms`` picked ``CUPTI_ACTIVITY_KIND_RUNTIME_V2``;
+* ``detect_iterations`` picked ``NVTX_EVENTS_V2`` *and* ``..._RUNTIME_V2``.
+
+Two more sites had the same shape one layer out:
+``profile_health_manifest``'s raw-SQLite NVTX fallback, and
+``NsightSchema._detect_kernel_table`` — which supplies the *other* table in
+``launch_overhead_ms``'s own join, so fixing only the three above left that one
+statement reading a ``_V3`` runtime table against a ``_V2`` kernel table. The
+rule these tests enforce is that no site outside the shared resolver orders
+variants itself.
+
+Only the raw-SQLite engine was affected. Both DuckDB paths (``open_cached_db``
+and ``open_direct_sqlite``) create an unversioned alias view pointing at the
+*resolver-chosen* table, so ``overlap.py``'s "prefer the unversioned name" first
+branch landed on the right data there by accident. That is not a corner case:
+thirteen builtin skill modules build a Profile with
+``Profile._from_conn(<connection>)``, and ``Skill.execute(sqlite_conn)`` is a
+first-class engine here — ``test_sync_table_resolution.py`` exercises it
+directly.
+
+The same commit that unified the resolver also claimed
+``CUPTI_ACTIVITY_KIND_MEMCPY2`` (peer-to-peer memcpy — a distinct CUPTI activity
+kind, not a version) could never be read as a memcpy variant. It could, twice
+over: the query-side resolver's permissive tier 3 returned it when it was the
+only memcpy-prefixed table, and two skills never called the resolver at all and
+picked whichever memcpy-prefixed name came first out of a *set*. The tests at
+the bottom pin both halves, and also pin what each of the three memcpy readers
+then *does* with a profile the resolver declines to answer for — two abstain,
+one carries on without a memcpy category. Declining to resolve is only half an
+answer; the readers used to raise or go quiet, which is what the resolver's
+docstring had claimed they did not do.
+
+Every real capture available here carries exactly one variant per table and none
+carries ``..._MEMCPY2``, so these cases have to be constructed rather than taken
+from a fixture.
+"""
+
+import shutil
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.connection import _find_activity_tables
+from nsys_ai.overlap import detect_iterations, launch_overhead_ms
+from nsys_ai.parquet_cache import _find_table
+from nsys_ai.profile import Profile
+from nsys_ai.skills.registry import get_skill
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+NVTX = "NVTX_EVENTS"
+RUNTIME = "CUPTI_ACTIVITY_KIND_RUNTIME"
+MEMCPY = "CUPTI_ACTIVITY_KIND_MEMCPY"
+KERNEL = "CUPTI_ACTIVITY_KIND_KERNEL"
+
+# How much of each table the stale ``_V2`` leftover keeps. Deliberately not a
+# half: at 50% (and above) this fixture's truncation no longer removes the rows
+# that decide either answer, so a test built on it would pass whether or not the
+# resolution is fixed. Measured on this fixture, the answers diverge from the
+# complete table at 25% and coincide at 50%.
+_KEEP_NUMERATOR, _KEEP_DENOMINATOR = 1, 4
+
+
+def _truncated_count(conn: sqlite3.Connection, table: str) -> int:
+    total = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]  # noqa: S608
+    kept = total * _KEEP_NUMERATOR // _KEEP_DENOMINATOR
+    if not 0 < kept < total:
+        raise ValueError(f"{table} is not distinguishable when truncated: {kept}/{total}")
+    return kept
+
+
+def _build(dst: Path, mode: str, bases: tuple[str, ...] = (NVTX, RUNTIME)) -> Path:
+    """Copy the fixture and rewrite each of ``bases`` into ``mode``.
+
+    ``v3_only``   — the complete tables, renamed to ``_V3``. The control.
+    ``dual``      — ``_V3`` complete, plus a truncated ``_V2`` alongside it.
+    ``v3_stale``  — only ``_V3``, holding the *truncated* rows. The premise
+                    guard: this is what a reader that picked ``_V2`` sees.
+
+    ``bases`` defaults to the two tables ``overlap.py`` resolves for itself, so
+    the tests of *its* three sites are not also exercising the kernel-table
+    resolution one layer down; the fixture that versions the kernel table too
+    passes ``bases`` explicitly.
+    """
+    shutil.copy(FIXTURE, dst)
+    conn = sqlite3.connect(dst)
+    try:
+        for base in bases:
+            kept = _truncated_count(conn, base)
+            if mode == "v3_only":
+                conn.execute(f"ALTER TABLE {base} RENAME TO {base}_V3")
+            elif mode == "dual":
+                conn.execute(f"ALTER TABLE {base} RENAME TO {base}_V3")
+                conn.execute(
+                    f"CREATE TABLE {base}_V2 AS "  # noqa: S608
+                    f"SELECT * FROM {base}_V3 ORDER BY start LIMIT {kept}"
+                )
+            elif mode == "v3_stale":
+                conn.execute(
+                    f"CREATE TABLE {base}_stale AS "  # noqa: S608
+                    f"SELECT * FROM {base} ORDER BY start LIMIT {kept}"
+                )
+                conn.execute(f"DROP TABLE {base}")
+                conn.execute(f"ALTER TABLE {base}_stale RENAME TO {base}_V3")
+            else:  # pragma: no cover - programming error
+                raise ValueError(f"unknown mode {mode!r}")
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+@pytest.fixture(scope="module")
+def v3_only(tmp_path_factory) -> Path:
+    return _build(tmp_path_factory.mktemp("v3_only") / "v3_only.sqlite", "v3_only")
+
+
+@pytest.fixture(scope="module")
+def dual_variant(tmp_path_factory) -> Path:
+    return _build(tmp_path_factory.mktemp("dual") / "dual.sqlite", "dual")
+
+
+@pytest.fixture(scope="module")
+def v3_stale(tmp_path_factory) -> Path:
+    return _build(tmp_path_factory.mktemp("stale") / "stale.sqlite", "v3_stale")
+
+
+@pytest.fixture(scope="module")
+def dual_variant_all(tmp_path_factory) -> Path:
+    """Every activity table this file touches doubled, kernel table included."""
+    return _build(
+        tmp_path_factory.mktemp("dual_all") / "dual_all.sqlite", "dual", (KERNEL, NVTX, RUNTIME)
+    )
+
+
+@pytest.fixture(scope="module")
+def v3_only_all(tmp_path_factory) -> Path:
+    return _build(
+        tmp_path_factory.mktemp("v3_all") / "v3_all.sqlite", "v3_only", (KERNEL, NVTX, RUNTIME)
+    )
+
+
+def _overlap_answers(path: Path) -> tuple[float, int]:
+    """``launch_overhead_ms`` and the iteration count, over raw SQLite.
+
+    ``Profile._from_conn`` on a ``sqlite3.Connection`` leaves ``prof.db`` None,
+    which is the engine with no alias-view layer to paper over the resolution.
+    """
+    conn = sqlite3.connect(path)
+    try:
+        prof = Profile._from_conn(conn)
+        return launch_overhead_ms(prof, 0), len(detect_iterations(prof, 0))
+    finally:
+        conn.close()
+
+
+# ── The premise ─────────────────────────────────────────────────────────────
+
+
+def test_the_two_variants_give_different_answers(v3_only, v3_stale):
+    """Without this, the assertions below could pass on any resolution at all.
+
+    The stale profile carries exactly what a reader landing on ``_V2`` would
+    see, so the gap measured here is the size of the bug.
+    """
+    assert _overlap_answers(v3_stale) != _overlap_answers(v3_only)
+
+
+# ── The fix, at the overlap.py API ──────────────────────────────────────────
+
+
+def test_overlap_reads_the_newest_variant_not_the_oldest(dual_variant, v3_only):
+    """All three sites at once: ``launch_overhead_ms`` resolves the runtime
+    table, ``detect_iterations`` resolves both NVTX and runtime.
+
+    A stale ``_V2`` sitting next to the real ``_V3`` must not change either
+    answer. Before the fix this returned the truncated profile's numbers.
+    """
+    assert _overlap_answers(dual_variant) == _overlap_answers(v3_only)
+
+
+def test_iteration_timing_agrees_across_engines(dual_variant):
+    """The user-visible consequence, through a shipped skill.
+
+    ``iteration_timing`` goes through ``detect_iterations``. The DuckDB path was
+    always right — its alias views point at the resolved table — so before the
+    fix the same skill on the same profile disagreed with itself depending on
+    which connection it was handed (``is_real_iteration`` flipped).
+    """
+    pytest.importorskip("duckdb", reason="requires duckdb")
+
+    skill = get_skill("iteration_timing")
+
+    conn = sqlite3.connect(dual_variant)
+    try:
+        via_sqlite = skill.execute(conn)
+    finally:
+        conn.close()
+
+    with Profile(str(dual_variant)) as prof:
+        if prof.db is None:  # pragma: no cover
+            pytest.skip("requires duckdb")
+        via_duckdb = skill.execute(prof.db)
+
+    assert via_sqlite == via_duckdb, "the two engines resolved different tables"
+
+
+def test_the_kernel_table_is_resolved_the_same_way_as_everything_else(
+    dual_variant_all, v3_only_all
+):
+    """A fifth site, and the one inside ``launch_overhead_ms``'s own FROM clause.
+
+    ``NsightSchema._detect_kernel_table`` had the same "exact name, else
+    ``sorted(candidates)[0]``" shape. Fixing the three ``overlap.py`` sites
+    without it left the two halves of that function's join disagreeing:
+    ``kernel_table`` came back ``..._KERNEL_V2`` while
+    ``resolve_activity_tables()["kernel"]`` said ``_V3``. The result was not
+    merely stale but empty — measured on this fixture, 0.0 ms and 0 iterations
+    against the control's 0.05 ms and 28 — because a correlationId join across
+    two differently-truncated tables matches almost nothing.
+    """
+    conn = sqlite3.connect(dual_variant_all)
+    try:
+        prof = Profile._from_conn(conn)
+        assert prof.schema.kernel_table == KERNEL + "_V3"
+        assert prof.adapter.resolve_activity_tables()["kernel"] == prof.schema.kernel_table
+    finally:
+        conn.close()
+
+    assert _overlap_answers(dual_variant_all) == _overlap_answers(v3_only_all)
+
+
+def test_the_manifest_auto_trim_reads_the_newest_nvtx_variant(dual_variant):
+    """A fourth site with the same defect, one skill over.
+
+    ``profile_health_manifest``'s raw-SQLite fallback had its own "exact name,
+    else first prefix match in sorted order" scan, and its docstring listed
+    ``_V2`` before ``_V3`` as if that were the preference. The rule is that no
+    site outside the shared resolver orders variants itself.
+    """
+    from nsys_ai.skills.builtins.profile_health_manifest import (
+        _resolve_nvtx_table_for_auto_trim,
+    )
+
+    conn = sqlite3.connect(dual_variant)
+    try:
+        prof = Profile._from_conn(conn)
+        assert _resolve_nvtx_table_for_auto_trim(prof) == NVTX + "_V3"
+    finally:
+        conn.close()
+
+
+# ── MEMCPY2 is not a memcpy variant, on every path that picks one ───────────
+
+
+def test_a_memcpy2_only_profile_resolves_no_memcpy_table():
+    """``CUPTI_ACTIVITY_KIND_MEMCPY2`` is peer-to-peer memcpy: a different
+    activity kind with a different ``copyKind`` domain, not a newer
+    ``..._MEMCPY``. Anchoring the ``_V<n>`` match kept the two apart only while
+    a real memcpy table was also present; with ``..._MEMCPY2`` alone the
+    query-side resolver's permissive tier 3 handed it back anyway.
+
+    Resolving to nothing beats reporting P2P copies as ordinary H2D/D2H
+    traffic. What each reader then *does* with "no memcpy table" is the
+    reader's own contract, pinned by the two tests below — this one only says
+    the resolver declines to answer.
+
+    The tier-3 escape hatch for a non-numeric unknown suffix stays open; that
+    is pinned by ``test_sync_table_resolution.py::
+    test_an_unrecognised_suffix_still_resolves_to_something``, which asserts the
+    same input this test would otherwise duplicate.
+    """
+    assert "memcpy" not in _find_activity_tables({MEMCPY + "2"})
+    assert _find_table({MEMCPY + "2"}, MEMCPY) is None
+
+
+@pytest.fixture(scope="module")
+def memcpy2_only(tmp_path_factory) -> Path:
+    """The fixture with its memcpy table renamed to ``..._MEMCPY2``.
+
+    A profile that traced *only* peer-to-peer copies. Nothing here should read
+    it as ordinary memcpy traffic.
+    """
+    dst = tmp_path_factory.mktemp("m2only") / "memcpy2_only.sqlite"
+    shutil.copy(FIXTURE, dst)
+    conn = sqlite3.connect(dst)
+    try:
+        conn.execute(f"ALTER TABLE {MEMCPY} RENAME TO {MEMCPY}2")
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+@pytest.mark.parametrize("skill_name", ["memory_transfers", "memory_bandwidth"])
+def test_the_memcpy_skills_abstain_on_a_memcpy2_only_profile(memcpy2_only, skill_name):
+    """"Cannot run" has one spelling in this codebase, and it is ``abstain``.
+
+    Declining to resolve ``..._MEMCPY2`` puts such a profile in the same class
+    as one with no memcpy table at all, and neither of those two used to say so:
+    ``memory_transfers`` is a SQL template, so the unresolved placeholder took
+    the canonical literal and the query died on ``no such table`` — which
+    ``EvidenceBuilder`` catches, so the skill vanished from the findings
+    silently. ``memory_bandwidth`` returned ``[]``, which ``abstain``'s own
+    docstring defines as "ran, nothing to report" and calls actively
+    misleading. Measured on this profile before the guard: 1 raise, 1 ``[]``.
+    """
+    from nsys_ai.skills.base import is_abstention
+
+    conn = sqlite3.connect(memcpy2_only)
+    try:
+        rows = get_skill(skill_name).execute(conn)
+    finally:
+        conn.close()
+
+    assert is_abstention(rows), f"{skill_name} did not abstain: {rows[:1]}"
+    assert MEMCPY in rows[0]["reason"], "the reason must name the table that is missing"
+
+
+def test_the_overlap_matrix_reports_what_it_still_has(memcpy2_only, clean_copy):
+    """The third memcpy reader, and the one that does *not* abstain.
+
+    ``kernel_overlap_matrix`` takes memcpy as one input among several, so a
+    profile without it is answerable from the kernel categories alone — an
+    abstention would throw away the compute/comm matrix over a missing extra.
+    It must still drop every ``memcpy_*`` category rather than fill them from
+    the P2P table.
+    """
+    skill = get_skill("kernel_overlap_matrix")
+
+    conn = sqlite3.connect(memcpy2_only)
+    try:
+        rows = skill.execute(conn)
+    finally:
+        conn.close()
+
+    assert rows, "the matrix should still be computed from kernels alone"
+    assert not any(
+        r["category_a"].startswith("memcpy") or r["category_b"].startswith("memcpy") for r in rows
+    ), "CUPTI_ACTIVITY_KIND_MEMCPY2 was read as memcpy"
+
+    conn = sqlite3.connect(clean_copy)
+    try:
+        with_memcpy = skill.execute(conn)
+    finally:
+        conn.close()
+    assert any(r["category_a"].startswith("memcpy") for r in with_memcpy), (
+        "premise: the untouched fixture does produce memcpy categories, "
+        "so their absence above means something"
+    )
+
+
+@pytest.fixture(scope="module")
+def clean_copy(tmp_path_factory) -> Path:
+    """The untouched fixture, copied. Analysis over a profile can leave indexes
+    behind, so nothing here opens ``tests/fixtures`` writable."""
+    dst = tmp_path_factory.mktemp("clean") / "clean.sqlite"
+    shutil.copy(FIXTURE, dst)
+    return dst
+
+
+@pytest.fixture(scope="module")
+def with_memcpy2(tmp_path_factory) -> Path:
+    """The fixture plus a ``..._MEMCPY2`` table holding *different* rows.
+
+    Its copies are relabelled P2P and confined to one device so a skill reading
+    it instead of ``..._MEMCPY`` produces visibly different output rather than
+    the same numbers by coincidence.
+    """
+    dst = tmp_path_factory.mktemp("memcpy2") / "memcpy2.sqlite"
+    shutil.copy(FIXTURE, dst)
+    conn = sqlite3.connect(dst)
+    try:
+        kept = _truncated_count(conn, MEMCPY)
+        conn.execute(
+            f"CREATE TABLE {MEMCPY}2 AS "  # noqa: S608
+            f"SELECT * FROM {MEMCPY} ORDER BY start LIMIT {kept}"
+        )
+        conn.execute(f"UPDATE {MEMCPY}2 SET copyKind = 10, deviceId = 0")  # noqa: S608
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+@pytest.mark.parametrize("skill_name", ["memory_bandwidth", "kernel_overlap_matrix"])
+def test_memcpy_skills_ignore_the_p2p_table_when_the_real_one_is_present(
+    with_memcpy2, clean_copy, skill_name
+):
+    """Both skills hand-rolled ``for t in prof.schema.tables: if
+    t.startswith(...)``. ``NsightSchema.tables`` is ``list(<set>)``, so which of
+    ``..._MEMCPY`` / ``..._MEMCPY2`` that loop found first was set-hash order —
+    non-deterministic across processes, and wrong whenever it landed on P2P.
+    """
+    skill = get_skill(skill_name)
+
+    conn = sqlite3.connect(with_memcpy2)
+    try:
+        polluted = skill.execute(conn)
+    finally:
+        conn.close()
+
+    conn = sqlite3.connect(clean_copy)
+    try:
+        clean = skill.execute(conn)
+    finally:
+        conn.close()
+
+    assert polluted == clean, f"{skill_name} read CUPTI_ACTIVITY_KIND_MEMCPY2"
+
+
+def test_the_memcpy2_fixture_would_change_the_answer(with_memcpy2, clean_copy):
+    """Premise for the two tests above: reading ``..._MEMCPY2`` really does
+    produce a different result, so agreeing with the clean profile is evidence
+    of the right table and not of an insensitive comparison."""
+    skill = get_skill("memory_bandwidth")
+
+    renamed = with_memcpy2.with_name("memcpy2_only.sqlite")
+    shutil.copy(with_memcpy2, renamed)
+    conn = sqlite3.connect(renamed)
+    try:
+        conn.execute(f"DROP TABLE {MEMCPY}")
+        conn.execute(f"ALTER TABLE {MEMCPY}2 RENAME TO {MEMCPY}")
+        conn.commit()
+        via_p2p = skill.execute(conn)
+    finally:
+        conn.close()
+
+    conn = sqlite3.connect(clean_copy)
+    try:
+        clean = skill.execute(conn)
+    finally:
+        conn.close()
+
+    assert via_p2p != clean

--- a/tests/test_sync_table_resolution.py
+++ b/tests/test_sync_table_resolution.py
@@ -88,6 +88,37 @@ def test_a_peer_to_peer_memcpy_table_is_not_mistaken_for_a_memcpy_variant():
     assert resolved["memcpy"] == "CUPTI_ACTIVITY_KIND_MEMCPY_V3"
 
 
+def test_a_versioned_peer_to_peer_table_is_not_a_memcpy_variant_either():
+    """The sibling case the first attempt at this guard let through.
+
+    Rejecting a remainder only when it is entirely digits stops ``..._MEMCPY2``
+    but not ``..._MEMCPY2_V2``, whose remainder ``2_V2`` is not all digits — so
+    a peer-to-peer export that also carried the version suffix this repo exists
+    to handle still had its copies resolved as ordinary memcpy traffic, and
+    counted into a different ``copyKind`` domain's totals.
+
+    Tested through ``_find_activity_tables`` rather than the resolver directly,
+    because it is the permissive tier 3 (``allow_other_suffixes=True``) that
+    lets these through, and only the query side enables it.
+    """
+    for name in (
+        "CUPTI_ACTIVITY_KIND_MEMCPY2",
+        "CUPTI_ACTIVITY_KIND_MEMCPY2_V2",
+        "CUPTI_ACTIVITY_KIND_MEMCPY2_V10",
+    ):
+        assert _find_activity_tables({name}).get("memcpy") is None, (
+            f"{name} was resolved as a memcpy variant"
+        )
+
+    # And the real variant still wins when both are present.
+    assert (
+        _find_activity_tables(
+            {"CUPTI_ACTIVITY_KIND_MEMCPY_V3", "CUPTI_ACTIVITY_KIND_MEMCPY2_V3"}
+        )["memcpy"]
+        == "CUPTI_ACTIVITY_KIND_MEMCPY_V3"
+    )
+
+
 def test_an_unrecognised_suffix_still_resolves_to_something():
     """The query-side resolver keeps a permissive last resort so a future
     suffix shape degrades to "reads the odd table" rather than "reads nothing"."""


### PR DESCRIPTION
`overlap.py` resolved Nsight table names by `sorted(...)[0]` — oldest variant first — the ordering #313 moved everything else off. On a profile carrying more than one variant the two paths read different tables.

## The defect

```
shared resolver  nvtx    -> NVTX_EVENTS_V3
overlap.py       nvtx    -> NVTX_EVENTS_V2        DISAGREE
shared resolver  runtime -> CUPTI_ACTIVITY_KIND_RUNTIME_V3
overlap.py       runtime -> CUPTI_ACTIVITY_KIND_RUNTIME_V2   DISAGREE
```

That is exactly the "two engines resolve different tables on the same profile" hazard #313 set out to close, still open. #313's commit also named two `overlap.py` sites and said both resolved RUNTIME; there are three — `:127`, `:517`, `:525` — and `:517` resolves `NVTX_EVENTS`, so the inventory was wrong by both count and kind.

All three now go through `resolve_table_variant`.

## The peer-to-peer guard, and the bug in the first attempt at it

#313 also claimed *"an anchored match so `CUPTI_ACTIVITY_KIND_MEMCPY2` is never read as a memcpy variant"*, which held on the cache side only — the query side passes `allow_other_suffixes=True`, and tier 3 returned it anyway.

The first attempt here rejected a remainder that was **entirely** digits. That stops `..._MEMCPY2` and lets `..._MEMCPY2_V2` straight through, because `"2_V2"` is not all digits. A peer-to-peer export that also carried the version suffix this repo exists to handle still had its copies resolved as ordinary memcpy traffic — a different `copyKind` domain counted into the same totals. Measured on the branch before the correction:

```
resolve_table_variant({"CUPTI_ACTIVITY_KIND_MEMCPY2_V2"},
                      "CUPTI_ACTIVITY_KIND_MEMCPY", allow_other_suffixes=True)
  -> "CUPTI_ACTIVITY_KIND_MEMCPY2_V2"
```

Testing the remainder's **first character** covers both, and leaves the version shapes alone because `_V<n>` begins with an underscore. Verified across the matrix:

| tables present | `memcpy` resolves to |
|---|---|
| `..._MEMCPY2` | `None` |
| `..._MEMCPY2_V2` | `None` |
| `..._MEMCPY2_V10` | `None` |
| `..._MEMCPY_V3` | `..._MEMCPY_V3` |
| `..._MEMCPY_V3` + `..._MEMCPY2_V3` | `..._MEMCPY_V3` |
| `..._MEMCPY` | `..._MEMCPY` |

The permissive escape hatch is intact: `_KERNEL_NEXTGEN` and the `ENUM_` and sync prefixes all begin with a non-digit, so a genuinely unforeseen suffix still resolves to something rather than to nothing.

## Consequence, stated deliberately

A MEMCPY2-only profile now resolves `memcpy` to `None` rather than reporting P2P copies as ordinary memcpy traffic. That puts it in the same class as a profile with no memcpy table at all, and each reader answers that the way it already did — `memory_transfers` and `memory_bandwidth` abstain naming the missing table, `kernel_overlap_matrix` reports a matrix with no `memcpy_*` category. The resolver does not itself decide any of that.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `bandit -q -r src/ -c pyproject.toml` — 0 issues
- [x] `pytest tests/` — **1527 passed, 135 skipped, 0 failed**
- [x] Resolver matrix above verified case by case
- [x] Mutation-verified: restoring the all-digit test fails `test_a_versioned_peer_to_peer_table_is_not_a_memcpy_variant_either` and nothing else

One earlier full-suite run dumped core; it was resource contention with a large-profile benchmark running concurrently on this 15 GB machine, and the run above is clean.

Closes #324.
