### PR TITLE
feat: add public profile command

### DIFF
--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -2,6 +2,7 @@
 """Simplified CLI application entrypoint.
 
 Public surface is focused on web UI and AI workflows:
+- profile
 - open
 - web
 - timeline-web
@@ -54,6 +55,9 @@ def show_help():
     print("    nsys-ai timeline <profile> --gpu N --trim S E   Timeline TUI")
     print("    nsys-ai tui     <profile> --gpu N --trim S E   Tree TUI")
     print()
+    print("  Capture:")
+    print("    nsys-ai profile -- <command> [args...]       Capture a local profile")
+    print()
     print("  Skills & Agent:")
     print("    nsys-ai skill list                       List analysis skills")
     print("    nsys-ai skill run <name> <profile>       Run a specific skill")
@@ -73,9 +77,8 @@ def show_help():
     print("    nsys-ai web        <profile> --gpu N       Browser UI")
     print()
     print("  Getting Started:")
-    print("    1. Profile:  nsys profile -o report python train.py")
-    print("    2. Export:   nsys export --type sqlite report.nsys-rep")
-    print("    3. Explore:  nsys-ai open <profile.sqlite>")
+    print("    1. Profile:  nsys-ai profile -- python train.py")
+    print("    2. Explore:  nsys-ai open <profile.sqlite>")
     print()
 
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -13,6 +13,19 @@ import os
 import subprocess  # nosec B404
 import sys
 
+
+def _cmd_profile(args, _profile):
+    """Run the public profiling wrapper."""
+    try:
+        from nsys_ai.profile_command import run_profile_command
+
+        exit_code = run_profile_command(args)
+    except KeyboardInterrupt:
+        print("Profile cancelled.", file=sys.stderr)
+        raise SystemExit(130) from None
+    if exit_code:
+        raise SystemExit(exit_code)
+
 # ---------------------------------------------------------------------------
 # cutracer subcommand
 # ---------------------------------------------------------------------------

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -37,6 +37,7 @@ from .handlers import (
     _cmd_open,
     _cmd_overlap,
     _cmd_perfetto,
+    _cmd_profile,
     _cmd_report,
     _cmd_root_cause,
     _cmd_search,
@@ -64,6 +65,93 @@ def _positive_pct(value: str) -> float:
     if not math.isfinite(pct) or pct <= 0:
         raise argparse.ArgumentTypeError(f"must be a positive percentage, got {value}")
     return pct
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be a positive integer")
+    return parsed
+
+
+def _nonnegative_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 0:
+        raise argparse.ArgumentTypeError("must be a non-negative integer")
+    return parsed
+
+
+class _WorkloadRemainder(argparse.Action):
+    """Require one workload token while preserving every remaining token."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        if not values or values == ["--"]:
+            parser.error("a workload command is required")
+        setattr(namespace, self.dest, values)
+
+
+def _register_profile_parser(sub):
+    p = sub.add_parser("profile", help="Capture and validate a local Nsight Systems profile")
+    p.add_argument("-o", "--output", default=None, help="Fresh artifact directory")
+    p.add_argument("--nsys", default="nsys", help="Nsight Systems executable")
+    p.add_argument(
+        "--env",
+        dest="public_env",
+        action="append",
+        default=[],
+        metavar="NAME=VALUE",
+        help="Persisted public environment override (repeatable)",
+    )
+    p.add_argument(
+        "--secret-env",
+        action="append",
+        default=[],
+        metavar="NAME",
+        help="Secret environment variable name (repeatable)",
+    )
+    p.add_argument(
+        "--env-policy",
+        choices=("inherit", "clean"),
+        default="inherit",
+        help="Workload environment base (default: inherit)",
+    )
+    p.add_argument("--warmup-steps", type=_nonnegative_int, default=0)
+    p.add_argument("--profile-steps", type=_positive_int, default=1)
+    p.add_argument("--seed", type=_nonnegative_int, default=None)
+    p.add_argument("--expected-gpu-count", type=_positive_int, default=None)
+    p.add_argument("--expected-rank-count", type=_positive_int, default=None)
+    p.add_argument("--timeout", type=_positive_int, default=None, metavar="SECONDS")
+    p.add_argument(
+        "--trace",
+        default="auto",
+        metavar="auto|API,API",
+        help="Trace domains (default: auto)",
+    )
+    p.add_argument(
+        "--sample",
+        choices=("none", "process-tree", "system-wide"),
+        default="none",
+    )
+    p.add_argument(
+        "--cpuctxsw",
+        choices=("none", "process-tree", "system-wide"),
+        default="none",
+    )
+    p.add_argument(
+        "--capture-range",
+        choices=("none", "cudaProfilerApi", "nvtx", "hotkey"),
+        default="none",
+    )
+    p.add_argument("--cuda-memory-usage", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    p.add_argument(
+        "workload",
+        nargs=argparse.REMAINDER,
+        action=_WorkloadRemainder,
+        help="Workload command and arguments; wrapper options must precede it",
+    )
+    p.set_defaults(handler=_cmd_profile)
+    return p
 
 
 def _register_info_parser(sub):
@@ -318,10 +406,12 @@ def _build_parser():
         dest="command",
         metavar=(
             "{open,web,timeline-web,loop,chat,ask,agent,agent-guide,"
-            "info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
+            "profile,info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
             "root-cause,help}"
         ),
     )
+
+    _register_profile_parser(sub)
 
     # Public commands (simplified)
     p = sub.add_parser("open", help="Open profile quickly in Perfetto/web/TUI")

--- a/src/nsys_ai/profile_command.py
+++ b/src/nsys_ai/profile_command.py
@@ -1,0 +1,360 @@
+"""Public ``nsys-ai profile`` command orchestration.
+
+This module translates CLI inputs into the versioned :class:`RunSpec` and
+delegates capture lifecycle to :class:`LocalProfileRunner`.  It deliberately
+does not own runner internals or durable session layout.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import shutil
+import subprocess  # nosec B404
+import sys
+from collections.abc import Callable, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, TextIO
+
+from .exceptions import NsysAiError
+from .profile_runner import LocalProfileRunner, RunProgress, RunStatus
+from .runspec import EnvironmentSpec, NsysTraceOptions, RunSpec, RunSpecError
+
+_PROBE_TIMEOUT_SECONDS = 10
+_GIT_TIMEOUT_SECONDS = 3
+_TRACE_HEADER_RE = re.compile(r"^\s*(?:-t,\s*)?--trace=")
+_OPTION_HEADER_RE = re.compile(r"^\s*(?:-[A-Za-z],\s*)?--[A-Za-z0-9-]+(?:=|<)")
+_QUOTED_VALUE_RE = re.compile(r"'([^']+)'")
+
+
+class ProfileCommandError(NsysAiError):
+    """The public profiling command could not build or execute its plan."""
+
+    error_code = "PROFILE_COMMAND_FAILED"
+
+
+def normalize_workload(tokens: Sequence[str]) -> tuple[str, ...]:
+    """Remove one CLI delimiter and apply only the documented Python shorthand."""
+    workload = list(tokens)
+    if workload and workload[0] == "--":
+        workload.pop(0)
+    if not workload:
+        raise ProfileCommandError("a workload command is required")
+    if workload[0].endswith(".py"):
+        workload.insert(0, sys.executable)
+    return tuple(workload)
+
+
+def resolve_nsys_executable(selected: str) -> str:
+    """Resolve the selected Nsight Systems executable exactly once."""
+    if not isinstance(selected, str) or not selected or "\x00" in selected:
+        raise ProfileCommandError("--nsys must name an executable")
+    resolved = shutil.which(selected)
+    if resolved is None:
+        raise ProfileCommandError(f"Nsight Systems executable not found: {selected}")
+    return str(Path(resolved).resolve())
+
+
+def parse_supported_trace_domains(help_text: str) -> tuple[str, ...]:
+    """Parse only the ``-t, --trace=`` option block from nsys help output."""
+    lines = help_text.splitlines()
+    start = next((i for i, line in enumerate(lines) if _TRACE_HEADER_RE.match(line)), None)
+    if start is None:
+        raise ProfileCommandError("nsys trace capability output has no --trace option block")
+
+    block: list[str] = []
+    for line in lines[start + 1 :]:
+        if _OPTION_HEADER_RE.match(line):
+            break
+        block.append(line)
+    block_text = "\n".join(block)
+    if "Possible values are" not in block_text or "Select the API" not in block_text:
+        raise ProfileCommandError("nsys --trace option block has no domain list")
+    possible = block_text.split("Possible values are", 1)[1].split("Select the API", 1)[0]
+    values = tuple(dict.fromkeys(_QUOTED_VALUE_RE.findall(possible)))
+    domains = tuple(value for value in values if value != "none")
+    if not domains or "cuda" not in domains:
+        raise ProfileCommandError(
+            "nsys trace capability output is unparseable or does not advertise CUDA"
+        )
+    return domains
+
+
+def detect_supported_trace_domains(nsys_executable: str) -> tuple[str, ...]:
+    """Run the bounded trace capability probe for one resolved executable."""
+    try:
+        completed = subprocess.run(  # nosec B603
+            [nsys_executable, "profile", "--help=trace"],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ProfileCommandError(
+            f"nsys trace capability probe timed out after {_PROBE_TIMEOUT_SECONDS}s"
+        ) from exc
+    except OSError as exc:
+        raise ProfileCommandError(
+            f"nsys trace capability probe could not start: {type(exc).__name__}"
+        ) from exc
+    if completed.returncode != 0:
+        raise ProfileCommandError(
+            f"nsys trace capability probe failed with exit code {completed.returncode}"
+        )
+    return parse_supported_trace_domains(completed.stdout + "\n" + completed.stderr)
+
+
+def select_trace_domains(
+    requested: str,
+    supported: Sequence[str],
+    *,
+    warning: Callable[[str], None] | None = None,
+) -> tuple[str, ...]:
+    """Resolve ``auto`` or validate an explicit comma-separated trace selection."""
+    supported_set = set(supported)
+    if "cuda" not in supported_set:
+        raise ProfileCommandError("the selected nsys does not advertise CUDA tracing")
+    if requested == "auto":
+        selected = ["cuda"]
+        for optional in ("nvtx", "nccl"):
+            if optional in supported_set:
+                selected.append(optional)
+            elif warning is not None:
+                warning(f"nsys does not support optional {optional} tracing; omitting it")
+        return tuple(selected)
+
+    selected = requested.split(",")
+    if not selected or any(not item for item in selected):
+        raise ProfileCommandError("--trace must be 'auto' or a comma-separated domain list")
+    duplicates = sorted({item for item in selected if selected.count(item) > 1})
+    if duplicates:
+        raise ProfileCommandError("--trace contains duplicate domain(s): " + ", ".join(duplicates))
+    unsupported = [item for item in selected if item not in supported_set]
+    if unsupported:
+        raise ProfileCommandError(
+            "unsupported trace domain(s): " + ", ".join(unsupported)
+        )
+    if "cuda" not in selected:
+        raise ProfileCommandError("--trace must include cuda")
+    return tuple(selected)
+
+
+def parse_environment(
+    public_entries: Sequence[str], secret_names: Sequence[str]
+) -> EnvironmentSpec:
+    """Validate repeatable public and secret environment declarations."""
+    public: dict[str, str] = {}
+    public_indexes: dict[str, int] = {}
+    for index, entry in enumerate(public_entries):
+        field = f"--env entry {index + 1}"
+        if "=" not in entry:
+            raise RunSpecError(f"{field} must use NAME=VALUE")
+        name, value = entry.split("=", 1)
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            raise RunSpecError(f"{field} has an invalid variable name")
+        if "\x00" in value:
+            raise RunSpecError(f"{field} value must not contain NUL bytes")
+        if name in public:
+            raise RunSpecError(
+                f"{field} duplicates --env entry {public_indexes[name] + 1}"
+            )
+        public[name] = value
+        public_indexes[name] = index
+
+    secret_indexes: dict[str, int] = {}
+    for index, name in enumerate(secret_names):
+        field = f"--secret-env entry {index + 1}"
+        if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
+            raise RunSpecError(f"{field} has an invalid variable name")
+        if name in secret_indexes:
+            raise RunSpecError(
+                f"{field} duplicates --secret-env entry {secret_indexes[name] + 1}"
+            )
+        if name in public_indexes:
+            raise RunSpecError(
+                f"{field} overlaps --env entry {public_indexes[name] + 1}"
+            )
+        secret_indexes[name] = index
+    return EnvironmentSpec(public=public, secrets=tuple(secret_names))
+
+
+def discover_git_provenance(cwd: Path) -> tuple[str | None, str | None, str]:
+    """Return repository, commit, and RunSpec cwd with clean non-Git fallback."""
+    absolute_cwd = cwd.resolve()
+    git_executable = shutil.which("git")
+    if git_executable is None:
+        return None, None, str(absolute_cwd)
+    git_executable = str(Path(git_executable).resolve())
+
+    def git(*args: str, working_directory: Path) -> str | None:
+        try:
+            completed = subprocess.run(  # nosec B603
+                [git_executable, *args],
+                cwd=working_directory,
+                capture_output=True,
+                text=True,
+                timeout=_GIT_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if completed.returncode != 0:
+            return None
+        value = completed.stdout.strip()
+        return value or None
+
+    root_text = git("rev-parse", "--show-toplevel", working_directory=absolute_cwd)
+    if root_text is None:
+        return None, None, str(absolute_cwd)
+    root = Path(root_text).resolve()
+    try:
+        relative = absolute_cwd.relative_to(root).as_posix() or "."
+    except ValueError:
+        return None, None, str(absolute_cwd)
+    commit = git("rev-parse", "--verify", "HEAD", working_directory=root)
+    if commit is None or not re.fullmatch(r"[0-9a-fA-F]{40}", commit):
+        return None, None, str(absolute_cwd)
+    return str(root), commit.lower(), relative
+
+
+def default_output_leaf(cwd: Path) -> Path:
+    """Choose a fresh, sortable local artifact leaf without creating it."""
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
+    return cwd / ".nsys-ai" / "profiles" / timestamp
+
+
+def _output_leaf(selected: str | None, cwd: Path) -> Path:
+    output = default_output_leaf(cwd) if selected is None else Path(selected).expanduser()
+    if not output.is_absolute():
+        output = cwd / output
+    output = output.resolve()
+    if output.exists():
+        raise ProfileCommandError(f"output leaf already exists: {output}")
+    return output
+
+
+def _dry_run_payload(
+    *,
+    nsys_executable: str,
+    output: Path,
+    workload: Sequence[str],
+    environment: EnvironmentSpec,
+    trace: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "mode": "dry-run",
+        "nsys_executable": nsys_executable,
+        "output": str(output),
+        "workload_token_count": len(workload),
+        "public_environment_names": sorted(environment.public),
+        "secret_environment": {
+            name: "unresolved" for name in environment.secrets
+        },
+        "environment_policy": environment.policy,
+        "trace": list(trace),
+    }
+
+
+def run_profile_command(
+    args: Any,
+    *,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+    cwd: Path | None = None,
+    runner_factory: Callable[[Path, str], LocalProfileRunner] = LocalProfileRunner,
+) -> int:
+    """Execute the public command and return its documented process exit code."""
+    working_directory = (cwd or Path.cwd()).resolve()
+    workload = normalize_workload(args.workload)
+    environment = parse_environment(args.public_env, args.secret_env)
+    environment = EnvironmentSpec(
+        policy=args.env_policy,
+        public=environment.public,
+        secrets=environment.secrets,
+    )
+    output = _output_leaf(args.output, working_directory)
+    nsys_executable = resolve_nsys_executable(args.nsys)
+    supported = detect_supported_trace_domains(nsys_executable)
+    trace = select_trace_domains(
+        args.trace,
+        supported,
+        warning=lambda message: print(f"Warning: {message}", file=stderr),
+    )
+
+    if args.dry_run:
+        print(
+            json.dumps(
+                _dry_run_payload(
+                    nsys_executable=nsys_executable,
+                    output=output,
+                    workload=workload,
+                    environment=environment,
+                    trace=trace,
+                ),
+                sort_keys=True,
+            ),
+            file=stdout,
+        )
+        return 0
+
+    repository, commit, runspec_cwd = discover_git_provenance(working_directory)
+    spec = RunSpec(
+        argv=workload,
+        cwd=runspec_cwd,
+        repository=repository,
+        commit=commit,
+        environment=environment,
+        warmup_steps=args.warmup_steps,
+        profile_steps=args.profile_steps,
+        seed=args.seed,
+        expected_gpu_count=args.expected_gpu_count,
+        expected_rank_count=args.expected_rank_count,
+        trace_options=NsysTraceOptions(
+            trace=trace,
+            sample=args.sample,
+            cpuctxsw=args.cpuctxsw,
+            capture_range=args.capture_range,
+            cuda_memory_usage=args.cuda_memory_usage,
+        ),
+        timeout_seconds=args.timeout,
+    )
+    runner = runner_factory(output, nsys_executable)
+
+    def progress(update: RunProgress) -> None:
+        print(
+            f"[{update.stage.value}] {update.elapsed_seconds:.1f}s",
+            file=stderr,
+            flush=True,
+        )
+
+    try:
+        result = runner.run(spec, progress_callback=progress)
+    except KeyboardInterrupt:
+        print("Profile cancelled.", file=stderr)
+        return 130
+
+    if result.status is RunStatus.CANCELLED:
+        print("Profile cancelled.", file=stderr)
+        return 130
+    if result.status is not RunStatus.SUCCEEDED:
+        print(f"Profile failed: {result.status.value}", file=stderr)
+        if result.detail:
+            print(result.detail, file=stderr)
+        if result.stdout_path:
+            print(f"stdout: {result.stdout_path}", file=stderr)
+        if result.stderr_path:
+            print(f"stderr: {result.stderr_path}", file=stderr)
+        return 1
+
+    if result.profile is None:
+        raise ProfileCommandError("runner returned success without profile metadata")
+    print(f"Report: {result.report_path}", file=stdout)
+    print(f"SQLite: {result.sqlite_path}", file=stdout)
+    print(f"RunSpec: {result.runspec_path}", file=stdout)
+    print(f"Profile ID: {result.profile.profile_id}", file=stdout)
+    print(f"Export schema: {result.profile.schema_version or 'unknown'}", file=stdout)
+    print(f"Nsight version: {result.profile.product_version or 'unknown'}", file=stdout)
+    print(f"Kernels: {result.profile.kernel_count}", file=stdout)
+    return 0

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -1,0 +1,591 @@
+import argparse
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.profile_command import (
+    ProfileCommandError,
+    discover_git_provenance,
+    normalize_workload,
+    parse_environment,
+    parse_supported_trace_domains,
+    run_profile_command,
+    select_trace_domains,
+)
+from nsys_ai.runspec import RunSpec, RunSpecError
+
+_FAKE_NSYS = r'''#!/usr/bin/env python3
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def value_after(flag):
+    return sys.argv[sys.argv.index(flag) + 1]
+
+
+if sys.argv[1:] == ['profile', '--help=trace']:
+    domains = [item for item in os.environ.get('FAKE_TRACE_DOMAINS', 'cuda,nvtx,nccl').split(',') if item]
+    advertised = ', '.join(repr(item) for item in domains + ['none'])
+    print(f"""usage: nsys profile
+
+    --unrelated=
+       Possible values are 'not-a-domain'.
+
+    -t, --trace=
+       Possible values are {advertised}.
+       Select the API(s) to trace. If '<api>-annotations' is selected, more text follows.
+       Default is 'cuda,nvtx,osrt'.
+
+    --trace-fork-before-exec=
+       Possible values are 'true' or 'false'.
+    """)
+    sys.exit(0)
+
+if sys.argv[1] == 'profile':
+    print(json.dumps(sys.argv), flush=True)
+    if '--fake-fail' in sys.argv:
+        sys.exit(17)
+    output = Path(value_after('-o'))
+    output.with_suffix('.nsys-rep').write_text('valid')
+    sys.exit(0)
+
+if sys.argv[1] == 'export':
+    output = Path(value_after('-o'))
+    with sqlite3.connect(output) as conn:
+        conn.executescript("""
+            CREATE TABLE META_DATA_EXPORT (name TEXT, value TEXT);
+            INSERT INTO META_DATA_EXPORT VALUES
+                ('EXPORT_PRODUCT_VERSION', '2026.2.1.106'),
+                ('EXPORT_SCHEMA_VERSION', '3.25.0');
+            CREATE TABLE TARGET_INFO_GPU (id INTEGER, name TEXT);
+            INSERT INTO TARGET_INFO_GPU VALUES (0, 'Fake GPU');
+            CREATE TABLE StringIds (id INTEGER, value TEXT);
+            INSERT INTO StringIds VALUES (1, 'fake_kernel');
+            CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+                deviceId INTEGER, streamId INTEGER, start INTEGER, end INTEGER,
+                shortName INTEGER, demangledName INTEGER, correlationId INTEGER
+            );
+            INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (0, 7, 10, 20, 1, 1, 1);
+        """)
+    sys.exit(0)
+
+sys.exit(99)
+'''
+
+
+@pytest.fixture
+def fake_nsys(tmp_path):
+    executable = tmp_path / "nsys"
+    executable.write_text(_FAKE_NSYS)
+    executable.chmod(executable.stat().st_mode | stat.S_IXUSR)
+    return executable
+
+
+def _args(fake_nsys, output, **overrides):
+    values = {
+        "workload": ["--", "train.py", "--model=public-model"],
+        "public_env": [],
+        "secret_env": [],
+        "env_policy": "inherit",
+        "output": str(output),
+        "nsys": str(fake_nsys),
+        "trace": "auto",
+        "dry_run": False,
+        "warmup_steps": 0,
+        "profile_steps": 1,
+        "seed": None,
+        "expected_gpu_count": None,
+        "expected_rank_count": None,
+        "sample": "none",
+        "cpuctxsw": "none",
+        "capture_range": "none",
+        "cuda_memory_usage": False,
+        "timeout": None,
+    }
+    values.update(overrides)
+    return argparse.Namespace(**values)
+
+
+def _run_cli(cwd, *argv, env=None):
+    cli_env = dict(os.environ)
+    cli_env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+    if env:
+        cli_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-m", "nsys_ai", *argv],
+        cwd=cwd,
+        env=cli_env,
+        capture_output=True,
+        text=True,
+        timeout=20,
+    )
+
+
+def test_normalize_workload_strips_one_delimiter_and_preserves_tokens():
+    assert normalize_workload(["--", "python", "train.py", "--", "--flag=a b"]) == (
+        "python",
+        "train.py",
+        "--",
+        "--flag=a b",
+    )
+    assert normalize_workload(["train.py", "--lr", "1e-4"]) == (
+        sys.executable,
+        "train.py",
+        "--lr",
+        "1e-4",
+    )
+    assert normalize_workload(["python", "train.py"])[0] == "python"
+    with pytest.raises(ProfileCommandError, match="workload"):
+        normalize_workload(["--"])
+
+
+def test_trace_parser_is_limited_to_trace_option_block():
+    help_text = """
+      --other=
+         Possible values are 'wrong'.
+      -t, --trace=
+         Possible values are 'cuda', 'nvtx', 'nccl' or 'none'.
+         Select the API(s) to trace. '<api>-annotations' is explanatory only.
+         Default is 'cuda,nvtx'.
+      --later=
+         Possible values are 'also-wrong'.
+    """
+    assert parse_supported_trace_domains(help_text) == ("cuda", "nvtx", "nccl")
+
+
+def test_trace_selection_degrades_auto_but_rejects_explicit_unsupported():
+    warnings = []
+    assert select_trace_domains("auto", ("cuda",), warning=warnings.append) == ("cuda",)
+    assert warnings == [
+        "nsys does not support optional nvtx tracing; omitting it",
+        "nsys does not support optional nccl tracing; omitting it",
+    ]
+    with pytest.raises(ProfileCommandError, match="unsupported.*nccl"):
+        select_trace_domains("cuda,nccl", ("cuda", "nvtx"))
+
+
+@pytest.mark.parametrize(
+    "help_text",
+    [
+        "--trace=\nPossible values are 'cuda', 'nvtx'.",
+        "--other=\nPossible values are 'cuda'.",
+    ],
+)
+def test_malformed_trace_help_is_rejected(help_text):
+    with pytest.raises(ProfileCommandError, match="trace|domain"):
+        parse_supported_trace_domains(help_text)
+
+
+def test_trace_help_without_cuda_is_rejected():
+    help_text = """
+      -t, --trace=
+         Possible values are 'nvtx', 'nccl' or 'none'.
+         Select the API(s) to trace.
+      --later=
+    """
+    with pytest.raises(ProfileCommandError, match="does not advertise CUDA"):
+        parse_supported_trace_domains(help_text)
+
+
+@pytest.mark.parametrize(
+    ("public", "secrets", "message"),
+    [
+        (["VISIBLE=one", "VISIBLE=two"], [], "entry 2 duplicates --env entry 1"),
+        (["BAD-NAME=value"], [], "entry 1 has an invalid variable name"),
+        (["TOKEN=public"], ["TOKEN"], "entry 1 overlaps --env entry 1"),
+        (["MISSING_EQUALS"], [], "NAME=VALUE"),
+        ([], ["TOKEN", "TOKEN"], "entry 2 duplicates --secret-env entry 1"),
+        ([], ["BAD-NAME"], "entry 1 has an invalid variable name"),
+    ],
+)
+def test_environment_declaration_errors_are_rejected(public, secrets, message):
+    with pytest.raises(RunSpecError, match=message):
+        parse_environment(public, secrets)
+
+
+def test_git_provenance_records_absolute_root_full_commit_and_relative_cwd(tmp_path):
+    repo = tmp_path / "repo"
+    nested = repo / "training" / "jobs"
+    nested.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    (repo / "tracked.txt").write_text("tracked")
+    subprocess.run(["git", "-C", str(repo), "add", "tracked.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "fixture"], check=True)
+
+    repository, commit, cwd = discover_git_provenance(nested)
+
+    assert repository == str(repo.resolve())
+    assert commit is not None and len(commit) == 40
+    assert cwd == "training/jobs"
+
+
+def test_non_git_provenance_degrades_to_absolute_cwd(tmp_path):
+    repository, commit, cwd = discover_git_provenance(tmp_path)
+    assert repository is None
+    assert commit is None
+    assert cwd == str(tmp_path.resolve())
+
+
+def test_dry_run_is_structurally_redacted_and_does_not_create_output(
+    tmp_path, fake_nsys, monkeypatch
+):
+    monkeypatch.delenv("UNSET_SECRET", raising=False)
+    output = tmp_path / "dry-artifacts"
+    stdout = io.StringIO()
+
+    def forbidden_runner(*_args):
+        raise AssertionError("dry-run must not construct the runner")
+
+    exit_code = run_profile_command(
+        _args(
+            fake_nsys,
+            output,
+            dry_run=True,
+            workload=["--", "train.py", "--token=workload-value"],
+            public_env=["VISIBLE=public-value"],
+            secret_env=["UNSET_SECRET"],
+        ),
+        stdout=stdout,
+        stderr=io.StringIO(),
+        cwd=tmp_path,
+        runner_factory=forbidden_runner,
+    )
+
+    payload = json.loads(stdout.getvalue())
+    assert exit_code == 0
+    assert payload["workload_token_count"] == 3
+    assert payload["public_environment_names"] == ["VISIBLE"]
+    assert payload["secret_environment"] == {"UNSET_SECRET": "unresolved"}
+    assert "workload-value" not in stdout.getvalue()
+    assert "public-value" not in stdout.getvalue()
+    assert not output.exists()
+
+
+def test_fake_nsys_cli_preserves_tokens_python_shorthand_and_artifacts(
+    tmp_path, fake_nsys
+):
+    output = tmp_path / "artifacts"
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        "--warmup-steps",
+        "2",
+        "--profile-steps",
+        "5",
+        "--",
+        "train.py",
+        "--model=x y",
+        "--",
+        "--tail",
+    )
+
+    assert result.returncode == 0, result.stderr
+    capture_argv = json.loads((output / "stdout.log").read_text())
+    workload_start = capture_argv.index(sys.executable)
+    assert capture_argv[workload_start:] == [
+        sys.executable,
+        "train.py",
+        "--model=x y",
+        "--",
+        "--tail",
+    ]
+    spec = RunSpec.from_json_bytes((output / "runspec.json").read_bytes())
+    assert spec.argv == tuple(capture_argv[workload_start:])
+    assert spec.warmup_steps == 2
+    assert spec.profile_steps == 5
+    assert spec.trace_options.trace == ("cuda", "nccl", "nvtx")
+    assert (output / "profile.nsys-rep").is_file()
+    assert (output / "profile.sqlite").is_file()
+    assert "Profile ID:" in result.stdout
+    assert "Kernels: 1" in result.stdout
+
+
+def test_fake_nsys_cli_records_git_provenance_and_environment(tmp_path, fake_nsys):
+    repo = tmp_path / "repo"
+    work = repo / "training"
+    work.mkdir(parents=True)
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    (repo / "tracked.txt").write_text("tracked")
+    subprocess.run(["git", "-C", str(repo), "add", "tracked.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "fixture"], check=True)
+    output = tmp_path / "artifacts"
+
+    result = _run_cli(
+        work,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        "--env",
+        "VISIBLE=a=b",
+        "--secret-env",
+        "CLI_SECRET",
+        "python",
+        "train.py",
+        "--wrapper-looking-token",
+        env={"CLI_SECRET": "secret-value"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    spec = RunSpec.from_json_bytes((output / "runspec.json").read_bytes())
+    assert spec.repository == str(repo.resolve())
+    assert spec.commit is not None and len(spec.commit) == 40
+    assert spec.cwd == "training"
+    assert spec.environment.public == {"VISIBLE": "a=b"}
+    assert spec.environment.secrets == ("CLI_SECRET",)
+    assert spec.argv == ("python", "train.py", "--wrapper-looking-token")
+    assert "secret-value" not in (output / "runspec.json").read_text()
+
+
+def test_auto_trace_omission_warns_and_reaches_persisted_runspec(tmp_path, fake_nsys):
+    output = tmp_path / "artifacts"
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        "--",
+        "train",
+        env={"FAKE_TRACE_DOMAINS": "cuda"},
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "optional nvtx tracing; omitting it" in result.stderr
+    assert "optional nccl tracing; omitting it" in result.stderr
+    spec = RunSpec.from_json_bytes((output / "runspec.json").read_bytes())
+    assert spec.trace_options.trace == ("cuda",)
+
+
+def test_secret_boundary_failure_creates_no_artifacts_and_never_echoes_value(
+    tmp_path, fake_nsys
+):
+    output = tmp_path / "artifacts"
+    secret = "highly-sensitive-value"
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        "--secret-env",
+        "CLI_SECRET",
+        "--",
+        "train",
+        f"--token={secret}",
+        env={"CLI_SECRET": secret},
+    )
+
+    assert result.returncode == 1
+    assert "secret command-line arguments are unsupported" in result.stderr
+    assert secret not in result.stderr
+    assert not output.exists()
+
+
+def test_missing_declared_secret_creates_no_artifacts(
+    tmp_path, fake_nsys, monkeypatch
+):
+    monkeypatch.delenv("DELIBERATELY_UNSET_SECRET", raising=False)
+    output = tmp_path / "artifacts"
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        "--secret-env",
+        "DELIBERATELY_UNSET_SECRET",
+        "--",
+        "train",
+    )
+
+    assert result.returncode == 1
+    assert "declared secret DELIBERATELY_UNSET_SECRET is not set" in result.stderr
+    assert not output.exists()
+
+
+def test_keyboard_interrupt_before_runner_returns_130_without_artifacts(
+    tmp_path, fake_nsys, monkeypatch, capsys
+):
+    import nsys_ai.profile_command as profile_command
+    from nsys_ai.cli.handlers import _cmd_profile
+
+    output = tmp_path / "artifacts"
+
+    def interrupt(_selected):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(profile_command, "resolve_nsys_executable", interrupt)
+    with pytest.raises(SystemExit) as exited:
+        _cmd_profile(_args(fake_nsys, output), None)
+
+    captured = capsys.readouterr()
+    assert exited.value.code == 130
+    assert captured.err == "Profile cancelled.\n"
+    assert "Traceback" not in captured.err
+    assert not output.exists()
+
+
+def test_keyboard_interrupt_during_lazy_import_returns_130_without_traceback(
+    tmp_path, fake_nsys, monkeypatch, capsys
+):
+    import builtins
+
+    from nsys_ai.cli.handlers import _cmd_profile
+
+    output = tmp_path / "artifacts"
+    original_import = builtins.__import__
+
+    def interrupt_profile_command(name, *args, **kwargs):
+        if name == "nsys_ai.profile_command":
+            raise KeyboardInterrupt
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", interrupt_profile_command)
+    with pytest.raises(SystemExit) as exited:
+        _cmd_profile(_args(fake_nsys, output), None)
+
+    captured = capsys.readouterr()
+    assert exited.value.code == 130
+    assert captured.err == "Profile cancelled.\n"
+    assert "Traceback" not in captured.err
+    assert not output.exists()
+
+
+@pytest.mark.parametrize(
+    ("declarations", "secret_name", "expected_location"),
+    [
+        (
+            ["--env", "DO_NOT_PRINT_THIS_SECRET=one", "--env", "DO_NOT_PRINT_THIS_SECRET=two"],
+            "DECLARED_SECRET",
+            "--env entry 2 duplicates --env entry 1",
+        ),
+        (
+            ["--env", "BAD-DO_NOT_PRINT_THIS_SECRET=value"],
+            "DECLARED_SECRET",
+            "--env entry 1 has an invalid variable name",
+        ),
+        (
+            ["--env", "DO_NOT_PRINT_THIS_SECRET=value"],
+            "DO_NOT_PRINT_THIS_SECRET",
+            "--secret-env entry 1 overlaps --env entry 1",
+        ),
+    ],
+)
+def test_environment_declaration_errors_never_echo_secret_values(
+    tmp_path, fake_nsys, declarations, secret_name, expected_location
+):
+    sentinel = "DO_NOT_PRINT_THIS_SECRET"
+    output = tmp_path / "artifacts"
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        *declarations,
+        "--secret-env",
+        secret_name,
+        "--",
+        "train",
+        env={secret_name: sentinel},
+    )
+
+    assert result.returncode == 1
+    assert expected_location in result.stderr
+    assert sentinel not in result.stderr
+    assert sentinel not in result.stdout
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("workload", [(), ("--",)])
+def test_missing_workload_is_argparse_error_with_no_artifacts(
+    tmp_path, fake_nsys, workload
+):
+    output = tmp_path / "artifacts"
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        *workload,
+    )
+
+    assert result.returncode == 2
+    assert "a workload command is required" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert not output.exists()
+
+
+def test_typed_runner_failure_returns_one_not_nsys_code(tmp_path, fake_nsys):
+    output = tmp_path / "artifacts"
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        "--",
+        "train",
+        "--fake-fail",
+    )
+
+    assert result.returncode == 1
+    assert "nsys_failed" in result.stderr
+    assert "exit code 17" not in result.stderr
+    assert (output / "runspec.json").is_file()
+
+
+def test_explicit_unsupported_trace_fails_before_artifacts(tmp_path, fake_nsys):
+    output = tmp_path / "artifacts"
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        "--trace",
+        "cuda,unknown",
+        "--",
+        "train",
+    )
+
+    assert result.returncode == 1
+    assert "unsupported trace domain" in result.stderr
+    assert not output.exists()
+
+
+def test_existing_bare_profile_shortcut_remains_viewer_routed():
+    from nsys_ai.cli.app import _normalize_default_profile_command
+
+    assert _normalize_default_profile_command(["nsys-ai", "profile.sqlite"]) == [
+        "nsys-ai",
+        "timeline-web",
+        "profile.sqlite",
+    ]


### PR DESCRIPTION
Closes #25.

## Summary

- add the public `nsys-ai profile` wrapper over the versioned RunSpec and local runner
- preserve workload argv exactly, with the documented Python-file shorthand
- detect supported Nsight trace domains and degrade optional auto defaults with warnings
- record Git provenance and expose the RunSpec capture, environment, and timeout fields
- keep dry-run structurally redacted and preserve the runner's zero-artifact secret preflight
- report validated profile metadata and stable CLI exit codes

## Validation

- focused RunSpec, runner, and profile CLI tests: 149 passed
- full suite: 1658 passed, 146 skipped, 1 known local coverage-gate failure because `NSYS_TEST_PROFILE` is unset
- Ruff, Bandit, CLI help smoke, and `git diff --check`: passed
- real RTX 3080 CLI capture: 32 kernels; SQLite reopened successfully
- persisted RunSpec canonical round-trip and unchanged LocalProfileRunner resubmission: succeeded with 32 kernels

## Scope

Session placement and loop wiring remain owned by #268 and the roadmap follow-up work.
