### PR TITLE
fix(smoke): treat an abstention row as absence of data, not as data

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -118,7 +118,10 @@ check_json_key() {
 
 check_field_conditional() {
   # Run check_regex but SKIP when JSON has no real data rows.
-  # Skips rows with: empty list, _metadata, _summary, _diagnostic, or top-level 'error' key.
+  # Skips rows with: empty list, _metadata, _summary, _diagnostic, _abstained,
+  # or top-level 'error' key. _abstained is how a skill reports it could not run
+  # at all (skills/base.py abstain()) — it carries a reason, never the fields a
+  # caller would grep for.
   local label="$1"; local file="$2"; local pattern="$3"; local skip_msg="$4"
   printf "  %-55s " "$label"
   EMPTY=$(python3 -c "
@@ -127,7 +130,8 @@ try:
     d = json.load(open('$file'))
     rows = d if isinstance(d, list) else [d]
     data = [r for r in rows if not r.get('_metadata') and not r.get('_summary')
-            and not r.get('_diagnostic') and 'error' not in r]
+            and not r.get('_diagnostic') and not r.get('_abstained')
+            and 'error' not in r]
     print('yes' if not data else 'no')
 except Exception:
     print('yes')


### PR DESCRIPTION
## What

`scripts/smoke_test.sh:check_field_conditional` decides whether a skill produced anything worth grepping by filtering out the non-data row shapes it knows: `_metadata`, `_summary`, `_diagnostic`, and a top-level `error` key. It does not know `_abstained` — the shape `skills/base.py` `abstain()` returns when a skill cannot run at all.

So an abstention row counts as a data row, the check goes looking for a field that row never carries, and the run fails.

## Reproduction

On `tests/fixtures/mock.sqlite`, `nsys-ai skill run iteration_timing` correctly abstains. The follow-up check then fails looking for `duration_ms`. This reproduces on `main` at 4c91415 with nothing else in the tree — it is not caused by any open PR.

It went unseen because the smoke workflow is path-filtered on `skills/**`, so it had not run since 2026-07-21.

## Fix

One clause in the skip predicate. An abstention now reads as `SKIP (<reason>)` rather than `FAIL`, which is what every other "skill produced no rows" case already does.

`bash -n scripts/smoke_test.sh` is clean. No source change.