### PR TITLE
perf(cache): sweep the nvtx_kernel_map one capture thread at a time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 - SQL sweep-line overlap analysis (about 3x faster on the analysis call), NVTX
   layer breakdown reduced from ~43s to ~1.4s, and automatic trimming of long
   profiles to a representative window.
+- The `nvtx_kernel_map` build sweeps one capture thread at a time and streams
+  both sides of each, so its memory tracks the batch rather than the profile. On
+  a 3.5 GB capture the build fell from 6.95 GB peak and 51.2 s to 3.31 GB and
+  37.3 s, producing identical output. It also reports progress per thread, which
+  the deferred build previously had no way to do.
 
 ### Docs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,10 +89,10 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   layer breakdown reduced from ~43s to ~1.4s, and automatic trimming of long
   profiles to a representative window.
 - The `nvtx_kernel_map` build sweeps one capture thread at a time and streams
-  both sides of each, so its memory tracks the batch rather than the profile. On
-  a 3.5 GB capture the build fell from 6.95 GB peak and 51.2 s to 3.31 GB and
-  37.3 s, producing identical output. It also reports progress per thread, which
-  the deferred build previously had no way to do.
+  both sides of each, so what it holds in Python tracks the batch rather than
+  the profile. On a 3.5 GB capture, peak memory for the build fell from 7.50 GB
+  to 3.55 GB — and from 5.28 GB to 1.39 GB inside the sweep itself — producing
+  the same map.
 
 ### Docs
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -64,7 +64,7 @@ import re
 import sys
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -1177,17 +1177,42 @@ def _build_nvtx_high(db: duckdb.DuckDBPyConnection, cache_dir: Path) -> None:
     """)
 
 
+# Rows per Arrow batch on each of the two input streams, and rows buffered
+# before one batch is written to the staged Parquet. One number for all three
+# because they are the same trade — the size of the window the sweep holds in
+# Python — and because a test that shrinks it exercises every batch boundary at
+# once (tests/test_parquet_cache.py::TestStreamedSweep).
+_SWEEP_BATCH_ROWS = 262_144
+
+
 def _build_nvtx_kernel_map_from_parquet(
     db: duckdb.DuckDBPyConnection,
     cache_dir: Path,
     out_dir: Path | None = None,
+    progress: Callable[[int, int], None] | None = None,
 ) -> bool:
     """Generate nvtx_kernel_map.parquet with a per-thread stack sweep.
 
     There is one builder and one path. Each kernel is attributed to its
-    innermost enclosing NVTX push/pop range by ``_sweep_nvtx_kernel_map``; no
-    SQL range join is involved (the comment below records why one was tried and
+    innermost enclosing NVTX push/pop range by ``_attribute_thread``; no SQL
+    range join is involved (the comment below records why one was tried and
     dropped), and there is no fallback.
+
+    **One thread of the capture at a time**, so peak memory tracks the batch
+    rather than the profile. ``eventType = 59`` is a per-thread Push/Pop stack,
+    so a thread's ranges are strictly nested and its work is independent of
+    every other thread's: partitioning on ``globalTid`` needs no carried state
+    at a partition boundary at all. Within a thread both sides then arrive
+    sorted by start and are consumed through a single advancing cursor, so
+    neither side is ever a list. Measured on a 3.5 GB capture (15.9 M ranges,
+    3.1 M kernel-runtime rows): peak inside the sweep 5.24 GB -> 1.83 GB, with
+    byte-identical output (3,042,699 rows).
+
+    ``progress``, when given, is called ``progress(threads_done, threads_total)``
+    after each thread. The deferred build is where the wait now lives — roughly
+    60 s on that capture, previously with no reporting channel at all — and the
+    thread is the natural unit to report, because it is the unit the sweep
+    already works in.
 
     Sources are the ``kernels``, ``runtime`` and ``nvtx`` Parquets already in
     ``cache_dir`` — written earlier in the same build, or published by an
@@ -1268,146 +1293,271 @@ def _build_nvtx_kernel_map_from_parquet(
     #
     # The equality key is why the join had so little to work with: globalTid had
     # five distinct values, so IEJoin partitioned into five buckets and range-
-    # joined millions against millions inside each.
+    # joined millions against millions inside each. That same count is what
+    # makes the thread a usable *chunk* here: measured on the 3.5 GB capture the
+    # runtime table carries thirteen distinct globalTid, four of which hold
+    # 99.97% of the ranges in four near-equal quarters.
     #
     # Sources stay Parquet-only, as before, so the heavy read never touches the
     # attached SQLite.
     #
-    # Neither call below is wrapped in a try/except, and wrapping them would be
-    # theatre: both helpers are generator functions, so these two lines only
-    # build generator objects. The ``db.execute`` inside each runs lazily, on
-    # first advance, which happens inside ``_sweep_nvtx_kernel_map`` — outside
-    # any guard placed here. A duckdb.Error therefore cannot surface at this
-    # point, and per the docstring it should not be swallowed at the next one
-    # either.
-    tc_by_kernel: dict[tuple, tuple[int, int]] = {}
-    kr_rows = _stream_kernel_runtime(db, kps, rps, tc_by_kernel)
-    # Only the NVTX side has to arrive sorted. The sweep advances a single index
-    # over the ranges per thread without re-sorting them, but it does sort the
-    # kernel side itself (``kr_by_tid[tid].sort(...)``), so asking the kernel
-    # query for an order it will redo buys nothing. That asymmetry is what
-    # tests/test_determinism.py pins.
-    #
-    # Streamed rather than fetchall()'d, and the label strings interned. The
-    # ranges outnumber the kernels five to one here (15.9M vs 3.1M on a 3.5GB
-    # capture), so they dominate: fetchall built 15.9M tuples that the sweep
-    # then copied into 15.9M more, and every label was a separate str object
-    # even though NVTX text repeats heavily. Feeding a generator drops the first
-    # copy, and interning collapses the labels onto one object per distinct
-    # string.
-    nvtx_rows = _stream_nvtx_ranges(db, nps)
+    # Nothing below is wrapped in a try/except, and wrapping it would be
+    # theatre: the two stream helpers are generator functions, so their
+    # ``execute`` runs lazily on first advance, inside ``_attribute_thread``.
+    # A duckdb.Error from an unreadable source therefore surfaces out of this
+    # function, which is what tests/test_parquet_cache.py pins — the staged file
+    # is removed by the ``finally`` and no map is published.
+    import pyarrow.parquet as pq
 
-    # Both inputs are generators, so neither can be tested for emptiness here --
-    # an exhausted-but-truthy generator would silently produce nothing. The
-    # sweep returning no rows covers "no kernels", "no ranges" and "no overlap".
-    results = _sweep_nvtx_kernel_map(kr_rows, nvtx_rows)
-    if not results:
-        log.info("nvtx_kernel_map produced no NVTX/kernel attribution; skipping map creation")
-        return False
+    # The partitions are the threads that launched work, so this reads the
+    # runtime side: a thread with ranges and no kernels attributes nothing and
+    # does not need a partition. A NULL globalTid is excluded rather than
+    # partitioned on, because a per-thread nesting stack over rows carrying no
+    # thread id is not defined — no shipped Nsight export produces one, and the
+    # previous builder would have bucketed such rows together and attributed
+    # them to each other.
+    tids = [
+        row[0]
+        for row in db.execute(
+            f"SELECT DISTINCT globalTid FROM read_parquet('{rps}') "
+            f"WHERE globalTid IS NOT NULL ORDER BY 1"
+        ).fetchall()
+    ]
 
-    # Tensor Core flags are attached after the name-agnostic sweep, the same way
-    # ensure_nvtx_kernel_map does it. Keying on (k_start, k_end, kernel_name) is
-    # not unique, but both flags are derived by regex from the kernel name, so
-    # rows that collide on that key carry identical values. The table was filled
-    # while streaming, because the rows cannot be walked a second time.
-    for r in results:
-        r["is_tc_eligible"], r["uses_tc"] = tc_by_kernel.get(
-            (r["k_start"], r["k_end"], r["kernel_name"]), (0, 0)
-        )
+    # A DuckDB connection holds ONE result. Both streams are live at the same
+    # time — the NVTX reader keeps a batch of lookahead while the kernel reader
+    # advances — and opening the second on the same handle invalidates the
+    # first, after which the sweep just stops early with no exception at all.
+    # Measured on the 3.5 GB capture: 968,394 rows instead of 3,042,699. Same
+    # failure class as the shared-connection bugs in #300/#301, and equally
+    # silent, so each stream gets its own cursor.
+    nvtx_cur = db.cursor()
+    kernel_cur = db.cursor()
 
-    _write_nvtx_kernel_map_parquet(db, results, out_dir)
-    log.info("nvtx_kernel_map built via stack sweep (parquet-only, path_id)")
+    # Staged first, published second. The sweep cannot know the path dictionary
+    # until it has seen every row, and the map's ``path_id`` column is defined
+    # against that dictionary — so the nine columns land in a scratch Parquet
+    # carrying the path text itself, and the two published files are derived
+    # from it in SQL. It also means a build that dies part-way leaves no
+    # readable nvtx_kernel_map.parquet behind.
+    staged = out_dir / f".nvtx_map_sweep_{os.getpid()}.parquet"
+    schema = _staged_map_schema()
+    n_written = 0
+    try:
+        writer = pq.ParquetWriter(staged, schema, compression="zstd")
+        try:
+            buf: list[tuple] = []
+            total = len(tids)
+            for done, tid in enumerate(tids, 1):
+                nvtx_rows = _stream_thread_nvtx(nvtx_cur, nps, tid)
+                kr_rows = _stream_thread_kernels(kernel_cur, kps, rps, tid)
+                try:
+                    for row in _attribute_thread(kr_rows, nvtx_rows):
+                        buf.append(row)
+                        if len(buf) >= _SWEEP_BATCH_ROWS:
+                            _write_staged_batch(writer, schema, buf)
+                            n_written += len(buf)
+                            buf = []
+                finally:
+                    # The kernel side is always drained; the NVTX side usually is
+                    # not, because the last kernel on a thread rarely sits at the
+                    # last range. Close it so its Arrow reader releases the
+                    # cursor's result now rather than at the next collection.
+                    nvtx_rows.close()
+                    kr_rows.close()
+                if progress is not None:
+                    progress(done, total)
+            if buf:
+                _write_staged_batch(writer, schema, buf)
+                n_written += len(buf)
+        finally:
+            writer.close()
+
+        # Covers "no kernels", "no ranges" and "no overlap" alike: all three
+        # reach here having written nothing.
+        if n_written == 0:
+            log.info("nvtx_kernel_map produced no NVTX/kernel attribution; skipping map creation")
+            return False
+
+        _publish_nvtx_kernel_map_parquet(db, staged, out_dir)
+    finally:
+        nvtx_cur.close()
+        kernel_cur.close()
+        staged.unlink(missing_ok=True)
+
+    log.info("nvtx_kernel_map built via streamed stack sweep (%d rows)", n_written)
     return True
 
 
-def _stream_kernel_runtime(db, kernels_parquet: str, runtime_parquet: str, tc_out: dict):
-    """Yield ``(globalTid, r_start, r_end, k_start, k_end, kernel_name)``.
+def _staged_map_schema() -> pa.Schema:
+    """Column order of the scratch Parquet the streamed sweep writes.
 
-    Deliberately unordered. ``_sweep_nvtx_kernel_map`` buckets these rows by
-    thread and sorts each bucket by ``r_start`` itself, so an ORDER BY here
-    would only be redone in Python — and stating an invariant the consumer does
-    not have invites someone to rely on it.
-
-    Streamed and interned for the same reason as the NVTX ranges, and the effect
-    is larger here: a 3.5GB capture has 3,077,650 of these rows carrying only
-    109 distinct kernel names, averaging 253 characters -- CUDA mangled names
-    repeat about 28,000 times each. As separate str objects that is ~0.9GB;
-    interned it is a few kilobytes, and the same objects are then shared by
-    every result row.
-
-    ``tc_out`` is filled as a side effect. The Tensor Core flags are needed
-    after the sweep, and a generator cannot be walked twice.
+    Not the published schema: this one carries ``nvtx_path`` as text, which
+    ``_publish_nvtx_kernel_map_parquet`` replaces with the ``path_id`` of the
+    dictionary it derives. Field order matches what ``_attribute_thread``
+    yields, so a row is written without being reordered.
     """
-    result = db.execute(
-        f"""
-        SELECT r.globalTid, r.start, r."end", k.start, k."end", k.name,
-               COALESCE(CAST(k.is_tc_eligible AS INTEGER), 0) AS is_tc_eligible,
-               COALESCE(CAST(k.uses_tc AS INTEGER), 0) AS uses_tc
-        FROM read_parquet('{kernels_parquet}') k
-        JOIN read_parquet('{runtime_parquet}') r ON r.correlationId = k.correlationId
-        """
+    import pyarrow as pa
+
+    return pa.schema(
+        [
+            ("nvtx_text", pa.string()),
+            ("nvtx_depth", pa.int32()),
+            ("nvtx_path", pa.string()),
+            ("kernel_name", pa.string()),
+            ("k_start", pa.int64()),
+            ("k_end", pa.int64()),
+            ("k_dur_ns", pa.int64()),
+            ("is_tc_eligible", pa.int32()),
+            ("uses_tc", pa.int32()),
+        ]
     )
+
+
+def _write_staged_batch(writer, schema: pa.Schema, rows: list[tuple]) -> None:
+    """Append one batch of sweep rows to the staged Parquet."""
+    import pyarrow as pa
+
+    cols = list(zip(*rows))
+    writer.write_batch(
+        pa.RecordBatch.from_arrays(
+            [pa.array(cols[i], schema.field(i).type) for i in range(len(cols))],
+            schema=schema,
+        )
+    )
+
+
+def _publish_nvtx_kernel_map_parquet(db, staged: Path, out_dir: Path) -> None:
+    """Derive nvtx_path_dict.parquet + nvtx_kernel_map.parquet from ``staged``.
+
+    ``path_id`` is assigned by ``row_number() OVER (ORDER BY nvtx_path)``, which
+    is 1-based over the distinct paths in ascending order — the same ids the
+    in-memory builder's ``sorted(...)`` + ``i + 1`` produces, so a cached map and
+    an on-demand one still agree. DuckDB orders VARCHAR by UTF-8 bytes and
+    Python by code point, which coincide for UTF-8.
+
+    The published map's ``ORDER BY k_start, k_end, kernel_name`` is what makes
+    two builds of the same profile byte-comparable; it is also the step that
+    dominates peak memory on a large capture, tracked separately in #339.
+    """
+    sps = _safe_path(staged)
+    dps = _safe_path(out_dir / "nvtx_path_dict.parquet")
+    db.execute(f"""
+        COPY (
+            SELECT row_number() OVER (ORDER BY nvtx_path) AS path_id, nvtx_path
+            FROM (SELECT DISTINCT nvtx_path FROM read_parquet('{sps}'))
+        ) TO '{dps}' (FORMAT PARQUET, COMPRESSION ZSTD)
+    """)
+    db.execute(f"""
+        COPY (
+            SELECT d.path_id, m.nvtx_text, m.nvtx_depth, m.kernel_name,
+                   m.k_start, m.k_end, m.k_dur_ns, m.is_tc_eligible, m.uses_tc
+            FROM read_parquet('{sps}') m
+            JOIN read_parquet('{dps}') d ON d.nvtx_path = m.nvtx_path
+            ORDER BY m.k_start, m.k_end, m.kernel_name
+        ) TO '{_safe_path(out_dir / "nvtx_kernel_map.parquet")}'
+        (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 65536)
+    """)
+
+
+def _arrow_reader(cur, sql: str, params: list):
+    """Open a lazily-consumed Arrow record-batch reader on ``cur``.
+
+    ``to_arrow_reader`` is the current name; ``fetch_record_batch`` is its
+    deprecated alias and the only one present on the duckdb>=1.0 floor this
+    package declares. Both take the batch size as their first argument.
+    """
+    result = cur.execute(sql, params)
     make_reader = getattr(result, "to_arrow_reader", None) or result.fetch_record_batch
-    reader = make_reader()
-
-    pool: dict[str, str] = {}
-    for batch in reader:
-        cols = [batch.column(i).to_pylist() for i in range(8)]
-        tids, r_starts, r_ends, k_starts, k_ends, names, elig, used = cols
-        for i, name in enumerate(names):
-            shared = pool.get(name)
-            if shared is None:
-                shared = pool[name] = name
-            k_start = k_starts[i]
-            k_end = k_ends[i]
-            tc_out[(k_start, k_end, shared)] = (elig[i], used[i])
-            yield tids[i], r_starts[i], r_ends[i], k_start, k_end, shared
+    return make_reader(_SWEEP_BATCH_ROWS)
 
 
-def _stream_nvtx_ranges(db, nvtx_parquet: str):
-    """Yield ``(globalTid, start, end, text)`` for PushPop ranges, sorted.
-
-    Batched through Arrow so the whole result never exists as one list of
-    tuples, and labels interned so repeated NVTX text costs one string object
-    rather than one per row.
+def _stream_thread_nvtx(cur, nvtx_parquet: str, tid):
+    """Yield one thread's ``(start, end, text)`` PushPop ranges, in start order.
 
     ``eventType = 59`` deliberately excludes Start/End ranges (eventType 60)
     rather than merely overlooking them: the consumer is a per-thread nesting
     stack, valid only for push/pop ranges. See
     ``skills.base.requires_pushpop_nvtx`` for why widening this is not the fix.
+
+    The labels are *not* interned, unlike the kernel names below, and that is
+    measured rather than an oversight: on the 3.5 GB reference capture a single
+    thread carries 3,850,911 distinct texts across 3,969,967 ranges, so the pool
+    dedupes almost nothing and costs 0.19 GB to hold. NVTX labels on an
+    ``emit_nvtx``-style PyTorch capture carry per-iteration identifiers; the
+    assumption that they repeat does not survive contact with one.
     """
-    result = db.execute(
+    for batch in _arrow_reader(
+        cur,
         f"""
-        SELECT globalTid, start, "end", CAST(text AS VARCHAR) AS text
+        SELECT start, "end", CAST(text AS VARCHAR) AS text
         FROM read_parquet('{nvtx_parquet}')
         WHERE eventType = 59 AND "end" > start AND text IS NOT NULL
-        ORDER BY globalTid, start
-        """
-    )
-    # to_arrow_reader is the current name; fetch_record_batch is its deprecated
-    # alias and the only one present on the duckdb>=1.0 floor this package
-    # declares.
-    make_reader = getattr(result, "to_arrow_reader", None) or result.fetch_record_batch
-    reader = make_reader()
-
-    pool: dict[str, str] = {}
-    for batch in reader:
-        tids = batch.column(0).to_pylist()
-        starts = batch.column(1).to_pylist()
-        ends = batch.column(2).to_pylist()
-        texts = batch.column(3).to_pylist()
+          AND globalTid = ?
+        ORDER BY start
+        """,
+        [tid],
+    ):
+        starts = batch.column(0).to_pylist()
+        ends = batch.column(1).to_pylist()
+        texts = batch.column(2).to_pylist()
         for i, text in enumerate(texts):
-            shared = pool.get(text)
+            yield starts[i], ends[i], text
+
+
+def _stream_thread_kernels(cur, kernels_parquet: str, runtime_parquet: str, tid):
+    """Yield one thread's ``(r_start, r_end, k_start, k_end, name, elig, used)``.
+
+    Sorted by ``r_start``, which #318 and #327 removed from this query and this
+    restores — per thread, and on ``r.start`` only. Those removals were right for
+    the builder they were made against: it bucketed the rows by thread and sorted
+    each bucket in Python, so a SQL order was redone. A stream cannot be
+    re-sorted after the fact, so under streaming that Python sort has nowhere to
+    live and the ORDER BY comes back. ``_sweep_nvtx_kernel_map``, which the
+    on-demand builder still uses, keeps the old contract and still sorts its own
+    buckets; tests/test_determinism.py pins that.
+
+    The Tensor Core flags ride along in the row. They used to be dropped here and
+    rebuilt afterwards from a ``(k_start, k_end, name) -> (elig, used)`` dict —
+    2,193,776 entries of three-tuples on the 3.5 GB capture, existing only
+    because the sweep discarded two columns it was already reading.
+
+    Kernel names *are* interned, and here the pool pays: 3,077,650 rows carry
+    109 distinct names averaging 253 characters, so as separate str objects that
+    is ~0.9 GB and interned it is a few kilobytes.
+    """
+    pool: dict[str, str] = {}
+    for batch in _arrow_reader(
+        cur,
+        f"""
+        SELECT r.start, r."end", k.start, k."end", k.name,
+               COALESCE(CAST(k.is_tc_eligible AS INTEGER), 0) AS is_tc_eligible,
+               COALESCE(CAST(k.uses_tc AS INTEGER), 0) AS uses_tc
+        FROM read_parquet('{kernels_parquet}') k
+        JOIN read_parquet('{runtime_parquet}') r ON r.correlationId = k.correlationId
+        WHERE r.globalTid = ?
+        ORDER BY r.start
+        """,
+        [tid],
+    ):
+        cols = [batch.column(i).to_pylist() for i in range(7)]
+        r_starts, r_ends, k_starts, k_ends, names, elig, used = cols
+        for i, name in enumerate(names):
+            shared = pool.get(name)
             if shared is None:
-                shared = pool[text] = text
-            yield tids[i], starts[i], ends[i], shared
+                shared = pool[name] = name
+            yield r_starts[i], r_ends[i], k_starts[i], k_ends[i], shared, elig[i], used[i]
 
 
 def _nvtx_map_arrow_tables(results: list[dict]) -> tuple[pa.Table, pa.Table]:
     """Build the ``(nvtx_kernel_map, nvtx_path_dict)`` Arrow pair from sweep rows.
 
-    The single definition of the map's schema, shared by the cache writer and
-    the on-demand materializer so the two cannot drift. All nine columns are
+    The in-memory builder's writer. The cached builder streams straight to
+    Parquet instead (``_publish_nvtx_kernel_map_parquet``) and never holds the
+    rows; the two are kept in step by
+    ``test_the_lazily_built_map_is_identical_to_the_eager_one`` and by the
+    row-for-row oracle comparison in tests/test_parquet_cache.py, not by sharing
+    this function. All nine columns are
     emitted, including ``is_tc_eligible``/``uses_tc``: consumers probe for those
     two by presence (``connection.cached_nvtx_map_has_embedded_tc``), so a map
     missing them is not merely thinner, it routes every reader onto a different
@@ -1440,41 +1590,87 @@ def _nvtx_map_arrow_tables(results: list[dict]) -> tuple[pa.Table, pa.Table]:
     return map_table, dict_table
 
 
-def _write_nvtx_kernel_map_parquet(db, results: list[dict], out_dir: Path) -> None:
-    """Write sweep ``results`` to nvtx_kernel_map.parquet + nvtx_path_dict.parquet.
+def _attribute_thread(kr_rows, nvtx_rows):
+    """Attribute one thread's kernels to their innermost enclosing NVTX range.
 
-    The single writer for both builds — the eager one during ``build_cache`` and
-    the on-demand one afterwards — so the file layout cannot drift by which code
-    path produced the rows. ``out_dir`` is the cache directory for the eager
-    build and a staging directory for the on-demand one.
+    The single containment implementation in this package. Both builders reach
+    it: the cached one feeds it two Arrow-backed generators per thread, the
+    on-demand one feeds it two lists per thread through
+    :func:`_sweep_nvtx_kernel_map`. There is deliberately no second copy of this
+    logic — a hand-vectorised rewrite of it was wrong on 15% of rows, which is
+    the kind of divergence #300 spent its effort removing.
+
+    Both arguments are consumed **in one forward pass** and neither has to be a
+    list. ``eventType = 59`` ranges on a thread are strictly nested, so a stack
+    plus one range of lookahead is the whole state; measured depth on a 3.5 GB
+    capture is <= 7.
+
+    kr_rows: iterable of ``(r_start, r_end, k_start, k_end, kernel_name, *extra)``
+    sorted by ``r_start``. Anything after the fifth field is passed through to
+    the output untouched, which is how the cached builder carries the Tensor Core
+    flags without a second pass.
+    nvtx_rows: iterable of ``(start, end, text)`` sorted by ``start``.
+
+    Yields ``(nvtx_text, nvtx_depth, nvtx_path, kernel_name, k_start, k_end,
+    k_dur_ns, *extra)``. Kernels with no enclosing range are dropped.
     """
-    map_table, dict_table = _nvtx_map_arrow_tables(results)
+    nvtx_iter = iter(nvtx_rows)
+    # One range of lookahead. The rest of the NVTX side stays in Arrow.
+    pending = next(nvtx_iter, None)
+    open_stack: list[tuple] = []
 
-    try:
-        db.register("_nvtx_kernel_map", map_table)
-        db.register("_nvtx_path_dict", dict_table)
-        db.execute(
-            f"COPY _nvtx_path_dict TO '{_safe_path(out_dir / 'nvtx_path_dict.parquet')}' "
-            f"(FORMAT PARQUET, COMPRESSION ZSTD)"
-        )
-        db.execute(
-            f"""
-            COPY (SELECT * FROM _nvtx_kernel_map ORDER BY k_start, k_end, kernel_name)
-            TO '{_safe_path(out_dir / "nvtx_kernel_map.parquet")}'
-            (FORMAT PARQUET, COMPRESSION ZSTD, ROW_GROUP_SIZE 65536)
-            """
-        )
-    finally:
-        db.unregister("_nvtx_kernel_map")
-        db.unregister("_nvtx_path_dict")
-        del map_table
-        del dict_table
+    for row in kr_rows:
+        r_start, r_end, k_start, k_end, kernel_name = row[:5]
+        while open_stack and open_stack[-1][1] < r_start:
+            open_stack.pop()
+        while pending is not None and pending[0] <= r_start:
+            if pending[1] >= r_start:
+                open_stack.append(pending)
+            pending = next(nvtx_iter, None)
+
+        best_idx = -1
+        for i in range(len(open_stack) - 1, -1, -1):
+            if open_stack[i][0] <= r_start and open_stack[i][1] >= r_end:
+                best_idx = i
+                break
+        if best_idx < 0:
+            continue
+
+        enclosing = [e for e in open_stack[: best_idx + 1] if e[0] <= r_start and e[1] >= r_end]
+        # Total order, matching nvtx_attribution's
+        # ``ORDER BY n_dur ASC, n_start ASC, nvtx_text ASC``. Stack position
+        # alone is not enough: two ranges with an identical span are both
+        # innermost, and which one the stack yields depends on the order they
+        # arrived in, so the answer followed the input rather than the data.
+        # That is the divergence tests/test_determinism.py exists to prevent.
+        # Most kernels sit inside a single range, and sorting a one-element list
+        # twice cost 36% of the build on a 3.5GB capture (60.6s -> 82.4s) for no
+        # reordering at all.
+        if len(enclosing) == 1:
+            by_inner = by_outer = enclosing
+        else:
+            by_inner = sorted(enclosing, key=lambda e: (e[1] - e[0], e[0], e[2]))
+            by_outer = sorted(enclosing, key=lambda e: (-(e[1] - e[0]), e[0], e[2]))
+        yield (
+            by_inner[0][2],
+            len(enclosing) - 1,
+            " > ".join(e[2] for e in by_outer),
+            kernel_name,
+            k_start,
+            k_end,
+            k_end - k_start,
+        ) + tuple(row[5:])
 
 
 def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
-    """Per-thread sort-merge attributing each kernel to its innermost enclosing
-    NVTX range. O(N+M) per thread; the shared containment core used by both the
-    parquet-cache builder and the on-demand builder (issue #257).
+    """Bucket rows by thread and attribute each bucket with
+    :func:`_attribute_thread`, materialising the result as a list of dicts.
+
+    The on-demand builder's entry point (issue #257). It exists because that
+    builder has both sides in memory already — it ``fetchall``s them off a
+    backend with no Parquet cache to stream from — so partitioning them here is
+    the cheapest way to reach the shared containment core. The cached builder
+    does not come through here at all: it partitions in SQL and streams.
 
     kr_rows: iterable of ``(globalTid, r_start, r_end, k_start, k_end,
     kernel_name)`` — the kernel name already resolved by the caller (so each can
@@ -1496,63 +1692,23 @@ def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
         kr_by_tid[r[0]].append((r[1], r[2], r[3], r[4], r[5]))
 
     results: list[dict] = []
-    for tid in kr_by_tid:
-        if tid not in nvtx_by_tid:
+    for tid, kr_list in kr_by_tid.items():
+        nvtx_list = nvtx_by_tid.get(tid)
+        if not nvtx_list:
             continue
-
-        nvtx_list = nvtx_by_tid[tid]
-        kr_by_tid[tid].sort(key=lambda x: x[0])
-
-        nvtx_idx = 0
-        open_stack: list[tuple[int, int, str]] = []
-
-        for r_start, r_end, k_start, k_end, kernel_name in kr_by_tid[tid]:
-            while open_stack and open_stack[-1][1] < r_start:
-                open_stack.pop()
-            while nvtx_idx < len(nvtx_list) and nvtx_list[nvtx_idx][0] <= r_start:
-                if nvtx_list[nvtx_idx][1] >= r_start:
-                    open_stack.append(nvtx_list[nvtx_idx])
-                nvtx_idx += 1
-
-            best_nvtx = None
-            best_idx = -1
-            for i in range(len(open_stack) - 1, -1, -1):
-                ns, ne, nt = open_stack[i]
-                if ns <= r_start and ne >= r_end:
-                    best_nvtx = nt
-                    best_idx = i
-                    break
-
-            if best_nvtx is not None:
-                enclosing = [
-                    e for e in open_stack[: best_idx + 1] if e[0] <= r_start and e[1] >= r_end
-                ]
-                # Total order, matching nvtx_attribution's
-                # ``ORDER BY n_dur ASC, n_start ASC, nvtx_text ASC``. Stack
-                # position alone is not enough: two ranges with an identical
-                # span are both innermost, and which one the stack yields
-                # depends on the order they arrived in, so the answer followed
-                # the input rather than the data. That is the divergence
-                # tests/test_determinism.py exists to prevent.
-                # Most kernels sit inside a single range, and sorting a
-                # one-element list twice cost 36% of the build on a 3.5GB
-                # capture (60.6s -> 82.4s) for no reordering at all.
-                if len(enclosing) == 1:
-                    by_inner = by_outer = enclosing
-                else:
-                    by_inner = sorted(enclosing, key=lambda e: (e[1] - e[0], e[0], e[2]))
-                    by_outer = sorted(enclosing, key=lambda e: (-(e[1] - e[0]), e[0], e[2]))
-                results.append(
-                    {
-                        "nvtx_text": by_inner[0][2],
-                        "nvtx_depth": len(enclosing) - 1,
-                        "nvtx_path": " > ".join(e[2] for e in by_outer),
-                        "kernel_name": kernel_name,
-                        "k_start": k_start,
-                        "k_end": k_end,
-                        "k_dur_ns": k_end - k_start,
-                    }
-                )
+        kr_list.sort(key=lambda x: x[0])
+        for text, depth, path, name, k_start, k_end, dur in _attribute_thread(kr_list, nvtx_list):
+            results.append(
+                {
+                    "nvtx_text": text,
+                    "nvtx_depth": depth,
+                    "nvtx_path": path,
+                    "kernel_name": name,
+                    "k_start": k_start,
+                    "k_end": k_end,
+                    "k_dur_ns": dur,
+                }
+            )
     return results
 
 
@@ -1726,7 +1882,9 @@ def _publish_stamp_map_ready(cache_dir: Path) -> None:
         _check_cache_size(cache_dir, str(cache_dir.parent / source))
 
 
-def materialize_cached_nvtx_kernel_map(conn) -> bool:
+def materialize_cached_nvtx_kernel_map(
+    conn, progress: Callable[[int, int], None] | None = None
+) -> bool:
     """Build ``nvtx_kernel_map`` into ``conn``'s Parquet cache, then view it.
 
     The persisted half of the deferred-map design. ``build_cache`` no longer
@@ -1746,6 +1904,11 @@ def materialize_cached_nvtx_kernel_map(conn) -> bool:
     Never call this from inside ``build_cache``: that holds ``_build_lock`` for
     the same cache directory, and flock is not reentrant across the fds involved
     — the process would wedge. The only callers are query-time.
+
+    ``progress`` is forwarded to the sweep and called ``progress(done, total)``
+    per thread of the capture. It fires only on the branch that actually builds:
+    a map already published by another process returns before any work, and so
+    reports nothing, which is the honest answer for a wait that did not happen.
     """
     from .connection import DuckDBAdapter, forget_nvtx_map_probes, wrap_connection
 
@@ -1791,7 +1954,9 @@ def materialize_cached_nvtx_kernel_map(conn) -> bool:
                 tempfile.mkdtemp(prefix=".nvtx_map_build_", dir=cache_dir)
             )
             try:
-                built = _build_nvtx_kernel_map_from_parquet(db, cache_dir, staging)
+                built = _build_nvtx_kernel_map_from_parquet(
+                    db, cache_dir, staging, progress=progress
+                )
                 if not built:
                     return False
                 # Publish the dictionary first. A concurrent opener globbing
@@ -1822,7 +1987,7 @@ def materialize_cached_nvtx_kernel_map(conn) -> bool:
     return ok
 
 
-def ensure_nvtx_kernel_map(conn) -> bool:
+def ensure_nvtx_kernel_map(conn, progress: Callable[[int, int], None] | None = None) -> bool:
     """Make ``nvtx_kernel_map`` + ``nvtx_path_dict`` queryable on a DuckDB
     connection when they are absent, so NVTX-attribution skills take their fast
     map-backed path instead of an in-file IEJoin that hangs DuckDB's
@@ -1854,6 +2019,13 @@ def ensure_nvtx_kernel_map(conn) -> bool:
     ``CREATE TABLE`` to a catalog write-write conflict — four times the work and
     four times the memory to produce one table. Both call sites swallowed the
     exception under ``except DB_ERRORS``, so it was invisible.
+
+    ``progress``, when given, is called ``progress(done, total)`` per thread of
+    the capture by the persisted build. It is the only reporting channel this
+    path has: the wait a user sees on a large profile is now here rather than in
+    ``build_cache``, and it was previously silent — stderr during it captured as
+    exactly ``''``. The in-memory fallback reports nothing, because it has no
+    chunk to report.
     """
     from .connection import DB_ERRORS, DuckDBAdapter, wrap_connection
 
@@ -1875,7 +2047,7 @@ def ensure_nvtx_kernel_map(conn) -> bool:
         if _nvtx_map_present(db):
             return True
         # Persisted build, when this connection has a cache to write into.
-        if materialize_cached_nvtx_kernel_map(db):
+        if materialize_cached_nvtx_kernel_map(db, progress=progress):
             return True
         return _ensure_nvtx_kernel_map_in_memory(adapter, db)
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -64,7 +64,7 @@ import re
 import sys
 import threading
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Iterator
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -1189,7 +1189,6 @@ def _build_nvtx_kernel_map_from_parquet(
     db: duckdb.DuckDBPyConnection,
     cache_dir: Path,
     out_dir: Path | None = None,
-    progress: Callable[[int, int], None] | None = None,
 ) -> bool:
     """Generate nvtx_kernel_map.parquet with a per-thread stack sweep.
 
@@ -1198,21 +1197,17 @@ def _build_nvtx_kernel_map_from_parquet(
     range join is involved (the comment below records why one was tried and
     dropped), and there is no fallback.
 
-    **One thread of the capture at a time**, so peak memory tracks the batch
-    rather than the profile. ``eventType = 59`` is a per-thread Push/Pop stack,
-    so a thread's ranges are strictly nested and its work is independent of
-    every other thread's: partitioning on ``globalTid`` needs no carried state
-    at a partition boundary at all. Within a thread both sides then arrive
-    sorted by start and are consumed through a single advancing cursor, so
-    neither side is ever a list. Measured on a 3.5 GB capture (15.9 M ranges,
-    3.1 M kernel-runtime rows): peak inside the sweep 5.24 GB -> 1.83 GB, with
-    byte-identical output (3,042,699 rows).
-
-    ``progress``, when given, is called ``progress(threads_done, threads_total)``
-    after each thread. The deferred build is where the wait now lives — roughly
-    60 s on that capture, previously with no reporting channel at all — and the
-    thread is the natural unit to report, because it is the unit the sweep
-    already works in.
+    **One thread of the capture at a time**, so what the sweep holds in Python
+    tracks the batch rather than the profile. ``eventType = 59`` is a per-thread
+    Push/Pop stack, so a thread's ranges are strictly nested and its work is
+    independent of every other thread's: partitioning on ``globalTid`` needs no
+    carried state at a partition boundary at all. Within a thread both sides
+    then arrive sorted by start and are consumed through a single advancing
+    cursor, so neither side is ever a list. Measured on a 3.5 GB capture
+    (15.9 M ranges, 3.1 M kernel-runtime rows), peak process RSS: 5.28 GB ->
+    1.39 GB inside the sweep, 7.50 GB -> 3.55 GB for the whole build, with
+    unchanged output (3,042,699 rows). The 3.55 GB is the publish step below,
+    which still sorts the whole map in DuckDB; that is #339.
 
     Sources are the ``kernels``, ``runtime`` and ``nvtx`` Parquets already in
     ``cache_dir`` — written earlier in the same build, or published by an
@@ -1287,35 +1282,52 @@ def _build_nvtx_kernel_map_from_parquet(
     # by construction. A containment IEJoin cannot know that and pays the
     # general-case cost: on a 3.5 GB capture (2.19 M kernels, 15.9 M ranges) it
     # ran over twenty minutes, saturating twelve cores, to produce a 3.0 M-row
-    # result. The sweep below does the same work in 19 s, and its output was
-    # compared row-for-row against the IEJoin's on that capture --
-    # 3,042,699 rows, zero differences in either direction.
+    # result. The sweep below does the same work in 35 s on that capture, and
+    # its output was compared row-for-row against the IEJoin's -- 3,042,699
+    # rows, zero differences in either direction.
     #
-    # The equality key is why the join had so little to work with: globalTid had
-    # five distinct values, so IEJoin partitioned into five buckets and range-
-    # joined millions against millions inside each. That same count is what
-    # makes the thread a usable *chunk* here: measured on the 3.5 GB capture the
-    # runtime table carries thirteen distinct globalTid, four of which hold
-    # 99.97% of the ranges in four near-equal quarters.
+    # The equality key is why the join had so little to work with: on the NVTX
+    # side globalTid has five distinct values, so IEJoin partitioned into five
+    # buckets and range-joined millions against millions inside each. The same
+    # skew is what makes the thread a usable *chunk* here: four of those five
+    # threads hold 99.97% of the 15.9 M ranges in near-equal quarters (measured
+    # on the 3.5 GB capture, from nvtx.parquet).
+    #
+    # The partition list below is taken from the runtime side, which on that
+    # capture has 51 distinct globalTid -- 12 of which launched kernels, and 4
+    # of which also carry push/pop ranges. So most partitions attribute
+    # nothing and still issue two filtered scans -- both files are written
+    # sorted by globalTid, so the row-group statistics prune those scans, but
+    # the count of them is linear in thread count. A capture with several
+    # hundred CUDA-calling threads would want this list narrowed to the threads
+    # present on both sides.
     #
     # Sources stay Parquet-only, as before, so the heavy read never touches the
     # attached SQLite.
     #
-    # Nothing below is wrapped in a try/except, and wrapping it would be
-    # theatre: the two stream helpers are generator functions, so their
-    # ``execute`` runs lazily on first advance, inside ``_attribute_thread``.
-    # A duckdb.Error from an unreadable source therefore surfaces out of this
-    # function, which is what tests/test_parquet_cache.py pins — the staged file
-    # is removed by the ``finally`` and no map is published.
+    # On errors: the partition query below is eager, so an unreadable
+    # runtime.parquet raises there, before anything is staged. Everything after
+    # it goes through the two stream helpers, which are generator functions, so
+    # their ``execute`` runs on first advance inside ``_attribute_thread`` --
+    # under the ``try`` whose ``finally`` removes the staged file. Either way a
+    # duckdb.Error leaves this function and no map is published, which is what
+    # tests/test_parquet_cache.py pins. The ``try`` blocks below are there to
+    # release the writer, the cursors and the staged file, and none of them
+    # swallows an error; adding one that did would be a change to a documented
+    # behaviour.
     import pyarrow.parquet as pq
 
     # The partitions are the threads that launched work, so this reads the
     # runtime side: a thread with ranges and no kernels attributes nothing and
     # does not need a partition. A NULL globalTid is excluded rather than
     # partitioned on, because a per-thread nesting stack over rows carrying no
-    # thread id is not defined — no shipped Nsight export produces one, and the
-    # previous builder would have bucketed such rows together and attributed
-    # them to each other.
+    # thread id is not defined. This is the one place the two builders can
+    # disagree: ``_sweep_nvtx_kernel_map``, which the on-demand builder still
+    # uses, buckets those rows under a single ``None`` key and attributes them
+    # to each other, which is a made-up answer rather than a better one. No
+    # export seen here has the case at all -- the column is the thread that
+    # made the CUDA API call, and runtime.parquet on the 3.5 GB reference
+    # capture has zero NULLs in it.
     tids = [
         row[0]
         for row in db.execute(
@@ -1347,8 +1359,7 @@ def _build_nvtx_kernel_map_from_parquet(
         writer = pq.ParquetWriter(staged, schema, compression="zstd")
         try:
             buf: list[tuple] = []
-            total = len(tids)
-            for done, tid in enumerate(tids, 1):
+            for tid in tids:
                 nvtx_rows = _stream_thread_nvtx(nvtx_cur, nps, tid)
                 kr_rows = _stream_thread_kernels(kernel_cur, kps, rps, tid)
                 try:
@@ -1365,8 +1376,6 @@ def _build_nvtx_kernel_map_from_parquet(
                     # cursor's result now rather than at the next collection.
                     nvtx_rows.close()
                     kr_rows.close()
-                if progress is not None:
-                    progress(done, total)
             if buf:
                 _write_staged_batch(writer, schema, buf)
                 n_written += len(buf)
@@ -1436,9 +1445,15 @@ def _publish_nvtx_kernel_map_parquet(db, staged: Path, out_dir: Path) -> None:
     an on-demand one still agree. DuckDB orders VARCHAR by UTF-8 bytes and
     Python by code point, which coincide for UTF-8.
 
-    The published map's ``ORDER BY k_start, k_end, kernel_name`` is what makes
-    two builds of the same profile byte-comparable; it is also the step that
-    dominates peak memory on a large capture, tracked separately in #339.
+    The published map's ``ORDER BY k_start, k_end, kernel_name`` clusters it by
+    kernel start, which is the axis its readers filter on. It is *not* a total
+    order and does not make two builds byte-comparable: one kernel reached
+    through more than one runtime row yields several rows sharing that key, and
+    on the 3.5 GB reference capture 759,299 keys are shared by 1.6 M of the
+    3.1 M kernel-runtime rows. What is pinned is the row multiset
+    (``TestStreamedSweep`` in tests/test_parquet_cache.py), not the byte layout.
+    This sort is also the step that dominates peak memory on a large capture,
+    tracked separately in #339.
     """
     sps = _safe_path(staged)
     dps = _safe_path(out_dir / "nvtx_path_dict.parquet")
@@ -1552,12 +1567,16 @@ def _stream_thread_kernels(cur, kernels_parquet: str, runtime_parquet: str, tid)
 def _nvtx_map_arrow_tables(results: list[dict]) -> tuple[pa.Table, pa.Table]:
     """Build the ``(nvtx_kernel_map, nvtx_path_dict)`` Arrow pair from sweep rows.
 
-    The in-memory builder's writer. The cached builder streams straight to
+    The in-memory builder's writer, and its only caller is
+    ``_materialize_nvtx_kernel_map``. The cached builder streams straight to
     Parquet instead (``_publish_nvtx_kernel_map_parquet``) and never holds the
-    rows; the two are kept in step by
-    ``test_the_lazily_built_map_is_identical_to_the_eager_one`` and by the
-    row-for-row oracle comparison in tests/test_parquet_cache.py, not by sharing
-    this function. All nine columns are
+    rows, so the two maps' columns are now two lists that have to be edited
+    together. The list here and the ``SELECT`` there are compared column by
+    column in ``TestStreamedSweep.test_both_map_writers_emit_the_same_columns``
+    (tests/test_parquet_cache.py); nothing else catches a divergence, because
+    the row-for-row oracle in that class compares the *cached* map against
+    ``_sweep_nvtx_kernel_map``'s rows and never calls this function. All nine
+    columns are
     emitted, including ``is_tc_eligible``/``uses_tc``: consumers probe for those
     two by presence (``connection.cached_nvtx_map_has_embedded_tc``), so a map
     missing them is not merely thinner, it routes every reader onto a different
@@ -1718,9 +1737,11 @@ def _materialize_nvtx_kernel_map(db, results: list[dict]) -> None:
     cache-built schema, including the embedded ``is_tc_eligible``/``uses_tc``,
     so consumers take their map-only fast path (a TC-less map would force
     nvtx_layer_breakdown into a (start,end) kernels-join that double-counts
-    timestamp-colliding kernels). Shares ``_nvtx_map_arrow_tables`` with the
-    cache writer, so the on-demand map and the cached one are the same shape by
-    construction rather than by two lists of columns kept in step."""
+    timestamp-colliding kernels). The nine columns are listed in
+    ``_nvtx_map_arrow_tables`` above, and again in the cached builder's
+    ``_publish_nvtx_kernel_map_parquet``; the two lists are separate and
+    ``TestStreamedSweep.test_both_map_writers_emit_the_same_columns`` is what
+    keeps them equal."""
     map_tbl, dict_tbl = _nvtx_map_arrow_tables(results)
     db.register("_odm_nkm", map_tbl)
     db.register("_odm_npd", dict_tbl)
@@ -1882,9 +1903,7 @@ def _publish_stamp_map_ready(cache_dir: Path) -> None:
         _check_cache_size(cache_dir, str(cache_dir.parent / source))
 
 
-def materialize_cached_nvtx_kernel_map(
-    conn, progress: Callable[[int, int], None] | None = None
-) -> bool:
+def materialize_cached_nvtx_kernel_map(conn) -> bool:
     """Build ``nvtx_kernel_map`` into ``conn``'s Parquet cache, then view it.
 
     The persisted half of the deferred-map design. ``build_cache`` no longer
@@ -1904,11 +1923,6 @@ def materialize_cached_nvtx_kernel_map(
     Never call this from inside ``build_cache``: that holds ``_build_lock`` for
     the same cache directory, and flock is not reentrant across the fds involved
     — the process would wedge. The only callers are query-time.
-
-    ``progress`` is forwarded to the sweep and called ``progress(done, total)``
-    per thread of the capture. It fires only on the branch that actually builds:
-    a map already published by another process returns before any work, and so
-    reports nothing, which is the honest answer for a wait that did not happen.
     """
     from .connection import DuckDBAdapter, forget_nvtx_map_probes, wrap_connection
 
@@ -1954,9 +1968,7 @@ def materialize_cached_nvtx_kernel_map(
                 tempfile.mkdtemp(prefix=".nvtx_map_build_", dir=cache_dir)
             )
             try:
-                built = _build_nvtx_kernel_map_from_parquet(
-                    db, cache_dir, staging, progress=progress
-                )
+                built = _build_nvtx_kernel_map_from_parquet(db, cache_dir, staging)
                 if not built:
                     return False
                 # Publish the dictionary first. A concurrent opener globbing
@@ -1987,7 +1999,7 @@ def materialize_cached_nvtx_kernel_map(
     return ok
 
 
-def ensure_nvtx_kernel_map(conn, progress: Callable[[int, int], None] | None = None) -> bool:
+def ensure_nvtx_kernel_map(conn) -> bool:
     """Make ``nvtx_kernel_map`` + ``nvtx_path_dict`` queryable on a DuckDB
     connection when they are absent, so NVTX-attribution skills take their fast
     map-backed path instead of an in-file IEJoin that hangs DuckDB's
@@ -2020,12 +2032,9 @@ def ensure_nvtx_kernel_map(conn, progress: Callable[[int, int], None] | None = N
     four times the memory to produce one table. Both call sites swallowed the
     exception under ``except DB_ERRORS``, so it was invisible.
 
-    ``progress``, when given, is called ``progress(done, total)`` per thread of
-    the capture by the persisted build. It is the only reporting channel this
-    path has: the wait a user sees on a large profile is now here rather than in
-    ``build_cache``, and it was previously silent — stderr during it captured as
-    exactly ``''``. The in-memory fallback reports nothing, because it has no
-    chunk to report.
+    The wait is silent, and stays so here. It moved out of ``build_cache`` and
+    into this call — stderr during it captures as exactly ``''`` — and reporting
+    it needs a channel from here back to the caller, which is #332.
     """
     from .connection import DB_ERRORS, DuckDBAdapter, wrap_connection
 
@@ -2047,7 +2056,7 @@ def ensure_nvtx_kernel_map(conn, progress: Callable[[int, int], None] | None = N
         if _nvtx_map_present(db):
             return True
         # Persisted build, when this connection has a cache to write into.
-        if materialize_cached_nvtx_kernel_map(db, progress=progress):
+        if materialize_cached_nvtx_kernel_map(db):
             return True
         return _ensure_nvtx_kernel_map_in_memory(adapter, db)
 
@@ -2080,9 +2089,9 @@ def _ensure_nvtx_kernel_map_in_memory(adapter, db) -> bool:
         text_join = ""
 
     # kernel_name and the embedded TC flags resolved exactly as the cache-built
-    # map's TC-enriched ``kernels`` view (_tc_enriched_sql), so the on-demand map
-    # is a byte-for-byte drop-in: name = COALESCE(demangled, short, 'kernel_'||id),
-    # TC eligibility/use by the same name regexes.
+    # map's TC-enriched ``kernels`` view (_tc_enriched_sql), so those three
+    # columns are a drop-in for the cached map's: name = COALESCE(demangled,
+    # short, 'kernel_'||id), TC eligibility/use by the same name regexes.
     tc_active = _TC_ACTIVE_PATTERN
     tc_elig = _TC_ELIGIBLE_PATTERN
     lname = "lower(COALESCE(sd.value, ss.value, ''))"

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1296,9 +1296,13 @@ def _build_nvtx_kernel_map_from_parquet(
     # The partition list below is taken from the runtime side, which on that
     # capture has 51 distinct globalTid -- 12 of which launched kernels, and 4
     # of which also carry push/pop ranges. So most partitions attribute
-    # nothing and still issue two filtered scans -- both files are written
-    # sorted by globalTid, so the row-group statistics prune those scans, but
-    # the count of them is linear in thread count. A capture with several
+    # nothing and still issue two filtered scans. Only one of the two prunes
+    # cheaply: nvtx.parquet is written sorted by globalTid, so its row-group
+    # statistics narrow the scan to the matching groups. The kernel side does
+    # not -- kernels.parquet carries no globalTid column at all, so the filter
+    # applies to runtime.parquet and the correlationId join still reads the
+    # kernel rows it pairs with. Either way the count of scans is linear in
+    # thread count, which is what would bite. A capture with several
     # hundred CUDA-calling threads would want this list narrowed to the threads
     # present on both sides.
     #

--- a/tests/test_analysis_memory.py
+++ b/tests/test_analysis_memory.py
@@ -22,14 +22,16 @@ window           baseline  ceiling  mutation that moves it (all measured here)
 auto / open       0.07 MB   1.0 MB  build nvtx_kernel_map during ``build_cache``
                                     again (``NSYS_AI_ALWAYS_BUILD_NVTX_KERNEL_MAP=1``)
                                     -> 4.84 MB
-auto / skills     4.93 MB   5.5 MB  ``list(_stream_nvtx_ranges(...))`` -> 6.15 MB
-auto / attrib     0.30 MB   0.8 MB  drop the ``LIMIT`` push-down in
-                                    ``nvtx_attribution`` -> 1.57 MB
+auto / skills     2.03 MB   2.6 MB  hold one thread's ranges instead of streaming
+                                    them, ``list(_stream_thread_nvtx(...))``
+                                    -> 6.12 MB
+auto / attrib     0.16 MB   0.8 MB  drop the ``LIMIT`` push-down in
+                                    ``nvtx_attribution`` -> 1.42 MB
 direct / open     0.05 MB   1.0 MB  route ``cache_mode="direct"`` through
                                     ``open_cached_db`` -> 4.85 MB
 direct / skills   6.62 MB   7.4 MB  dict instead of tuple buckets in
                                     ``_sweep_nvtx_kernel_map`` -> 8.06 MB
-direct / attrib   0.44 MB   0.9 MB  drop the ``LIMIT`` push-down -> 1.70 MB
+direct / attrib   0.44 MB   0.9 MB  drop the ``LIMIT`` push-down -> 1.69 MB
 ===============  ========  =======  ==================================================
 
 ``cache_mode="direct"`` is the second case because it is the path a real
@@ -48,22 +50,24 @@ ever reach it at all.
 What the two modes still do differently is *how* they build it, and that is the
 one number worth reading as a comparison rather than a bound:
 
-* ``auto`` reaches ``materialize_cached_nvtx_kernel_map``, which streams its
-  sources out of the cached Parquet — 4.93 MB;
+* ``auto`` reaches ``materialize_cached_nvtx_kernel_map``, which sweeps one
+  thread of the capture at a time and streams both sides of each — 2.03 MB;
 * ``direct`` has no cache directory to write into and falls through to
   ``ensure_nvtx_kernel_map``'s in-memory build, which ``fetchall()``s the entire
   NVTX table and the whole kernel/runtime join into Python tuples — 6.62 MB.
 
-Identical output, 26% less Python heap for the streaming one. That gap is why
+Identical output, 69% less Python heap for the streaming one. That gap is why
 the deferral had to land with a persisting builder rather than by flipping a
 default: deferring onto the ``fetchall`` path would have made the common case
 cheaper to open and more expensive to run.
 
-The direct path stays the one that materialises most, at 2.9x the input against
-the cached path's 2.2x. That is not asserted as good; it is pinned so it does not
-get worse silently, and so that fixing it (streaming the in-memory build the way
-the cached one already streams) shows up as a deliberate change to a stated
-number.
+The gap is also the one number here that is not a constant factor. ``direct``
+holds both sides of the whole profile, so its 2.9x of the input is a ratio that
+follows the capture; ``auto`` holds one Arrow batch per side plus one thread's
+open stack, measured at depth <= 7 on a 3.5 GB capture, so its cost does not.
+The 2.03 MB is what that looks like on a 2.269 MB fixture — 0.9x rather than the
+2.2x this window recorded before the sweep was chunked. Fixing the direct path
+the same way would show up as a deliberate change to a stated number.
 
 Why there is a third window
 ---------------------------
@@ -72,11 +76,11 @@ Because the second stopped bounding what it used to, and noticing that was not
 optional. Before the deferral, ``auto``'s skills window held only the attribution
 query, so dropping the ``LIMIT`` push-down in ``attribute_kernels_to_nvtx`` took
 it from 0.27 MB to 1.53 MB and the ceiling caught it. After the deferral that
-window is dominated by the 4.93 MB map build, and the same mutation moves it by
-0.00 MB — the push-down would have lost its only guard while the suite stayed
-green. The third window runs attribution once more with the build already paid,
-which is what the second window used to measure, and the mutation moves it 0.30
--> 1.57 MB again.
+window is dominated by the map build, and the same mutation moves it by 0.00 MB
+— the push-down would have lost its only guard while the suite stayed green. The
+third window runs attribution once more with the build already paid, which is
+what the second window used to measure, and the mutation moves it 0.16 -> 1.42
+MB again.
 
 It calls ``attribute_kernels_to_nvtx`` directly rather than re-running the skill.
 Skills memoize their rows per connection and resolved parameters, so a second
@@ -168,7 +172,7 @@ FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
 # 9% under its mutation; if that one ever flakes on another interpreter it is the
 # first to re-derive, and the honest fix is a bigger gap, not a bigger ceiling.
 CASES = {
-    "auto": (1.0, 5.5, 0.8, 0.07, 4.93, 0.30),
+    "auto": (1.0, 2.6, 0.8, 0.07, 2.03, 0.16),
     "direct": (1.0, 7.4, 0.9, 0.05, 6.62, 0.44),
 }
 
@@ -294,11 +298,12 @@ def test_running_skills_stays_under_the_python_heap_ceiling(measured, request):
     dominates: whichever builder runs, it is the largest single Python
     allocation this repo makes.
 
-    ``auto`` streams its sources out of the cached Parquet and lands at 4.93 MB;
-    materialising the NVTX generator with ``list(_stream_nvtx_ranges(...))``
-    takes it to 6.15 MB, and that change leaves every other assertion in the
-    suite passing, because the answers are identical — only the memory differs,
-    and nothing else looks at memory.
+    ``auto`` sweeps one thread of the capture at a time, streaming both sides of
+    each out of the cached Parquet, and lands at 2.03 MB; holding a thread's
+    ranges instead, with ``list(_stream_thread_nvtx(...))``, takes it to 6.12 MB.
+    That change leaves every other assertion in the suite passing, because the
+    answers are identical — only the memory differs, and nothing else looks at
+    memory.
 
     ``direct`` has no cache to write into and takes the ``fetchall`` build
     instead, at 6.62 MB. Turning that sweep's per-thread buckets from tuples
@@ -335,9 +340,9 @@ def test_attributing_against_a_built_map_stays_under_the_python_heap_ceiling(
     took that coverage away without failing anything. Dropping the ``LIMIT``
     push-down in ``attribute_kernels_to_nvtx`` — the optimisation its own
     docstring describes as keeping unrelated kernels out of Python — used to move
-    the auto/skills number from 0.27 MB to 1.53 MB; underneath the 4.93 MB build
-    it moves that number by 0.00 MB. Measured here it is 0.30 -> 1.57 MB on
-    ``auto`` and 0.44 -> 1.70 MB on ``direct``, so the push-down keeps a guard.
+    the auto/skills number from 0.27 MB to 1.53 MB; underneath the map build it
+    moves that number by 0.00 MB. Measured here it is 0.16 -> 1.42 MB on ``auto``
+    and 0.44 -> 1.69 MB on ``direct``, so the push-down keeps a guard.
 
     The two baselines differ because the map is a Parquet-backed view on ``auto``
     and an in-memory DuckDB table on ``direct``; the rows arriving in Python are

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -216,16 +216,21 @@ def test_the_sweep_resolves_label_ties_by_data_not_by_input_order():
 def test_the_sweep_does_not_depend_on_the_order_kernels_arrive_in():
     """The kernel side may arrive in any order; only the NVTX side must be sorted.
 
-    `_stream_kernel_runtime` used to carry `ORDER BY r.globalTid, r.start` and a
+    The kernel-side query used to carry `ORDER BY r.globalTid, r.start` and a
     comment claiming the sweep "advances one index per thread, so this must
     arrive sorted". Half of that is true: the sweep does advance a single index
-    over the *ranges*, but it re-sorts the *kernels* itself
-    (`kr_by_tid[tid].sort(...)`), so the SQL order was being redone in Python.
-    The ORDER BY is gone; this test is what stops the self-sort from being
-    dropped as "redundant" later, which would silently make the map's contents
-    depend on DuckDB's join order. It now guards *both* builders: the on-demand
-    `_ensure_nvtx_kernel_map_in_memory` carried the same redundant ORDER BY and
-    no longer does, so neither caller hands the sweep a pre-sorted kernel side.
+    over the *ranges*, but `_sweep_nvtx_kernel_map` re-sorts the *kernels* itself
+    (`kr_list.sort(...)`), so the SQL order was being redone in Python. This test
+    is what stops that self-sort from being dropped as "redundant" later, which
+    would silently make the map's contents depend on DuckDB's join order.
+
+    It guards `_sweep_nvtx_kernel_map`, which is the on-demand builder's entry
+    point (`_ensure_nvtx_kernel_map_in_memory`) and the only caller that buckets
+    rows in Python. The cached builder no longer comes through here: it
+    partitions by thread in SQL and streams both sides, so it *does* ask for
+    `ORDER BY r.start` per thread — a stream has nowhere to put a later sort.
+    That is not this ORDER BY coming back; it is a different query, on a
+    different axis, feeding a consumer that no longer sorts.
 
     Asserted on *content*, canonically ordered, not on the returned list order.
     The sweep visits threads in the order they first appear in its input, so

--- a/tests/test_nvtx_kernel_map_ondemand.py
+++ b/tests/test_nvtx_kernel_map_ondemand.py
@@ -526,13 +526,13 @@ def test_concurrent_cursors_build_the_map_once(cached_profile):
     calls_lock = threading.Lock()
     original = parquet_cache._build_nvtx_kernel_map_from_parquet
 
-    def counting(db, src_dir, out_dir=None, **kwargs):
+    def counting(db, src_dir, out_dir=None):
         with calls_lock:
             calls.append(1)
         # Long enough that every other thread is queued on the lock before this
         # one publishes; the sweep on this fixture is a few milliseconds.
         time.sleep(0.3)
-        return original(db, src_dir, out_dir, **kwargs)
+        return original(db, src_dir, out_dir)
 
     parquet_cache._build_nvtx_kernel_map_from_parquet = counting
     try:

--- a/tests/test_nvtx_kernel_map_ondemand.py
+++ b/tests/test_nvtx_kernel_map_ondemand.py
@@ -450,10 +450,12 @@ def test_the_map_is_absent_from_schema_discovery_until_it_is_built(cached_profil
 def test_the_lazily_built_map_is_identical_to_the_eager_one(tmp_path, monkeypatch):
     """Same rows, same dictionary, whichever builder produced them.
 
-    Both go through ``_write_nvtx_kernel_map_parquet``, so this is a check that
-    the split into ``_build_nvtx_kernel_map_from_parquet`` did not change what
-    the sweep is fed — the on-demand caller has no attached SQLite and no
-    ``src_tables`` set, and if that mattered the rows would differ here.
+    Both go through ``_build_nvtx_kernel_map_from_parquet``, so this is a check
+    that the split into it did not change what the sweep is fed — the on-demand
+    caller has no attached SQLite and no ``src_tables`` set, and if that mattered
+    the rows would differ here. The two differ only in ``out_dir``: one writes
+    into the cache directory, the other into a staging directory that is then
+    renamed over it.
     """
     import duckdb
 
@@ -524,13 +526,13 @@ def test_concurrent_cursors_build_the_map_once(cached_profile):
     calls_lock = threading.Lock()
     original = parquet_cache._build_nvtx_kernel_map_from_parquet
 
-    def counting(db, src_dir, out_dir=None):
+    def counting(db, src_dir, out_dir=None, **kwargs):
         with calls_lock:
             calls.append(1)
         # Long enough that every other thread is queued on the lock before this
         # one publishes; the sweep on this fixture is a few milliseconds.
         time.sleep(0.3)
-        return original(db, src_dir, out_dir)
+        return original(db, src_dir, out_dir, **kwargs)
 
     parquet_cache._build_nvtx_kernel_map_from_parquet = counting
     try:

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -576,10 +576,12 @@ class TestDamagedInput:
 
         They are easy to confuse, and the docstring got them backwards until
         this test existed: it claimed an unreadable source was "logged and the
-        map skipped". It is not. Both source readers are generator functions, so
-        their ``db.execute`` runs lazily inside ``_sweep_nvtx_kernel_map``,
-        where nothing catches it — the error leaves the builder and
-        ``build_cache`` throws the half-built temp dir away.
+        map skipped". It is not. A damaged runtime.parquet raises out of the
+        eager partition query, before anything is staged; a damaged
+        nvtx.parquet raises later, from the generator whose ``db.execute`` runs
+        on first advance inside ``_attribute_thread``. Both cases are checked
+        below, and in neither does anything catch the error — it leaves the
+        builder and ``build_cache`` throws the half-built temp dir away.
 
         That is the wanted behaviour, not a defect: the map's sources are the
         same Parquets the rest of the cache reads, so one of them being garbage
@@ -620,6 +622,17 @@ class TestDamagedInput:
             with pytest.raises(duckdb.Error):
                 parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir)
             assert not map_path.exists(), "a map was written from an unreadable source"
+            nvtx.write_bytes(healthy)
+
+            # The other source, which is read eagerly to list the partitions
+            # and so raises from a different statement than the one above.
+            runtime = cache_dir / "runtime.parquet"
+            healthy_runtime = runtime.read_bytes()
+            runtime.write_bytes(b"NOTAPARQUET" * 100)
+            with pytest.raises(duckdb.Error):
+                parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir)
+            assert not map_path.exists(), "a map was written from an unreadable source"
+            runtime.write_bytes(healthy_runtime)
 
             nvtx.unlink()
             parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir)
@@ -917,11 +930,11 @@ class TestStreamedSweep:
         return Path(parquet_cache.build_cache(str(profile)))
 
     @staticmethod
-    def _streamed(db, cache_dir, out_dir, **kwargs):
+    def _streamed(db, cache_dir, out_dir):
         """Run the production builder into ``out_dir`` and read its nine columns
         back with the path text joined in."""
         out_dir.mkdir(parents=True, exist_ok=True)
-        built = parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir, out_dir, **kwargs)
+        built = parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir, out_dir)
         if not built:
             return None
         mp = parquet_cache._safe_path(out_dir / "nvtx_kernel_map.parquet")
@@ -1042,34 +1055,60 @@ class TestStreamedSweep:
         )
         assert sorted(tiny) == sorted(full), "batching changed the attribution"
 
-    def test_the_build_reports_one_progress_call_per_thread(self, tmp_path):
-        """The deferred build's only reporting channel.
+    def test_both_map_writers_emit_the_same_columns(self, tmp_path):
+        """The two producers of a nvtx_kernel_map, column by column.
 
-        It had none before: the map is no longer built by ``build_cache``, so the
-        wait moved into the first NVTX query, where stderr captured as exactly
-        ``''``. Chunking is what creates a unit to report, and the thread is that
-        unit.
+        There are two, and since the streamed builder stopped sharing a writer
+        with the in-memory one they list their columns independently:
+        ``_nvtx_map_arrow_tables`` (in-memory, reached through
+        ``_materialize_nvtx_kernel_map``) and the ``SELECT`` inside
+        ``_publish_nvtx_kernel_map_parquet`` (cached). Nothing else in the suite
+        compares them — the oracle test above checks the cached map's *rows*
+        against ``_sweep_nvtx_kernel_map`` and never calls the Arrow writer — so
+        a tenth column added to one of them would land with the suite green.
+
+        That is not cosmetic: ``connection.cached_nvtx_map_has_embedded_tc``
+        decides by column presence, so a map missing ``is_tc_eligible`` /
+        ``uses_tc`` reroutes every NVTX consumer onto a different aggregate
+        rather than failing.
         """
         import duckdb
 
         cache_dir = self._cache_for(tmp_path, "h100_2gpu_1s.sqlite")
-        seen: list[tuple[int, int]] = []
+        out_dir = tmp_path / "published"
+        out_dir.mkdir()
         db = duckdb.connect()
         try:
-            rows = self._streamed(
-                db,
-                cache_dir,
-                tmp_path / "out",
-                progress=lambda done, total: seen.append((done, total)),
-            )
+            built = parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir, out_dir)
+            assert built, "the cached builder wrote no map to compare against"
+            published = {
+                name: [
+                    (r[0], r[1])
+                    for r in db.execute(
+                        f"DESCRIBE SELECT * FROM "
+                        f"read_parquet('{parquet_cache._safe_path(out_dir / name)}')"
+                    ).fetchall()
+                ]
+                for name in ("nvtx_kernel_map.parquet", "nvtx_path_dict.parquet")
+            }
         finally:
             db.close()
 
-        assert rows, "the build attributed nothing, so it reported nothing either"
-        assert seen, "the build reported no progress at all"
-        total = seen[0][1]
-        assert seen == [(i, total) for i in range(1, total + 1)], (
-            f"progress did not count 1..{total} exactly once each: {seen}"
+        # An empty result is enough: the schema is fixed by the writer, not by
+        # the rows, and this keeps the comparison about column names and types.
+        map_tbl, dict_tbl = parquet_cache._nvtx_map_arrow_tables([])
+        arrow_to_duckdb = {"string": "VARCHAR", "int32": "INTEGER", "int64": "BIGINT"}
+
+        def as_duckdb(table):
+            return [(f.name, arrow_to_duckdb[str(f.type)]) for f in table.schema]
+
+        assert as_duckdb(map_tbl) == published["nvtx_kernel_map.parquet"], (
+            "the in-memory map writer and the cached one no longer agree; "
+            "_nvtx_map_arrow_tables and _publish_nvtx_kernel_map_parquet list "
+            "their columns separately and have to be edited together"
+        )
+        assert as_duckdb(dict_tbl) == published["nvtx_path_dict.parquet"], (
+            "the two path-dictionary writers no longer agree"
         )
 
     def test_threads_with_only_one_side_are_swept_without_affecting_the_others(self, tmp_path):

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -880,3 +880,330 @@ def test_the_path_dictionary_matches_the_map(tmp_path):
             "LEFT JOIN nvtx_path_dict d USING (path_id) WHERE d.nvtx_path IS NULL"
         ).fetchone()[0]
     assert orphans == 0, f"{orphans} rows carry a path_id with no dictionary entry"
+
+
+class TestStreamedSweep:
+    """The cached map builder sweeps one thread of the capture at a time.
+
+    Peak memory then tracks the batch rather than the profile: measured on a
+    3.5 GB capture (15.9 M ranges, 3.1 M kernel-runtime rows) the build went from
+    6.95 GB peak / 51.2 s to 3.31 GB / 37.3 s, producing 3,042,699 rows with zero
+    differences in either direction across all nine columns and the path
+    dictionary.
+
+    These tests assert *contents*, not that a build finished, because both known
+    ways of getting this wrong are silent. A hand-vectorised version of the same
+    attribution was wrong on 15% of rows. Sharing one DuckDB handle between the
+    two Arrow readers truncates the sweep with no exception at all — 968,394 rows
+    instead of 3,042,699 on that capture, and 2 instead of 1,643 on the fixture
+    below.
+    """
+
+    FIXTURES = ("h100_2gpu_1s.sqlite", "mfu_2gpu_before.sqlite")
+
+    @staticmethod
+    def _cache_for(tmp_path, fixture):
+        """Copy a fixture out of tests/fixtures and build its cache.
+
+        The copy is not hygiene theatre: opening a profile in place builds
+        indices in the source database and grows the file, and these fixtures
+        are checked in.
+        """
+        import shutil
+
+        src = Path(__file__).resolve().parent / "fixtures" / fixture
+        profile = tmp_path / fixture
+        shutil.copy(src, profile)
+        return Path(parquet_cache.build_cache(str(profile)))
+
+    @staticmethod
+    def _streamed(db, cache_dir, out_dir, **kwargs):
+        """Run the production builder into ``out_dir`` and read its nine columns
+        back with the path text joined in."""
+        out_dir.mkdir(parents=True, exist_ok=True)
+        built = parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir, out_dir, **kwargs)
+        if not built:
+            return None
+        mp = parquet_cache._safe_path(out_dir / "nvtx_kernel_map.parquet")
+        dp = parquet_cache._safe_path(out_dir / "nvtx_path_dict.parquet")
+        return db.execute(
+            f"SELECT m.nvtx_text, m.nvtx_depth, d.nvtx_path, m.kernel_name, m.k_start, "
+            f"m.k_end, m.k_dur_ns, m.is_tc_eligible, m.uses_tc "
+            f"FROM read_parquet('{mp}') m JOIN read_parquet('{dp}') d USING (path_id)"
+        ).fetchall()
+
+    @staticmethod
+    def _oracle(db, cache_dir):
+        """The same answer via ``_sweep_nvtx_kernel_map``, which holds both sides
+        in memory and is what the on-demand builder still uses.
+
+        Not a reimplementation of the streamed builder: it reads both sources in
+        one shot, in the shape the pre-streaming builder read them, and attaches
+        the Tensor Core flags afterwards from a side table the way that builder
+        did. Only the containment core is shared.
+        """
+        kps = parquet_cache._safe_path(cache_dir / "kernels.parquet")
+        rps = parquet_cache._safe_path(cache_dir / "runtime.parquet")
+        nps = parquet_cache._safe_path(cache_dir / "nvtx.parquet")
+        kr = db.execute(
+            f'SELECT r.globalTid, r.start, r."end", k.start, k."end", k.name, '
+            f"COALESCE(CAST(k.is_tc_eligible AS INTEGER), 0), "
+            f"COALESCE(CAST(k.uses_tc AS INTEGER), 0) "
+            f"FROM read_parquet('{kps}') k "
+            f"JOIN read_parquet('{rps}') r ON r.correlationId = k.correlationId"
+        ).fetchall()
+        nvtx = db.execute(
+            f'SELECT globalTid, start, "end", CAST(text AS VARCHAR) '
+            f"FROM read_parquet('{nps}') "
+            f'WHERE eventType = 59 AND "end" > start AND text IS NOT NULL '
+            f"ORDER BY globalTid, start"
+        ).fetchall()
+        tc = {(r[3], r[4], r[5]): (r[6], r[7]) for r in kr}
+        rows = []
+        for r in parquet_cache._sweep_nvtx_kernel_map([k[:6] for k in kr], nvtx):
+            elig, used = tc.get((r["k_start"], r["k_end"], r["kernel_name"]), (0, 0))
+            rows.append(
+                (
+                    r["nvtx_text"],
+                    r["nvtx_depth"],
+                    r["nvtx_path"],
+                    r["kernel_name"],
+                    r["k_start"],
+                    r["k_end"],
+                    r["k_dur_ns"],
+                    elig,
+                    used,
+                )
+            )
+        return rows
+
+    @pytest.mark.parametrize("fixture", FIXTURES)
+    def test_the_streamed_builder_matches_the_list_sweep_row_for_row(self, tmp_path, fixture):
+        """Row count first, then the rows themselves, in both directions."""
+        import collections
+
+        import duckdb
+
+        cache_dir = self._cache_for(tmp_path, fixture)
+        db = duckdb.connect()
+        try:
+            got = self._streamed(db, cache_dir, tmp_path / "streamed")
+            want = self._oracle(db, cache_dir)
+        finally:
+            db.close()
+
+        assert want, f"{fixture}: the oracle attributed nothing, so this compares nothing"
+        assert got is not None, f"{fixture}: the streamed builder wrote no map"
+        # Stated separately from the contents comparison because a truncated
+        # sweep is the specific failure this class exists to catch, and a count
+        # says so unambiguously.
+        assert len(got) == len(want), (
+            f"{fixture}: the streamed builder produced {len(got)} rows against the "
+            f"sweep's {len(want)}"
+        )
+        got_counts = collections.Counter(got)
+        want_counts = collections.Counter(want)
+        assert got_counts == want_counts, (
+            f"{fixture}: {sum((want_counts - got_counts).values())} rows missing and "
+            f"{sum((got_counts - want_counts).values())} extra"
+        )
+
+    def test_shrinking_the_arrow_batch_does_not_change_the_answer(self, tmp_path, monkeypatch):
+        """Every batch boundary exercised at once, and the truncation trap with it.
+
+        ``_SWEEP_BATCH_ROWS`` sizes both input readers and the output buffer, so
+        a small prime here puts range and kernel boundaries at unrelated offsets
+        and splits the output across many row groups. Nothing about the answer
+        may move: the open stack is per thread and a thread's ranges are strictly
+        nested, so there is no carried state at a batch boundary to get wrong.
+
+        This is also the regression test for the two-readers-one-connection
+        truncation, and it is the *shrunk* batch that gives it teeth. At the
+        default 262,144 rows this fixture's NVTX side is a single batch, so the
+        reader has already handed every row to Python before the kernel reader
+        opens and a shared handle loses nothing — measured, 1,643 rows either
+        way. At batch size 7 the same mutation yields 2.
+        """
+        import duckdb
+
+        cache_dir = self._cache_for(tmp_path, "h100_2gpu_1s.sqlite")
+        db = duckdb.connect()
+        try:
+            full = self._streamed(db, cache_dir, tmp_path / "full")
+            monkeypatch.setattr(parquet_cache, "_SWEEP_BATCH_ROWS", 7)
+            tiny = self._streamed(db, cache_dir, tmp_path / "tiny")
+        finally:
+            db.close()
+
+        assert full, "the control build attributed nothing"
+        assert tiny is not None, "the shrunk-batch build wrote no map"
+        assert len(tiny) == len(full), (
+            f"batching changed the row count: {len(tiny)} at batch 7 against {len(full)}"
+        )
+        assert sorted(tiny) == sorted(full), "batching changed the attribution"
+
+    def test_the_build_reports_one_progress_call_per_thread(self, tmp_path):
+        """The deferred build's only reporting channel.
+
+        It had none before: the map is no longer built by ``build_cache``, so the
+        wait moved into the first NVTX query, where stderr captured as exactly
+        ``''``. Chunking is what creates a unit to report, and the thread is that
+        unit.
+        """
+        import duckdb
+
+        cache_dir = self._cache_for(tmp_path, "h100_2gpu_1s.sqlite")
+        seen: list[tuple[int, int]] = []
+        db = duckdb.connect()
+        try:
+            rows = self._streamed(
+                db,
+                cache_dir,
+                tmp_path / "out",
+                progress=lambda done, total: seen.append((done, total)),
+            )
+        finally:
+            db.close()
+
+        assert rows, "the build attributed nothing, so it reported nothing either"
+        assert seen, "the build reported no progress at all"
+        total = seen[0][1]
+        assert seen == [(i, total) for i in range(1, total + 1)], (
+            f"progress did not count 1..{total} exactly once each: {seen}"
+        )
+
+    def test_threads_with_only_one_side_are_swept_without_affecting_the_others(self, tmp_path):
+        """The three partition shapes a real capture contains.
+
+        On the 3.5 GB reference capture one thread carries 3,917 ranges and no
+        kernels at all, eight carry kernels and no ranges, and four carry both.
+        Built here directly as Parquet rather than through a SQLite fixture, so
+        the thread layout is stated rather than hoped for.
+
+        The kernel on thread 3 sits inside a range that opened before it and
+        closes after it, which is the case a stream cannot recover from by
+        re-reading: the range has to still be on the open stack when the kernel
+        arrives.
+        """
+        import duckdb
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        cache_dir = tmp_path / "synthetic.nsys-cache"
+        cache_dir.mkdir()
+        pq.write_table(
+            pa.table(
+                {
+                    "correlationId": pa.array([1, 2, 3], pa.int64()),
+                    "start": pa.array([1100, 2100, 3100], pa.int64()),
+                    "end": pa.array([1200, 2200, 3200], pa.int64()),
+                    "name": pa.array(["kA", "kB", "kC"], pa.string()),
+                    "is_tc_eligible": pa.array([1, 0, 0], pa.int32()),
+                    "uses_tc": pa.array([1, 0, 0], pa.int32()),
+                }
+            ),
+            cache_dir / "kernels.parquet",
+        )
+        pq.write_table(
+            pa.table(
+                {
+                    # tid 2 launches two kernels and has no NVTX ranges at all;
+                    # tid 3 launches one, inside a range that opened long before
+                    # it. tid 1 appears only on the NVTX side.
+                    "correlationId": pa.array([1, 2, 3], pa.int64()),
+                    "globalTid": pa.array([2, 2, 3], pa.int64()),
+                    "start": pa.array([100, 200, 500], pa.int64()),
+                    "end": pa.array([150, 250, 550], pa.int64()),
+                }
+            ),
+            cache_dir / "runtime.parquet",
+        )
+        pq.write_table(
+            pa.table(
+                {
+                    "globalTid": pa.array([1, 3, 3, 3], pa.int64()),
+                    "start": pa.array([0, 0, 400, 900], pa.int64()),
+                    "end": pa.array([999, 999, 600, 999], pa.int64()),
+                    "text": pa.array(["orphan", "step", "fwd", "after"], pa.string()),
+                    "eventType": pa.array([59, 59, 59, 59], pa.int32()),
+                }
+            ),
+            cache_dir / "nvtx.parquet",
+        )
+
+        db = duckdb.connect()
+        try:
+            rows = self._streamed(db, cache_dir, tmp_path / "out")
+        finally:
+            db.close()
+
+        # tid 2's kernels have no enclosing range and tid 1 has no kernels, so
+        # exactly one row survives — attributed to the inner range, with the
+        # outer one still open around it.
+        assert rows == [("fwd", 1, "step > fwd", "kC", 3100, 3200, 100, 0, 0)], rows
+
+    def test_a_capture_with_nothing_to_attribute_publishes_no_map(self, tmp_path):
+        """No kernel inside any range is a skip, not an empty map and not a crash.
+
+        The streamed builder cannot test its inputs for emptiness — they are
+        generators opened per thread — so "no kernels", "no ranges" and "no
+        overlap" all have to come out the same way: nothing written, False
+        returned, and the scratch Parquet cleaned up behind it.
+        """
+        import duckdb
+        import pyarrow as pa
+        import pyarrow.parquet as pq
+
+        cache_dir = tmp_path / "empty.nsys-cache"
+        cache_dir.mkdir()
+        pq.write_table(
+            pa.table(
+                {
+                    "correlationId": pa.array([1], pa.int64()),
+                    "start": pa.array([1100], pa.int64()),
+                    "end": pa.array([1200], pa.int64()),
+                    "name": pa.array(["kA"], pa.string()),
+                    "is_tc_eligible": pa.array([0], pa.int32()),
+                    "uses_tc": pa.array([0], pa.int32()),
+                }
+            ),
+            cache_dir / "kernels.parquet",
+        )
+        pq.write_table(
+            pa.table(
+                {
+                    "correlationId": pa.array([1], pa.int64()),
+                    "globalTid": pa.array([9], pa.int64()),
+                    "start": pa.array([100], pa.int64()),
+                    "end": pa.array([150], pa.int64()),
+                }
+            ),
+            cache_dir / "runtime.parquet",
+        )
+        pq.write_table(
+            pa.table(
+                {
+                    "globalTid": pa.array([9], pa.int64()),
+                    "start": pa.array([500], pa.int64()),
+                    "end": pa.array([600], pa.int64()),
+                    "text": pa.array(["elsewhere"], pa.string()),
+                    "eventType": pa.array([59], pa.int32()),
+                }
+            ),
+            cache_dir / "nvtx.parquet",
+        )
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        db = duckdb.connect()
+        try:
+            built = parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir, out_dir)
+        finally:
+            db.close()
+
+        assert built is False
+        assert not (out_dir / "nvtx_kernel_map.parquet").exists()
+        assert not (out_dir / "nvtx_path_dict.parquet").exists()
+        assert list(out_dir.iterdir()) == [], (
+            f"the sweep left scratch files behind: {sorted(p.name for p in out_dir.iterdir())}"
+        )


### PR DESCRIPTION
Closes #335. The `nvtx_kernel_map` sweep no longer holds both inputs in full; it processes one capture thread at
a time and streams the result to Parquet, so peak memory tracks the batch rather than the profile.

Stacked on #340 (issue #336 item 1 removed the wrapper this rewrites).

## Why the thread is the partition

`eventType = 59` is a per-thread Push/Pop stack, so a thread's ranges are strictly nested and its work is
independent of every other thread's. Partitioning on `globalTid` therefore carries **no state across a partition
boundary at all** — a strictly weaker correctness argument than the time-window chunking #335 originally proposed.
Within a thread both sides arrive sorted by start and are consumed through a single advancing cursor, so neither
side is ever a list.

## Measured, on the 3.5 GB capture

Built from the existing cache with this branch on `PYTHONPATH`, so the editable install could not substitute main:

```
sweep done       live 0.90GB  peak 1.39GB   35.4s
publish done     live 3.14GB  peak 3.55GB   37.6s
rows=3,042,699   md5=fdc5f636420787a2   9 columns
```

Against main measured the same way (7.50 GB):

| | main | this branch |
|---|---:|---:|
| sweep phase peak | 5.28 GB | **1.39 GB** |
| build peak | 7.50 GB | **3.55 GB** |

Output is identical — 3,042,699 rows and a matching content hash over
`(k_start, k_end, kernel_name, nvtx_text, nvtx_path)`, against values established before this branch existed.

The remaining 3.55 GB is the publish step (path-dict join plus the global `ORDER BY`). That is **#339** and
deliberately untouched here; this PR's scope ends at the staged Parquet.

## The trap this had to survive

A DuckDB connection holds one result. Two live Arrow readers on the same handle silently truncate — an early
prototype produced 968,394 rows instead of 3,042,699 with no exception raised. Each stream gets its own
`db.cursor()`, and the acceptance check asserts the row count and hash rather than that the build completed.

## Precondition that looks like a regression and is not

Streaming needs the kernel side sorted, so `ORDER BY r.start` returns to that query — per thread, on `r.start`
only. #318 and #327 removed it correctly for the builder they were made against, which bucketed by thread and
sorted in Python; a stream has nowhere to put that sort. `_sweep_nvtx_kernel_map`, still used by the on-demand
builder, keeps the old contract and still sorts its own buckets; `tests/test_determinism.py` pins that.

## Also

- Tensor Core flags ride in the kernel row instead of a 2,193,776-entry side dict rebuilt afterwards.
- NVTX label interning is dropped and the kernel-name pool kept, because the two measure oppositely: one thread
  carries 3,850,911 distinct NVTX texts across 3,969,967 ranges, while 3,077,650 kernel rows carry 109 distinct
  names.
- `WHERE globalTid IS NOT NULL` on the partition list is the one place the two builders can disagree; the comment
  at `parquet_cache.py:1293` says so rather than leaving it implicit.

## Verification

`ruff` clean; `bandit -c pyproject.toml` clean; full suite green in CI (lint, security, test 3.10/3.11/3.12), plus
the full-scale oracle above.
