### PR TITLE
feat(cli): add a warm verb that builds the cache and the NVTX kernel map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Added
 
+- `nsys-ai warm <profile>` builds the Parquet cache and the NVTX kernel map in
+  one step, so the stack sweep is paid deliberately up front rather than by
+  whoever issues the first NVTX-attribution query. It reports how long each half
+  took, tells "warmed" apart from "already warm", and exits non-zero with the
+  reason when the cache cannot be written.
 - `nsys-ai baseline` keeps a local store of named profile snapshots (`tag`,
   `list`, `show`) so `diff --against baseline:<name>` resolves a stable name to a
   known snapshot instead of a fragile path. The store lives in

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ via `--against` or as the `before` positional.
 | `tui` | NVTX tree TUI |
 | `web` | Web viewer server |
 | `info` | Profile metadata and GPU hardware |
+| `warm` | Build the Parquet cache and NVTX kernel map up front |
 | `summary` | Top kernels and stream breakdown |
 | `analyze` | Full auto-report (`--format json` emits evidence findings) |
 | `overlap` | Compute / NCCL overlap analysis |

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -49,6 +49,7 @@ def show_help():
     print()
     print("  Analysis:")
     print("    nsys-ai info    <profile>                Profile metadata & GPUs")
+    print("    nsys-ai warm    <profile>                Pre-build cache & NVTX map")
     print("    nsys-ai summary <profile> [--gpu N]      Kernel stats & commentary")
     print("    nsys-ai timeline <profile> --gpu N --trim S E   Timeline TUI")
     print("    nsys-ai tui     <profile> --gpu N --trim S E   Tree TUI")

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -408,37 +408,22 @@ def _cmd_doctor(args, _profile):
         sys.exit(1)
 
 
-def _warm_failure_reason(path: str) -> str:
-    """Why the Parquet cache for *path* could not be built, in the build's words.
-
-    ``Profile`` turns a failed cache build into a log warning and falls back to
-    SQLite, which is the right trade for every command that only wants to answer
-    a question — and the wrong one for ``warm``, whose entire job is the cache.
-    Repeating the build is how the reason gets said out loud; on the case this
-    exists for (a read-only profile directory) it fails the same way every time.
-    """
-    from nsys_ai import parquet_cache
-
-    try:
-        parquet_cache.build_cache(path)
-    except Exception as exc:  # noqa: BLE001 - reported verbatim, not handled
-        return str(exc) or exc.__class__.__name__
-    return "the Parquet cache was built but could not be opened"
-
-
 def _cmd_warm(args, _profile):
     """Build the Parquet cache and the NVTX kernel map before anything reads them.
 
     Both halves already existed and neither was reachable up front: opening with
     ``cache_mode="parquet"`` forces the base-table build, and
-    ``materialize_cached_nvtx_kernel_map`` runs the stack sweep and writes it
-    back into the cache directory. What was missing is a verb that runs them
-    together, so the sweep — seconds on a small capture, around a minute on a
-    multi-gigabyte one — lands here instead of on whoever happens to issue the
+    ``materialize_cached_nvtx_kernel_map_outcome`` runs the stack sweep and
+    writes it back into the cache directory. What was missing is a verb that runs
+    them together, so the sweep — seconds on a small capture, around a minute on
+    a multi-gigabyte one — lands here instead of on whoever happens to issue the
     first NVTX-attribution query.
 
-    Exits non-zero, with the reason, when the cache could not be written: a warm
-    that silently did not warm defeats the point of running it.
+    Exits non-zero, with the reason, when either half could not be persisted: a
+    warm that silently did not warm defeats the point of running it. That is why
+    the map build is asked for its outcome rather than its bool — the bool
+    cannot tell "this profile has nothing to attribute" from "the cache could
+    not be written", and only the second is a failure.
     """
     import time
     from pathlib import Path
@@ -451,10 +436,23 @@ def _cmd_warm(args, _profile):
 
     started = time.perf_counter()
     with _profile.open(path, cache_mode="parquet") as prof:
-        base_s = time.perf_counter() - started
+        # This spans the whole open — the build when one is needed, plus the
+        # schema probe and metadata discovery Profile.__init__ always runs. It
+        # is reported as such below rather than as a build time.
+        open_s = time.perf_counter() - started
         profile_path = prof.path
         if prof.db is None:
-            print(f"cannot warm: {_warm_failure_reason(profile_path)}", file=sys.stderr)
+            # Profile swallowed the build failure and fell back to SQLite, which
+            # is right for a command that just wants an answer and wrong for
+            # this one. It records the exception so warm can name it without
+            # re-running an ETL that may have run for minutes before failing.
+            failed = prof.cache_error
+            why = (
+                f"{failed.__class__.__name__}: {failed}"
+                if failed is not None
+                else "no error was recorded"
+            )
+            print(f"cannot warm: the Parquet cache is unavailable ({why})", file=sys.stderr)
             sys.exit(1)
         registered = cache_dir_for_connection(prof.db)
         if registered is None:
@@ -467,42 +465,49 @@ def _cmd_warm(args, _profile):
         map_was_present = (cache_dir / "nvtx_kernel_map.parquet").is_file()
 
         map_started = time.perf_counter()
-        mapped = parquet_cache.materialize_cached_nvtx_kernel_map(prof.db)
+        outcome, detail = parquet_cache.materialize_cached_nvtx_kernel_map_outcome(prof.db)
         map_s = time.perf_counter() - map_started
+        mapped = outcome == parquet_cache.MAP_MATERIALIZED
         map_rows = (
             prof.db.execute("SELECT count(*) FROM nvtx_kernel_map").fetchone()[0] if mapped else 0
         )
         map_files = {"nvtx_kernel_map.parquet", "nvtx_path_dict.parquet"}
         base_count = sum(1 for p in cache_dir.glob("*.parquet") if p.name not in map_files)
 
-    # materialize_cached_nvtx_kernel_map answers False both for "the sweep found
-    # nothing to attribute" and for "the cache directory could not be written",
-    # and only the second is a failure to warm. A profile whose base cache was
-    # already valid reaches build_cache's fast path without ever touching the
-    # lock file, so a read-only cache directory gets this far unnoticed.
-    if not mapped and not (cache_dir / "nvtx_kernel_map.parquet").is_file():
-        if not os.access(cache_dir, os.W_OK):
-            print(
-                f"cannot warm: {cache_dir} is not writable, so the NVTX kernel map "
-                "cannot be built",
-                file=sys.stderr,
-            )
-            sys.exit(1)
+    # Confirmed failures only. MAP_NO_ATTRIBUTION and MAP_SOURCES_MISSING mean
+    # the sweep had nothing to write; the three below mean it could not write.
+    if outcome in (
+        parquet_cache.MAP_NOT_WRITABLE,
+        parquet_cache.MAP_VIEWS_FAILED,
+        parquet_cache.MAP_NO_CACHE_DIR,
+    ):
+        print(
+            f"cannot warm: the NVTX kernel map could not be persisted ({detail})",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     print(f"Profile: {profile_path}")
     print(f"Cache:   {cache_dir}")
     base_state = "already built" if base_was_valid else "built"
-    print(f"  base tables: {base_count} parquet files ({base_state}, {base_s:.2f}s)")
+    print(f"  base tables: {base_count} parquet files ({base_state}; opened in {open_s:.2f}s)")
     if mapped:
         map_state = "already built" if map_was_present else "built"
         print(f"  nvtx kernel map: {map_rows} rows ({map_state}, {map_s:.2f}s)")
+    elif outcome == parquet_cache.MAP_SOURCES_MISSING:
+        print(f"  nvtx kernel map: nothing for the sweep to read — {detail} ({map_s:.2f}s)")
     else:
         print(
-            "  nvtx kernel map: no NVTX/kernel attribution in this profile "
-            f"(nothing to build, {map_s:.2f}s)"
+            "  nvtx kernel map: the sweep found no kernel inside any NVTX range, "
+            f"so there was nothing to cache ({map_s:.2f}s)"
         )
 
-    if base_was_valid and (map_was_present or not mapped):
+    if outcome == parquet_cache.MAP_NO_ATTRIBUTION:
+        # The sweep ran to completion and published nothing, so the next caller
+        # pays it again. Claiming "already warm" here would be the one lie this
+        # verb cannot afford.
+        print("partly warm: the empty sweep is not cached, so it runs again on the next call")
+    elif base_was_valid and (map_was_present or outcome == parquet_cache.MAP_SOURCES_MISSING):
         print("already warm")
     else:
         print(f"warmed in {time.perf_counter() - started:.2f}s")

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -408,6 +408,106 @@ def _cmd_doctor(args, _profile):
         sys.exit(1)
 
 
+def _warm_failure_reason(path: str) -> str:
+    """Why the Parquet cache for *path* could not be built, in the build's words.
+
+    ``Profile`` turns a failed cache build into a log warning and falls back to
+    SQLite, which is the right trade for every command that only wants to answer
+    a question — and the wrong one for ``warm``, whose entire job is the cache.
+    Repeating the build is how the reason gets said out loud; on the case this
+    exists for (a read-only profile directory) it fails the same way every time.
+    """
+    from nsys_ai import parquet_cache
+
+    try:
+        parquet_cache.build_cache(path)
+    except Exception as exc:  # noqa: BLE001 - reported verbatim, not handled
+        return str(exc) or exc.__class__.__name__
+    return "the Parquet cache was built but could not be opened"
+
+
+def _cmd_warm(args, _profile):
+    """Build the Parquet cache and the NVTX kernel map before anything reads them.
+
+    Both halves already existed and neither was reachable up front: opening with
+    ``cache_mode="parquet"`` forces the base-table build, and
+    ``materialize_cached_nvtx_kernel_map`` runs the stack sweep and writes it
+    back into the cache directory. What was missing is a verb that runs them
+    together, so the sweep — seconds on a small capture, around a minute on a
+    multi-gigabyte one — lands here instead of on whoever happens to issue the
+    first NVTX-attribution query.
+
+    Exits non-zero, with the reason, when the cache could not be written: a warm
+    that silently did not warm defeats the point of running it.
+    """
+    import time
+    from pathlib import Path
+
+    from nsys_ai import parquet_cache
+    from nsys_ai.connection import cache_dir_for_connection
+
+    path = _profile.resolve_profile_path(args.profile)
+    base_was_valid = parquet_cache.is_cache_valid(path)
+
+    started = time.perf_counter()
+    with _profile.open(path, cache_mode="parquet") as prof:
+        base_s = time.perf_counter() - started
+        profile_path = prof.path
+        if prof.db is None:
+            print(f"cannot warm: {_warm_failure_reason(profile_path)}", file=sys.stderr)
+            sys.exit(1)
+        registered = cache_dir_for_connection(prof.db)
+        if registered is None:
+            print(
+                "cannot warm: this profile is not served from a Parquet cache",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        cache_dir = Path(registered)
+        map_was_present = (cache_dir / "nvtx_kernel_map.parquet").is_file()
+
+        map_started = time.perf_counter()
+        mapped = parquet_cache.materialize_cached_nvtx_kernel_map(prof.db)
+        map_s = time.perf_counter() - map_started
+        map_rows = (
+            prof.db.execute("SELECT count(*) FROM nvtx_kernel_map").fetchone()[0] if mapped else 0
+        )
+        map_files = {"nvtx_kernel_map.parquet", "nvtx_path_dict.parquet"}
+        base_count = sum(1 for p in cache_dir.glob("*.parquet") if p.name not in map_files)
+
+    # materialize_cached_nvtx_kernel_map answers False both for "the sweep found
+    # nothing to attribute" and for "the cache directory could not be written",
+    # and only the second is a failure to warm. A profile whose base cache was
+    # already valid reaches build_cache's fast path without ever touching the
+    # lock file, so a read-only cache directory gets this far unnoticed.
+    if not mapped and not (cache_dir / "nvtx_kernel_map.parquet").is_file():
+        if not os.access(cache_dir, os.W_OK):
+            print(
+                f"cannot warm: {cache_dir} is not writable, so the NVTX kernel map "
+                "cannot be built",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+    print(f"Profile: {profile_path}")
+    print(f"Cache:   {cache_dir}")
+    base_state = "already built" if base_was_valid else "built"
+    print(f"  base tables: {base_count} parquet files ({base_state}, {base_s:.2f}s)")
+    if mapped:
+        map_state = "already built" if map_was_present else "built"
+        print(f"  nvtx kernel map: {map_rows} rows ({map_state}, {map_s:.2f}s)")
+    else:
+        print(
+            "  nvtx kernel map: no NVTX/kernel attribution in this profile "
+            f"(nothing to build, {map_s:.2f}s)"
+        )
+
+    if base_was_valid and (map_was_present or not mapped):
+        print("already warm")
+    else:
+        print(f"warmed in {time.perf_counter() - started:.2f}s")
+
+
 def _cmd_analyze(args, _profile):
     fmt = getattr(args, "format", "text") or "text"
     if fmt == "json":

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -475,7 +475,15 @@ def _cmd_warm(args, _profile):
         base_count = sum(1 for p in cache_dir.glob("*.parquet") if p.name not in map_files)
 
     # Confirmed failures only. MAP_NO_ATTRIBUTION and MAP_SOURCES_MISSING mean
-    # the sweep had nothing to write; the three below mean it could not write.
+    # the sweep had nothing to write, which is not a failure of `warm`.
+    #
+    # The three below all leave this process unable to serve the map, which is
+    # what `warm` promises and so what it must report. They are not the same on
+    # disk, though: MAP_NOT_WRITABLE and MAP_NO_CACHE_DIR persisted nothing,
+    # while MAP_VIEWS_FAILED wrote both Parquets and only failed to create the
+    # views over them — so a later process finds them by glob and skips the
+    # sweep. Reporting it is still right; describing it as "could not write"
+    # would not be.
     if outcome in (
         parquet_cache.MAP_NOT_WRITABLE,
         parquet_cache.MAP_VIEWS_FAILED,

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -48,6 +48,7 @@ from .handlers import (
     _cmd_tree,
     _cmd_tui,
     _cmd_viewer,
+    _cmd_warm,
     _cmd_web,
 )
 
@@ -100,6 +101,17 @@ def _register_doctor_parser(sub):
         help="Run slow checks too (e.g. NCCL eager/inductor split); off by default",
     )
     p.set_defaults(handler=_cmd_doctor)
+    return p
+
+
+def _register_warm_parser(sub):
+    """Register the ``warm`` subcommand on *sub*."""
+    p = sub.add_parser(
+        "warm",
+        help="Build the Parquet cache and NVTX kernel map ahead of the first query",
+    )
+    p.add_argument("profile", help="Path to profile (.sqlite or .nsys-rep)")
+    p.set_defaults(handler=_cmd_warm)
     return p
 
 
@@ -306,7 +318,7 @@ def _build_parser():
         dest="command",
         metavar=(
             "{open,web,timeline-web,loop,chat,ask,agent,agent-guide,"
-            "info,doctor,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
+            "info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
             "root-cause,help}"
         ),
     )
@@ -808,6 +820,7 @@ def _build_parser():
     # Agent-facing commands (promoted from legacy so --help exposes them)
     _register_info_parser(sub)
     _register_doctor_parser(sub)
+    _register_warm_parser(sub)
     _register_skill_parser(sub, include_management=False)
     _register_agent_parser(sub)
     _register_evidence_parser(sub)

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1943,9 +1943,16 @@ def materialize_cached_nvtx_kernel_map_outcome(conn) -> tuple[str, str]:
 
     Returns ``(outcome, detail)``. ``outcome`` is one of the ``MAP_*`` constants
     above; ``detail`` is a human-readable elaboration, empty when there is
-    nothing to add. Everything other than ``MAP_MATERIALIZED`` leaves the cache
-    directory unchanged and the caller falling back to the in-memory build,
-    which is exactly the behaviour those backends had before.
+    nothing to add. Everything other than ``MAP_MATERIALIZED`` leaves the caller
+    falling back to the in-memory build, which is exactly the behaviour those
+    backends had before.
+
+    That is *not* the same as leaving the cache directory unchanged, and
+    ``MAP_VIEWS_FAILED`` is the exception that matters: the two Parquets were
+    written, and only the views over them could not be created. The next process
+    finds them by glob and skips the sweep. So it is a failure of this call, not
+    a failure to persist, and code that groups it with the "could not write"
+    outcomes is wrong about what is on disk.
 
     Note that ``MAP_NO_ATTRIBUTION`` publishes nothing, so it is *not* a state
     the next process inherits: a profile that reaches it re-runs the full sweep

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1907,7 +1907,30 @@ def _publish_stamp_map_ready(cache_dir: Path) -> None:
         _check_cache_size(cache_dir, str(cache_dir.parent / source))
 
 
+# Outcomes of :func:`materialize_cached_nvtx_kernel_map_outcome`. Only
+# MAP_MATERIALIZED leaves the map queryable; the rest are the distinct reasons
+# the bool-returning wrapper collapses into a single False.
+MAP_MATERIALIZED = "materialized"  # views exist over a published map
+MAP_NO_CACHE_DIR = "no-cache-dir"  # connection is not backed by a Parquet cache
+MAP_SOURCES_MISSING = "sources-missing"  # a source Parquet the sweep reads is absent
+MAP_NO_ATTRIBUTION = "no-attribution"  # the sweep ran and produced no rows
+MAP_NOT_WRITABLE = "not-writable"  # an OSError while locking, staging or publishing
+MAP_VIEWS_FAILED = "views-failed"  # published, but the views would not create
+
+
 def materialize_cached_nvtx_kernel_map(conn) -> bool:
+    """True when ``nvtx_kernel_map`` is queryable on ``conn`` off the cache.
+
+    Thin wrapper over :func:`materialize_cached_nvtx_kernel_map_outcome`, which
+    is the one to call when the *reason* for a False matters — the six outcomes
+    it distinguishes range from "this profile has nothing to attribute" to "the
+    cache directory could not be written", and a caller that only sees False
+    cannot tell a warm profile from a failed one.
+    """
+    return materialize_cached_nvtx_kernel_map_outcome(conn)[0] == MAP_MATERIALIZED
+
+
+def materialize_cached_nvtx_kernel_map_outcome(conn) -> tuple[str, str]:
     """Build ``nvtx_kernel_map`` into ``conn``'s Parquet cache, then view it.
 
     The persisted half of the deferred-map design. ``build_cache`` no longer
@@ -1918,11 +1941,15 @@ def materialize_cached_nvtx_kernel_map(conn) -> bool:
     merely move the cost — and onto the more expensive in-memory path, which
     ``fetchall``s where this streams.
 
-    Returns False, changing nothing, when there is no cache directory behind
-    ``conn`` (direct SQLite attach, ``parquetdir`` export, a bare test
-    connection) or when the directory cannot be written (read-only mount). The
-    caller then falls back to the in-memory build, which is exactly the
-    behaviour those backends had before.
+    Returns ``(outcome, detail)``. ``outcome`` is one of the ``MAP_*`` constants
+    above; ``detail`` is a human-readable elaboration, empty when there is
+    nothing to add. Everything other than ``MAP_MATERIALIZED`` leaves the cache
+    directory unchanged and the caller falling back to the in-memory build,
+    which is exactly the behaviour those backends had before.
+
+    Note that ``MAP_NO_ATTRIBUTION`` publishes nothing, so it is *not* a state
+    the next process inherits: a profile that reaches it re-runs the full sweep
+    on every call.
 
     Never call this from inside ``build_cache``: that holds ``_build_lock`` for
     the same cache directory, and flock is not reentrant across the fds involved
@@ -1932,22 +1959,22 @@ def materialize_cached_nvtx_kernel_map(conn) -> bool:
 
     adapter = wrap_connection(conn)
     if not isinstance(adapter, DuckDBAdapter):
-        return False
+        return (MAP_NO_CACHE_DIR, "the connection is not DuckDB-backed")
     db = adapter.raw_conn
 
     registered = cache_dir_for_connection(db)
     if registered is None:
-        return False
+        return (MAP_NO_CACHE_DIR, "no cache directory is registered for this connection")
     cache_dir = Path(registered)
     if not cache_dir.is_dir():
-        return False
+        return (MAP_NO_CACHE_DIR, f"{cache_dir} is not a directory")
 
     # Cheap path first: a previous process already published the map, and this
     # connection just has not created the views yet. No lock, no write — which
     # is also what makes a read-only cache directory work.
     if _create_nvtx_map_views(db, cache_dir):
         forget_nvtx_map_probes(db)
-        return True
+        return (MAP_MATERIALIZED, "")
 
     import shutil
     import tempfile
@@ -1957,7 +1984,7 @@ def materialize_cached_nvtx_kernel_map(conn) -> bool:
             # Another process may have published while we waited.
             if _create_nvtx_map_views(db, cache_dir):
                 forget_nvtx_map_probes(db)
-                return True
+                return (MAP_MATERIALIZED, "")
 
             # Staged inside the cache directory so the os.replace below is a
             # rename within one filesystem rather than a copy. A process killed
@@ -1974,7 +2001,19 @@ def materialize_cached_nvtx_kernel_map(conn) -> bool:
             try:
                 built = _build_nvtx_kernel_map_from_parquet(db, cache_dir, staging)
                 if not built:
-                    return False
+                    # That helper answers False for exactly two reasons and does
+                    # not say which. Re-test the cheaper one — the same
+                    # ``is_file()`` predicate it checked a moment ago, on files
+                    # nothing creates in between — so the caller can tell a
+                    # degraded cache from a profile with nothing to attribute.
+                    missing = [
+                        name
+                        for name in ("kernels.parquet", "runtime.parquet", "nvtx.parquet")
+                        if not (cache_dir / name).is_file()
+                    ]
+                    if missing:
+                        return (MAP_SOURCES_MISSING, f"missing from the cache: {', '.join(missing)}")
+                    return (MAP_NO_ATTRIBUTION, "")
                 # Publish the dictionary first. A concurrent opener globbing
                 # mid-publish then sees a dict with no map and falls back, which
                 # is correct; the reverse order would give it a map whose
@@ -1992,15 +2031,17 @@ def materialize_cached_nvtx_kernel_map(conn) -> bool:
 
             _publish_stamp_map_ready(cache_dir)
     except OSError as exc:
-        # Read-only cache directory: no lock file, no staging dir. Degrade to
-        # the in-memory build rather than failing the query.
+        # Read-only cache directory, a full disk, an unwritable lock file in the
+        # cache's *parent* — anything that stops the lock/stage/publish sequence.
+        # Degrade to the in-memory build rather than failing the query, and hand
+        # the caller the OSError's own words so it can name the real path.
         log.info("cannot persist nvtx_kernel_map into %s (%s)", cache_dir, exc)
-        return False
+        return (MAP_NOT_WRITABLE, str(exc))
 
-    ok = _create_nvtx_map_views(db, cache_dir)
-    if ok:
+    if _create_nvtx_map_views(db, cache_dir):
         forget_nvtx_map_probes(db)
-    return ok
+        return (MAP_MATERIALIZED, "")
+    return (MAP_VIEWS_FAILED, f"the map was published into {cache_dir} but no view could be created")
 
 
 def ensure_nvtx_kernel_map(conn) -> bool:

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -306,6 +306,14 @@ class Profile:
 
     _log = logging.getLogger(__name__)
 
+    #: The exception that sent this Profile down the SQLite fallback, or None.
+    #: ``db is None`` says only *that* the cache is unavailable; commands whose
+    #: job is the cache itself (``warm``) need to say *why*, and re-running the
+    #: build to find out would repeat an ETL that can take minutes. Set only in
+    #: the fallback branch below; every other construction path leaves the class
+    #: default in place.
+    cache_error: Exception | None = None
+
     def __init__(self, path: str, *, cache_mode: str = "auto", backend: str = "sqlite"):
         if cache_mode not in ("auto", "parquet", "direct"):
             raise ValueError(
@@ -360,6 +368,7 @@ class Profile:
                             self.db = parquet_cache.open_cached_db(path)
             except Exception as e:
                 self._log.warning("DuckDB cache unavailable, falling back to SQLite: %s", e)
+                self.cache_error = e
                 self.db = None  # type: ignore[assignment]
         from .connection import wrap_connection
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -641,12 +641,120 @@ def test_warm_on_a_read_only_cache_directory_says_why_and_exits_nonzero(tmp_path
     assert "already warm" not in result.stdout
 
 
-def test_warm_succeeds_when_there_is_no_nvtx_attribution(tmp_path):
+def test_warm_when_only_the_lock_directory_is_read_only(tmp_path):
+    """The map's lock file lives *beside* the cache, not inside it.
+
+    ``_build_lock`` creates ``<cache_dir>.build.lock`` in the parent directory,
+    so a writable cache dir under a read-only parent stops the build just as
+    dead as a read-only cache dir does — and probing the cache dir's own mode
+    cannot see it. warm has to learn this from the build, not infer it.
+    """
+    import os
+    import shutil
+    from pathlib import Path
+
+    from nsys_ai import parquet_cache
+
+    fixture = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile = tmp_path / "lock.sqlite"
+    shutil.copy(fixture, profile)
+    cache_dir = Path(parquet_cache.build_cache(str(profile)))
+    lock = cache_dir.parent / f"{cache_dir.name}.build.lock"
+    if lock.exists():
+        lock.unlink()
+
+    parent_mode = cache_dir.parent.stat().st_mode
+    os.chmod(cache_dir.parent, 0o500)  # cache_dir itself stays writable
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "nsys_ai", "warm", str(profile)],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chmod(cache_dir.parent, parent_mode)
+
+    assert result.returncode == 1, f"stdout: {result.stdout}"
+    assert "cannot warm" in result.stderr
+    assert "already warm" not in result.stdout
+    assert not (cache_dir / "nvtx_kernel_map.parquet").exists()
+
+
+def test_a_command_run_after_warm_builds_nothing(tmp_path):
+    """The payoff the file-existence assertions do not pin.
+
+    warm is only worth running if the next process finds both halves on disk.
+    A cold ``skill run`` prints the cache build's own progress lines to stderr,
+    so their absence after a warm is the observable form of "nothing was built".
+    """
+    import shutil
+    from pathlib import Path
+
+    fixture = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile = tmp_path / "p.sqlite"
+    shutil.copy(fixture, profile)
+
+    warm = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "warm", str(profile)],
+        capture_output=True,
+        text=True,
+    )
+    assert warm.returncode == 0, f"stderr: {warm.stderr}\nstdout: {warm.stdout}"
+
+    after = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "skill", "run", "nvtx_layer_breakdown", str(profile)],
+        capture_output=True,
+        text=True,
+    )
+    assert after.returncode == 0, f"stderr: {after.stderr}"
+    noise = after.stderr + after.stdout
+    for marker in ("Building cache", "Cache ready", "skipping map"):
+        assert marker not in noise, f"{marker!r} means warm left work behind:\n{noise}"
+
+
+def test_warm_does_not_report_already_warm_after_an_empty_sweep(tmp_path, capsys, monkeypatch):
+    """An empty sweep publishes nothing, so the next call repeats it.
+
+    ``already warm`` is the signal a caller uses to decide repeat warms are
+    free. For this outcome they are not: the sweep runs to completion, finds no
+    kernel inside any range, writes no Parquet, and the whole cost returns on
+    the next invocation. The outcome is forced here for the same reason as in
+    ``test_an_empty_sweep_is_told_apart_from_a_missing_source``.
+    """
+    import argparse
+    import shutil
+    from pathlib import Path
+
+    from nsys_ai import parquet_cache
+    from nsys_ai import profile as profile_module
+    from nsys_ai.cli.handlers import _cmd_warm
+
+    fixture = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile = tmp_path / "empty.sqlite"
+    shutil.copy(fixture, profile)
+    # Base cache valid, map absent: exactly the state that used to print
+    # "already warm" while the sweep it just paid for cached nothing.
+    parquet_cache.build_cache(str(profile))
+    monkeypatch.setattr(
+        parquet_cache,
+        "materialize_cached_nvtx_kernel_map_outcome",
+        lambda conn: (parquet_cache.MAP_NO_ATTRIBUTION, ""),
+    )
+
+    _cmd_warm(argparse.Namespace(profile=str(profile)), profile_module)
+
+    out = capsys.readouterr().out
+    assert "already warm" not in out, out
+    assert "partly warm" in out, out
+
+
+def test_warm_succeeds_when_there_is_nothing_for_the_sweep_to_read(tmp_path):
     """A profile the sweep can find nothing in is warm, not broken.
 
-    ``materialize_cached_nvtx_kernel_map`` answers False both for "nothing to
-    attribute" and for "could not write". Only the second is a failure, and this
-    pins the first at exit 0.
+    This minimal export has no RUNTIME table, so ``runtime.parquet`` never
+    reaches the cache and the map build stops before the sweep. That is a
+    property of the capture, not a failure to warm: exit 0, and the missing
+    source named rather than described as "no attribution".
     """
     profile = tmp_path / "min.sqlite"
     _write_min_profile(profile, dur_ns=10_000_000)
@@ -657,5 +765,6 @@ def test_warm_succeeds_when_there_is_no_nvtx_attribution(tmp_path):
         text=True,
     )
     assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
-    assert "no NVTX/kernel attribution" in result.stdout
+    assert "nothing for the sweep to read" in result.stdout
+    assert "runtime.parquet" in result.stdout
     assert (tmp_path / "min.nsys-cache").is_dir()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,7 @@ def test_subcommands():
         "agent",
         "agent-guide",
         "info",
+        "warm",
         "skill",
         "evidence",
         "cutracer",
@@ -538,3 +539,123 @@ def test_diff_against_unknown_baseline_errors(tmp_path):
     )
     assert result.returncode == 2
     assert "unknown baseline" in result.stderr.lower()
+
+
+def test_warm_subcommand_help():
+    """warm should be a public verb taking a profile path."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "warm", "--help"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "profile" in result.stdout
+
+
+def test_warm_missing_profile_exits_nonzero(tmp_path):
+    """A missing profile is an error, not a silent no-op."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "warm", str(tmp_path / "nope.sqlite")],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1
+    assert "Traceback" not in result.stderr
+
+
+def test_warm_builds_the_nvtx_kernel_map_and_then_reports_already_warm(tmp_path):
+    """The behavioural gate: warm must leave the map on disk, not defer it.
+
+    Building the cache alone does not build the map — that is deliberate
+    (``_should_defer_nvtx_kernel_map``), and it is exactly the cost warm exists
+    to move off the first NVTX-attribution query. If warm ever stops calling
+    ``materialize_cached_nvtx_kernel_map``, the two Parquets below go missing.
+    """
+    import shutil
+    from pathlib import Path
+
+    fixture = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile = tmp_path / "p.sqlite"
+    shutil.copy(fixture, profile)
+
+    first = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "warm", str(profile)],
+        capture_output=True,
+        text=True,
+    )
+    assert first.returncode == 0, f"stderr: {first.stderr}\nstdout: {first.stdout}"
+    assert "warmed in" in first.stdout
+
+    cache_dir = tmp_path / "p.nsys-cache"
+    assert (cache_dir / "nvtx_kernel_map.parquet").is_file()
+    assert (cache_dir / "nvtx_path_dict.parquet").is_file()
+    assert "nvtx kernel map: 0 rows" not in first.stdout
+
+    # Second run finds both halves already on disk and builds nothing.
+    second = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "warm", str(profile)],
+        capture_output=True,
+        text=True,
+    )
+    assert second.returncode == 0, f"stderr: {second.stderr}\nstdout: {second.stdout}"
+    assert "already warm" in second.stdout
+    assert "warmed in" not in second.stdout
+
+
+def test_warm_on_a_read_only_cache_directory_says_why_and_exits_nonzero(tmp_path):
+    """A warm that silently did not warm defeats the point of running it.
+
+    A prebuilt cache on a read-only mount still serves queries — the lazy map
+    build degrades to an in-memory one — so nothing else notices. ``warm`` has
+    to, because the artifact it exists to persist cannot be persisted.
+    """
+    import os
+    import shutil
+    from pathlib import Path
+
+    from nsys_ai import parquet_cache
+
+    fixture = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile = tmp_path / "ro.sqlite"
+    shutil.copy(fixture, profile)
+    cache_dir = Path(parquet_cache.build_cache(str(profile)))
+    assert not (cache_dir / "nvtx_kernel_map.parquet").exists(), (
+        "the cache build produced the map, so this test is no longer testing warm"
+    )
+
+    mode = cache_dir.stat().st_mode
+    parent_mode = cache_dir.parent.stat().st_mode
+    # The lock file lives beside the cache dir, the staging dir inside it.
+    os.chmod(cache_dir, 0o500)
+    os.chmod(cache_dir.parent, 0o500)
+    try:
+        result = subprocess.run(
+            [sys.executable, "-m", "nsys_ai", "warm", str(profile)],
+            capture_output=True,
+            text=True,
+        )
+    finally:
+        os.chmod(cache_dir.parent, parent_mode)
+        os.chmod(cache_dir, mode)
+
+    assert result.returncode == 1, f"stdout: {result.stdout}"
+    assert "cannot warm" in result.stderr
+    assert "already warm" not in result.stdout
+
+
+def test_warm_succeeds_when_there_is_no_nvtx_attribution(tmp_path):
+    """A profile the sweep can find nothing in is warm, not broken.
+
+    ``materialize_cached_nvtx_kernel_map`` answers False both for "nothing to
+    attribute" and for "could not write". Only the second is a failure, and this
+    pins the first at exit 0.
+    """
+    profile = tmp_path / "min.sqlite"
+    _write_min_profile(profile, dur_ns=10_000_000)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "warm", str(profile)],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}\nstdout: {result.stdout}"
+    assert "no NVTX/kernel attribution" in result.stdout
+    assert (tmp_path / "min.nsys-cache").is_dir()

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -1246,3 +1246,34 @@ class TestStreamedSweep:
         assert list(out_dir.iterdir()) == [], (
             f"the sweep left scratch files behind: {sorted(p.name for p in out_dir.iterdir())}"
         )
+def test_an_empty_sweep_is_told_apart_from_a_missing_source(tmp_path, monkeypatch):
+    """The two Falses ``_build_nvtx_kernel_map_from_parquet`` returns are not
+    the same event, and a caller that cannot tell them apart cannot report
+    either honestly.
+
+    The builder is forced to fail because provoking a genuinely empty sweep
+    needs a capture with kernels, runtime and NVTX that overlap nowhere; what is
+    under test is the classification around it, not the sweep.
+    """
+    import shutil
+
+    src = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile = tmp_path / "p.sqlite"
+    shutil.copy(src, profile)
+
+    from nsys_ai.profile import Profile
+
+    monkeypatch.setattr(
+        parquet_cache, "_build_nvtx_kernel_map_from_parquet", lambda *a, **k: False
+    )
+    with Profile(str(profile), cache_mode="parquet") as prof:
+        cache_dir = Path(parquet_cache.cache_dir_for_connection(prof.db))
+        assert (cache_dir / "runtime.parquet").is_file(), "fixture no longer has a runtime table"
+
+        outcome, _ = parquet_cache.materialize_cached_nvtx_kernel_map_outcome(prof.db)
+        assert outcome == parquet_cache.MAP_NO_ATTRIBUTION
+
+        (cache_dir / "runtime.parquet").unlink()
+        outcome, detail = parquet_cache.materialize_cached_nvtx_kernel_map_outcome(prof.db)
+        assert outcome == parquet_cache.MAP_SOURCES_MISSING
+        assert "runtime.parquet" in detail


### PR DESCRIPTION
## What

Adds `nsys-ai warm <profile>`, a front door onto two functions that already
existed but were only ever reached as side effects:

- `Profile(path, cache_mode="parquet")` forces the base-table build.
- `materialize_cached_nvtx_kernel_map(conn)` runs the stack sweep and writes
  both Parquets back into the cache directory.

The map is deferred on purpose (`_should_defer_nvtx_kernel_map`), so before
this the sweep always landed on whoever issued the first NVTX-attribution
query — exactly the person or process a pre-warm step exists to protect.

## Behaviour

```
$ nsys-ai warm p.sqlite
Profile: /tmp/p.sqlite
Cache:   /tmp/p.nsys-cache
  base tables: 14 parquet files (built, 0.39s)
  nvtx kernel map: 1643 rows (built, 0.40s)
warmed in 0.79s

$ nsys-ai warm p.sqlite
...
  base tables: 14 parquet files (already built, 0.05s)
  nvtx kernel map: 1643 rows (already built, 0.00s)
already warm
```

Three distinguishable outcomes, as the issue asks:

- `warmed in <t>` — something was built. Exit 0.
- `already warm` — both halves were on disk. Exit 0.
- `cannot warm: <reason>` on stderr, exit 1.

The failure path carries the reason verbatim, in two shapes:

- Read-only profile directory, cold cache. `Profile` turns a failed cache build
  into a log warning and falls back to SQLite, which is right for commands that
  only want to answer a question and wrong for `warm`. `_warm_failure_reason`
  repeats the build so the reason gets said out loud:
  `cannot warm: [Errno 13] Permission denied: '/…/q.nsys-cache.build.lock'`
- Read-only cache directory, warm base tables. `build_cache` takes its
  `is_cache_valid` fast path and never touches the lock file, so the failure
  only surfaces at the map:
  `cannot warm: /…/p.nsys-cache is not writable, so the NVTX kernel map cannot be built`

That second check is needed because `materialize_cached_nvtx_kernel_map`
returns `False` both for "the sweep found nothing to attribute" and for "the
directory could not be written". Only the second is a failure to warm; a
profile with no NVTX push/pop ranges reports `no NVTX/kernel attribution in
this profile` and exits 0.

No new cache machinery, no new runtime dependency, and no progress reporting of
its own — per the issue, the map half inherits chunk progress once that work
lands.

## Note on the issue text

The issue refers to `cache_is_affordable`'s reason. No such function exists on
`main` — `grep -rn affordable src/ tests/` is empty. The equivalent is
implemented with the functions that do exist: `parquet_cache.is_cache_valid`,
`parquet_cache.build_cache` and `connection.cache_dir_for_connection`, all
public. Everything else the issue states about the code checked out correct.

## Files

- `src/nsys_ai/cli/handlers.py` — `_cmd_warm` and `_warm_failure_reason`
- `src/nsys_ai/cli/parsers.py` — `_register_warm_parser`, registration, usage metavar
- `src/nsys_ai/cli/app.py` — one line in the getting-started help
- `CHANGELOG.md` — Unreleased / Added
- `tests/test_cli.py` — five tests

## Tests

- `test_warm_subcommand_help` — the CLI smoke test this repo requires for a new
  subcommand.
- `test_warm_builds_the_nvtx_kernel_map_and_then_reports_already_warm` — the
  behavioural gate. Fails if `warm` stops materialising the map: it asserts
  both Parquets on disk after the first run, and `already warm` from the second.
- `test_warm_on_a_read_only_cache_directory_says_why_and_exits_nonzero` —
  the degradation story, exit 1 with a reason.
- `test_warm_succeeds_when_there_is_no_nvtx_attribution` — nothing to attribute
  is not a failure.
- `test_warm_missing_profile_exits_nonzero` — no traceback.

`warm` was also added to the public-surface list in `test_subcommands`, whose
metavar/registration equality check the new subcommand would otherwise break.

## Verification

Run in a clean worktree off `origin/main`, with `NSYS_TEST_PROFILE` set as CI
sets it:

- `python3 -m pytest tests/ -q --tb=short` → `1512 passed, 140 skipped`, exit 0
- `ruff check src/ tests/` → `All checks passed!`, exit 0
- `bandit -q -r src/ -c pyproject.toml` → exit 0

Closes #337
