### PR TITLE
perf: scan iteration runtimes once

### DIFF
--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -480,6 +480,39 @@ def _flag_real_iterations(results: list[dict]) -> list[dict]:
     return results
 
 
+def _correlate_iteration_kernels(iterations, runtime_rows, kernel_map):
+    """Yield kernels contained in each ordered, non-overlapping CPU window."""
+    previous_end = None
+    for index, iteration in enumerate(iterations):
+        start, end = iteration["start"], iteration["end"]
+        if end <= start:
+            raise ValueError(f"iteration {index} has a non-positive time range")
+        if previous_end is not None and start < previous_end:
+            raise ValueError(f"iteration {index} overlaps or precedes the previous iteration")
+        previous_end = end
+
+    rows = iter(runtime_rows)
+    current = next(rows, None)
+    for index, iteration in enumerate(iterations):
+        cpu_start, cpu_end = iteration["start"], iteration["end"]
+        next_start = iterations[index + 1]["start"] if index + 1 < len(iterations) else None
+
+        while current is not None and current["start"] < cpu_start:
+            current = next(rows, None)
+
+        kernels = []
+        while current is not None and current["start"] <= cpu_end:
+            if current["end"] <= cpu_end:
+                kernel = kernel_map.get(current["correlationId"])
+                if kernel:
+                    kernels.append(kernel)
+            elif next_start is not None and current["start"] >= next_start:
+                break
+            current = next(rows, None)
+
+        yield kernels
+
+
 def detect_iterations(
     prof: Profile, device: int, trim: tuple[int, int] | None = None, marker: str = "sample_0"
 ) -> list[dict]:
@@ -619,7 +652,13 @@ def detect_iterations(
                 boundaries.append(entry["rt_start"])
             last_k_end = max(last_k_end, k["end"])
 
-        boundaries.append(kernel_entries[-1]["rt_end"])
+        # GPU execution order can differ from CPU launch order across streams.
+        # Correlation below advances through CPU runtime rows exactly once, so
+        # make its ordered, non-overlapping window invariant explicit here.
+        boundaries = sorted(set(boundaries))
+        final_runtime_end = max(entry["rt_end"] for entry in kernel_entries)
+        if final_runtime_end > boundaries[-1]:
+            boundaries.append(final_runtime_end)
 
         # Construct synthetic iterations from these boundaries
         for i in range(len(boundaries) - 1):
@@ -644,19 +683,8 @@ def detect_iterations(
     )
 
     results = []
-    for i, it in enumerate(iterations):
-        cpu_start, cpu_end = it["start"], it["end"]
-
-        # Find correlated kernels
-        kernels_in_iter = []
-        for rt in rt_all:
-            if rt["start"] > cpu_end:
-                break
-            if rt["start"] >= cpu_start and rt["end"] <= cpu_end:
-                k = kmap.get(rt["correlationId"])
-                if k:
-                    kernels_in_iter.append(k)
-
+    correlated = _correlate_iteration_kernels(iterations, rt_all, kmap)
+    for i, (it, kernels_in_iter) in enumerate(zip(iterations, correlated)):
         if not kernels_in_iter:
             continue
 

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -491,34 +491,42 @@ def _correlate_iteration_kernels(iterations, runtime_rows, kernel_map):
             raise ValueError(f"iteration {index} overlaps or precedes the previous iteration")
         previous_end = end
 
-    rows = iter(runtime_rows)
-    current = next(rows, None)
-    carried_kernels = []
+    def grouped_rows():
+        rows = iter(runtime_rows)
+        current = next(rows, None)
+        while current is not None:
+            start = current["start"]
+            group = [current]
+            current = next(rows, None)
+            while current is not None and current["start"] == start:
+                group.append(current)
+                current = next(rows, None)
+            yield group
+
+    groups = iter(grouped_rows())
+    current_group = next(groups, None)
     for index, iteration in enumerate(iterations):
         cpu_start, cpu_end = iteration["start"], iteration["end"]
         next_start = iterations[index + 1]["start"] if index + 1 < len(iterations) else None
 
-        while current is not None and current["start"] < cpu_start:
-            current = next(rows, None)
+        while current_group is not None and current_group[0]["start"] < cpu_start:
+            current_group = next(groups, None)
 
-        kernels = carried_kernels
-        carried_kernels = []
-        while current is not None and current["start"] <= cpu_end:
-            if current["end"] <= cpu_end:
-                kernel = kernel_map.get(current["correlationId"])
+        kernels = []
+        while current_group is not None and current_group[0]["start"] <= cpu_end:
+            for runtime in current_group:
+                if runtime["end"] > cpu_end:
+                    continue
+                kernel = kernel_map.get(runtime["correlationId"])
                 if kernel:
                     kernels.append(kernel)
-                    # Containment is inclusive: a zero-duration row at a
-                    # shared boundary belongs to both adjacent windows.
-                    if (
-                        next_start == cpu_end
-                        and current["start"] == cpu_end
-                        and current["end"] == cpu_end
-                    ):
-                        carried_kernels.append(kernel)
-            elif next_start is not None and current["start"] >= next_start:
+
+            # Containment is inclusive. Keep the whole equal-start group at a
+            # shared boundary: zero-duration rows belong to both windows, while
+            # rows spanning the boundary belong only to the following one.
+            if next_start == cpu_end == current_group[0]["start"]:
                 break
-            current = next(rows, None)
+            current_group = next(groups, None)
 
         yield kernels
 

--- a/src/nsys_ai/overlap.py
+++ b/src/nsys_ai/overlap.py
@@ -493,6 +493,7 @@ def _correlate_iteration_kernels(iterations, runtime_rows, kernel_map):
 
     rows = iter(runtime_rows)
     current = next(rows, None)
+    carried_kernels = []
     for index, iteration in enumerate(iterations):
         cpu_start, cpu_end = iteration["start"], iteration["end"]
         next_start = iterations[index + 1]["start"] if index + 1 < len(iterations) else None
@@ -500,12 +501,21 @@ def _correlate_iteration_kernels(iterations, runtime_rows, kernel_map):
         while current is not None and current["start"] < cpu_start:
             current = next(rows, None)
 
-        kernels = []
+        kernels = carried_kernels
+        carried_kernels = []
         while current is not None and current["start"] <= cpu_end:
             if current["end"] <= cpu_end:
                 kernel = kernel_map.get(current["correlationId"])
                 if kernel:
                     kernels.append(kernel)
+                    # Containment is inclusive: a zero-duration row at a
+                    # shared boundary belongs to both adjacent windows.
+                    if (
+                        next_start == cpu_end
+                        and current["start"] == cpu_end
+                        and current["end"] == cpu_end
+                    ):
+                        carried_kernels.append(kernel)
             elif next_start is not None and current["start"] >= next_start:
                 break
             current = next(rows, None)
@@ -641,7 +651,7 @@ def detect_iterations(
         # but boundaries are recorded in runtime timestamps (CPU domain)
         # so the downstream rt-based filter works correctly.
         GAP_THRESHOLD_NS = 2_000_000
-        boundaries = [kernel_entries[0]["rt_start"]]
+        boundaries = [min(entry["rt_start"] for entry in kernel_entries)]
 
         last_k_end = kernel_entries[0]["kernel"]["end"]
         for entry in kernel_entries[1:]:

--- a/tests/test_iteration_correlation.py
+++ b/tests/test_iteration_correlation.py
@@ -1,5 +1,7 @@
 """Correctness and complexity guards for iteration/runtime correlation."""
 
+from itertools import permutations
+
 import pytest
 
 from nsys_ai.overlap import _correlate_iteration_kernels, detect_iterations
@@ -53,21 +55,24 @@ class _OneShotRuntimeProfile:
         return rows
 
 
-def _adjacent_nvtx_profile(conn, correlation_id, runtime_start, runtime_end):
+def _adjacent_nvtx_profile(conn, runtime_rows):
     conn.execute(
         "INSERT INTO NVTX_EVENTS (globalTid, start, end, text, eventType, rangeId) "
         "VALUES (100, 4500000, 8500000, 'train_step', 59, 2)"
     )
-    conn.execute(
+    conn.executemany(
         "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME "
         "(globalTid, correlationId, start, end, nameId) VALUES (100, ?, ?, ?, 24)",
-        (correlation_id, runtime_start, runtime_end),
+        runtime_rows,
     )
-    conn.execute(
+    conn.executemany(
         "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL "
         "(globalPid, deviceId, streamId, correlationId, start, end, shortName, demangledName) "
-        "VALUES (100, 0, 9, ?, 6000000, 6100000, 1, 1)",
-        (correlation_id,),
+        "VALUES (100, 0, 9, ?, ?, ?, 1, 1)",
+        [
+            (correlation_id, 6_000_000 + index * 200_000, 6_100_000 + index * 200_000)
+            for index, (correlation_id, _, _) in enumerate(runtime_rows)
+        ],
     )
     return _OneShotRuntimeProfile(Profile._from_conn(conn))
 
@@ -110,6 +115,36 @@ def test_multiple_iterations_retain_the_first_row_for_the_next_window():
         [1],
         [2, 3],
     ]
+
+
+def test_equal_start_group_matches_restart_semantics_in_every_row_order():
+    iterations = [{"start": 0, "end": 10}, {"start": 10, "end": 20}]
+    kernels = {i: _kernel(i) for i in range(1, 5)}
+    boundary_rows = [
+        _runtime(1, 10, 11),
+        _runtime(2, 10, 10),
+        _runtime(3, 10, 12),
+    ]
+
+    repro = list(_correlate_iteration_kernels(iterations, boundary_rows[:2], kernels))
+    assert [[kernel["correlation_id"] for kernel in group] for group in repro] == [
+        [2],
+        [1, 2],
+    ]
+
+    def legacy(rows):
+        return [
+            [
+                kernels[row["correlationId"]]
+                for row in rows
+                if row["start"] >= window["start"] and row["end"] <= window["end"]
+            ]
+            for window in iterations
+        ]
+
+    for same_start_order in permutations(boundary_rows):
+        rows = list(same_start_order) + [_runtime(4, 12, 13)]
+        assert list(_correlate_iteration_kernels(iterations, rows, kernels)) == legacy(rows)
 
 
 def test_runtime_rows_are_iterated_once_without_rewind():
@@ -158,7 +193,7 @@ def test_detect_iterations_correlates_multiple_nvtx_windows(minimal_nsys_conn):
 def test_detect_iterations_retains_a_spanning_row_for_the_next_nvtx_window(
     minimal_nsys_conn,
 ):
-    prof = _adjacent_nvtx_profile(minimal_nsys_conn, 200, 4_500_000, 4_600_000)
+    prof = _adjacent_nvtx_profile(minimal_nsys_conn, [(200, 4_500_000, 4_600_000)])
 
     rows = detect_iterations(prof, 0, marker="train_step")
 
@@ -169,11 +204,28 @@ def test_detect_iterations_retains_a_spanning_row_for_the_next_nvtx_window(
 def test_detect_iterations_keeps_zero_duration_row_in_both_adjacent_windows(
     minimal_nsys_conn,
 ):
-    prof = _adjacent_nvtx_profile(minimal_nsys_conn, 200, 4_500_000, 4_500_000)
+    prof = _adjacent_nvtx_profile(minimal_nsys_conn, [(200, 4_500_000, 4_500_000)])
 
     rows = detect_iterations(prof, 0, marker="train_step")
 
     assert [row["kernel_count"] for row in rows] == [5, 2]
+    assert prof.runtime_rows.iterations == 1
+
+
+def test_detect_iterations_handles_spanning_then_zero_row_at_the_same_boundary(
+    minimal_nsys_conn,
+):
+    prof = _adjacent_nvtx_profile(
+        minimal_nsys_conn,
+        [
+            (200, 4_500_000, 4_600_000),
+            (201, 4_500_000, 4_500_000),
+        ],
+    )
+
+    rows = detect_iterations(prof, 0, marker="train_step")
+
+    assert [row["kernel_count"] for row in rows] == [5, 3]
     assert prof.runtime_rows.iterations == 1
 
 

--- a/tests/test_iteration_correlation.py
+++ b/tests/test_iteration_correlation.py
@@ -19,6 +19,59 @@ def _runtime(correlation_id, start, end):
     return {"correlationId": correlation_id, "start": start, "end": end}
 
 
+class _OneShotRows:
+    def __init__(self, rows):
+        self.rows = rows
+        self.iterations = 0
+        self.yields = 0
+
+    def __iter__(self):
+        self.iterations += 1
+        if self.iterations > 1:
+            raise AssertionError("runtime rows were restarted")
+        for row in self.rows:
+            self.yields += 1
+            yield row
+
+
+class _OneShotRuntimeProfile:
+    """Delegate to a real Profile but make the correlation query one-shot."""
+
+    def __init__(self, profile):
+        self._profile = profile
+        self.runtime_rows = None
+
+    def __getattr__(self, name):
+        return getattr(self._profile, name)
+
+    def _duckdb_query(self, sql, params=()):
+        rows = self._profile._duckdb_query(sql, params)
+        normalized = " ".join(sql.split())
+        if normalized.startswith("SELECT start, [end], correlationId FROM"):
+            self.runtime_rows = _OneShotRows(rows)
+            return self.runtime_rows
+        return rows
+
+
+def _adjacent_nvtx_profile(conn, correlation_id, runtime_start, runtime_end):
+    conn.execute(
+        "INSERT INTO NVTX_EVENTS (globalTid, start, end, text, eventType, rangeId) "
+        "VALUES (100, 4500000, 8500000, 'train_step', 59, 2)"
+    )
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME "
+        "(globalTid, correlationId, start, end, nameId) VALUES (100, ?, ?, ?, 24)",
+        (correlation_id, runtime_start, runtime_end),
+    )
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL "
+        "(globalPid, deviceId, streamId, correlationId, start, end, shortName, demangledName) "
+        "VALUES (100, 0, 9, ?, 6000000, 6100000, 1, 1)",
+        (correlation_id,),
+    )
+    return _OneShotRuntimeProfile(Profile._from_conn(conn))
+
+
 def test_zero_iterations_produce_no_groups():
     assert list(_correlate_iteration_kernels([], [], {})) == []
 
@@ -60,21 +113,7 @@ def test_multiple_iterations_retain_the_first_row_for_the_next_window():
 
 
 def test_runtime_rows_are_iterated_once_without_rewind():
-    class OneShotRows:
-        def __init__(self, rows):
-            self.rows = rows
-            self.iterations = 0
-            self.yields = 0
-
-        def __iter__(self):
-            self.iterations += 1
-            if self.iterations > 1:
-                raise AssertionError("runtime rows were restarted")
-            for row in self.rows:
-                self.yields += 1
-                yield row
-
-    rows = OneShotRows([_runtime(i, i * 10, i * 10 + 1) for i in range(1, 5)])
+    rows = _OneShotRows([_runtime(i, i * 10, i * 10 + 1) for i in range(1, 5)])
     kernels = {i: _kernel(i) for i in range(1, 5)}
     iterations = [
         {"start": 0, "end": 15},
@@ -116,6 +155,28 @@ def test_detect_iterations_correlates_multiple_nvtx_windows(minimal_nsys_conn):
     assert all(row["heuristic"] is False for row in rows)
 
 
+def test_detect_iterations_retains_a_spanning_row_for_the_next_nvtx_window(
+    minimal_nsys_conn,
+):
+    prof = _adjacent_nvtx_profile(minimal_nsys_conn, 200, 4_500_000, 4_600_000)
+
+    rows = detect_iterations(prof, 0, marker="train_step")
+
+    assert [row["kernel_count"] for row in rows] == [4, 2]
+    assert prof.runtime_rows.iterations == 1
+
+
+def test_detect_iterations_keeps_zero_duration_row_in_both_adjacent_windows(
+    minimal_nsys_conn,
+):
+    prof = _adjacent_nvtx_profile(minimal_nsys_conn, 200, 4_500_000, 4_500_000)
+
+    rows = detect_iterations(prof, 0, marker="train_step")
+
+    assert [row["kernel_count"] for row in rows] == [5, 2]
+    assert prof.runtime_rows.iterations == 1
+
+
 def test_heuristic_windows_follow_cpu_order_across_gpu_stream_reordering(
     minimal_nsys_conn,
 ):
@@ -125,7 +186,7 @@ def test_heuristic_windows_follow_cpu_order_across_gpu_stream_reordering(
     minimal_nsys_conn.executemany(
         "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME "
         "(globalTid, correlationId, start, end, nameId) VALUES (100, ?, ?, ?, 24)",
-        [(1, 100, 110), (2, 300, 310), (3, 200, 210)],
+        [(1, 300, 310), (2, 100, 110), (3, 200, 210)],
     )
     minimal_nsys_conn.executemany(
         "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL "
@@ -141,10 +202,10 @@ def test_heuristic_windows_follow_cpu_order_across_gpu_stream_reordering(
 
     rows = detect_iterations(prof, 0)
 
-    assert [row["gpu_start_ns"] for row in rows] == [1_000, 6_000_000, 3_000_000]
+    assert [row["gpu_start_ns"] for row in rows] == [3_000_000, 1_000]
+    assert sum(row["kernel_count"] for row in rows) == 3
     assert [row["text"] for row in rows] == [
         "heuristic_step_0",
         "heuristic_step_1",
-        "heuristic_step_2",
     ]
     assert all(row["heuristic"] is True for row in rows)

--- a/tests/test_iteration_correlation.py
+++ b/tests/test_iteration_correlation.py
@@ -1,0 +1,150 @@
+"""Correctness and complexity guards for iteration/runtime correlation."""
+
+import pytest
+
+from nsys_ai.overlap import _correlate_iteration_kernels, detect_iterations
+from nsys_ai.profile import Profile
+
+
+def _kernel(correlation_id):
+    return {
+        "correlation_id": correlation_id,
+        "name": f"kernel_{correlation_id}",
+        "start": correlation_id * 100,
+        "end": correlation_id * 100 + 10,
+    }
+
+
+def _runtime(correlation_id, start, end):
+    return {"correlationId": correlation_id, "start": start, "end": end}
+
+
+def test_zero_iterations_produce_no_groups():
+    assert list(_correlate_iteration_kernels([], [], {})) == []
+
+
+def test_single_full_capture_iteration_preserves_whole_row_containment():
+    kernels = {i: _kernel(i) for i in range(1, 5)}
+    rows = [
+        _runtime(1, 0, 1),
+        _runtime(2, 2, 3),
+        _runtime(3, 9, 10),
+        _runtime(4, 9, 11),
+    ]
+
+    groups = list(
+        _correlate_iteration_kernels([{"start": 0, "end": 10}], rows, kernels)
+    )
+
+    assert [[kernel["correlation_id"] for kernel in group] for group in groups] == [
+        [1, 2, 3]
+    ]
+
+
+def test_multiple_iterations_retain_the_first_row_for_the_next_window():
+    kernels = {i: _kernel(i) for i in range(1, 5)}
+    rows = [
+        _runtime(1, 1, 2),
+        _runtime(2, 10, 11),
+        _runtime(3, 12, 19),
+        _runtime(4, 20, 21),
+    ]
+    iterations = [{"start": 0, "end": 10}, {"start": 10, "end": 20}]
+
+    groups = list(_correlate_iteration_kernels(iterations, rows, kernels))
+
+    assert [[kernel["correlation_id"] for kernel in group] for group in groups] == [
+        [1],
+        [2, 3],
+    ]
+
+
+def test_runtime_rows_are_iterated_once_without_rewind():
+    class OneShotRows:
+        def __init__(self, rows):
+            self.rows = rows
+            self.iterations = 0
+            self.yields = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            if self.iterations > 1:
+                raise AssertionError("runtime rows were restarted")
+            for row in self.rows:
+                self.yields += 1
+                yield row
+
+    rows = OneShotRows([_runtime(i, i * 10, i * 10 + 1) for i in range(1, 5)])
+    kernels = {i: _kernel(i) for i in range(1, 5)}
+    iterations = [
+        {"start": 0, "end": 15},
+        {"start": 20, "end": 25},
+        {"start": 30, "end": 35},
+        {"start": 40, "end": 45},
+    ]
+
+    groups = list(_correlate_iteration_kernels(iterations, rows, kernels))
+
+    assert rows.iterations == 1
+    assert rows.yields == len(rows.rows)
+    assert sum(len(group) for group in groups) == 4
+
+
+@pytest.mark.parametrize(
+    "iterations",
+    [
+        [{"start": 10, "end": 10}],
+        [{"start": 10, "end": 20}, {"start": 19, "end": 30}],
+        [{"start": 20, "end": 30}, {"start": 10, "end": 15}],
+    ],
+)
+def test_correlation_rejects_invalid_iteration_windows(iterations):
+    with pytest.raises(ValueError):
+        list(_correlate_iteration_kernels(iterations, [], {}))
+
+
+def test_detect_iterations_correlates_multiple_nvtx_windows(minimal_nsys_conn):
+    minimal_nsys_conn.execute(
+        "INSERT INTO NVTX_EVENTS (globalTid, start, end, text, eventType, rangeId) "
+        "VALUES (100, 7500000, 8500000, 'train_step', 59, 2)"
+    )
+    prof = Profile._from_conn(minimal_nsys_conn)
+
+    rows = detect_iterations(prof, 0, marker="train_step")
+
+    assert [row["kernel_count"] for row in rows] == [4, 1]
+    assert all(row["heuristic"] is False for row in rows)
+
+
+def test_heuristic_windows_follow_cpu_order_across_gpu_stream_reordering(
+    minimal_nsys_conn,
+):
+    minimal_nsys_conn.execute("DELETE FROM NVTX_EVENTS")
+    minimal_nsys_conn.execute("DELETE FROM CUPTI_ACTIVITY_KIND_RUNTIME")
+    minimal_nsys_conn.execute("DELETE FROM CUPTI_ACTIVITY_KIND_KERNEL")
+    minimal_nsys_conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME "
+        "(globalTid, correlationId, start, end, nameId) VALUES (100, ?, ?, ?, 24)",
+        [(1, 100, 110), (2, 300, 310), (3, 200, 210)],
+    )
+    minimal_nsys_conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL "
+        "(globalPid, deviceId, streamId, correlationId, start, end, shortName, demangledName) "
+        "VALUES (100, 0, ?, ?, ?, ?, 1, 1)",
+        [
+            (7, 1, 1_000, 2_000),
+            (8, 2, 3_000_000, 3_001_000),
+            (7, 3, 6_000_000, 6_001_000),
+        ],
+    )
+    prof = Profile._from_conn(minimal_nsys_conn)
+
+    rows = detect_iterations(prof, 0)
+
+    assert [row["gpu_start_ns"] for row in rows] == [1_000, 6_000_000, 3_000_000]
+    assert [row["text"] for row in rows] == [
+        "heuristic_step_0",
+        "heuristic_step_1",
+        "heuristic_step_2",
+    ]
+    assert all(row["heuristic"] is True for row in rows)


### PR DESCRIPTION
Closes #348.

## Summary

- replace the per-iteration restart of the primary-thread runtime list with one advancing grouped cursor
- validate that iteration windows are ordered and non-overlapping before permanently advancing that cursor
- normalize heuristic CPU boundaries when GPU execution order differs across streams
- preserve whole-row containment for zero-duration and spanning rows at shared boundaries, independent of equal-start SQL tie order

## Correctness

The 3.5 GB oracle produced the same 952 rows field-for-field before and after the change. Canonical sorted compact JSON, including its trailing newline, is byte-identical with SHA256:

```text
ddc2b3e24d96d049ff305a195a0b8bc98da7aa4932cd554d8ffb5acff0e26d72
```

Outputs also matched upstream `main` byte-for-byte on the four committed profiles using one canonical dictionary keyed by fixture filename:

```text
healthy_1pct.sqlite          1 row
healthy_judged_1pct.sqlite   1 row
mfu_2gpu_before.sqlite       3 rows
mfu_2gpu_after.sqlite        3 rows
SHA256 9c1b4db25d594775702a928612d945b77125f330e13291beae7919a95105af2a
```

Final adversarial review compared the grouped cursor to the previous restart semantics across 636 exhaustive cases and 30,000 deterministic randomized cases covering zero-duration rows, equal-start permutations, adjacent and gapped windows, spanning rows, and missing correlations. Every case matched exactly. The independent 3.5 GB rerun also reproduced the 952-row hash above.

## Performance

Warm Parquet cache, 3.5 GB profile, 12 cores, otherwise quiet machine:

| Measurement | Before | After |
| --- | ---: | ---: |
| `iteration_timing` internal | 27.654 s | 4.666 s |
| process wall time | 27.93 s | 4.90 s |
| process peak RSS | 1,914,604 KB | 1,845,112 KB |
| warm `EvidenceBuilder` | 76.0 s | 48.1 s |
| builder findings / skipped | 36 / 0 | 36 / 0 |
| builder peak RSS | 4,347,760 KB | 4,357,792 KB |

The builder run measured the iteration skill at 5.92x faster and the complete warm builder at 36.7% faster. Independent review measured 4.885 s internal / 5.09 s wall for the final iteration implementation, and a separate builder pair measured a 30.1% end-to-end reduction; that spread is ordinary run/environment variance. Peak builder memory is unchanged within run noise, as expected because columnar loading is outside this issue.

## Validation

- `pytest tests/test_iteration_correlation.py tests/test_iteration_noise.py tests/test_no_nvtx_profile.py tests/test_overlap_table_resolution.py -q`: 46 passed
- `pytest tests/ -q --tb=short -rs`: 1 failed, 1560 passed, 146 skipped; the sole failure is the pre-existing local coverage gate reporting `No test profile` because `NSYS_TEST_PROFILE` is not configured
- `ruff check src/ tests/`: passed
- `bandit -r src/ -c pyproject.toml`: passed, no issues
- `python -m nsys_ai --help`: passed

The change does not alter Arrow loading or runtime-row materialization.
