### PR TITLE
docs(skills): say where the table-resolution abstention is actually visible

### DIFF
--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -535,11 +535,22 @@ class Skill:
                 unresolved.append(canonical)
         if unresolved:
             # The template reads a table this profile does not have. Substituting
-            # the canonical literal anyway (which is what the ``.get`` fallback
-            # above does, and all this branch used to do) sends the skill into
-            # ``sqlite3.OperationalError: no such table`` — and ``EvidenceBuilder``
-            # catches that, so the skill vanishes from the findings with no trace.
-            # ``abstain`` is the contract for "cannot run"; see its docstring.
+            # the canonical literal anyway — which is what the ``.get`` fallback
+            # above does, and all this branch used to do — sends the skill into
+            # ``sqlite3.OperationalError: no such table``. ``abstain`` is the
+            # contract for "cannot run"; see its docstring.
+            #
+            # Where that is visible, precisely, because the obvious answer is
+            # wrong: NOT in ``EvidenceBuilder``. Its ``_invoke_to_findings``
+            # drops abstention rows before they reach ``to_findings_fn``, so an
+            # abstaining skill contributes no finding — exactly as a raising one
+            # did. Measured on a profile whose only memcpy table is the P2P
+            # ``..._MEMCPY2``: 16 findings either way, none of them memcpy.
+            # It shows up where a caller reads the rows rather than the findings
+            # — ``skill run`` prints "not applicable to this profile" with the
+            # reason, and ``Agent.analyze`` branches on ``is_abstention_row``.
+            # The reason to raise it here is the contract, not a change in what
+            # the evidence pipeline emits.
             #
             # Only a placeholder the template actually uses counts: the fallbacks
             # are still written into ``resolved`` because ``str.format`` needs a


### PR DESCRIPTION
A comment merged in #328 justifies its guard with a consequence that does not occur. The guard is right; the reason given for it is not.

## The claim

`skills/base.py` on the abstention it raises when a template reads an unresolvable table:

> sends the skill into `sqlite3.OperationalError: no such table` — and `EvidenceBuilder` catches that, so **the skill vanishes from the findings with no trace**.

Read as a justification, that says abstaining stops the vanishing. It does not. `_invoke_to_findings` drops abstention rows before they reach `to_findings_fn` — by explicit design, documented in its own docstring — so an abstaining skill contributes no finding either.

## Measured

A copy of `h100_2gpu_1s.sqlite` with its memcpy table renamed to the peer-to-peer `CUPTI_ACTIVITY_KIND_MEMCPY2`, so `memcpy` resolves to `None`:

```
memory_transfers abstains: True
  reason: This profile has no CUPTI_ACTIVITY_KIND_MEMCPY table, so 'memory_transfers'...
EvidenceBuilder findings: 16
  of which memcpy-related: []
```

Sixteen findings, none about memcpy — the same as the raise-and-swallow path produced.

## Where it is visible

Callers that read rows rather than findings:

```
$ nsys-ai skill run memory_transfers <profile>
Memory Transfer Summary: not applicable to this profile.

This profile has no CUPTI_ACTIVITY_KIND_MEMCPY table, so 'memory_transfers' has
nothing to read. Either the capture did not trace that activity kind, or the
export names it something this version does not recognise as a variant.
```

and `Agent.analyze`, which branches on `is_abstention_row` (`agent/loop.py:482`).

## Why bother

The guard stays — it is what the repo's abstention contract requires, and the CLI output above is the improvement. Only the stated reason changes.

A reason that names the wrong consumer is worse than no reason: someone later weighing this guard against a different failure mode would weigh it against something that does not happen. The framing was inherited from `abstain()`'s own docstring rather than invented here, which is worth knowing — that docstring is the next place to look, but correcting it is a wider change than this.

## Test plan

- [x] `ruff check src/ tests/` — clean
- [x] `pytest tests/` — **1527 passed, 135 skipped, 0 failed**
- [x] The 16-findings comparison above, run on this machine
- [x] The `skill run` output above, run on this machine
- [x] `grep` for other copies of the claim in `src/` and `tests/` — none

Comment-only; no behaviour change, so no mutation check is possible and none is claimed.

Found in the review of #328, after it had merged.
