### PR TITLE
feat(evidence): carry the analyses that could not run beside the findings

### DIFF
--- a/docs/agent_skills/commands/evidence-build.md
+++ b/docs/agent_skills/commands/evidence-build.md
@@ -78,9 +78,18 @@ The JSON output is an EvidenceReport object following the [Evidence Schema](evid
       "severity": "warning",
       "note": "Stream 7: 12.34ms idle — CPU: cudaLaunchKernel (11.2ms)"
     }
-  ]
+  ],
+  "skipped": []
 }
 ```
+
+`skipped` lists the analyzers that could not run on this profile — a missing
+memcpy table, a profile with no NVTX annotation — with the reason each one
+gave. It is emitted even when empty, so `[]` means "everything ran" rather
+than "this build does not report it". `--format text` prints the same list as
+a `Skipped` section after the findings; `--format json` prints it to stderr so
+stdout stays a single JSON document. See the
+[Evidence Schema](evidence_schema.md#evidencereport-wrapper) for the field.
 
 ### Finding Types
 

--- a/docs/agent_skills/commands/evidence_schema.md
+++ b/docs/agent_skills/commands/evidence_schema.md
@@ -110,7 +110,14 @@ Findings should encode **conclusions**, not raw data. The agent must reason abou
   "title": "Human-readable title for the report",
   "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "profile_path": "path/to/profile.sqlite",
-  "findings": [ ... ]
+  "findings": [ ... ],
+  "skipped": [
+    {
+      "analyzer": "memory_anomalies",
+      "skill": "memory_bandwidth",
+      "reason": "This profile has no CUPTI_ACTIVITY_KIND_MEMCPY table, so it records no host/device copies. Bandwidth analysis needs them — ..."
+    }
+  ]
 }
 ```
 
@@ -121,8 +128,9 @@ Findings should encode **conclusions**, not raw data. The agent must reason abou
 - `profile_id`: Content-derived stable identifier produced by `fingerprint.get_profile_id`. Format: `nsys1:sha256:<64-hex>` (or `nsys1:path:<64-hex>` fallback when the source carries no Nsight metadata, e.g. a parquetdir-only backend). Two surfaces looking at the same profile agree on this value without depending on the filesystem path. **Every `TraceSelection.profile_id` produced during the same build carries the same value** — readers can join across surfaces by equality.
 - `profile_path`: Filesystem path the producer opened. Reference only — not an identifier.
 - `findings`: Array of Finding objects (see above).
+- `skipped`: Array of analyses that could not run on this profile, and why. A Finding says something about the profile's performance; an entry here says something about the analysis's *coverage*, which is why the two are separate arrays rather than one ranked list. Each entry carries `analyzer` (the name `evidence build --analyzers` accepts), `skill` (the name `skill run` accepts — several analyzers can share one skill), and `reason` (the text the skill passed to `abstain`). **The key is always emitted, empty array included**: `"skipped": []` means nothing was skipped, while a missing key means the producer predates the field. Do not read an empty array as a clean bill of health without checking that the key was present.
 
-Legacy payloads without the envelope keys (`schema_version` / `producer` / `producer_version` / `profile_id`) load identically — readers ignore unknown / missing envelope fields, and `profile_id` defaults to `""` for pre-`profile_id` payloads.
+Legacy payloads without the envelope keys (`schema_version` / `producer` / `producer_version` / `profile_id`) load identically — readers ignore unknown / missing envelope fields, and `profile_id` defaults to `""` for pre-`profile_id` payloads. Payloads written before `skipped` existed load with an empty `skipped` list. `skipped` is additive, so it does not bump `schema_version`.
 
 ---
 

--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -11,6 +11,7 @@ surfaces (CLI, GUI, agent, diff) share:
     TraceSelection   — a region in a profile (time, GPU, rank, stream, NVTX)
     DiffLineage      — links a Finding to the diff that surfaced it
     Diagnostic       — an agent's summarized diagnosis with verification command
+    SkippedAnalysis  — an analysis that could not run on this profile, and why
 
 ``Finding`` carries optional v0.1 fields (id, category, confidence,
 evidence rows, selection, diff lineage, etc.) that the new surfaces
@@ -182,6 +183,48 @@ def rank_findings(findings: list["Finding"]) -> list["Finding"]:
 
 
 @dataclass
+class SkippedAnalysis:
+    """One analysis that could not run on this profile, and why.
+
+    A ``Finding`` asserts something about the profile's *performance*; this
+    asserts something about the *analysis's coverage*. They are kept apart
+    deliberately — ranking a "could not run" among headroom-bearing findings
+    would put bookkeeping in the middle of a priority list, which is the same
+    reason ``EvidenceBuilder`` never hands an abstention row to a
+    ``to_findings_fn``.
+
+    Two names, because they are two different handles and a reader needs the
+    one that matches the surface they are on:
+
+    * ``analyzer`` — the key ``EvidenceBuilder._SKILL_PIPELINE`` runs it under,
+      which is what ``evidence build --analyzers`` accepts. This is the name a
+      user can act on.
+    * ``skill`` — the skill that actually abstained, which is what
+      ``skill run`` accepts. Several analyzers can share one skill, so this
+      alone does not say which coverage was lost.
+
+    ``reason`` is the text the skill passed to ``skills.base.abstain``, unless
+    the abstention row carried none — see ``EvidenceBuilder.build``, which
+    substitutes a short placeholder rather than emitting an empty string.
+    """
+
+    analyzer: str
+    skill: str
+    reason: str
+
+    def to_dict(self) -> dict:
+        return {"analyzer": self.analyzer, "skill": self.skill, "reason": self.reason}
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "SkippedAnalysis":
+        return cls(
+            analyzer=str(d.get("analyzer", "")),
+            skill=str(d.get("skill", "")),
+            reason=str(d.get("reason", "")),
+        )
+
+
+@dataclass
 class EvidenceReport:
     """A collection of findings for a profile, produced by an AI agent.
 
@@ -205,6 +248,14 @@ class EvidenceReport:
     profile_path: str = ""
     findings: list[Finding] = field(default_factory=list)
     profile_id: str = field(default="", kw_only=True)
+    # Analyses that could not run, beside the findings rather than among
+    # them. Keyword-only by the class convention noted above, which is a
+    # convention and not a fix for a live hazard: appending a positional
+    # field here could not rebind an existing caller, because a fourth
+    # positional argument to ``EvidenceReport`` is a TypeError today. The
+    # convention exists so the *next* field is not inserted before
+    # ``findings``, where it would rebind.
+    skipped: list[SkippedAnalysis] = field(default_factory=list, kw_only=True)
 
     def __post_init__(self) -> None:
         # Callers occasionally hand in ``pathlib.Path`` even though the
@@ -225,19 +276,26 @@ class EvidenceReport:
             "profile_id": self.profile_id,
             "profile_path": self.profile_path,
             "findings": [f.to_dict() for f in self.findings],
+            # Always emitted, empty list included: a consumer can then tell
+            # "nothing was skipped" from "this producer predates the field"
+            # by the key's presence, instead of guessing from its absence.
+            "skipped": [s.to_dict() for s in self.skipped],
         }
 
     @classmethod
     def from_dict(cls, d: dict) -> "EvidenceReport":
         # Envelope fields (schema_version / producer / producer_version)
         # are informational only — readers ignore them. Pre-profile_id
-        # payloads load with an empty profile_id (additive, not breaking).
+        # payloads load with an empty profile_id (additive, not breaking);
+        # pre-``skipped`` payloads load with an empty skipped list.
         findings = [Finding.from_dict(f) for f in d.get("findings", [])]
+        skipped = [SkippedAnalysis.from_dict(s) for s in d.get("skipped") or []]
         return cls(
             title=d.get("title", "Untitled"),
             profile_id=d.get("profile_id", ""),
             profile_path=d.get("profile_path", ""),
             findings=findings,
+            skipped=skipped,
         )
 
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -479,6 +479,27 @@ def _write_evidence_report_or_die(report, out_path: str) -> None:
     )
 
 
+def _print_skipped_section(report, stream) -> None:
+    """Print the analyses that could not run, or nothing when they all ran.
+
+    Beside the findings, never among them: an abstention says the analysis had
+    no coverage, not that the profile has a problem. A report with no
+    abstentions prints exactly what it printed before this section existed.
+    """
+    if not report.skipped:
+        return
+    print(f"── Skipped ({len(report.skipped)}) ──", file=stream, flush=True)
+    for entry in report.skipped:
+        # The analyzer name leads because that is the one the user can act on:
+        # it is what ``evidence build --analyzers`` accepts. The skill follows
+        # in parentheses as the handle for ``skill run``.
+        print(
+            f"  {entry.analyzer} ({entry.skill}) — skipped: {entry.reason}",
+            file=stream,
+            flush=True,
+        )
+
+
 def _cmd_analyze_json(args, _profile):
     """Emit a v0.1 evidence findings report as JSON.
 
@@ -504,6 +525,10 @@ def _cmd_analyze_json(args, _profile):
         # single source of truth.
         payload = report.to_dict()
         print(_json.dumps(payload, indent=2))
+        # stdout stays a single JSON document, so the human-readable notice
+        # goes to stderr — the same split `_write_evidence_report_or_die`
+        # already uses for its "Saved N finding(s)" line.
+        _print_skipped_section(report, sys.stderr)
 
         out = getattr(args, "output", None)
         if out:
@@ -1325,6 +1350,7 @@ def _cmd_evidence(args, _profile):
         if fmt == "json":
             payload = report.to_dict()
             print(json.dumps(payload, indent=2))
+            _print_skipped_section(report, sys.stderr)
         else:
             sev_icons = {"critical": "🔴", "warning": "🟡", "info": "🔵"}
             print(f"── Evidence Findings ({len(report.findings)}) ──")
@@ -1334,6 +1360,7 @@ def _cmd_evidence(args, _profile):
                 print(f"  {icon} [{f.type}] {f.label}  ({dur_ms:.1f}ms)")
                 if f.note:
                     print(f"      {f.note}")
+            _print_skipped_section(report, sys.stdout)
 
         out = getattr(args, "output", None)
         if out:

--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -10,7 +10,7 @@ import logging
 import os
 from collections.abc import Callable
 
-from .annotation import EvidenceReport, Finding, rank_findings
+from .annotation import EvidenceReport, Finding, SkippedAnalysis, rank_findings
 from .profile import Profile
 
 _log = logging.getLogger(__name__)
@@ -109,6 +109,7 @@ class EvidenceBuilder:
                   If None, run all analyzers.
         """
         from .fingerprint import get_profile_id
+        from .skills.base import is_abstention
         from .skills.registry import get_skill
 
         # Coerce to str up-front: ``Profile.path`` is whatever the caller
@@ -126,6 +127,10 @@ class EvidenceBuilder:
         profile_id = get_profile_id(getattr(self.prof, "conn", None), fallback_path=profile_path)
 
         findings: list[Finding] = []
+        # Analyses that abstained, in pipeline order. An abstention makes no
+        # finding by design, so without this the report is indistinguishable
+        # from one where every skill ran and the profile came out clean.
+        skipped: list[SkippedAnalysis] = []
         # v0.1 context handed to upgraded skills' to_findings_fn for
         # constructing TraceSelection / EvidenceRow with provenance.
         context: dict = {"profile_id": profile_id}
@@ -150,6 +155,21 @@ class EvidenceBuilder:
                 # Use DuckDB if available, fallback to SQLite
                 conn = self.prof.query_conn()
                 rows = skill.execute(conn, **kwargs)
+                if is_abstention(rows):
+                    # One entry per analyzer, not per skill: two pipeline
+                    # entries can share a skill (kernel_instances runs as both
+                    # nccl_stalls and kernel_hotspots), and each of them is a
+                    # separate piece of coverage the report lost. The pipeline
+                    # is a dict, so the analyzer name cannot repeat.
+                    #
+                    # ``reason`` should always be present — ``abstain`` sets
+                    # it — but a hand-rolled abstention row could omit it, and
+                    # an empty reason renders as a dangling "skipped:" line.
+                    reason = str(rows[0].get("reason") or "could not run")
+                    skipped.append(
+                        SkippedAnalysis(analyzer=analyzer_name, skill=skill_name, reason=reason)
+                    )
+                    continue
                 if skill.to_findings_fn:
                     findings.extend(_invoke_to_findings(skill.to_findings_fn, rows, context))
             except Exception as e:
@@ -164,4 +184,5 @@ class EvidenceBuilder:
             profile_id=profile_id,
             profile_path=profile_path,
             findings=rank_findings(findings),
+            skipped=skipped,
         )

--- a/tests/test_annotation_models.py
+++ b/tests/test_annotation_models.py
@@ -772,6 +772,10 @@ class TestEvidenceReportEnvelope:
         # not supplied), so consumers can rely on the key existing.
         assert "profile_id" in d
         assert d["profile_id"] == ""
+        # ``skipped`` (the analyses that could not run) is additive the same
+        # way: always present, empty when nothing abstained, so "nothing was
+        # skipped" is distinguishable from "this producer had no such field".
+        assert d["skipped"] == []
 
     def test_envelope_carries_profile_id(self):
         """When set, profile_id is serialized verbatim in the envelope."""

--- a/tests/test_evidence_skipped.py
+++ b/tests/test_evidence_skipped.py
@@ -1,0 +1,307 @@
+"""An analysis that could not run has to survive into the report.
+
+`abstain()` distinguishes "ran, found nothing" from "could not run", and that
+distinction reached `skill run` and `Agent.analyze` — but not `EvidenceBuilder`,
+which is the path behind `analyze --format json`, `evidence build`, the web
+`/api/analyze` endpoint and `loop_state.run_diagnose`. There the abstention row
+was dropped before `to_findings_fn` and nothing else was recorded, so a profile
+missing a table it needs produced a report identical in shape to a clean one.
+Findings and no explanation is the failure mode a verify-first tool can least
+afford, so the abstentions now travel beside the findings as `skipped`.
+
+They travel *beside* them, not among them: a finding asserts something about the
+profile's performance, an abstention asserts something about the analysis's
+coverage, and ranking the second among the first would put bookkeeping in the
+middle of a priority list.
+"""
+
+import io
+import json
+from contextlib import redirect_stderr, redirect_stdout
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from nsys_ai.annotation import EvidenceReport, Finding, SkippedAnalysis
+from nsys_ai.evidence_builder import EvidenceBuilder
+
+# No NVTX_EVENTS table at all, so `iteration_timing` — a pipeline entry —
+# genuinely cannot run. `tests/test_no_nvtx_profile.py` pins the premise.
+NO_NVTX = Path(__file__).resolve().parent / "fixtures" / "healthy_1pct.sqlite"
+
+# The profile #338 opens with: everything present except the memcpy tables.
+ANNOTATED = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+@pytest.fixture(scope="module")
+def no_memcpy_profile(tmp_path_factory):
+    """A copy of the annotated fixture with its memcpy tables removed.
+
+    Copied and stripped rather than shipped as a second fixture so the premise
+    stays visible: this is the same profile as `ANNOTATED` minus one table, so
+    a difference in the report is attributable to that table and nothing else.
+    """
+    import shutil
+    import sqlite3
+
+    dst = tmp_path_factory.mktemp("no_memcpy") / "no_memcpy.sqlite"
+    shutil.copy(ANNOTATED, dst)
+    conn = sqlite3.connect(str(dst))
+    try:
+        conn.execute("DROP TABLE CUPTI_ACTIVITY_KIND_MEMCPY")
+        conn.execute("DROP TABLE ENUM_CUDA_MEMCPY_OPER")
+        conn.commit()
+    finally:
+        conn.close()
+    return dst
+
+
+def _build(path) -> EvidenceReport:
+    from nsys_ai import profile as profile_module
+
+    with profile_module.open(str(path)) as prof:
+        return EvidenceBuilder(prof, device=0).build()
+
+
+def _capture(handler, args):
+    from nsys_ai import profile as profile_module
+
+    out, err = io.StringIO(), io.StringIO()
+    with redirect_stdout(out), redirect_stderr(err):
+        handler(args, profile_module)
+    return out.getvalue(), err.getvalue()
+
+
+# ── The report says what it could not analyse ──────────────────────────────
+
+
+def test_an_abstaining_analysis_reaches_the_report():
+    report = _build(NO_NVTX)
+
+    skipped = {s.analyzer: s for s in report.skipped}
+    assert "slow_iterations" in skipped, (
+        f"iteration_timing abstains on a profile with no NVTX, but the report "
+        f"lists only {sorted(skipped)}"
+    )
+    entry = skipped["slow_iterations"]
+    assert entry.skill == "iteration_timing", entry
+    assert "NVTX" in entry.reason, entry.reason
+    # The abstention explains a gap in coverage; it must not be dressed up as
+    # something found in the profile.
+    assert all(
+        "iteration_timing" not in (f.label or "") for f in report.findings
+    ), "an abstention leaked into the findings list"
+
+
+def test_a_profile_with_no_memcpy_table_names_the_memory_analyses(no_memcpy_profile):
+    """The case #338 opens with, end to end.
+
+    On this profile the memcpy-backed analyses cannot run at all. Before this
+    change they abstained and the report had nowhere to say so — the rows were
+    dropped before `to_findings_fn` and nothing else was recorded, so the
+    output was findings and no explanation.
+    """
+    report = _build(no_memcpy_profile)
+
+    assert report.skipped, "a profile with no memcpy table reported nothing skipped"
+    by_analyzer = {s.analyzer: s for s in report.skipped}
+    assert "memory_anomalies" in by_analyzer, sorted(by_analyzer)
+    assert "h2d_spikes" in by_analyzer, sorted(by_analyzer)
+    assert by_analyzer["memory_anomalies"].skill == "memory_bandwidth"
+    assert by_analyzer["h2d_spikes"].skill == "h2d_distribution"
+    for analyzer in ("memory_anomalies", "h2d_spikes"):
+        assert "MEMCPY" in by_analyzer[analyzer].reason, by_analyzer[analyzer].reason
+    # Still a usable report: the analyses that could run still ran.
+    assert report.findings, "dropping one table should not empty the report"
+
+
+def test_the_memcpy_skills_abstain_rather_than_returning_empty(no_memcpy_profile):
+    """The premise this file rests on, pinned so it cannot drift.
+
+    Nothing here is this change's doing — the abstentions come from
+    `Skill.execute`'s unresolved-table guard and `memory_bandwidth`'s own
+    check, both already in place. But `skipped` can only carry what the skills
+    emit, so if these three stopped abstaining the report assertions above
+    would go vacuous rather than fail.
+    """
+    from nsys_ai import profile as profile_module
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    with profile_module.open(str(no_memcpy_profile)) as prof:
+        conn = prof.query_conn()
+        for name in ("memory_transfers", "memory_bandwidth", "h2d_distribution"):
+            rows = get_skill(name).execute(conn, device=0)
+            assert is_abstention(rows), f"{name} did not abstain: {rows[:1]}"
+
+
+def test_no_abstention_is_dropped_silently():
+    """The regression guard: every pipeline skill that abstains is listed.
+
+    Written against the pipeline rather than one known skill, so a future entry
+    that starts abstaining cannot quietly go missing from the report.
+    """
+    from nsys_ai import profile as profile_module
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    abstaining = set()
+    with profile_module.open(str(NO_NVTX)) as prof:
+        builder = EvidenceBuilder(prof, device=0)
+        conn = prof.query_conn()
+        for analyzer_name, (skill_name, params) in builder._SKILL_PIPELINE.items():
+            skill = get_skill(skill_name)
+            if skill is None:
+                continue
+            kwargs = {**params, "device": 0}
+            if builder.trim:
+                kwargs["trim_start_ns"] = builder.trim[0]
+                kwargs["trim_end_ns"] = builder.trim[1]
+            try:
+                rows = skill.execute(conn, **kwargs)
+            except Exception:
+                continue
+            if is_abstention(rows):
+                abstaining.add(analyzer_name)
+        report = builder.build()
+
+    assert abstaining, "fixture no longer makes any pipeline analyzer abstain"
+    assert abstaining <= {s.analyzer for s in report.skipped}
+
+
+def test_a_report_lists_each_analyzer_once():
+    """One entry per analyzer: the report is a coverage list, not a log.
+
+    Two pipeline entries share `kernel_instances`, so keying on the skill would
+    collapse them and lose which analyzer went uncovered; keying on the
+    analyzer cannot repeat, because the pipeline is a dict.
+    """
+    report = _build(NO_NVTX)
+    names = [s.analyzer for s in report.skipped]
+    assert len(names) == len(set(names)), names
+
+
+def test_a_profile_where_nothing_abstains_is_unchanged(minimal_nsys_db_path):
+    report = _build(minimal_nsys_db_path)
+    assert report.skipped == []
+    assert report.findings, "fixture stopped producing findings; test is vacuous"
+
+
+# ── The JSON envelope and the text renderer ────────────────────────────────
+
+
+def test_analyze_json_emits_skipped_and_names_it_on_stderr():
+    from nsys_ai.cli.handlers import _cmd_analyze
+
+    args = SimpleNamespace(
+        profile=str(NO_NVTX), gpu=0, trim=None, output=None, format="json"
+    )
+    stdout, stderr = _capture(_cmd_analyze, args)
+
+    payload = json.loads(stdout)
+    listed = {entry["analyzer"]: entry for entry in payload["skipped"]}
+    assert "slow_iterations" in listed, payload["skipped"]
+    assert listed["slow_iterations"]["skill"] == "iteration_timing"
+    assert listed["slow_iterations"]["reason"]
+    # stdout stays a single JSON document, so the readable notice is on stderr.
+    assert "slow_iterations (iteration_timing) — skipped:" in stderr, stderr
+
+
+def test_analyze_json_on_a_clean_profile_prints_no_skipped_notice(minimal_nsys_db_path):
+    from nsys_ai.cli.handlers import _cmd_analyze
+
+    args = SimpleNamespace(
+        profile=str(minimal_nsys_db_path), gpu=0, trim=None, output=None, format="json"
+    )
+    stdout, stderr = _capture(_cmd_analyze, args)
+
+    assert json.loads(stdout)["skipped"] == []
+    assert "Skipped" not in stderr, stderr
+
+
+def test_evidence_build_text_prints_a_skipped_section():
+    from nsys_ai.cli.handlers import _cmd_evidence
+
+    args = SimpleNamespace(
+        profile=str(NO_NVTX),
+        evidence_action="build",
+        format="text",
+        analyzers=None,
+        trim=None,
+        gpu=0,
+        output=None,
+    )
+    stdout, _ = _capture(_cmd_evidence, args)
+
+    assert "── Evidence Findings" in stdout
+    assert "── Skipped (" in stdout
+    assert "slow_iterations (iteration_timing) — skipped:" in stdout
+    # After the findings, not among them.
+    assert stdout.index("── Evidence Findings") < stdout.index("── Skipped (")
+
+
+# ── Additive: consumers that ignore the field keep working ─────────────────
+
+
+def test_skipped_is_keyword_only():
+    """The class convention: envelope fields are ``kw_only``.
+
+    Not because a four-positional caller exists to protect — a fourth
+    positional argument was a ``TypeError`` before this field too — but so the
+    next field is not inserted ahead of ``findings``, where it would rebind
+    the callers that do pass three.
+    """
+    with pytest.raises(TypeError):
+        EvidenceReport("T", "/p", [], [SkippedAnalysis("a", "s", "r")])  # type: ignore[misc]
+
+    report = EvidenceReport("T", "/some/profile.sqlite", [])
+    assert report.profile_path == "/some/profile.sqlite"
+    assert report.skipped == []
+
+
+def test_findings_serialization_is_untouched():
+    """`web._handle_analyze` and `loop_state.run_diagnose` read only
+    ``report.findings``; the new field must not reach into a Finding."""
+    f = Finding(type="region", label="L", start_ns=10)
+    report = EvidenceReport(
+        title="T",
+        findings=[f],
+        skipped=[SkippedAnalysis("slow_iterations", "iteration_timing", "no NVTX")],
+    )
+    assert [d for d in (f.to_dict() for f in report.findings) if "skipped" in d] == []
+    assert report.to_dict()["findings"] == [f.to_dict()]
+
+
+def test_run_diagnose_ignores_skipped_and_still_ranks_findings():
+    from nsys_ai import profile as profile_module
+    from nsys_ai.loop_state import DiffLoopState
+
+    state = DiffLoopState()
+    with profile_module.open(str(NO_NVTX)) as prof:
+        ranked = state.run_diagnose(prof, device=0)
+
+    assert state.diagnose_ran
+    assert len(ranked) == state.diagnose_findings_count
+
+
+# ── Round-trip ─────────────────────────────────────────────────────────────
+
+
+def test_skipped_round_trips_through_json():
+    entry = SkippedAnalysis("slow_iterations", "iteration_timing", "no NVTX_EVENTS table")
+    report = EvidenceReport(title="T", profile_path="/p", skipped=[entry])
+    restored = EvidenceReport.from_dict(json.loads(json.dumps(report.to_dict())))
+    assert restored.skipped == [entry]
+
+
+def test_a_payload_written_before_the_field_existed_loads_empty():
+    restored = EvidenceReport.from_dict(
+        {"title": "Legacy", "profile_path": "/x.sqlite", "findings": []}
+    )
+    assert restored.skipped == []
+
+
+def test_an_explicit_null_skipped_loads_empty():
+    restored = EvidenceReport.from_dict({"title": "T", "skipped": None})
+    assert restored.skipped == []


### PR DESCRIPTION
Closes #338.

## The problem

A skill that cannot run on a profile abstains — `skills.base.abstain` returns a
single marker row with a reason — rather than returning `[]` (which reads as
"ran, found nothing") or raising (which callers swallow). That answer is
visible on the two surfaces that *format* rows: `skill run` and `Agent.analyze`
both go through `Skill.format_rows`, which prints "not applicable to this
profile".

It stopped at `EvidenceBuilder`. `_invoke_to_findings` drops abstention rows
before `to_findings_fn`, and nothing else recorded them, so a profile missing a
table an analysis needs produced a report shaped exactly like one where every
analysis ran and the profile came out clean. That is the path behind
`analyze --format json`, `evidence build`, the web `/api/analyze` endpoint and
`loop_state.run_diagnose` — findings and no explanation, which is the failure
mode a verify-first tool can least afford.

## What this PR adds

Only the reporting plumbing:

- **`SkippedAnalysis(analyzer, skill, reason)`** in `annotation.py`. Two names
  because they address different commands: `analyzer` is what
  `evidence build --analyzers` takes, `skill` is what `skill run` takes, and two
  analyzers can share one skill (`kernel_instances` runs as both `nccl_stalls`
  and `kernel_hotspots`), so keying on the skill would collapse two lost
  analyses into one line naming neither.
- **`EvidenceReport.skipped`**, keyword-only and additive, so it does not bump
  `SCHEMA_VERSION`. It sits *beside* `findings`, not among them: a finding
  asserts something about the profile's performance, an abstention asserts
  something about the analysis's coverage, and ranking the second among the
  first would put bookkeeping in the middle of a priority list.
- **`EvidenceBuilder.build`** records one entry per abstaining analyzer and
  `continue`s, so the abstention still never reaches `to_findings_fn`.
- **Rendering.** `analyze --format json` and `evidence build --format json`
  name the skipped analyses on stderr, leaving stdout a single JSON document;
  `evidence build --format text` prints a `Skipped` section *after* the
  findings. A report with no abstentions prints exactly what it printed before.
- **Serialization.** The `skipped` key is emitted even when empty, so a
  consumer can tell "nothing was skipped" from "this producer predates the
  field". `from_dict` loads a pre-`skipped` payload (and an explicit `null`)
  as an empty list.
- Docs: `evidence_schema.md` and `evidence-build.md` describe the field,
  including the always-emitted-when-empty contract.

## What this PR deliberately does not add

**No new abstention mechanism.** An earlier revision of this branch added a
`requires_memcpy` / `resolve_memcpy_table` pair to `skills/base.py` and per-skill
memcpy guards to `memory_bandwidth` and `memory_transfers`. That branch was cut
from a stale base; #328 has since landed both the generic unresolved-table guard
in `Skill.execute` and the `memory_bandwidth` rewrite that resolves through
`resolve_activity_tables` and abstains. Those additions were redundant and
conflicted with the real thing, so they are gone —
the diff no longer touches `skills/base.py` or any builtin skill.

The branch also carried two fixture binaries modified in place
(`h100_2gpu_1s.sqlite` 2.2MB → 3.9MB, `healthy_1pct.sqlite` 57KB → 114KB). That
delta was nsys-ai's own `_nsysai_*` indexes, written by `ensure_indexes` during
a local test run and committed by accident. Both are reverted; the diff contains
no binary.

## Verification

The acceptance case from the issue, run against this branch on top of current
`main`: a copy of `tests/fixtures/h100_2gpu_1s.sqlite` with
`CUPTI_ACTIVITY_KIND_MEMCPY` and `ENUM_CUDA_MEMCPY_OPER` dropped, through
`EvidenceBuilder(Profile(...)).build()`:

```
findings: 16
skipped count: 2
  analyzer='memory_anomalies' skill='memory_bandwidth'
    reason=This profile has no CUPTI_ACTIVITY_KIND_MEMCPY table, so it records
    no host/device copies. Bandwidth analysis needs them — ...
  analyzer='h2d_spikes' skill='h2d_distribution'
    reason=This profile has no CUPTI_ACTIVITY_KIND_MEMCPY table, so
    'h2d_distribution' has nothing to read. ...
```

Before this change the same profile reported those 16 findings and said nothing
about the two analyses that never ran. Note that the two reasons differ in
wording: `memory_bandwidth` builds its own SQL and abstains itself, while
`h2d_distribution` goes through the `Skill.execute` template guard. Both are
`main`'s code, not this PR's — which is what makes the removals above safe.

`tests/test_evidence_skipped.py` covers this end to end plus the JSON envelope,
the text renderer, the round-trip and the legacy-payload load.
`test_the_memcpy_skills_abstain_rather_than_returning_empty` pins the premise —
that the three memcpy skills abstain — so the report assertions cannot go
vacuous if that ever changes.

Suite on this branch: `1536 passed, 146 skipped, 1 failed`. The failure is
`tests/test_ci_coverage.py::test_every_skip_has_a_known_reason`, which is
pre-existing and unrelated: it fails in any local run without `NSYS_TEST_PROFILE`
set (CI sets it). `ruff check src/ tests/` and
`bandit -c pyproject.toml -r src/ -ll` are both clean.
