### PR TITLE
docs: correct the analyze plugin's account of the first-open cache cost

### DIFF
--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -410,24 +410,39 @@ Trim modes on `nsys-ai skill run` (preference order):
 | `--trim START_S END_S` | manual window, seconds |
 | `-p trim_start_ns=… -p trim_end_ns=…` | when ns precision matters |
 
-Heavy skills (range-IEJoin: kernels × avg NVTX depth):
+Heavy skills:
 
-| Skill | Trim trigger |
-|---|---|
-| `nvtx_layer_breakdown` | `nvtx.iteration_count > 1` OR full span > 30 s* |
-| `nvtx_kernel_map` | same |
-| `gpu_idle_gaps` | full span > 30 s* |
+| Skill | Cost driver | Trim trigger |
+|---|---|---|
+| `nvtx_layer_breakdown` | reads `nvtx_kernel_map`; falls back to an in-file range join (kernels × avg NVTX depth) when the map is unavailable | `nvtx.iteration_count > 1` OR full span > 30 s* |
+| `nvtx_kernel_map` | per-thread stack sweep over the NVTX table, building the map if it is not there yet | same |
+| `gpu_idle_gaps` | window scan over the kernel table (no NVTX join) | full span > 30 s* |
 
 \* When `data_quality.auto_trim.applied == true` the top-level `profile_span_ms`
 is the trimmed window; read the actual span from
 `data_quality.auto_trim.profile_full_span_ms`.
 
-**First-open cache trap.** The cache builder materializes
-`nvtx_kernel_map.parquet` via the same range-IEJoin, so on NVTX-heavy
-profiles even a cheap skill (`iteration_timing`, `profile_health_manifest`)
-blocks on it the first time — observed > 10 min on a 10 M NVTX × 1 M
-kernel profile. Once `<profile>.nsys-cache/nvtx_kernel_map.parquet`
-exists, subsequent skill runs range from sub-second (`top_kernels`,
+**Where the first-open cost lands.** By default `build_cache` exports the base
+tables only. `nvtx_kernel_map.parquet` is deferred to the first skill that needs
+NVTX attribution — `nvtx_kernel_map`, `nvtx_layer_breakdown`,
+`nccl_compile_context_breakdown`, `cutracer_analysis`. Skills that never read
+the map, including `iteration_timing`, `profile_health_manifest` and
+`top_kernels`, do not wait on it. Deferring it is worth real time: the map was
+measured at 11.6 s of a 19.8 s cache build on an 881 MB profile and 59.9 s of a
+93.2 s build on a 3.5 GB profile.
+
+That first skill runs a per-thread stack sweep. Where the connection has a
+Parquet cache directory behind it, the result is written back into
+`<profile>.nsys-cache/` and the sweep is paid once per profile. Where it does
+not — a direct SQLite attach, a `parquetdir` export — the map is built as
+in-memory tables instead, so the sweep is paid once per process. Policy lives in
+`_should_defer_nvtx_kernel_map()` in `parquet_cache.py`:
+`NSYS_AI_ALWAYS_BUILD_NVTX_KERNEL_MAP=1` (or `NSYS_AI_DEFER_NVTX_KERNEL_MAP=0`)
+moves the cost back into `build_cache`, and
+`NSYS_AI_DEFER_NVTX_KERNEL_MAP_MB=<float>` makes it size-dependent, building
+profiles under the threshold eagerly.
+
+Once the cache exists, skill runs range from sub-second (`top_kernels`,
 `memory_transfers`, `h2d_distribution`) to 20–30 s for the heavier ones
 (`iteration_detail`, `host_sync_parent_ranges`, `nvtx_layer_breakdown`).
 

--- a/skills/analyze/references/PRINCIPLES.md
+++ b/skills/analyze/references/PRINCIPLES.md
@@ -425,9 +425,18 @@ is the trimmed window; read the actual span from
 **Where the first-open cost lands.** By default `build_cache` exports the base
 tables only. `nvtx_kernel_map.parquet` is deferred to the first skill that needs
 NVTX attribution — `nvtx_kernel_map`, `nvtx_layer_breakdown`,
-`nccl_compile_context_breakdown`, `cutracer_analysis`. Skills that never read
-the map, including `iteration_timing`, `profile_health_manifest` and
-`top_kernels`, do not wait on it. Deferring it is worth real time: the map was
+`nccl_compile_context_breakdown`, `cutracer_analysis`. Skills that never reach
+NVTX attribution, such as `iteration_timing` and `top_kernels`, do not wait on
+it.
+
+`profile_health_manifest` is **not** one of them, which matters because §9 opens
+by telling you to run it. It calls `root_cause_matcher`, which reaches NVTX
+attribution, so the manifest triggers the deferred build and pays for it.
+Verified by running it against a freshly built cache: `nvtx_kernel_map.parquet`
+is absent after `open()` and present after the manifest returns. Budget the
+first `profile_health_manifest` on a large profile as a build, not as a query.
+
+Deferring it is still worth real time: the map was
 measured at 11.6 s of a 19.8 s cache build on an 881 MB profile and 59.9 s of a
 93.2 s build on a 3.5 GB profile.
 


### PR DESCRIPTION
`skills/analyze/references/PRINCIPLES.md` is loaded by the `nsys-ai:analyze` plugin and fed to the analysis agent, so a falsified sentence in it is a falsified premise in the product.

**Scope was cut back after review.** The first version of this PR corrected both statements named in #334 and did the whole-file anchor sweep the issue also asked for. That bundling produced two fresh false claims of its own, in a PR whose purpose is deleting false claims — which is the argument for keeping it minimal, made concretely. What remains is one statement: the §9 first-open paragraph. See the review reply below for the per-finding accounting.

## The first-open cache statement

§9's "First-open cache trap" said the cache builder materializes `nvtx_kernel_map.parquet` via a range-IEJoin, and that cheap skills block on it the first time. All three parts are false on `main`:

- the map is built by a per-thread stack sweep, not a SQL range join
- `_should_defer_nvtx_kernel_map` defaults to deferring, so `build_cache` does not write the map at all
- `iteration_timing` does not mention the map; `profile_health_manifest` mentions it only in advice prose and never queries it

Rewritten to describe the deferral, name the four skills that actually consume it (`nvtx_kernel_map`, `nvtx_layer_breakdown`, `nccl_compile_context_breakdown`, `cutracer_analysis` — the four that import `nvtx_attribution` or call `ensure_nvtx_kernel_map`), and carry the build costs already measured in `parquet_cache`'s module docstring.

Two things the first version got wrong and this one states carefully:

- **Where the sweep is paid.** Once per profile only when the connection has a Parquet cache directory to publish into. `materialize_cached_nvtx_kernel_map` returns False and changes nothing on a direct SQLite attach or a `parquetdir` export; `ensure_nvtx_kernel_map` then falls back to `_ensure_nvtx_kernel_map_in_memory`, which is once per process.
- **The env vars.** `NSYS_AI_ALWAYS_BUILD_NVTX_KERNEL_MAP=1` and `NSYS_AI_DEFER_NVTX_KERNEL_MAP=0` both force the eager build; `NSYS_AI_DEFER_NVTX_KERNEL_MAP_MB=<float>` defers only at or above the threshold, so smaller profiles stay eager. Deferral is a default, not an invariant.

The heavy-skills table immediately above carried the same falsehood in its heading (`range-IEJoin: kernels × avg NVTX depth`), so it is corrected here too: it now has a cost-driver column, because the three rows no longer share one mechanism — `nvtx_layer_breakdown` is a range join only on its map-less fallback path, `nvtx_kernel_map` is the stack sweep, `gpu_idle_gaps` is a window scan over the kernel table with no NVTX join at all.

## Not in this PR

- **The 50 MB row (§4.2).** #334's own comment asks for this to land with or after #317, which is still open and changes that policy again. Correcting it now means writing it twice. Row left exactly as it is on `main`.
- **The anchor sweep.** Every `file.py:NNN` anchor in §4.1/§4.2/§5.1/§5.4 has drifted, and rewriting them to file-plus-symbol is worth doing — as its own change, with the CI check that makes the convention enforceable rather than merely auditable.

So this closes the §9 half of #334; the issue stays open for the rest.

## Verification

Docs-only; one markdown file. `git diff` against the merge base touches nothing under `src/` or `tests/`.

- `ruff check src/ tests/` — exit 0, clean.
- `bandit -q -c pyproject.toml -r src/ -ll` — exit 0.
- `pytest tests/ -q` (with `PYTHONPATH` pointed at this worktree, not the editable install) — 1500 passed, 146 skipped, 1 failed.

The one failure is `test_ci_coverage.py::test_every_skip_has_a_known_reason`, on the skip reason `"No test profile"`. That gates on `NSYS_TEST_PROFILE`, which CI sets and a bare local run does not — pre-existing, not from this PR.

## Unrelated red check

The `smoke` failure is not from this PR — it reproduces on `main` at 4c91415. `check_field_conditional` counts an `_abstained` row as data. Fixed separately in #346.

Part of #334.
