### PR TITLE
fix(chat-tui): stop the stream worker when its turn is cancelled

### DIFF
--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -584,9 +584,14 @@ def stream_agent_loop(
     path touches is ``profile_db_tool._schema_cache``, which is lock-guarded
     and holds strings — so two turns may overlap freely, and they do:
     ``@work(thread=True, exclusive=True)`` cancels the asyncio task, not the OS
-    thread, so a cancelled chat turn keeps running alongside its replacement
-    (Textual's own docs: thread workers cannot be interrupted, only asked to
-    check ``is_cancelled``). That overlap is harmless only because each
+    thread, so a cancelled chat turn is not stopped by anything Textual does
+    (its own docs: thread workers cannot be interrupted, only asked to check
+    ``is_cancelled``). Both Textual consumers do the asking — ``tui_textual``
+    on ``worker.is_cancelled``, ``tree/chat.py`` on its own cancel event — and
+    break out of the loop, so the overlap now lasts until the abandoned turn's
+    next event rather than to the end of its turn. Bounded, not eliminated: the
+    break cannot land mid-event, and the replacement turn starts before the
+    abandoned one notices. That overlap is harmless only because each
     invocation holds its own connection; see ``_prepare_session``. The
     *diff_context* path holds no connection of its own — its ``ToolDispatcher``
     is built with ``conn=None``, as is the one in ``diff_tools.run_diff_tool``

--- a/src/nsys_ai/tui_textual.py
+++ b/src/nsys_ai/tui_textual.py
@@ -11,6 +11,23 @@ Layout:
 Threading:
     stream_agent_loop runs in a @work(thread=True) worker.
     UI updates are dispatched via self.call_from_thread().
+
+    A thread worker cannot be interrupted: Worker.cancel() only marks it
+    cancelled, and all three ways a turn ends go through that same non-stopping
+    path — cancel_all() on Ctrl+C, exclusive supersession by a new submit, and
+    the cancel_all() Textual itself runs when the message loop exits on quit.
+    The worker therefore stops itself, by checking worker.is_cancelled on every
+    stream event; that is what stops it pulling the LLM stream and holding the
+    profile DB connection open.
+
+    Each turn also carries a _generation_id, and every worker-to-UI hop goes
+    via _ui_call, which drops the call if the turn it belongs to is no longer
+    the live one. The two guards do not subsume each other: quitting cancels
+    the worker without bumping the id, and the early-return paths below never
+    reach the stream loop that consults is_cancelled. _ui_call is also defence
+    in depth against a window is_cancelled does not close by construction — a
+    callback already handed to call_from_thread when the cancel lands still
+    runs on the main thread — for which we have no deterministic test.
 """
 
 from __future__ import annotations
@@ -23,6 +40,7 @@ from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.message import Message
 from textual.widgets import DataTable, Footer, Header, Input, Label, RichLog, Static
+from textual.worker import NoActiveWorker, get_current_worker
 
 # ---------------------------------------------------------------------------
 # Profile helper — load top kernels without importing the full Profile class.
@@ -173,6 +191,9 @@ class NsysChatApp(App):
         self._streaming_buffer: list[str] = []
         # Last navigation message (set by _on_action_navigate, consumed by _on_stream_done).
         self._last_nav_message: str = ""
+        # Bumped on every submit and every cancel; a worker whose id no longer
+        # matches is stale and must not touch the UI or the history.
+        self._generation_id: int = 0
 
     # ── Compose ──────────────────────────────────────────────────────────────
 
@@ -250,11 +271,15 @@ class NsysChatApp(App):
         event.input.value = ""
         self._add_user_turn(user_msg)
         self._is_generating = True
+        self._generation_id += 1
         self._streaming_buffer = []
         self._last_nav_message = ""
         # Show "AI: " prefix in RichLog; streaming chunks go to #streaming-area.
         self.query_one("#streaming-area", Static).update("[bold green]AI:[/bold green] …")
-        self._run_stream_worker(user_msg)
+        # Hand the worker its own generation id. Reading it off self on the worker
+        # thread would let a late-scheduled stale worker pick up a newer turn's id
+        # and pass every guard below.
+        self._run_stream_worker(user_msg, self._generation_id)
 
     # ── Main-thread UI callbacks (called via call_from_thread) ────────────────
 
@@ -263,6 +288,11 @@ class NsysChatApp(App):
         log = self.query_one("#chat-log", RichLog)
         log.write(f"[bold yellow]You:[/bold yellow] {text}")
         self._chat_messages.append({"role": "user", "content": text})
+
+    def _ui_call(self, gen: int, fn, *args) -> None:
+        """Run *fn* on the main thread only if *gen* is still the live turn."""
+        if gen == self._generation_id:
+            fn(*args)
 
     def _on_text_chunk(self, chunk: str) -> None:
         """Append streaming text chunk to the Static display area."""
@@ -361,25 +391,42 @@ class NsysChatApp(App):
     # ── Background worker ─────────────────────────────────────────────────────
 
     @work(thread=True, exclusive=True)
-    def _run_stream_worker(self, user_msg: str) -> None:
+    def _run_stream_worker(self, user_msg: str, gen: int) -> None:
         """Background thread: calls stream_agent_loop, posts UI updates via call_from_thread.
+
+        *gen* is the generation id of the turn that started this worker, passed in
+        by the caller rather than read off self here — a worker that starts late
+        would otherwise read whatever generation is live by then, including one
+        belonging to a turn that superseded it.
 
         Imports chat module lazily so the rest of the app works without litellm installed.
         """
         try:
+            worker = get_current_worker()
+        except NoActiveWorker:
+            worker = None
+
+        def cancelled() -> bool:
+            return (worker is not None and worker.is_cancelled) or gen != self._generation_id
+
+        try:
             from .chat import _get_model_and_key, distill_history, stream_agent_loop
         except ImportError as e:
-            self.call_from_thread(self._on_system_event, f"chat module unavailable: {e}")
-            self.call_from_thread(self._on_stream_done, "")
+            self.call_from_thread(
+                self._ui_call, gen, self._on_system_event, f"chat module unavailable: {e}"
+            )
+            self.call_from_thread(self._ui_call, gen, self._on_stream_done, "")
             return
 
         model, _ = _get_model_and_key()
         if not model:
             self.call_from_thread(
+                self._ui_call,
+                gen,
                 self._on_system_event,
                 "No LLM configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or GEMINI_API_KEY.",
             )
-            self.call_from_thread(self._on_stream_done, "")
+            self.call_from_thread(self._ui_call, gen, self._on_stream_done, "")
             return
 
         # Build a lightweight ui_context so the model knows which profile it's analyzing.
@@ -399,27 +446,34 @@ class NsysChatApp(App):
         messages = list(self._chat_messages)
         accumulated: list[str] = []
 
+        stream = stream_agent_loop(
+            model=model,
+            messages=messages,
+            ui_context=ui_context,
+            profile_path=self.profile_path,
+            max_turns=5,
+        )
         try:
-            for event in stream_agent_loop(
-                model=model,
-                messages=messages,
-                ui_context=ui_context,
-                profile_path=self.profile_path,
-                max_turns=5,
-            ):
+            for event in stream:
+                if cancelled():
+                    break
                 etype = event.get("type")
                 if etype == "text":
                     chunk = event.get("content", "")
                     if chunk:
                         accumulated.append(chunk)
-                        self.call_from_thread(self._on_text_chunk, chunk)
+                        self.call_from_thread(self._ui_call, gen, self._on_text_chunk, chunk)
                 elif etype == "system":
-                    self.call_from_thread(self._on_system_event, event.get("content", ""))
+                    self.call_from_thread(
+                        self._ui_call, gen, self._on_system_event, event.get("content", "")
+                    )
                 elif etype == "action":
                     action = event.get("action", {})
                     atype = action.get("type")
                     if atype == "navigate_to_kernel":
                         self.call_from_thread(
+                            self._ui_call,
+                            gen,
                             self._on_action_navigate,
                             action.get("target_name", ""),
                             action.get("reason"),
@@ -428,15 +482,39 @@ class NsysChatApp(App):
                         start_s = action.get("start_s", 0)
                         end_s = action.get("end_s", 0)
                         self.call_from_thread(
+                            self._ui_call,
+                            gen,
                             self._on_system_event,
                             f"🔍 Zoom: {start_s:.3f}s – {end_s:.3f}s",
                         )
                 # "done" type is handled by loop termination.
         except Exception as e:
-            self.call_from_thread(self._on_system_event, f"Stream error: {e}")
+            if not cancelled():
+                self.call_from_thread(
+                    self._ui_call, gen, self._on_system_event, f"Stream error: {e}"
+                )
+        finally:
+            # Close on this thread: the generator owns the profile DB connection
+            # and must be finalized by the thread that advanced it (chat.py
+            # _prepare_session). This is not what makes that true — CPython
+            # refcounting finalizes the generator on this thread anyway, when
+            # this frame is released at function exit (measured). What the
+            # explicit close buys is that the thread and the ordering are a
+            # stated contract rather than an artefact of refcount semantics,
+            # and that a cancelled turn frees the connection at the break
+            # instead of holding it to function exit. Teardown failures are
+            # swallowed as they were when GC did the finalizing — raising here
+            # would skip _on_stream_done and strand the submit guard.
+            try:
+                stream.close()
+            except Exception:
+                pass
+
+        if cancelled():
+            return
 
         final_content = "".join(accumulated)
-        self.call_from_thread(self._on_stream_done, final_content)
+        self.call_from_thread(self._ui_call, gen, self._on_stream_done, final_content)
 
         # Distill history to compress tool call/result sequences for lean context (§11.7).
         try:
@@ -457,6 +535,7 @@ class NsysChatApp(App):
         """Cancel the current AI generation if running (Ctrl+C)."""
         if self._is_generating:
             self.workers.cancel_all()
+            self._generation_id += 1
             self._is_generating = False
             self._streaming_buffer = []
             self.query_one("#streaming-area", Static).update("")

--- a/src/nsys_ai/tui_textual.py
+++ b/src/nsys_ai/tui_textual.py
@@ -22,12 +22,27 @@ Threading:
 
     Each turn also carries a _generation_id, and every worker-to-UI hop goes
     via _ui_call, which drops the call if the turn it belongs to is no longer
-    the live one. The two guards do not subsume each other: quitting cancels
-    the worker without bumping the id, and the early-return paths below never
-    reach the stream loop that consults is_cancelled. _ui_call is also defence
-    in depth against a window is_cancelled does not close by construction — a
-    callback already handed to call_from_thread when the cancel lands still
-    runs on the main thread — for which we have no deterministic test.
+    the live one. Which guard covers which path is worth stating exactly,
+    because the short version gets it wrong:
+
+    - is_cancelled is what the stream loop needs. Quitting cancels the worker
+      without bumping the generation, so nothing else stops that case;
+      removing it leaves test_quitting_the_app_stops_the_worker red.
+    - _generation_id is what the early-return paths need. They return before
+      reaching the loop that consults is_cancelled, so their only guard is the
+      one inside _ui_call; removing it leaves
+      test_stale_worker_early_return_leaves_the_live_turn_alone red.
+    - cancelled() tests both, and its generation half earns its place only
+      where get_current_worker() raises NoActiveWorker and `worker` is None:
+      every production path that bumps the id also cancels the worker, so
+      is_cancelled covers the loop by itself there. Pinned by
+      test_a_stale_worker_with_no_worker_handle_stops_at_the_stream_loop —
+      before that test existed, removing this half left the whole suite green.
+
+    _ui_call is also defence in depth against a window is_cancelled does not
+    close by construction — a callback already handed to call_from_thread when
+    the cancel lands still runs on the main thread — for which we have no
+    deterministic test.
 """
 
 from __future__ import annotations

--- a/tests/test_tui_chat_app.py
+++ b/tests/test_tui_chat_app.py
@@ -1,0 +1,311 @@
+"""Tests for the Textual chat TUI (src/nsys_ai/tui_textual.py).
+
+Issue #311: Ctrl+C (and an exclusive supersession by a new submit) only *marks*
+a Textual thread worker cancelled — it cannot interrupt the OS thread. The
+worker has to stop itself. These tests drive a real NsysChatApp with a fake
+stream and assert that a cancelled turn stops writing to the UI and to the
+LLM history.
+
+The fake stream is gate-driven, never sleep-driven, so the tests are
+deterministic. Note that `_until` must pump the app with `await pilot.pause()`:
+awaiting `asyncio.sleep` instead lets a whole turn's `call_from_thread`
+callbacks arrive in one batch, which makes the assertions vacuous.
+"""
+
+from __future__ import annotations
+
+import shutil
+import threading
+from pathlib import Path
+
+import pytest
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+@pytest.fixture
+def profile_copy(tmp_path):
+    """A private copy of the profile — on_mount builds a .nsys-cache beside it."""
+    dest = tmp_path / FIXTURE.name
+    shutil.copy(FIXTURE, dest)
+    return str(dest)
+
+
+class _GatedStream:
+    """Fake stream_agent_loop: yields one chunk, parks on a gate, then yields more.
+
+    Labels every chunk with the user message that produced it (``<A0>``,
+    ``<B3>``, …) so a turn's output can be attributed unambiguously.
+    """
+
+    def __init__(self) -> None:
+        self.gates: dict[str, threading.Event] = {}
+        self.parked: dict[str, threading.Event] = {}
+        self.finished: dict[str, threading.Event] = {}
+        # Chunks the generator actually produced, i.e. what the worker pulled.
+        # Distinct from what reached the UI: this pins that the worker stopped
+        # *reading* the stream, not merely that its UI writes were dropped.
+        self.produced: list[str] = []
+
+    def gate(self, label: str) -> threading.Event:
+        return self.gates.setdefault(label, threading.Event())
+
+    def parked_at(self, label: str) -> threading.Event:
+        return self.parked.setdefault(label, threading.Event())
+
+    def finished_at(self, label: str) -> threading.Event:
+        """Set when the generator frame ends — exhausted, closed, or GC'd."""
+        return self.finished.setdefault(label, threading.Event())
+
+    def __call__(self, model, messages, ui_context, profile_path=None, max_turns=5, **kw):
+        label = messages[-1]["content"] if messages else "?"
+        try:
+            self.produced.append(f"<{label}0>")
+            yield {"type": "text", "content": f"<{label}0>"}
+            self.parked_at(label).set()
+            # Park until the test opens the gate. Generous timeout: this is a
+            # deadlock backstop, not a synchronisation mechanism.
+            self.gate(label).wait(10)
+            for i in range(1, 6):
+                self.produced.append(f"<{label}{i}>")
+                yield {"type": "text", "content": f"<{label}{i}>"}
+            yield {"type": "done"}
+        finally:
+            # Lets a test wait for the worker to be done with this stream instead
+            # of sleeping. The worker's `finally: stream.close()` throws
+            # GeneratorExit in here, so this fires on the cancelled path too.
+            self.finished_at(label).set()
+
+
+async def _until(pilot, pred, limit: int = 400) -> bool:
+    """Pump the app until *pred* holds. Must use pilot.pause(), not asyncio.sleep."""
+    for _ in range(limit):
+        if pred():
+            return True
+        await pilot.pause()
+    return pred()
+
+
+def _spy_on_chunks(app, seen: list[str]) -> None:
+    orig = app._on_text_chunk
+
+    def spy(chunk):
+        seen.append(chunk)
+        return orig(chunk)
+
+    app._on_text_chunk = spy
+
+
+@pytest.fixture
+def fake_stream(monkeypatch):
+    import nsys_ai.chat as chat_mod
+
+    stream = _GatedStream()
+    monkeypatch.setattr(chat_mod, "stream_agent_loop", stream)
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda *a, **k: ("fake/model", "key"))
+    return stream
+
+
+@pytest.mark.asyncio
+async def test_cancelled_turn_stops_writing(profile_copy, fake_stream):
+    """Ctrl+C must stop the worker writing text, history, and the submit guard."""
+    from nsys_ai.tui_textual import NsysChatApp
+
+    app = NsysChatApp(profile_copy)
+    seen: list[str] = []
+    _spy_on_chunks(app, seen)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        inp = app.query_one("#chat-input")
+        inp.focus()
+        inp.value = "A"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: "<A0>" in seen), "turn A never streamed"
+        assert fake_stream.parked_at("A").wait(5), "turn A generator never parked"
+
+        app.action_cancel_generation()
+        await pilot.pause()
+        fake_stream.gate("A").set()  # let the abandoned worker run on
+
+        # Wait for the abandoned worker to be *done with the stream* before asserting
+        # what it did not do. A bounded pump on "<A5>" in seen would pass vacuously on
+        # a slow runner -- the worker simply may not have produced yet -- which is a
+        # false green rather than a false red. finished_at fires on both paths (fixed:
+        # stream.close() throws GeneratorExit into the generator's finally; unfixed:
+        # exhaustion does), so this is the same terminal condition either way.
+        # Pumped rather than a bare Event.wait(): the worker blocks inside
+        # call_from_thread until the main thread runs the callback, so a blocking wait
+        # here would deadlock the unfixed path against its own dispatches.
+        assert await _until(pilot, lambda: fake_stream.finished_at("A").is_set()), (
+            f"cancelled worker never let go of the stream; it pulled {fake_stream.produced}"
+        )
+
+        assert "<A1>" not in seen, f"cancelled turn A kept streaming: {seen}"
+        # The worker must stop *pulling* the stream, not just stop writing to the
+        # UI: draining it means real LLM spend and the profile DB connection held
+        # open until the generator finishes. Pins the `if cancelled(): break` in
+        # the stream loop specifically, which the UI-side assertions do not.
+        assert "<A3>" not in fake_stream.produced, (
+            f"worker kept pulling the cancelled stream: {fake_stream.produced}"
+        )
+        assert not any(m["role"] == "assistant" for m in app._chat_messages), (
+            f"cancelled turn A wrote an assistant turn: {app._chat_messages}"
+        )
+        assert app._is_generating is False
+
+        # A replacement turn must not be polluted by the cancelled one.
+        inp.focus()
+        inp.value = "B"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: "<B0>" in seen), "turn B never streamed"
+        assert fake_stream.parked_at("B").wait(5), "turn B generator never parked"
+        assert app._is_generating is True, "stale worker released the submit guard mid-turn B"
+        fake_stream.gate("B").set()
+        assert await _until(pilot, lambda: app._is_generating is False), "turn B never finished"
+
+        assistant = [m["content"] for m in app._chat_messages if m["role"] == "assistant"]
+        assert assistant == ["<B0><B1><B2><B3><B4><B5>"], f"history polluted: {app._chat_messages}"
+        assert not any(c.startswith("<A") and c != "<A0>" for c in seen), seen
+
+        # The decision this change actually makes, pinned: the cancelled turn's
+        # *question* stays in the history with no assistant reply, so two consecutive
+        # user messages reach the model. That shape is unchanged by the fix -- what
+        # the fix removes is A's assistant text landing after B's question. Asserting
+        # the full role sequence is what catches a regression on either side; the
+        # role == "assistant" filters above are blind to the user messages.
+        assert [m["role"] for m in app._chat_messages] == ["user", "user", "assistant"], (
+            f"unexpected history shape: {app._chat_messages}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_stale_worker_early_return_leaves_the_live_turn_alone(profile_copy, monkeypatch):
+    """A worker that starts after its turn was superseded must not touch the UI.
+
+    The two early-return paths — no chat module, no LLM configured — never reach
+    the stream loop, so ``worker.is_cancelled`` is never consulted on them. Only
+    the generation id the *caller* hands the worker keeps them from clearing a
+    later turn's submit guard. Drives the undecorated worker body on a plain
+    thread, which is what a stale worker amounts to.
+    """
+    import nsys_ai.chat as chat_mod
+
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda *a, **k: (None, None))
+
+    from nsys_ai.tui_textual import NsysChatApp
+
+    app = NsysChatApp(profile_copy)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        # Turn A was submitted at generation 1; it was then cancelled (2) and a
+        # replacement turn B submitted (3). Only now does A's worker body run.
+        app._generation_id = 3
+        app._is_generating = True
+
+        raw = NsysChatApp._run_stream_worker.__wrapped__
+        errors: list[BaseException] = []
+
+        def run() -> None:
+            try:
+                raw(app, "A", 1)
+            except BaseException as exc:  # recorded, then asserted on below
+                errors.append(exc)
+
+        t = threading.Thread(target=run, daemon=True)
+        t.start()
+        assert await _until(pilot, lambda: not t.is_alive()), "stale worker never finished"
+        t.join(5)
+
+        # Guards the assertion below against passing vacuously: a worker that
+        # never ran (e.g. because it no longer takes a generation argument)
+        # cannot clear anything either.
+        assert not errors, f"stale worker raised instead of returning quietly: {errors}"
+        assert app._is_generating is True, "stale worker cleared the live turn's submit guard"
+
+
+@pytest.mark.asyncio
+async def test_superseded_turn_stops_writing(profile_copy, fake_stream):
+    """A new submit while one is in flight cancels via exclusive=True — same rule.
+
+    The submit guard blocks this in the UI, so drive the worker directly to
+    exercise the supersession path itself.
+    """
+    from nsys_ai.tui_textual import NsysChatApp
+
+    app = NsysChatApp(profile_copy)
+    seen: list[str] = []
+    _spy_on_chunks(app, seen)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        inp = app.query_one("#chat-input")
+        inp.focus()
+        inp.value = "A"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: "<A0>" in seen), "turn A never streamed"
+        assert fake_stream.parked_at("A").wait(5), "turn A generator never parked"
+
+        # Supersede A without going through the guard: this is what exclusive=True
+        # does to the in-flight worker.
+        app._is_generating = False
+        inp.value = "B"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: "<B0>" in seen), "turn B never streamed"
+        assert fake_stream.parked_at("B").wait(5), "turn B generator never parked"
+
+        fake_stream.gate("A").set()  # release the superseded worker
+        # Terminal condition, not a bounded guess -- see test_cancelled_turn_stops_writing.
+        assert await _until(pilot, lambda: fake_stream.finished_at("A").is_set()), (
+            f"superseded worker never let go of the stream; it pulled {fake_stream.produced}"
+        )
+        assert "<A1>" not in seen, f"superseded turn A kept streaming: {seen}"
+        assert "<A3>" not in fake_stream.produced, (
+            f"worker kept pulling the superseded stream: {fake_stream.produced}"
+        )
+
+        fake_stream.gate("B").set()
+        assert await _until(pilot, lambda: app._is_generating is False), "turn B never finished"
+        assistant = [m["content"] for m in app._chat_messages if m["role"] == "assistant"]
+        assert assistant == ["<B0><B1><B2><B3><B4><B5>"], f"history polluted: {app._chat_messages}"
+
+
+@pytest.mark.asyncio
+async def test_quitting_the_app_stops_the_worker(profile_copy, fake_stream):
+    """Quitting mid-turn must stop the worker too — and only ``is_cancelled`` can.
+
+    Textual calls ``workers.cancel_all()`` itself when the message loop ends
+    (app.py, the ``finally`` around ``_process_messages_loop``). Nothing bumps
+    ``_generation_id`` on that path, so the generation guard is blind to it and
+    ``worker.is_cancelled`` is the only thing that stops the worker draining the
+    LLM response — and releasing the profile DB connection — into a dead app.
+    This is what pins that half of ``cancelled()`` on its own.
+    """
+    from nsys_ai.tui_textual import NsysChatApp
+
+    app = NsysChatApp(profile_copy)
+    seen: list[str] = []
+    _spy_on_chunks(app, seen)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        inp = app.query_one("#chat-input")
+        inp.focus()
+        inp.value = "A"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: "<A0>" in seen), "turn A never streamed"
+        assert fake_stream.parked_at("A").wait(5), "turn A generator never parked"
+        app.exit()
+
+    # The app is down and its workers cancelled; the worker thread is still
+    # parked inside the generator. Release it and let it discover that.
+    assert app._generation_id == 1, "quitting must not bump the generation id"
+    fake_stream.gate("A").set()
+    let_go = fake_stream.finished_at("A").wait(10)
+
+    # Two ways an is_cancelled regression shows up here, so both are asserted.
+    # Measured on the unfixed code: the worker pulls the next chunk and then
+    # wedges in call_from_thread on the dead message loop — it never comes back,
+    # so `let_go` is the one that fires and the stream is left open behind a
+    # thread that will never finish.
+    assert "<A3>" not in fake_stream.produced, (
+        f"worker kept pulling the stream after the app quit: {fake_stream.produced}"
+    )
+    assert let_go, f"worker never let go of the stream; it pulled {fake_stream.produced}"

--- a/tests/test_tui_chat_app.py
+++ b/tests/test_tui_chat_app.py
@@ -309,3 +309,63 @@ async def test_quitting_the_app_stops_the_worker(profile_copy, fake_stream):
         f"worker kept pulling the stream after the app quit: {fake_stream.produced}"
     )
     assert let_go, f"worker never let go of the stream; it pulled {fake_stream.produced}"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_worker_with_no_worker_handle_stops_at_the_stream_loop(
+    profile_copy, fake_stream
+):
+    """The generation half of ``cancelled()``, which nothing else observes.
+
+    ``cancelled()`` tests ``worker.is_cancelled or gen != self._generation_id``.
+    The first half is what every production path trips, so removing the second
+    alone leaves the rest of this file green — it is only load-bearing where
+    ``get_current_worker()`` raises ``NoActiveWorker`` and ``worker`` is None,
+    which is the undecorated body running on a plain thread.
+
+    ``test_stale_worker_early_return_leaves_the_live_turn_alone`` already runs
+    it that way, but returns before the stream loop, so it never reaches
+    ``cancelled()`` at all. This one gets past the early returns with a working
+    fake model and a real stream, so the loop runs with the generation as its
+    only guard.
+
+    Asserted on what the generator *produced*, not on what reached the UI: the
+    point is that the worker stopped pulling the stream — and so released the
+    profile connection — rather than merely having its writes dropped.
+    """
+    from nsys_ai.tui_textual import NsysChatApp
+
+    app = NsysChatApp(profile_copy)
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        # Turn A was handed generation 1; the app has since moved on to 3.
+        # Seed the history the worker snapshots: _GatedStream labels its chunks
+        # from messages[-1], and this test drives the body directly rather than
+        # through on_input_submitted, which is what normally appends it.
+        app._chat_messages.append({"role": "user", "content": "A"})
+        app._generation_id = 3
+        app._is_generating = True
+
+        raw = NsysChatApp._run_stream_worker.__wrapped__
+        errors: list[BaseException] = []
+
+        def run() -> None:
+            try:
+                raw(app, "A", 1)
+            except BaseException as exc:  # noqa: BLE001 - surfaced below
+                errors.append(exc)
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        fake_stream.gate("A").set()
+        thread.join(timeout=10)
+        await pilot.pause()
+
+    assert not thread.is_alive(), "the stale worker never finished"
+    assert not errors, f"the stale worker raised: {errors}"
+
+    produced = [c for c in fake_stream.produced if c.startswith("<A")]
+    assert produced == ["<A0>"], (
+        f"a stale worker kept pulling the stream: produced {produced}. Only the "
+        "first chunk is unavoidable — the loop checks cancelled() after it."
+    )


### PR DESCRIPTION
Closes #311

## The defect

A Textual thread worker cannot be interrupted. `Worker.cancel()` only sets a flag and cancels the awaiting asyncio task; the OS thread runs to completion. All three ways a chat turn ends go through that same non-stopping path:

- `cancel_all()` on Ctrl+C (`action_cancel_generation`),
- the exclusive supersession a new submit triggers (`@work(thread=True, exclusive=True)`),
- the `cancel_all()` Textual itself runs when the message loop exits on quit.

`_run_stream_worker` never consulted `is_cancelled`, so the abandoned worker kept pulling the stream and kept calling `call_from_thread`. Its chunks interleaved with the replacement turn's, and its `_on_stream_done` cleared `_is_generating` while the replacement was still mid-stream, reopening the submit guard. It also appended its assistant turn *after* the next user turn.

On quit it is worse: with the message loop gone, the next `call_from_thread` never returns, so the thread wedges there holding the profile DB connection open.

## Evidence

The four guards are each pinned by a test that fails when only that guard is removed. Baseline, on this branch:

```
$ PYTHONPATH=$PWD/src python3 -m pytest tests/test_tui_chat_app.py -q
....                                                                     [100%]
4 passed in 2.73s
```

Mutation 1 — remove `if cancelled(): break` from the stream loop, leaving everything else:

```
FAILED tests/test_tui_chat_app.py::test_cancelled_turn_stops_writing - Assert...
FAILED tests/test_tui_chat_app.py::test_superseded_turn_stops_writing - Asser...
FAILED tests/test_tui_chat_app.py::test_quitting_the_app_stops_the_worker - A...
3 failed, 1 passed in 22.34s
```

Note the runtime: 2.73s green against 22.34s red. The unfixed workers are wedged in `call_from_thread` on a dead message loop, which is the quit-path symptom described above showing up directly in the clock.

Mutation 2 — keep the break, drop `is_cancelled` from the predicate so only the generation id remains:

```
FAILED tests/test_tui_chat_app.py::test_quitting_the_app_stops_the_worker - A...
1 failed, 3 passed in 12.75s
```

Only the quit test falls, which is the point: quitting cancels the worker without bumping the id, so `is_cancelled` is the only thing that stops it there.

Mutation 3 — read the generation id off `self` on the worker thread instead of taking the caller's:

```
FAILED tests/test_tui_chat_app.py::test_stale_worker_early_return_leaves_the_live_turn_alone
1 failed, 3 passed in 2.73s
```

Mutation 4 — neuter the `_ui_call` gate:

```
FAILED tests/test_tui_chat_app.py::test_stale_worker_early_return_leaves_the_live_turn_alone
1 failed, 3 passed in 2.74s
```

Each mutation was reverted with `git checkout --` and the baseline re-confirmed between runs. Mutations 2 and 3/4 falling on *different* tests is what shows the two guards do not subsume each other.

Full suite, ruff and bandit on this branch:

```
$ ruff check src/ tests/
All checks passed!

$ bandit -q -r src/ -c pyproject.toml     # exit 0, nosec warnings only

$ PYTHONPATH=$PWD/src python3 -m pytest tests/ -q
1 failed, 1519 passed, 146 skipped in 196.97s
```

The one failure is `test_ci_coverage.py::test_every_skip_has_a_known_reason`, and it is an artefact of my *worktree*, not of this branch. `tests/test_integration.py::_profile_path()` falls back to `data/nsys-hero/...` resolved against the cwd; that directory is uncommitted local data present in my main checkout but absent from a fresh worktree, so six integration tests skip with the unregistered reason `No test profile`. CI sets `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`, so the skip does not arise there. Re-run the way CI runs it:

```
$ PYTHONPATH=$PWD/src NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite \
    python3 -m pytest tests/test_ci_coverage.py -q
.....                                                                    [100%]
5 passed in 102.78s
```

I checked this rather than assumed it: my first hypothesis was that the env var alone explained it, but the same gate passes on unmodified `main` *without* the env var, which falsified that and pointed at the missing `data/` directory instead.

## The fix

`src/nsys_ai/tui_textual.py`:

- The worker stops itself, checking `worker.is_cancelled` on every stream event. That is what stops it draining the LLM response after the user has walked away, and what releases the profile DB connection the generator holds.
- Each turn carries a `_generation_id`, handed to the worker **by the submit that started it** rather than read off `self` on the worker thread — a worker that starts late would otherwise pick up whatever generation is live by then, including one belonging to the turn that superseded it.
- Every worker-to-UI hop goes through `_ui_call`, which drops the call when the turn is no longer live. This also covers a window `is_cancelled` cannot close by construction: a callback already handed to `call_from_thread` when the cancel lands still runs on the main thread. That window has no deterministic test and is not claimed to have one.
- The stream is bound to a name and closed in a `finally`, so the generator's cleanup — which closes the profile DB connection — runs at the break rather than at function exit, on the thread that advanced it, as `chat.py::_prepare_session` requires. Teardown errors are swallowed there, as they were when GC did the finalizing; raising would skip `_on_stream_done` and strand the submit guard.

`src/nsys_ai/chat.py`: `stream_agent_loop`'s docstring claimed a cancelled chat turn keeps running alongside its replacement. This change falsifies that, so the docstring is corrected. Both Textual consumers now break at the next stream event — `tui_textual` on `worker.is_cancelled`, `tree/chat.py` on its own `threading.Event` (`tree/chat.py:204-206`, verified by reading it, not grepping for it). The overlap is **bounded, not eliminated**: the break cannot land mid-event, and the replacement turn starts before the abandoned one notices. The thread-affinity contract in that same docstring is unchanged and still load-bearing.

## Deliberately out of scope

- **A cancelled turn's question stays in the history with no assistant reply.** `_add_user_turn` appends the user message at submit time and the cancel path does not remove it, so the next turn still sends two consecutive user messages. Measured both ways: that shape is identical before and after this change. What is narrowed is the assistant side alone. `test_cancelled_turn_stops_writing` asserts the full role sequence `["user", "user", "assistant"]` so this decision cannot drift unnoticed in either direction.
- This diverges from `tree/chat.py`, which keeps the partial assistant text of a cancelled turn. Unifying the two is not attempted here.
- No change to `tree/chat.py` itself — it already checks a cancel event and does not have this bug.
- This is a UI-correctness fix, not a data-correctness one. Each `stream_agent_loop` invocation holds its own DuckDB connection, so the overlap never corrupted query results (established in #302 / #310).

No new runtime dependencies. `pytest-asyncio` and `textual` are already in the `[dev]`/core extras the CI test job installs.
