### PR TITLE
docs(cache): correct two docstrings the lazy map split falsified, and drop the guard it left dead

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -225,9 +225,12 @@ def invalidate_cache(sqlite_path: str) -> None:
 def build_cache(sqlite_path: str) -> Path:
     """Build a Parquet cache from a SQLite profile (first-run ETL).
 
-    Attaches the SQLite DB via DuckDB, exports key tables to Parquet with
-    ZSTD compression, and generates ``nvtx_kernel_map.parquet`` using the
-    Python Tier 2 sort-merge logic.
+    Attaches the SQLite DB via DuckDB and exports the base tables to Parquet
+    with ZSTD compression. It does **not** build ``nvtx_kernel_map.parquet``:
+    that one is derived, only four skills read it, and it is materialised on
+    first use instead (see :func:`materialize_cached_nvtx_kernel_map`). A cache
+    with the map and one without are both complete — consumers probe for it
+    rather than assuming it.
 
     Concurrency: serialized by :func:`_build_lock` across threads and
     processes operating on the same profile, with a double-checked
@@ -697,7 +700,7 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
         # ── Generate nvtx_kernel_map ──────────────────────────────────────
         if has_kernel and has_nvtx and has_runtime and not defer_nvtx_map:
             _progress("nvtx_kernel_map.parquet")
-            _build_nvtx_kernel_map(db, src_tables, cache_dir)
+            _build_nvtx_kernel_map(db, cache_dir)
         elif defer_nvtx_map:
             # Not a degraded cache: the first NVTX-attribution query calls
             # ensure_nvtx_kernel_map, which builds the same two Parquets into
@@ -745,8 +748,12 @@ def open_cached_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
 
     Returns a DuckDB connection with views named after each cached table:
       ``kernels``, ``nvtx``, ``runtime``, ``memcpy``, ``memset``,
-      ``string_ids``, ``gpu_info``, ``cuda_device``, ``nvtx_kernel_map``,
-     ``nvtx_path_dict`` (when map uses ``path_id``).
+      ``string_ids``, ``gpu_info``, ``cuda_device``.
+
+    ``nvtx_kernel_map`` and ``nvtx_path_dict`` are deliberately absent: the map
+    is built on first use, so a connection from a cache that has not needed it
+    yet carries neither view. Probe for them rather than assuming them —
+    :func:`ensure_nvtx_kernel_map` is the supported way to ask.
     """
     _require_profile_exists(sqlite_path)
     if not is_cache_valid(sqlite_path):
@@ -1165,7 +1172,6 @@ def _build_nvtx_high(db: duckdb.DuckDBPyConnection, cache_dir: Path) -> None:
 
 def _build_nvtx_kernel_map(
     db: duckdb.DuckDBPyConnection,
-    src_tables: set[str],
     cache_dir: Path,
 ) -> None:
     """Generate nvtx_kernel_map.parquet with a per-thread stack sweep.
@@ -1184,21 +1190,14 @@ def _build_nvtx_kernel_map(
     three sources are not. They are shared with the rest of the cache, so an
     unreadable one is not a reason to drop the map and keep the cache, it is a
     reason to have no cache. ``Profile.__init__`` then logs and falls back to raw
-    SQLite; the profile stays readable, just without Parquet acceleration. The
-    only degraded-but-continue case is a *missing* source, handled below.
+    SQLite; the profile stays readable, just without Parquet acceleration. A
+    *missing* Parquet source is the degraded-but-continue case, and
+    :func:`_build_nvtx_kernel_map_from_parquet` handles it by returning False.
 
     Sources are the ``kernels``, ``runtime`` and ``nvtx`` Parquets already
     exported by this cache build, so the heavy read never scans the attached
     SQLite ``NVTX_EVENTS`` table.
     """
-    kernel_table = _find_table(src_tables, "CUPTI_ACTIVITY_KIND_KERNEL")
-    runtime_table = _find_table(src_tables, "CUPTI_ACTIVITY_KIND_RUNTIME")
-    nvtx_table = _find_table(src_tables, "NVTX_EVENTS")
-
-    if not all([kernel_table, runtime_table, nvtx_table]):
-        log.info("Skipping nvtx_kernel_map: missing required tables")
-        return
-
     _build_nvtx_kernel_map_from_parquet(db, cache_dir)
 
 

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -588,8 +588,11 @@ class TestDamagedInput:
         which would look like a tidy-up — is a visible change to a documented
         behaviour instead of a silent one.
 
-        A *missing* source is the opposite and stays a logged skip; that branch
-        is unreachable in a normal build, so this is its only exercise.
+        A *missing* source is the opposite and stays a logged skip. It is
+        ``_build_nvtx_kernel_map_from_parquet``'s ``is_file()`` check that does
+        that, not the ``src_tables`` guard the caller used to carry: probing
+        that guard with a raise left the whole suite green, so it never fired
+        here either, and it has been removed.
         """
         import shutil
 
@@ -607,14 +610,6 @@ class TestDamagedInput:
         map_path = cache_dir / "nvtx_kernel_map.parquet"
         assert map_path.is_file(), "control: the healthy build must produce a map"
 
-        con = sqlite3.connect(str(profile))
-        try:
-            src_tables = {
-                r[0] for r in con.execute("SELECT name FROM sqlite_master WHERE type='table'")
-            }
-        finally:
-            con.close()
-
         db = duckdb.connect()
         try:
             nvtx = cache_dir / "nvtx.parquet"
@@ -623,18 +618,18 @@ class TestDamagedInput:
 
             nvtx.write_bytes(b"NOTAPARQUET" * 100)
             with pytest.raises(duckdb.Error):
-                parquet_cache._build_nvtx_kernel_map(db, src_tables, cache_dir)
+                parquet_cache._build_nvtx_kernel_map(db, cache_dir)
             assert not map_path.exists(), "a map was written from an unreadable source"
 
             nvtx.unlink()
-            parquet_cache._build_nvtx_kernel_map(db, src_tables, cache_dir)
+            parquet_cache._build_nvtx_kernel_map(db, cache_dir)
             assert not map_path.exists(), "the missing-source skip wrote a map anyway"
 
             # Control: the same call on the restored source does build one, so
             # the two assertions above are about the damage, not about the
             # arguments being wrong.
             nvtx.write_bytes(healthy)
-            parquet_cache._build_nvtx_kernel_map(db, src_tables, cache_dir)
+            parquet_cache._build_nvtx_kernel_map(db, cache_dir)
             assert map_path.is_file(), "the builder no longer works on healthy sources"
         finally:
             db.close()


### PR DESCRIPTION
Two docstrings that were true when written and were falsified by later changes, plus the dead guard one of those changes left behind. Everything below was measured on this machine, not read.

## The prose

**`build_cache`** said it *"generates `nvtx_kernel_map.parquet` using the Python Tier 2 sort-merge logic"*. Both halves are false: #321 deleted that builder, and #322 made the map lazy so `build_cache` does not generate it at all.

```
cold build produced 14 parquet files, containing nvtx_kernel_map.parquet: False
```

**`open_cached_db`** listed `nvtx_kernel_map` and `nvtx_path_dict` among the views its connection carries.

```
open_cached_db views contain nvtx_kernel_map : False
                             nvtx_path_dict  : False
```

Both sentences survived the changes that falsified them because every diff hunk since started **below** them — the same failure mode #321 was opened to fix, and missed one level up in the same file.

## The dead guard

`_build_nvtx_kernel_map` carried `if not all([kernel_table, runtime_table, nvtx_table]): return`. Its only production caller already gates on `has_kernel and has_nvtx and has_runtime`, computed from the identical `_find_table` calls over an unmutated `src_tables`.

Verified rather than argued: replacing the guard body with a `raise` and running the full suite gave **1514 passed, 135 skipped** and the probe never fired. So it was unreachable from the tests too, and `src_tables` — the parameter that existed only to feed it — went with it.

That also corrects a test. `test_an_unreadable_map_source_aborts_the_build_and_a_missing_one_skips` claimed to be *"its only exercise"*. It never was: the missing source it observes is caught by `_build_nvtx_kernel_map_from_parquet`'s `is_file()` check, which is what actually logs and returns `False`. The wrapper's own docstring pointed at the removed guard as *"the only degraded-but-continue case ... handled below"*; it now points at the check that really handles it.

## Deliberately not fixed here

**The lazy build is silent.** `build_cache` writes 14 progress lines; the first NVTX query then builds 1,643 map rows with stderr captured as exactly `''`. On a 3.5 GB capture that deferred portion was around 60 s. Whether it should report progress is a behaviour decision rather than a docstring correction, and it belongs with the auto-policy work in #317, which is where the progress machinery lives.

## One claim on the issue was mine and was wrong

#325 asked to move `_heartbeat`/`_substep` onto the lazy path. Neither symbol exists in this tree — `grep -rn "_heartbeat\|_substep" --include=*.py .` returns nothing. They live only on the unmerged `fix/issue-317-cache-auto-policy` branch, and the "50s of the 77s build" justification I quoted is that branch's commit message. I lifted the claim from a review whose range included that branch without checking it had landed. Struck on the issue, with the correction recorded there.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `bandit -q -r src/ -c pyproject.toml` — 0 issues
- [x] `pytest tests/` — **1514 passed, 135 skipped, 0 failed**
- [x] Dead-guard probe: guard replaced with a raise, full suite green, probe never fired
- [x] Both corrected docstrings verified by execution against the behaviour they now describe

No mutation check on the docstrings: correcting prose is behaviour-preserving by construction, and inventing a test that goes red on a comment change would be theatre. The guard removal's evidence is the probe above.

Refs #325.
