### PR TITLE
feat: add synchronous local profile runner

### DIFF
--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -948,7 +948,9 @@ class Profile:
         self.close()
 
 
-def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
+def resolve_profile_path(
+    path: str, *, backend: str = "sqlite", nsys_executable: str = "nsys"
+) -> str:
     """
     Resolve a profile path for the selected backend.
 
@@ -965,7 +967,7 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
     if not os.path.exists(path):
         raise ProfileNotFoundError(f"profile not found: {path}")
     if backend == "parquetdir":
-        return _resolve_parquetdir_path(path)
+        return _resolve_parquetdir_path(path, nsys_executable=nsys_executable)
     if not path.lower().endswith(".nsys-rep"):
         return path
 
@@ -982,7 +984,7 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
             return out
         # Missing NVTX payload blobs: re-export only when nsys is available so we
         # do not regress users with a valid sidecar .sqlite but no Nsight install.
-        if not shutil.which("nsys"):
+        if not shutil.which(nsys_executable):
             logging.getLogger(__name__).warning(
                 "Reusing existing SQLite export at %r without NVTX payload blobs; "
                 "communicator-aware analysis and other payload-dependent features may be incomplete. "
@@ -992,7 +994,7 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
             )
             return out
 
-    nsys_exe = shutil.which("nsys")
+    nsys_exe = shutil.which(nsys_executable)
     if not nsys_exe:
         raise ExportToolMissingError(
             "Profile is .nsys-rep; conversion requires 'nsys' (NVIDIA Nsight Systems) on PATH. "
@@ -1045,7 +1047,7 @@ def resolve_profile_path(path: str, *, backend: str = "sqlite") -> str:
     return out
 
 
-def _resolve_parquetdir_path(path: str) -> str:
+def _resolve_parquetdir_path(path: str, *, nsys_executable: str = "nsys") -> str:
     """Return a path to an Nsight `parquetdir` export."""
     if os.path.isdir(path):
         parquet_files = [name for name in os.listdir(path) if name.endswith(".parquet")]
@@ -1065,7 +1067,7 @@ def _resolve_parquetdir_path(path: str) -> str:
     ):
         return out
 
-    nsys_exe = shutil.which("nsys")
+    nsys_exe = shutil.which(nsys_executable)
     if not nsys_exe:
         raise ExportToolMissingError(
             "Profile is .nsys-rep; conversion requires 'nsys' (NVIDIA Nsight Systems) on PATH. "

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -1,0 +1,418 @@
+"""Synchronous local execution of a :class:`~nsys_ai.runspec.RunSpec`.
+
+The local runner owns capture process lifecycle and artifact production.  It
+does not own CLI presentation, session layout, or remote execution.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess  # nosec B404
+import time
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Protocol
+
+from .connection import DB_ERRORS
+from .exceptions import NsysAiError
+from .fingerprint import get_profile_id
+from .profile import Profile, resolve_profile_path
+from .runspec import RunSpec, RunSpecError, build_nsys_profile_argv, validate_secret_boundaries
+
+
+class RunStatus(str, Enum):
+    """Terminal outcome of a local profile run."""
+
+    LAUNCH_FAILED = "launch_failed"
+    TIMED_OUT = "timed_out"
+    CANCELLED = "cancelled"
+    NSYS_FAILED = "nsys_failed"
+    APPLICATION_FAILED = "application_failed"
+    EXPORT_FAILED = "export_failed"
+    INVALID_PROFILE = "invalid_profile"
+    SUCCEEDED = "succeeded"
+
+
+class RunStage(str, Enum):
+    """Observable stages emitted to a progress callback."""
+
+    PREPARING = "preparing"
+    CAPTURING = "capturing"
+    EXPORTING = "exporting"
+    VALIDATING = "validating"
+    FINISHED = "finished"
+
+
+@dataclass(frozen=True)
+class RunProgress:
+    """One immutable progress notification."""
+
+    stage: RunStage
+    elapsed_seconds: float
+
+
+@dataclass(frozen=True)
+class LocalProfileReference:
+    """Validated identity and schema metadata for a local SQLite export."""
+
+    path: str
+    profile_id: str
+    schema_version: str | None
+    product_version: str | None
+    kernel_count: int
+
+
+@dataclass(frozen=True)
+class RunTimings:
+    """Wall-clock durations for the stages completed by a run."""
+
+    started_at_utc: str
+    capture_seconds: float
+    export_seconds: float
+    validation_seconds: float
+    total_seconds: float
+
+
+@dataclass(frozen=True)
+class RunResult:
+    """Artifacts and deterministic terminal classification for a run."""
+
+    status: RunStatus
+    nsys_return_code: int | None
+    application_return_code: int | None
+    timings: RunTimings
+    runspec_path: str
+    stdout_path: str
+    stderr_path: str
+    report_path: str | None = None
+    sqlite_path: str | None = None
+    profile: LocalProfileReference | None = None
+    detail: str | None = None
+
+
+class _CancellationEvent(Protocol):
+    def is_set(self) -> bool: ...
+
+
+Cancellation = Callable[[], bool] | _CancellationEvent
+ProgressCallback = Callable[[RunProgress], None]
+
+_POLL_SECONDS = 0.05
+_TERMINATION_GRACE_SECONDS = 2.0
+
+
+class _EmptyProfileError(ValueError):
+    """A readable profile has no GPU kernel rows."""
+
+
+class LocalProfileRunner:
+    """Run one local ``nsys profile`` capture into an artifact directory.
+
+    ``nsys`` exposes one process return code for both its own work and the
+    wrapped application.  A non-zero return with a non-empty report is therefore
+    classified as ``application_failed`` by inference; it is not a separately
+    observed application exit code.
+
+    Export uses the existing blocking :func:`resolve_profile_path` API.  The
+    cancellation token is consequently observed during capture, not while that
+    shared export call is in progress.
+    """
+
+    def __init__(self, artifact_dir: str | os.PathLike[str], nsys_executable: str = "nsys"):
+        self.artifact_dir = Path(artifact_dir)
+        self.nsys_executable = os.fspath(nsys_executable)
+
+    def run(
+        self,
+        spec: RunSpec,
+        progress_callback: ProgressCallback | None = None,
+        cancellation: Cancellation | None = None,
+    ) -> RunResult:
+        """Capture, export, and validate one local profile.
+
+        Invalid inputs and secret-boundary failures raise :class:`RunSpecError`
+        before the artifact directory or any file is created.  All failures
+        after that boundary are returned as a typed :class:`RunResult`.
+        """
+        self._validate_inputs(spec, progress_callback, cancellation)
+        resolved_secrets = self._resolve_declared_secrets(spec)
+        validate_secret_boundaries(spec, resolved_secrets)
+
+        started = time.monotonic()
+        started_at = datetime.now(timezone.utc).isoformat()
+        capture_seconds = 0.0
+        export_seconds = 0.0
+        validation_seconds = 0.0
+
+        artifact_dir = self.artifact_dir.absolute()
+        runspec_path = artifact_dir / "runspec.json"
+        stdout_path = artifact_dir / "stdout.log"
+        stderr_path = artifact_dir / "stderr.log"
+        report_base = artifact_dir / "profile"
+        report_path = report_base.with_suffix(".nsys-rep")
+
+        def progress(stage: RunStage) -> None:
+            if progress_callback is not None:
+                progress_callback(RunProgress(stage, time.monotonic() - started))
+
+        def result(
+            status: RunStatus,
+            *,
+            return_code: int | None = None,
+            report: Path | None = None,
+            sqlite: Path | None = None,
+            profile: LocalProfileReference | None = None,
+            detail: str | None = None,
+        ) -> RunResult:
+            progress(RunStage.FINISHED)
+            return RunResult(
+                status=status,
+                nsys_return_code=return_code,
+                # nsys exposes no separate application exit code.  Keep the
+                # unknown value explicit even for the inferred failure status.
+                application_return_code=None,
+                timings=RunTimings(
+                    started_at_utc=started_at,
+                    capture_seconds=capture_seconds,
+                    export_seconds=export_seconds,
+                    validation_seconds=validation_seconds,
+                    total_seconds=time.monotonic() - started,
+                ),
+                runspec_path=str(runspec_path),
+                stdout_path=str(stdout_path),
+                stderr_path=str(stderr_path),
+                report_path=str(report) if report is not None else None,
+                sqlite_path=str(sqlite) if sqlite is not None else None,
+                profile=profile,
+                detail=detail,
+            )
+
+        if self._cancelled(cancellation):
+            return result(RunStatus.CANCELLED)
+
+        progress(RunStage.PREPARING)
+        try:
+            artifact_dir.mkdir(parents=True, exist_ok=False)
+            runspec_path.write_bytes(spec.canonical_json_bytes())
+        except OSError as exc:
+            return result(RunStatus.LAUNCH_FAILED, detail=f"artifact setup failed: {exc}")
+
+        environment = self._build_environment(spec, resolved_secrets)
+        executable = shutil.which(self.nsys_executable, path=environment.get("PATH"))
+        if executable is not None:
+            executable = os.path.abspath(executable)
+        elif os.path.isfile(self.nsys_executable):
+            executable = os.path.abspath(self.nsys_executable)
+        nsys_argv = build_nsys_profile_argv(
+            spec, report_base, nsys_executable=executable or self.nsys_executable
+        )
+        cwd = self._resolve_cwd(spec)
+
+        progress(RunStage.CAPTURING)
+        capture_started = time.monotonic()
+        process: subprocess.Popen[bytes] | None = None
+        try:
+            with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
+                try:
+                    process = subprocess.Popen(  # nosec B603
+                        nsys_argv,
+                        cwd=cwd,
+                        env=environment,
+                        stdin=subprocess.DEVNULL,
+                        stdout=stdout,
+                        stderr=stderr,
+                        shell=False,
+                        start_new_session=True,
+                    )
+                except (OSError, ValueError) as exc:
+                    capture_seconds = time.monotonic() - capture_started
+                    return result(
+                        RunStatus.LAUNCH_FAILED,
+                        detail=f"capture process could not be launched: {type(exc).__name__}",
+                    )
+
+                terminal_status: RunStatus | None = None
+                while process.poll() is None:
+                    if self._cancelled(cancellation):
+                        terminal_status = RunStatus.CANCELLED
+                        break
+                    if (
+                        spec.timeout_seconds is not None
+                        and time.monotonic() - capture_started >= spec.timeout_seconds
+                    ):
+                        terminal_status = RunStatus.TIMED_OUT
+                        break
+                    time.sleep(_POLL_SECONDS)
+
+                if terminal_status is not None:
+                    self._terminate_process_group(process)
+                    capture_seconds = time.monotonic() - capture_started
+                    return result(
+                        terminal_status,
+                        return_code=process.poll(),
+                        report=report_path if report_path.exists() else None,
+                    )
+                return_code = process.wait()
+        finally:
+            if process is not None and process.poll() is None:
+                self._terminate_process_group(process)
+
+        capture_seconds = time.monotonic() - capture_started
+        report_exists = report_path.exists()
+        report_nonempty = report_exists and report_path.stat().st_size > 0
+        if return_code != 0:
+            # Nsight gives the runner no independent application return code.
+            status = RunStatus.APPLICATION_FAILED if report_nonempty else RunStatus.NSYS_FAILED
+            return result(
+                status,
+                return_code=return_code,
+                report=report_path if report_exists else None,
+                detail=(
+                    "non-zero nsys return with report; application failure inferred"
+                    if report_nonempty
+                    else "nsys returned non-zero without a usable report"
+                ),
+            )
+        if not report_exists:
+            return result(
+                RunStatus.NSYS_FAILED,
+                return_code=return_code,
+                detail="nsys completed without producing a report",
+            )
+        if not report_nonempty:
+            return result(
+                RunStatus.INVALID_PROFILE,
+                return_code=return_code,
+                report=report_path,
+                detail="nsys produced an empty report",
+            )
+
+        progress(RunStage.EXPORTING)
+        export_started = time.monotonic()
+        try:
+            sqlite_path = Path(
+                resolve_profile_path(str(report_path), nsys_executable=executable)
+            ).absolute()
+        except (NsysAiError, OSError, subprocess.SubprocessError) as exc:
+            export_seconds = time.monotonic() - export_started
+            return result(
+                RunStatus.EXPORT_FAILED,
+                return_code=return_code,
+                report=report_path,
+                detail=f"profile export failed: {type(exc).__name__}",
+            )
+        export_seconds = time.monotonic() - export_started
+
+        progress(RunStage.VALIDATING)
+        validation_started = time.monotonic()
+        try:
+            with Profile(str(sqlite_path), cache_mode="direct") as profile:
+                if profile.meta.kernel_count <= 0:
+                    raise _EmptyProfileError("profile contains no GPU kernel activity")
+                reference = LocalProfileReference(
+                    path=str(sqlite_path),
+                    profile_id=get_profile_id(
+                        profile.conn, fallback_path=str(sqlite_path.absolute())
+                    ),
+                    schema_version=profile.schema.schema_version,
+                    product_version=profile.schema.version,
+                    kernel_count=profile.meta.kernel_count,
+                )
+        except (NsysAiError, OSError, *DB_ERRORS, _EmptyProfileError) as exc:
+            validation_seconds = time.monotonic() - validation_started
+            return result(
+                RunStatus.INVALID_PROFILE,
+                return_code=return_code,
+                report=report_path,
+                sqlite=sqlite_path,
+                detail=f"profile validation failed: {type(exc).__name__}",
+            )
+        validation_seconds = time.monotonic() - validation_started
+        return result(
+            RunStatus.SUCCEEDED,
+            return_code=return_code,
+            report=report_path,
+            sqlite=sqlite_path,
+            profile=reference,
+        )
+
+    @staticmethod
+    def _validate_inputs(
+        spec: RunSpec,
+        progress_callback: ProgressCallback | None,
+        cancellation: Cancellation | None,
+    ) -> None:
+        if not isinstance(spec, RunSpec):
+            raise RunSpecError("spec must be a RunSpec")
+        if progress_callback is not None and not callable(progress_callback):
+            raise RunSpecError("progress_callback must be callable or null")
+        if cancellation is not None and not (
+            callable(cancellation) or callable(getattr(cancellation, "is_set", None))
+        ):
+            raise RunSpecError("cancellation must be callable, an event, or null")
+
+    @staticmethod
+    def _resolve_declared_secrets(spec: RunSpec) -> dict[str, str]:
+        resolved: dict[str, str] = {}
+        for name in spec.environment.secrets:
+            if name not in os.environ:
+                raise RunSpecError(f"declared secret {name} is not set in the runner environment")
+            resolved[name] = os.environ[name]
+        return resolved
+
+    @staticmethod
+    def _build_environment(spec: RunSpec, secrets: Mapping[str, str]) -> dict[str, str]:
+        environment = dict(os.environ) if spec.environment.policy == "inherit" else {}
+        environment.update(spec.environment.public)
+        environment.update(secrets)
+        return environment
+
+    @staticmethod
+    def _resolve_cwd(spec: RunSpec) -> str:
+        if spec.repository is not None:
+            return str((Path(spec.repository).expanduser() / spec.cwd).absolute())
+        return str(Path(spec.cwd).expanduser().absolute())
+
+    @staticmethod
+    def _cancelled(cancellation: Cancellation | None) -> bool:
+        if cancellation is None:
+            return False
+        if callable(cancellation):
+            return bool(cancellation())
+        return bool(cancellation.is_set())
+
+    @staticmethod
+    def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+        """Terminate the complete session, escalating after a bounded grace."""
+        process_group = process.pid
+        try:
+            os.killpg(process_group, signal.SIGTERM)
+        except ProcessLookupError:
+            process.wait()
+            return
+
+        deadline = time.monotonic() + _TERMINATION_GRACE_SECONDS
+        while time.monotonic() < deadline:
+            process.poll()
+            try:
+                os.killpg(process_group, 0)
+            except ProcessLookupError:
+                process.wait()
+                return
+            time.sleep(_POLL_SECONDS)
+
+        try:
+            os.killpg(process_group, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+        try:
+            process.wait(timeout=_TERMINATION_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            # The group has received SIGKILL; avoid an unbounded wait if the
+            # platform cannot promptly reap the group leader.
+            pass

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from typing import Protocol
+from typing import BinaryIO, Protocol
 
 from .connection import DB_ERRORS
 from .exceptions import NsysAiError
@@ -28,7 +28,8 @@ from .runspec import RunSpec, RunSpecError, build_nsys_profile_argv, validate_se
 class RunStatus(str, Enum):
     """Terminal outcome of a local profile run."""
 
-    LAUNCH_FAILED = "launch_failed"
+    ARTIFACT_SETUP_FAILED = "artifact_setup_failed"
+    CAPTURE_LAUNCH_FAILED = "capture_launch_failed"
     TIMED_OUT = "timed_out"
     CANCELLED = "cancelled"
     NSYS_FAILED = "nsys_failed"
@@ -86,9 +87,9 @@ class RunResult:
     nsys_return_code: int | None
     application_return_code: int | None
     timings: RunTimings
-    runspec_path: str
-    stdout_path: str
-    stderr_path: str
+    runspec_path: str | None
+    stdout_path: str | None
+    stderr_path: str | None
     report_path: str | None = None
     sqlite_path: str | None = None
     profile: LocalProfileReference | None = None
@@ -110,6 +111,22 @@ class _EmptyProfileError(ValueError):
     """A readable profile has no GPU kernel rows."""
 
 
+class _CaptureLaunchError(Exception):
+    """The nsys capture process could not be started."""
+
+    def __init__(self, cause: Exception):
+        self.cause_name = type(cause).__name__
+        super().__init__(self.cause_name)
+
+
+class _ArtifactSetupError(Exception):
+    """A private runner-owned artifact file could not be created."""
+
+    def __init__(self, cause: Exception):
+        self.cause_name = type(cause).__name__
+        super().__init__(self.cause_name)
+
+
 class LocalProfileRunner:
     """Run one local ``nsys profile`` capture into an artifact directory.
 
@@ -120,12 +137,14 @@ class LocalProfileRunner:
 
     Export uses the existing blocking :func:`resolve_profile_path` API.  The
     cancellation token is consequently observed during capture, not while that
-    shared export call is in progress.
+    shared export call is in progress. Progress callbacks are observers:
+    ordinary callback exceptions are isolated from the run, while
+    :class:`BaseException` is not intercepted.
     """
 
     def __init__(self, artifact_dir: str | os.PathLike[str], nsys_executable: str = "nsys"):
         self.artifact_dir = Path(artifact_dir)
-        self.nsys_executable = os.fspath(nsys_executable)
+        self.nsys_executable = nsys_executable
 
     def run(
         self,
@@ -139,7 +158,7 @@ class LocalProfileRunner:
         before the artifact directory or any file is created.  All failures
         after that boundary are returned as a typed :class:`RunResult`.
         """
-        self._validate_inputs(spec, progress_callback, cancellation)
+        nsys_executable = self._validate_inputs(spec, progress_callback, cancellation)
         resolved_secrets = self._resolve_declared_secrets(spec)
         validate_secret_boundaries(spec, resolved_secrets)
 
@@ -155,10 +174,20 @@ class LocalProfileRunner:
         stderr_path = artifact_dir / "stderr.log"
         report_base = artifact_dir / "profile"
         report_path = report_base.with_suffix(".nsys-rep")
+        sqlite_candidate = report_base.with_suffix(".sqlite")
+        created_files: set[Path] = set()
 
         def progress(stage: RunStage) -> None:
             if progress_callback is not None:
-                progress_callback(RunProgress(stage, time.monotonic() - started))
+                try:
+                    progress_callback(RunProgress(stage, time.monotonic() - started))
+                except Exception:
+                    # Progress is an observer. Its ordinary failures must not
+                    # alter capture lifecycle or discard a completed result.
+                    pass
+
+        def created_path(path: Path | None) -> str | None:
+            return str(path) if path is not None and path in created_files else None
 
         def result(
             status: RunStatus,
@@ -183,11 +212,11 @@ class LocalProfileRunner:
                     validation_seconds=validation_seconds,
                     total_seconds=time.monotonic() - started,
                 ),
-                runspec_path=str(runspec_path),
-                stdout_path=str(stdout_path),
-                stderr_path=str(stderr_path),
-                report_path=str(report) if report is not None else None,
-                sqlite_path=str(sqlite) if sqlite is not None else None,
+                runspec_path=created_path(runspec_path),
+                stdout_path=created_path(stdout_path),
+                stderr_path=created_path(stderr_path),
+                report_path=created_path(report),
+                sqlite_path=created_path(sqlite),
                 profile=profile,
                 detail=detail,
             )
@@ -197,73 +226,77 @@ class LocalProfileRunner:
 
         progress(RunStage.PREPARING)
         try:
-            artifact_dir.mkdir(parents=True, exist_ok=False)
-            runspec_path.write_bytes(spec.canonical_json_bytes())
-        except OSError as exc:
-            return result(RunStatus.LAUNCH_FAILED, detail=f"artifact setup failed: {exc}")
+            artifact_dir.mkdir(mode=0o700, parents=True, exist_ok=False)
+            artifact_dir.chmod(0o700)
+            with self._create_private_file(runspec_path) as runspec_file:
+                created_files.add(runspec_path)
+                runspec_file.write(spec.canonical_json_bytes())
+        except (OSError, _ArtifactSetupError) as exc:
+            return result(
+                RunStatus.ARTIFACT_SETUP_FAILED,
+                detail=f"artifact setup failed: {type(exc).__name__}",
+            )
 
         environment = self._build_environment(spec, resolved_secrets)
-        executable = shutil.which(self.nsys_executable, path=environment.get("PATH"))
+        executable = shutil.which(nsys_executable, path=environment.get("PATH"))
         if executable is not None:
             executable = os.path.abspath(executable)
-        elif os.path.isfile(self.nsys_executable):
-            executable = os.path.abspath(self.nsys_executable)
+        elif os.path.isfile(nsys_executable):
+            executable = os.path.abspath(nsys_executable)
         nsys_argv = build_nsys_profile_argv(
-            spec, report_base, nsys_executable=executable or self.nsys_executable
+            spec, report_base, nsys_executable=executable or nsys_executable
         )
         cwd = self._resolve_cwd(spec)
 
         progress(RunStage.CAPTURING)
+        if self._cancelled(cancellation):
+            return result(RunStatus.CANCELLED)
         capture_started = time.monotonic()
         process: subprocess.Popen[bytes] | None = None
         try:
-            with stdout_path.open("wb") as stdout, stderr_path.open("wb") as stderr:
-                try:
-                    process = subprocess.Popen(  # nosec B603
+            with self._create_private_file(stdout_path) as stdout:
+                created_files.add(stdout_path)
+                with self._create_private_file(stderr_path) as stderr:
+                    created_files.add(stderr_path)
+                    return_code, stop_status, process = self._capture_process(
                         nsys_argv,
-                        cwd=cwd,
-                        env=environment,
-                        stdin=subprocess.DEVNULL,
-                        stdout=stdout,
-                        stderr=stderr,
-                        shell=False,
-                        start_new_session=True,
+                        cwd,
+                        environment,
+                        stdout,
+                        stderr,
+                        spec,
+                        cancellation,
+                        capture_started,
                     )
-                except (OSError, ValueError) as exc:
+                if stop_status is not None:
                     capture_seconds = time.monotonic() - capture_started
+                    if report_path.exists():
+                        created_files.add(report_path)
                     return result(
-                        RunStatus.LAUNCH_FAILED,
-                        detail=f"capture process could not be launched: {type(exc).__name__}",
+                        stop_status,
+                        return_code=return_code,
+                        report=report_path,
                     )
-
-                terminal_status: RunStatus | None = None
-                while process.poll() is None:
-                    if self._cancelled(cancellation):
-                        terminal_status = RunStatus.CANCELLED
-                        break
-                    if (
-                        spec.timeout_seconds is not None
-                        and time.monotonic() - capture_started >= spec.timeout_seconds
-                    ):
-                        terminal_status = RunStatus.TIMED_OUT
-                        break
-                    time.sleep(_POLL_SECONDS)
-
-                if terminal_status is not None:
-                    self._terminate_process_group(process)
-                    capture_seconds = time.monotonic() - capture_started
-                    return result(
-                        terminal_status,
-                        return_code=process.poll(),
-                        report=report_path if report_path.exists() else None,
-                    )
-                return_code = process.wait()
+        except _CaptureLaunchError as exc:
+            capture_seconds = time.monotonic() - capture_started
+            return result(
+                RunStatus.CAPTURE_LAUNCH_FAILED,
+                detail=f"capture process could not be launched: {exc.cause_name}",
+            )
+        except _ArtifactSetupError as exc:
+            capture_seconds = time.monotonic() - capture_started
+            return result(
+                RunStatus.ARTIFACT_SETUP_FAILED,
+                detail=f"capture log setup failed: {exc.cause_name}",
+            )
         finally:
             if process is not None and process.poll() is None:
                 self._terminate_process_group(process)
 
         capture_seconds = time.monotonic() - capture_started
         report_exists = report_path.exists()
+        if report_exists:
+            created_files.add(report_path)
         report_nonempty = report_exists and report_path.stat().st_size > 0
         if return_code != 0:
             # Nsight gives the runner no independent application return code.
@@ -298,12 +331,16 @@ class LocalProfileRunner:
             sqlite_path = Path(
                 resolve_profile_path(str(report_path), nsys_executable=executable)
             ).absolute()
+            created_files.add(sqlite_path)
         except (NsysAiError, OSError, subprocess.SubprocessError) as exc:
+            if sqlite_candidate.exists():
+                created_files.add(sqlite_candidate)
             export_seconds = time.monotonic() - export_started
             return result(
                 RunStatus.EXPORT_FAILED,
                 return_code=return_code,
                 report=report_path,
+                sqlite=sqlite_candidate,
                 detail=f"profile export failed: {type(exc).__name__}",
             )
         export_seconds = time.monotonic() - export_started
@@ -341,12 +378,12 @@ class LocalProfileRunner:
             profile=reference,
         )
 
-    @staticmethod
     def _validate_inputs(
+        self,
         spec: RunSpec,
         progress_callback: ProgressCallback | None,
         cancellation: Cancellation | None,
-    ) -> None:
+    ) -> str:
         if not isinstance(spec, RunSpec):
             raise RunSpecError("spec must be a RunSpec")
         if progress_callback is not None and not callable(progress_callback):
@@ -355,6 +392,94 @@ class LocalProfileRunner:
             callable(cancellation) or callable(getattr(cancellation, "is_set", None))
         ):
             raise RunSpecError("cancellation must be callable, an event, or null")
+        try:
+            executable = os.fspath(self.nsys_executable)
+        except TypeError as exc:
+            raise RunSpecError("nsys_executable must be a path string") from exc
+        if not isinstance(executable, str):
+            raise RunSpecError("nsys_executable must be a path string")
+        if not executable:
+            raise RunSpecError("nsys_executable must not be empty")
+        if "\x00" in executable:
+            raise RunSpecError("nsys_executable must not contain NUL bytes")
+        return executable
+
+    @staticmethod
+    def _create_private_file(path: Path) -> BinaryIO:
+        descriptor: int | None = None
+        try:
+            descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            path.chmod(0o600)
+            return os.fdopen(descriptor, "wb")
+        except (OSError, ValueError) as exc:
+            if descriptor is not None:
+                os.close(descriptor)
+            raise _ArtifactSetupError(exc) from exc
+
+    @classmethod
+    def _capture_process(
+        cls,
+        argv: list[str],
+        cwd: str,
+        environment: Mapping[str, str],
+        stdout: BinaryIO,
+        stderr: BinaryIO,
+        spec: RunSpec,
+        cancellation: Cancellation | None,
+        capture_started: float,
+    ) -> tuple[int | None, RunStatus | None, subprocess.Popen[bytes] | None]:
+        """Launch and poll capture, resolving exit-versus-stop races explicitly."""
+
+        def requested_stop() -> RunStatus | None:
+            if cls._cancelled(cancellation):
+                return RunStatus.CANCELLED
+            if (
+                spec.timeout_seconds is not None
+                and time.monotonic() - capture_started >= spec.timeout_seconds
+            ):
+                return RunStatus.TIMED_OUT
+            return None
+
+        # This check is intentionally adjacent to Popen. A progress callback
+        # may have requested cancellation immediately before this helper.
+        stop_status = requested_stop()
+        if stop_status is not None:
+            return None, stop_status, None
+
+        try:
+            process = subprocess.Popen(  # nosec B603
+                argv,
+                cwd=cwd,
+                env=environment,
+                stdin=subprocess.DEVNULL,
+                stdout=stdout,
+                stderr=stderr,
+                shell=False,
+                start_new_session=True,
+            )
+        except (OSError, ValueError) as exc:
+            raise _CaptureLaunchError(exc) from exc
+        try:
+            while True:
+                stop_status = requested_stop()
+                return_code = process.poll()
+                if return_code is not None:
+                    # The leader may exit between the loop condition and an
+                    # already-due cancellation/deadline. Recheck before accepting
+                    # its exit so surviving children cannot escape the process group.
+                    stop_status = requested_stop() or stop_status
+                    if stop_status is not None:
+                        cls._terminate_process_group(process)
+                    return process.poll(), stop_status, process
+                if stop_status is not None:
+                    cls._terminate_process_group(process)
+                    return process.poll(), stop_status, process
+                time.sleep(_POLL_SECONDS)
+        except Exception:
+            # Cancellation callables are control inputs, not observers. Their
+            # failures propagate, but never leave the capture tree running.
+            cls._terminate_process_group(process)
+            raise
 
     @staticmethod
     def _resolve_declared_secrets(spec: RunSpec) -> dict[str, str]:

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -430,19 +430,22 @@ class LocalProfileRunner:
     ) -> tuple[int | None, RunStatus | None, subprocess.Popen[bytes] | None]:
         """Launch and poll capture, resolving exit-versus-stop races explicitly."""
 
-        def requested_stop() -> RunStatus | None:
+        deadline = (
+            capture_started + spec.timeout_seconds
+            if spec.timeout_seconds is not None
+            else None
+        )
+
+        def cancellation_status() -> RunStatus | None:
             if cls._cancelled(cancellation):
                 return RunStatus.CANCELLED
-            if (
-                spec.timeout_seconds is not None
-                and time.monotonic() - capture_started >= spec.timeout_seconds
-            ):
-                return RunStatus.TIMED_OUT
             return None
 
         # This check is intentionally adjacent to Popen. A progress callback
         # may have requested cancellation immediately before this helper.
-        stop_status = requested_stop()
+        stop_status = cancellation_status()
+        if stop_status is None and deadline is not None and time.monotonic() >= deadline:
+            stop_status = RunStatus.TIMED_OUT
         if stop_status is not None:
             return None, stop_status, None
 
@@ -461,23 +464,36 @@ class LocalProfileRunner:
             raise _CaptureLaunchError(exc) from exc
         try:
             while True:
-                stop_status = requested_stop()
-                return_code = process.poll()
-                if return_code is not None:
-                    # The leader may exit between the loop condition and an
-                    # already-due cancellation/deadline. Recheck before accepting
-                    # its exit so surviving children cannot escape the process group.
-                    stop_status = requested_stop() or stop_status
-                    if stop_status is not None:
-                        cls._terminate_process_group(process)
-                    return process.poll(), stop_status, process
+                stop_status = cancellation_status()
                 if stop_status is not None:
                     cls._terminate_process_group(process)
                     return process.poll(), stop_status, process
-                time.sleep(_POLL_SECONDS)
-        except Exception:
+
+                remaining = None if deadline is None else deadline - time.monotonic()
+                if remaining is not None and remaining <= 0:
+                    cls._terminate_process_group(process)
+                    return process.poll(), RunStatus.TIMED_OUT, process
+                wait_seconds = (
+                    _POLL_SECONDS
+                    if remaining is None
+                    else min(_POLL_SECONDS, remaining)
+                )
+                try:
+                    return_code = process.wait(timeout=wait_seconds)
+                except subprocess.TimeoutExpired:
+                    continue
+
+                # wait() returning proves the leader completed inside the
+                # bounded interval, so completion wins over a later clock read.
+                # Cancellation is still rechecked because it is independent of
+                # the deadline and may have won while wait() was blocked.
+                stop_status = cancellation_status()
+                cls._terminate_process_group(process)
+                return return_code, stop_status, process
+        except BaseException:
             # Cancellation callables are control inputs, not observers. Their
-            # failures propagate, but never leave the capture tree running.
+            # failures (including KeyboardInterrupt) propagate, but never leave
+            # the capture tree running.
             cls._terminate_process_group(process)
             raise
 

--- a/src/nsys_ai/runspec.py
+++ b/src/nsys_ai/runspec.py
@@ -466,14 +466,18 @@ def validate_secret_boundaries(
 
     def persisted_strings(value: Any, path: str = ""):
         if isinstance(value, Mapping):
+            if path == "environment.public":
+                for index, (public_name, public_value) in enumerate(value.items()):
+                    yield f"environment.public.key[{index}]", public_name
+                    yield from persisted_strings(
+                        public_value, f"environment.public.value[{index}]"
+                    )
+                return
             for key, nested in value.items():
                 if path == "environment" and key == "secrets":
                     # These persisted strings are declarations, not values.
                     continue
-                if path == "environment.public":
-                    nested_path = f"environment.public[{key!r}]"
-                else:
-                    nested_path = f"{path}.{key}" if path else str(key)
+                nested_path = f"{path}.{key}" if path else str(key)
                 yield from persisted_strings(nested, nested_path)
         elif isinstance(value, (list, tuple)):
             for index, nested in enumerate(value):

--- a/src/nsys_ai/runspec.py
+++ b/src/nsys_ai/runspec.py
@@ -436,12 +436,13 @@ def build_nsys_profile_argv(
 def validate_secret_boundaries(
     spec: RunSpec, resolved_secrets: Mapping[str, str]
 ) -> None:
-    """Reject declared secret values placed in fields persisted verbatim.
+    """Reject declared secret values placed in any persisted RunSpec string.
 
     This is an execution-boundary check for the local runner. It can only
     protect values whose environment-variable names were declared in
     :attr:`EnvironmentSpec.secrets`; arbitrary strings cannot be identified as
-    secrets. Secret command-line arguments are unsupported in RunSpec v0.1.
+    secrets. The persisted declaration-name list itself is excluded. Secret
+    command-line arguments are unsupported in RunSpec v0.1.
     The caller must run this check before writing ``runspec.json`` or logging
     argv. Error messages name the declaration and location, never its value.
     """
@@ -463,6 +464,24 @@ def validate_secret_boundaries(
             "resolved_secrets is missing declared name(s): " + ", ".join(missing)
         )
 
+    def persisted_strings(value: Any, path: str = ""):
+        if isinstance(value, Mapping):
+            for key, nested in value.items():
+                if path == "environment" and key == "secrets":
+                    # These persisted strings are declarations, not values.
+                    continue
+                if path == "environment.public":
+                    nested_path = f"environment.public[{key!r}]"
+                else:
+                    nested_path = f"{path}.{key}" if path else str(key)
+                yield from persisted_strings(nested, nested_path)
+        elif isinstance(value, (list, tuple)):
+            for index, nested in enumerate(value):
+                yield from persisted_strings(nested, f"{path}[{index}]")
+        elif isinstance(value, str):
+            yield path, value
+
+    persisted = tuple(persisted_strings(spec.to_dict()))
     for secret_name in sorted(declared):
         secret_value = values[secret_name]
         if not isinstance(secret_value, str):
@@ -471,15 +490,13 @@ def validate_secret_boundaries(
             )
         if not secret_value:
             continue
-        for index, argument in enumerate(spec.argv):
-            if secret_value in argument:
-                raise RunSpecError(
-                    f"declared secret {secret_name} appears in argv[{index}]; "
-                    "secret command-line arguments are unsupported"
+        for location, persisted_value in persisted:
+            if secret_value in persisted_value:
+                suffix = (
+                    "; secret command-line arguments are unsupported"
+                    if location.startswith("argv[")
+                    else ""
                 )
-        for public_name, public_value in spec.environment.public.items():
-            if secret_value in public_value:
                 raise RunSpecError(
-                    f"declared secret {secret_name} appears in "
-                    f"environment.public[{public_name!r}]"
+                    f"declared secret {secret_name} appears in {location}{suffix}"
                 )

--- a/tests/test_profile_resolve.py
+++ b/tests/test_profile_resolve.py
@@ -138,6 +138,28 @@ def test_resolve_nsys_rep_success(monkeypatch, tmp_path: Path):
     assert str(rep) in args
 
 
+def test_resolve_nsys_rep_uses_selected_executable(monkeypatch, tmp_path: Path):
+    selected = "/opt/custom/nsys"
+    which_calls = []
+    monkeypatch.setattr(
+        profile_mod.shutil,
+        "which",
+        lambda name: which_calls.append(name) or selected,
+    )
+
+    def fake_run(args, **kwargs):
+        Path(args[args.index("-o") + 1]).write_bytes(b"x")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(profile_mod.subprocess, "run", fake_run)
+    rep = tmp_path / "selected.nsys-rep"
+    rep.write_bytes(b"report")
+
+    profile_mod.resolve_profile_path(str(rep), nsys_executable=selected)
+
+    assert which_calls == [selected]
+
+
 def test_resolve_nsys_rep_parquetdir_success(monkeypatch, tmp_path: Path):
     calls = {}
     monkeypatch.setattr(profile_mod.shutil, "which", lambda name: "/opt/nsys")

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -1,0 +1,390 @@
+import json
+import os
+import stat
+import threading
+import time
+from dataclasses import FrozenInstanceError
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.profile_runner import (
+    LocalProfileRunner,
+    RunProgress,
+    RunStage,
+    RunStatus,
+)
+from nsys_ai.runspec import EnvironmentSpec, RunSpec, RunSpecError
+
+_FAKE_NSYS = r'''#!/usr/bin/env python3
+import json
+import os
+import signal
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def value_after(flag):
+    index = sys.argv.index(flag)
+    return sys.argv[index + 1]
+
+
+def make_sqlite(path, with_kernel=True):
+    with sqlite3.connect(path) as conn:
+        conn.executescript("""
+            CREATE TABLE META_DATA_EXPORT (name TEXT, value TEXT);
+            INSERT INTO META_DATA_EXPORT VALUES
+                ('EXPORT_PRODUCT_NAME', 'NVIDIA Nsight Systems'),
+                ('EXPORT_PRODUCT_VERSION', '2026.2.1.106'),
+                ('EXPORT_SCHEMA_VERSION', '3.25.0');
+            CREATE TABLE TARGET_INFO_GPU (id INTEGER, name TEXT);
+            INSERT INTO TARGET_INFO_GPU VALUES (0, 'Fake GPU');
+            CREATE TABLE StringIds (id INTEGER, value TEXT);
+            INSERT INTO StringIds VALUES (1, 'fake_kernel');
+            CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+                deviceId INTEGER, streamId INTEGER, start INTEGER, end INTEGER,
+                shortName INTEGER, demangledName INTEGER, correlationId INTEGER
+            );
+        """)
+        if with_kernel:
+            conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (0, 7, 10, 20, 1, 1, 1)")
+
+
+if sys.argv[1] == 'profile':
+    output = Path(value_after('-o'))
+    mode_arg = next((arg for arg in sys.argv if arg.startswith('--fake-mode=')), '')
+    mode = mode_arg.partition('=')[2] or 'valid'
+    print(json.dumps(sys.argv), flush=True)
+
+    if mode == 'hang':
+        child = subprocess.Popen([
+            sys.executable,
+            '-c',
+            'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)',
+        ])
+        output.with_suffix('.child.pid').write_text(str(child.pid))
+        signal.signal(signal.SIGTERM, signal.SIG_IGN)
+        while True:
+            time.sleep(1)
+    if mode == 'env':
+        ok = (
+            os.environ.get('VISIBLE_SETTING') == 'enabled'
+            and os.environ.get('RUNNER_SECRET') == 'private-value'
+            and os.environ.get('INHERITED_SETTING') == 'inherited'
+        )
+        if not ok:
+            sys.exit(21)
+    if mode == 'clean_env':
+        ok = (
+            os.environ.get('VISIBLE_SETTING') == 'enabled'
+            and 'INHERITED_SETTING' not in os.environ
+        )
+        if not ok:
+            sys.exit(22)
+    if mode == 'large_logs':
+        sys.stdout.write('o' * (2 * 1024 * 1024))
+        sys.stderr.write('e' * (2 * 1024 * 1024))
+    if mode in {'missing_report', 'nonzero_without_report'}:
+        sys.exit(17 if mode == 'nonzero_without_report' else 0)
+
+    report = output.with_suffix('.nsys-rep')
+    if mode == 'empty_report':
+        report.touch()
+    else:
+        report.write_text(mode)
+    if mode == 'nonzero_with_report':
+        sys.exit(19)
+    sys.exit(0)
+
+if sys.argv[1] == 'export':
+    output = Path(value_after('-o'))
+    report = Path(sys.argv[-1])
+    mode = report.read_text()
+    if mode == 'export_failed':
+        print('intentional export failure', file=sys.stderr)
+        sys.exit(23)
+    if mode == 'invalid':
+        output.write_bytes(b'not a sqlite database')
+    else:
+        make_sqlite(output, with_kernel=mode != 'empty_profile')
+    sys.exit(0)
+
+sys.exit(99)
+'''
+
+
+@pytest.fixture
+def fake_nsys(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    executable = bin_dir / "nsys"
+    executable.write_text(_FAKE_NSYS)
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("PATH", f"{bin_dir}{os.pathsep}{os.environ.get('PATH', '')}")
+    return executable
+
+
+def _spec(mode="valid", **overrides):
+    values = {
+        "argv": ("/usr/bin/true", f"--fake-mode={mode}"),
+        "environment": EnvironmentSpec(),
+    }
+    values.update(overrides)
+    return RunSpec(**values)
+
+
+def _run(tmp_path, fake_nsys, mode="valid", **spec_overrides):
+    runner = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys))
+    return runner.run(_spec(mode, **spec_overrides))
+
+
+def test_success_returns_validated_reference_and_artifacts(tmp_path, fake_nsys):
+    stages = []
+    runner = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys))
+    result = runner.run(_spec(), lambda update: stages.append(update))
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert result.nsys_return_code == 0
+    assert result.application_return_code is None
+    assert result.profile is not None
+    assert result.profile.kernel_count == 1
+    assert result.profile.profile_id.startswith("nsys1:sha256:")
+    assert result.profile.schema_version == "3.25.0"
+    assert result.profile.product_version == "2026.2.1.106"
+    assert Path(result.report_path).is_file()
+    assert Path(result.sqlite_path).is_file()
+    assert RunSpec.from_json_bytes(Path(result.runspec_path).read_bytes()) == _spec()
+    assert [update.stage for update in stages] == [
+        RunStage.PREPARING,
+        RunStage.CAPTURING,
+        RunStage.EXPORTING,
+        RunStage.VALIDATING,
+        RunStage.FINISHED,
+    ]
+    with pytest.raises(FrozenInstanceError):
+        stages[0].stage = RunStage.FINISHED
+    with pytest.raises(FrozenInstanceError):
+        result.status = RunStatus.NSYS_FAILED
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        ("missing_report", RunStatus.NSYS_FAILED),
+        ("nonzero_without_report", RunStatus.NSYS_FAILED),
+        ("nonzero_with_report", RunStatus.APPLICATION_FAILED),
+        ("empty_report", RunStatus.INVALID_PROFILE),
+        ("export_failed", RunStatus.EXPORT_FAILED),
+        ("invalid", RunStatus.INVALID_PROFILE),
+        ("empty_profile", RunStatus.INVALID_PROFILE),
+    ],
+)
+def test_capture_export_and_validation_failures_are_distinct(
+    tmp_path, fake_nsys, mode, expected
+):
+    result = _run(tmp_path, fake_nsys, mode)
+
+    assert result.status is expected
+    if mode == "nonzero_with_report":
+        assert result.nsys_return_code == 19
+        assert result.application_return_code is None
+        assert "inferred" in result.detail
+
+
+def test_launch_failure_is_returned_with_file_backed_logs(tmp_path, monkeypatch):
+    monkeypatch.setenv("PATH", "")
+    result = LocalProfileRunner(
+        tmp_path / "artifacts", "/definitely/missing/nsys"
+    ).run(_spec())
+
+    assert result.status is RunStatus.LAUNCH_FAILED
+    assert result.nsys_return_code is None
+    assert Path(result.runspec_path).is_file()
+    assert Path(result.stdout_path).is_file()
+    assert Path(result.stderr_path).is_file()
+
+
+def test_existing_artifact_directory_is_rejected_without_using_stale_report(
+    tmp_path, fake_nsys
+):
+    artifact_dir = tmp_path / "artifacts"
+    artifact_dir.mkdir()
+    stale_report = artifact_dir / "profile.nsys-rep"
+    stale_report.write_text("valid")
+
+    result = LocalProfileRunner(artifact_dir, str(fake_nsys)).run(
+        _spec("nonzero_with_report")
+    )
+
+    assert result.status is RunStatus.LAUNCH_FAILED
+    assert result.nsys_return_code is None
+    assert stale_report.read_text() == "valid"
+
+
+def test_already_cancelled_run_has_no_launch_or_artifact_side_effects(
+    tmp_path, fake_nsys
+):
+    cancellation = threading.Event()
+    cancellation.set()
+    artifact_dir = tmp_path / "artifacts"
+
+    result = LocalProfileRunner(artifact_dir, str(fake_nsys)).run(
+        _spec(), cancellation=cancellation
+    )
+
+    assert result.status is RunStatus.CANCELLED
+    assert result.nsys_return_code is None
+    assert not artifact_dir.exists()
+
+
+def test_relative_executable_is_resolved_before_switching_to_spec_cwd(
+    tmp_path, monkeypatch
+):
+    tools_dir = tmp_path / "tools"
+    tools_dir.mkdir()
+    executable = tools_dir / "nsys"
+    executable.write_text(_FAKE_NSYS)
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    workload_dir = tmp_path / "workload"
+    workload_dir.mkdir()
+    monkeypatch.chdir(tmp_path)
+
+    result = LocalProfileRunner(
+        tmp_path / "artifacts", "./tools/nsys"
+    ).run(_spec(cwd=str(workload_dir)))
+
+    assert result.status is RunStatus.SUCCEEDED
+
+
+@pytest.mark.parametrize("bad_location", ["argv", "public", "missing"])
+def test_secret_preflight_has_zero_filesystem_side_effects(
+    tmp_path, fake_nsys, monkeypatch, bad_location
+):
+    secret = "private-value"
+    if bad_location != "missing":
+        monkeypatch.setenv("RUNNER_SECRET", secret)
+    argv = (
+        ("/usr/bin/true", f"--token={secret}")
+        if bad_location == "argv"
+        else ("/usr/bin/true", "--fake-mode=valid")
+    )
+    public = {"ENDPOINT": f"https://example.test/{secret}"} if bad_location == "public" else {}
+    spec = RunSpec(
+        argv=argv,
+        environment=EnvironmentSpec(public=public, secrets=("RUNNER_SECRET",)),
+    )
+    artifact_dir = tmp_path / "artifacts"
+
+    with pytest.raises(RunSpecError) as exc_info:
+        LocalProfileRunner(artifact_dir, str(fake_nsys)).run(spec)
+
+    assert secret not in str(exc_info.value)
+    assert not artifact_dir.exists()
+
+
+def test_invalid_runner_inputs_have_zero_filesystem_side_effects(tmp_path, fake_nsys):
+    artifact_dir = tmp_path / "artifacts"
+    runner = LocalProfileRunner(artifact_dir, str(fake_nsys))
+
+    with pytest.raises(RunSpecError, match="spec must be"):
+        runner.run("not-a-spec")
+    with pytest.raises(RunSpecError, match="progress_callback"):
+        runner.run(_spec(), progress_callback="not-callable")
+    with pytest.raises(RunSpecError, match="cancellation"):
+        runner.run(_spec(), cancellation=object())
+
+    assert not artifact_dir.exists()
+
+
+@pytest.mark.parametrize(("policy", "mode"), [("inherit", "env"), ("clean", "clean_env")])
+def test_environment_policy_public_values_and_declared_secrets(
+    tmp_path, fake_nsys, monkeypatch, policy, mode
+):
+    monkeypatch.setenv("INHERITED_SETTING", "inherited")
+    monkeypatch.setenv("RUNNER_SECRET", "private-value")
+    environment = EnvironmentSpec(
+        policy=policy,
+        public={"VISIBLE_SETTING": "enabled"},
+        secrets=("RUNNER_SECRET",) if policy == "inherit" else (),
+    )
+
+    result = _run(tmp_path, fake_nsys, mode, environment=environment)
+
+    assert result.status is RunStatus.SUCCEEDED
+    persisted = Path(result.runspec_path).read_text()
+    logs = Path(result.stdout_path).read_text() + Path(result.stderr_path).read_text()
+    assert "private-value" not in persisted
+    assert "private-value" not in logs
+
+
+def test_workload_argv_tokens_are_preserved_without_shell_parsing(tmp_path, fake_nsys):
+    tokens = ("value with spaces", "$(not-run)", "semi;colon", "--flag=literal")
+    spec = RunSpec(argv=("/usr/bin/true", "--fake-mode=valid", *tokens))
+
+    result = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(spec)
+
+    assert result.status is RunStatus.SUCCEEDED
+    captured_argv = json.loads(Path(result.stdout_path).read_text().splitlines()[0])
+    assert captured_argv[-len(tokens) :] == list(tokens)
+
+
+def test_large_stdout_and_stderr_do_not_deadlock_or_buffer_in_memory(tmp_path, fake_nsys):
+    result = _run(tmp_path, fake_nsys, "large_logs")
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert Path(result.stdout_path).stat().st_size > 2 * 1024 * 1024
+    assert Path(result.stderr_path).stat().st_size == 2 * 1024 * 1024
+
+
+def test_unexpected_validation_bug_is_not_relabelled_as_invalid_profile(
+    tmp_path, fake_nsys, monkeypatch
+):
+    def fail_identity(*args, **kwargs):
+        raise RuntimeError("identity implementation bug")
+
+    monkeypatch.setattr("nsys_ai.profile_runner.get_profile_id", fail_identity)
+
+    with pytest.raises(RuntimeError, match="identity implementation bug"):
+        _run(tmp_path, fake_nsys)
+
+
+def _process_is_running(pid):
+    try:
+        state = Path(f"/proc/{pid}/stat").read_text().split()[2]
+    except (FileNotFoundError, ProcessLookupError):
+        return False
+    return state != "Z"
+
+
+@pytest.mark.parametrize("stop_kind", ["timeout", "cancel"])
+def test_timeout_and_cancellation_kill_the_process_tree(
+    tmp_path, fake_nsys, monkeypatch, stop_kind
+):
+    monkeypatch.setattr("nsys_ai.profile_runner._TERMINATION_GRACE_SECONDS", 0.15)
+    cancellation = threading.Event()
+    timeout = 1 if stop_kind == "timeout" else None
+    if stop_kind == "cancel":
+        threading.Timer(0.15, cancellation.set).start()
+    runner = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys))
+
+    result = runner.run(
+        _spec("hang", timeout_seconds=timeout),
+        cancellation=cancellation,
+    )
+
+    expected = RunStatus.TIMED_OUT if stop_kind == "timeout" else RunStatus.CANCELLED
+    assert result.status is expected
+    child_pid = int((tmp_path / "artifacts" / "profile.child.pid").read_text())
+    deadline = time.monotonic() + 2
+    while _process_is_running(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not _process_is_running(child_pid)
+
+
+def test_progress_model_is_frozen():
+    progress = RunProgress(RunStage.CAPTURING, 1.0)
+    with pytest.raises(FrozenInstanceError):
+        progress.elapsed_seconds = 2.0

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -14,7 +14,7 @@ from nsys_ai.profile_runner import (
     RunStage,
     RunStatus,
 )
-from nsys_ai.runspec import EnvironmentSpec, RunSpec, RunSpecError
+from nsys_ai.runspec import EnvironmentSpec, NsysTraceOptions, RunSpec, RunSpecError
 
 _FAKE_NSYS = r'''#!/usr/bin/env python3
 import json
@@ -69,6 +69,15 @@ if sys.argv[1] == 'profile':
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
         while True:
             time.sleep(1)
+    if mode in {'race_cancel', 'race_timeout'}:
+        child = subprocess.Popen([
+            sys.executable,
+            '-c',
+            'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)',
+        ])
+        output.with_suffix('.child.pid').write_text(str(child.pid))
+        time.sleep(0.15 if mode == 'race_cancel' else 0.9)
+        sys.exit(17)
     if mode == 'env':
         ok = (
             os.environ.get('VISIBLE_SETTING') == 'enabled'
@@ -169,6 +178,11 @@ def test_success_returns_validated_reference_and_artifacts(tmp_path, fake_nsys):
     with pytest.raises(FrozenInstanceError):
         result.status = RunStatus.NSYS_FAILED
 
+    artifact_dir = Path(result.runspec_path).parent
+    assert stat.S_IMODE(artifact_dir.stat().st_mode) == 0o700
+    for private_path in (result.runspec_path, result.stdout_path, result.stderr_path):
+        assert stat.S_IMODE(Path(private_path).stat().st_mode) == 0o600
+
 
 @pytest.mark.parametrize(
     ("mode", "expected"),
@@ -200,7 +214,7 @@ def test_launch_failure_is_returned_with_file_backed_logs(tmp_path, monkeypatch)
         tmp_path / "artifacts", "/definitely/missing/nsys"
     ).run(_spec())
 
-    assert result.status is RunStatus.LAUNCH_FAILED
+    assert result.status is RunStatus.CAPTURE_LAUNCH_FAILED
     assert result.nsys_return_code is None
     assert Path(result.runspec_path).is_file()
     assert Path(result.stdout_path).is_file()
@@ -219,8 +233,13 @@ def test_existing_artifact_directory_is_rejected_without_using_stale_report(
         _spec("nonzero_with_report")
     )
 
-    assert result.status is RunStatus.LAUNCH_FAILED
+    assert result.status is RunStatus.ARTIFACT_SETUP_FAILED
     assert result.nsys_return_code is None
+    assert result.runspec_path is None
+    assert result.stdout_path is None
+    assert result.stderr_path is None
+    assert result.report_path is None
+    assert result.sqlite_path is None
     assert stale_report.read_text() == "valid"
 
 
@@ -237,6 +256,11 @@ def test_already_cancelled_run_has_no_launch_or_artifact_side_effects(
 
     assert result.status is RunStatus.CANCELLED
     assert result.nsys_return_code is None
+    assert result.runspec_path is None
+    assert result.stdout_path is None
+    assert result.stderr_path is None
+    assert result.report_path is None
+    assert result.sqlite_path is None
     assert not artifact_dir.exists()
 
 
@@ -285,6 +309,44 @@ def test_secret_preflight_has_zero_filesystem_side_effects(
     assert not artifact_dir.exists()
 
 
+@pytest.mark.parametrize(
+    ("secret", "overrides", "location"),
+    [
+        ("private-commit", {"commit": "rev-private-commit"}, "commit"),
+        (
+            "private-repository",
+            {"repository": "/work/private-repository", "cwd": "."},
+            "repository",
+        ),
+        (
+            "private-cwd",
+            {"repository": "/work/repo", "cwd": "jobs/private-cwd"},
+            "cwd",
+        ),
+        (
+            "process-tree",
+            {"trace_options": NsysTraceOptions(sample="process-tree")},
+            "trace_options.sample",
+        ),
+    ],
+)
+def test_secret_preflight_covers_all_persisted_runspec_strings(
+    tmp_path, fake_nsys, monkeypatch, secret, overrides, location
+):
+    monkeypatch.setenv("RUNNER_SECRET", secret)
+    spec = _spec(
+        environment=EnvironmentSpec(secrets=("RUNNER_SECRET",)),
+        **overrides,
+    )
+    artifact_dir = tmp_path / "artifacts"
+
+    with pytest.raises(RunSpecError, match=location) as exc_info:
+        LocalProfileRunner(artifact_dir, str(fake_nsys)).run(spec)
+
+    assert secret not in str(exc_info.value)
+    assert not artifact_dir.exists()
+
+
 def test_invalid_runner_inputs_have_zero_filesystem_side_effects(tmp_path, fake_nsys):
     artifact_dir = tmp_path / "artifacts"
     runner = LocalProfileRunner(artifact_dir, str(fake_nsys))
@@ -295,6 +357,18 @@ def test_invalid_runner_inputs_have_zero_filesystem_side_effects(tmp_path, fake_
         runner.run(_spec(), progress_callback="not-callable")
     with pytest.raises(RunSpecError, match="cancellation"):
         runner.run(_spec(), cancellation=object())
+
+    assert not artifact_dir.exists()
+
+
+@pytest.mark.parametrize("executable", [123, "", "bad\x00nsys"])
+def test_invalid_nsys_executable_has_zero_filesystem_side_effects(
+    tmp_path, executable
+):
+    artifact_dir = tmp_path / "artifacts"
+
+    with pytest.raises(RunSpecError, match="nsys_executable"):
+        LocalProfileRunner(artifact_dir, executable).run(_spec())
 
     assert not artifact_dir.exists()
 
@@ -351,6 +425,47 @@ def test_unexpected_validation_bug_is_not_relabelled_as_invalid_profile(
         _run(tmp_path, fake_nsys)
 
 
+def test_progress_callback_exception_does_not_change_completed_result(
+    tmp_path, fake_nsys
+):
+    calls = []
+
+    def broken_observer(update):
+        calls.append(update.stage)
+        raise RuntimeError("observer failed")
+
+    result = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(
+        _spec(), progress_callback=broken_observer
+    )
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert calls[-1] is RunStage.FINISHED
+
+
+def test_capturing_callback_cancellation_prevents_popen(
+    tmp_path, fake_nsys, monkeypatch
+):
+    cancellation = threading.Event()
+    popen_calls = 0
+
+    def cancel_at_capture(update):
+        if update.stage is RunStage.CAPTURING:
+            cancellation.set()
+
+    def unexpected_popen(*args, **kwargs):
+        nonlocal popen_calls
+        popen_calls += 1
+        raise AssertionError("Popen must not be called")
+
+    monkeypatch.setattr("nsys_ai.profile_runner.subprocess.Popen", unexpected_popen)
+    result = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(
+        _spec(), progress_callback=cancel_at_capture, cancellation=cancellation
+    )
+
+    assert result.status is RunStatus.CANCELLED
+    assert popen_calls == 0
+
+
 def _process_is_running(pid):
     try:
         state = Path(f"/proc/{pid}/stat").read_text().split()[2]
@@ -378,6 +493,54 @@ def test_timeout_and_cancellation_kill_the_process_tree(
     expected = RunStatus.TIMED_OUT if stop_kind == "timeout" else RunStatus.CANCELLED
     assert result.status is expected
     child_pid = int((tmp_path / "artifacts" / "profile.child.pid").read_text())
+    deadline = time.monotonic() + 2
+    while _process_is_running(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not _process_is_running(child_pid)
+
+
+@pytest.mark.parametrize("stop_kind", ["timeout", "cancel"])
+def test_due_stop_beats_leader_exit_and_kills_surviving_child(
+    tmp_path, fake_nsys, monkeypatch, stop_kind
+):
+    monkeypatch.setattr("nsys_ai.profile_runner._POLL_SECONDS", 0.25)
+    monkeypatch.setattr("nsys_ai.profile_runner._TERMINATION_GRACE_SECONDS", 0.1)
+    cancellation = threading.Event()
+    mode = "race_timeout" if stop_kind == "timeout" else "race_cancel"
+    timeout = 1 if stop_kind == "timeout" else None
+    if stop_kind == "cancel":
+        threading.Timer(0.08, cancellation.set).start()
+
+    result = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(
+        _spec(mode, timeout_seconds=timeout), cancellation=cancellation
+    )
+
+    expected = RunStatus.TIMED_OUT if stop_kind == "timeout" else RunStatus.CANCELLED
+    assert result.status is expected
+    child_pid = int((tmp_path / "artifacts" / "profile.child.pid").read_text())
+    deadline = time.monotonic() + 2
+    while _process_is_running(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not _process_is_running(child_pid)
+
+
+def test_cancellation_callable_failure_propagates_after_process_tree_cleanup(
+    tmp_path, fake_nsys, monkeypatch
+):
+    monkeypatch.setattr("nsys_ai.profile_runner._TERMINATION_GRACE_SECONDS", 0.1)
+    pid_path = tmp_path / "artifacts" / "profile.child.pid"
+
+    def broken_cancellation():
+        if pid_path.exists():
+            raise OSError("cancellation source failed")
+        return False
+
+    with pytest.raises(OSError, match="cancellation source failed"):
+        LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(
+            _spec("hang"), cancellation=broken_cancellation
+        )
+
+    child_pid = int(pid_path.read_text())
     deadline = time.monotonic() + 2
     while _process_is_running(child_pid) and time.monotonic() < deadline:
         time.sleep(0.02)

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -69,14 +69,29 @@ if sys.argv[1] == 'profile':
         signal.signal(signal.SIGTERM, signal.SIG_IGN)
         while True:
             time.sleep(1)
-    if mode in {'race_cancel', 'race_timeout'}:
+    if mode == 'race_cancel':
         child = subprocess.Popen([
             sys.executable,
             '-c',
             'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)',
         ])
         output.with_suffix('.child.pid').write_text(str(child.pid))
-        time.sleep(0.15 if mode == 'race_cancel' else 0.9)
+        time.sleep(0.15)
+        sys.exit(17)
+    if mode == 'leader_exit_child':
+        child = subprocess.Popen([
+            sys.executable,
+            '-c',
+            'import signal,time; signal.signal(signal.SIGTERM, signal.SIG_IGN); time.sleep(60)',
+        ])
+        output.with_suffix('.child.pid').write_text(str(child.pid))
+        time.sleep(0.1)
+        sys.exit(17)
+    if mode == 'exit_094':
+        time.sleep(0.94)
+        sys.exit(17)
+    if mode == 'exit_070':
+        time.sleep(0.70)
         sys.exit(17)
     if mode == 'env':
         ok = (
@@ -499,29 +514,66 @@ def test_timeout_and_cancellation_kill_the_process_tree(
     assert not _process_is_running(child_pid)
 
 
-@pytest.mark.parametrize("stop_kind", ["timeout", "cancel"])
-def test_due_stop_beats_leader_exit_and_kills_surviving_child(
-    tmp_path, fake_nsys, monkeypatch, stop_kind
+def test_due_cancellation_beats_leader_exit_and_kills_surviving_child(
+    tmp_path, fake_nsys, monkeypatch
 ):
     monkeypatch.setattr("nsys_ai.profile_runner._POLL_SECONDS", 0.25)
     monkeypatch.setattr("nsys_ai.profile_runner._TERMINATION_GRACE_SECONDS", 0.1)
     cancellation = threading.Event()
-    mode = "race_timeout" if stop_kind == "timeout" else "race_cancel"
-    timeout = 1 if stop_kind == "timeout" else None
-    if stop_kind == "cancel":
-        threading.Timer(0.08, cancellation.set).start()
+    threading.Timer(0.08, cancellation.set).start()
 
     result = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(
-        _spec(mode, timeout_seconds=timeout), cancellation=cancellation
+        _spec("race_cancel"), cancellation=cancellation
     )
 
-    expected = RunStatus.TIMED_OUT if stop_kind == "timeout" else RunStatus.CANCELLED
-    assert result.status is expected
+    assert result.status is RunStatus.CANCELLED
     child_pid = int((tmp_path / "artifacts" / "profile.child.pid").read_text())
     deadline = time.monotonic() + 2
     while _process_is_running(child_pid) and time.monotonic() < deadline:
         time.sleep(0.02)
     assert not _process_is_running(child_pid)
+
+
+def test_leader_exit_always_cleans_surviving_process_group(
+    tmp_path, fake_nsys, monkeypatch
+):
+    monkeypatch.setattr("nsys_ai.profile_runner._TERMINATION_GRACE_SECONDS", 0.1)
+
+    result = _run(tmp_path, fake_nsys, "leader_exit_child")
+
+    assert result.status is RunStatus.NSYS_FAILED
+    assert result.nsys_return_code == 17
+    child_pid = int((tmp_path / "artifacts" / "profile.child.pid").read_text())
+    deadline = time.monotonic() + 2
+    while _process_is_running(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not _process_is_running(child_pid)
+
+
+@pytest.mark.parametrize(
+    ("mode", "poll_seconds"),
+    [("exit_094", 2.0), ("exit_070", 5.0)],
+)
+def test_completion_before_deadline_wins_over_coarse_polling(
+    tmp_path, fake_nsys, monkeypatch, mode, poll_seconds
+):
+    monkeypatch.setattr("nsys_ai.profile_runner._POLL_SECONDS", poll_seconds)
+
+    result = _run(tmp_path, fake_nsys, mode, timeout_seconds=1)
+
+    assert result.status is RunStatus.NSYS_FAILED
+    assert result.nsys_return_code == 17
+
+
+def test_true_timeout_with_coarse_polling_is_still_timed_out(
+    tmp_path, fake_nsys, monkeypatch
+):
+    monkeypatch.setattr("nsys_ai.profile_runner._POLL_SECONDS", 5.0)
+    monkeypatch.setattr("nsys_ai.profile_runner._TERMINATION_GRACE_SECONDS", 0.1)
+
+    result = _run(tmp_path, fake_nsys, "hang", timeout_seconds=1)
+
+    assert result.status is RunStatus.TIMED_OUT
 
 
 def test_cancellation_callable_failure_propagates_after_process_tree_cleanup(
@@ -538,6 +590,29 @@ def test_cancellation_callable_failure_propagates_after_process_tree_cleanup(
     with pytest.raises(OSError, match="cancellation source failed"):
         LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(
             _spec("hang"), cancellation=broken_cancellation
+        )
+
+    child_pid = int(pid_path.read_text())
+    deadline = time.monotonic() + 2
+    while _process_is_running(child_pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not _process_is_running(child_pid)
+
+
+def test_keyboard_interrupt_from_cancellation_cleans_process_tree(
+    tmp_path, fake_nsys, monkeypatch
+):
+    monkeypatch.setattr("nsys_ai.profile_runner._TERMINATION_GRACE_SECONDS", 0.1)
+    pid_path = tmp_path / "artifacts" / "profile.child.pid"
+
+    def interrupted_cancellation():
+        if pid_path.exists():
+            raise KeyboardInterrupt
+        return False
+
+    with pytest.raises(KeyboardInterrupt):
+        LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(
+            _spec("hang"), cancellation=interrupted_cancellation
         )
 
     child_pid = int(pid_path.read_text())

--- a/tests/test_runspec.py
+++ b/tests/test_runspec.py
@@ -241,6 +241,41 @@ def test_secret_preflight_requires_exact_declared_names_without_values_in_errors
         )
 
 
+@pytest.mark.parametrize(
+    ("secret_value", "overrides", "location"),
+    [
+        ("private-commit", {"commit": "rev-private-commit"}, "commit"),
+        (
+            "private-repository",
+            {"repository": "/work/private-repository", "cwd": "."},
+            "repository",
+        ),
+        (
+            "private-cwd",
+            {"repository": "/work/repo", "cwd": "jobs/private-cwd"},
+            "cwd",
+        ),
+        (
+            "process-tree",
+            {"trace_options": NsysTraceOptions(sample="process-tree")},
+            "trace_options.sample",
+        ),
+    ],
+)
+def test_secret_preflight_checks_every_persisted_string_value(
+    secret_value, overrides, location
+):
+    spec = _full_spec(
+        environment=EnvironmentSpec(secrets=("HF_TOKEN",)),
+        **overrides,
+    )
+
+    with pytest.raises(RunSpecError, match=location) as exc_info:
+        validate_secret_boundaries(spec, {"HF_TOKEN": secret_value})
+
+    assert secret_value not in str(exc_info.value)
+
+
 def test_environment_validation_rejects_ambiguous_or_invalid_names():
     with pytest.raises(RunSpecError, match="both public and secret"):
         EnvironmentSpec(public={"TOKEN": "public"}, secrets=("TOKEN",))

--- a/tests/test_runspec.py
+++ b/tests/test_runspec.py
@@ -206,7 +206,7 @@ def test_environment_persists_names_but_never_resolved_secret_values(monkeypatch
         (
             ("python", "train.py"),
             {"TRAINING_ENDPOINT": "https://host/private-value/data"},
-            r"environment.public\['TRAINING_ENDPOINT'\]",
+            r"environment.public.value\[0\]",
         ),
     ],
 )
@@ -274,6 +274,40 @@ def test_secret_preflight_checks_every_persisted_string_value(
         validate_secret_boundaries(spec, {"HF_TOKEN": secret_value})
 
     assert secret_value not in str(exc_info.value)
+
+
+def test_secret_preflight_checks_public_mapping_keys_without_echoing_them():
+    secret_value = "PRIVATE_KEY_FRAGMENT"
+    public_name = f"PREFIX_{secret_value}_SUFFIX"
+    spec = _full_spec(
+        environment=EnvironmentSpec(
+            public={public_name: "safe-value"}, secrets=("HF_TOKEN",)
+        )
+    )
+
+    with pytest.raises(RunSpecError, match=r"environment.public.key\[0\]") as exc_info:
+        validate_secret_boundaries(spec, {"HF_TOKEN": secret_value})
+
+    message = str(exc_info.value)
+    assert secret_value not in message
+    assert public_name not in message
+
+
+def test_public_value_error_does_not_echo_its_user_controlled_key():
+    secret_value = "private_value"
+    public_name = "SENSITIVE_LOOKING_PUBLIC_NAME"
+    spec = _full_spec(
+        environment=EnvironmentSpec(
+            public={public_name: f"prefix-{secret_value}"}, secrets=("HF_TOKEN",)
+        )
+    )
+
+    with pytest.raises(RunSpecError, match=r"environment.public.value\[0\]") as exc_info:
+        validate_secret_boundaries(spec, {"HF_TOKEN": secret_value})
+
+    message = str(exc_info.value)
+    assert secret_value not in message
+    assert public_name not in message
 
 
 def test_environment_validation_rejects_ambiguous_or_invalid_names():


### PR DESCRIPTION
Closes #269.

## Summary

- add a synchronous local profile runner with immutable progress, result, timing, status, and profile-reference models
- validate declared secret values against every persisted RunSpec string, including public-environment mapping keys, before any artifact or process side effect; diagnostics use indexed locations and never echo user-controlled keys
- create each run directory as `0700`, create runner-owned RunSpec/stdout/stderr files as `0600`, and return paths only for artifacts this invocation actually created
- persist stdout/stderr directly to files, use deadline-bounded `Popen.wait()` so completion-before-timeout wins, and terminate remaining process-group members on timeout, cancellation, exceptions, or leader exit
- distinguish artifact setup, profiler capture-process launch, timeout, cancellation, nsys, inferred application, export, invalid-profile, and successful outcomes deterministically
- isolate ordinary progress-observer exceptions from execution while allowing cancellation-source failures to propagate after process-tree cleanup
- export through `resolve_profile_path`, validate through direct-mode `Profile`, require kernel activity, and record the stable profile ID plus Nsight schema/product metadata
- let `resolve_profile_path` accept an optional nsys executable so capture and export cannot silently use different installations

## Contract notes

Nsight exposes one return code for the profiler and wrapped application. A separate workload launch/exit status is not observable. A non-zero code with a non-empty report is therefore classified as `application_failed` by inference; `application_return_code` remains unknown. Cancellation is observed during capture, while the existing shared export API remains blocking.

Resolved secret values are supported only through declared environment names in RunSpec v0.1. Every persisted RunSpec string and user-controlled public-environment key is checked against those values, excluding the declaration-name list itself. Raw argv and public environment values are persisted public inputs; secret CLI arguments are rejected before artifact creation.

Stdout, stderr, `.nsys-rep`, and exported data are workload-controlled sensitive artifacts persisted verbatim. `--discard-environment=true` prevents nsys from embedding the resolved environment, but it cannot redact a secret printed by the workload. Runner metadata/log files use `0600`; child-created report/export files are protected by the private `0700` run directory.

## Validation

- `PYTHONPATH=<worktree>/src pytest -q tests/test_profile_runner.py tests/test_runspec.py tests/test_profile_resolve.py --tb=short`: 96 passed after review fixes
- pre-review head, `PYTHONPATH=<worktree>/src pytest tests/ -v --tb=short`: 1 failed, 1624 passed, 146 skipped; sole failure is the predeclared `test_every_skip_has_a_known_reason` gate because `NSYS_TEST_PROFILE` is unset (`No test profile`); current-head CI reruns the suite
- `ruff check src/ tests/`: passed
- `bandit -q -c pyproject.toml -r src/`: passed, no issues
- `PYTHONPATH=<worktree>/src python3 -m nsys_ai --help`: passed
- real local probe with nsys 2026.2.1 and an RTX 3080: capture, export, direct Profile open, and identity validation succeeded with one CUDA kernel; export schema 3.25.0 and product 2026.2.1.210
