### PR TITLE
feat: add deterministic proposal artifact

### DIFF
--- a/src/nsys_ai/proposal.py
+++ b/src/nsys_ai/proposal.py
@@ -1,0 +1,555 @@
+"""Deterministic proposal artifacts derived from evidence findings.
+
+Proposal v0 records a change hypothesis and an exact ``(profile_id,
+finding_id)`` pointer. It never infers source code, patches, or realized gain.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Any
+
+from .annotation import Finding, TraceSelection
+from .exceptions import NsysAiError
+from .runspec import (
+    RunSpec,
+    RunSpecError,
+    validate_persisted_secret_strings,
+    validate_secret_boundaries,
+)
+
+PROPOSAL_SCHEMA_VERSION = "0.1"
+_PROPOSAL_ID_PREFIX = "proposal1:sha256:"
+_BASE_LIMITATIONS = (
+    "Proposal v0 is a change hypothesis, not a source patch.",
+    "The trace does not attribute an exact source file or line.",
+    "Realized performance gain requires reprofiling and diffing.",
+)
+_TRACE_TARGET_FIELDS = {
+    "id",
+    "profile_id",
+    "source",
+    "start_ns",
+    "end_ns",
+    "gpu_ids",
+    "rank_ids",
+    "stream_ids",
+    "nvtx_path",
+    "event_ids",
+    "label",
+}
+
+
+class ProposalError(NsysAiError):
+    """A Proposal payload or construction argument is invalid."""
+
+    error_code = "PROPOSAL_INVALID"
+
+
+class UnsupportedProposalVersionError(ProposalError):
+    """A Proposal artifact uses a schema this installation cannot read."""
+
+    error_code = "PROPOSAL_VERSION_UNSUPPORTED"
+
+
+def _canonical_json_bytes(value: Any, label: str) -> bytes:
+    try:
+        return json.dumps(
+            value,
+            allow_nan=False,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise ProposalError(f"{label} must contain JSON-compatible values") from exc
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return MappingProxyType({key: _freeze_json(item) for key, item in value.items()})
+    if isinstance(value, list):
+        return tuple(_freeze_json(item) for item in value)
+    return value
+
+
+def _thaw_json(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _thaw_json(item) for key, item in value.items()}
+    if isinstance(value, tuple):
+        return [_thaw_json(item) for item in value]
+    return value
+
+
+def _snapshot_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ProposalError(f"{label} must be an object")
+    canonical = _canonical_json_bytes(dict(value), label)
+    return _freeze_json(json.loads(canonical))
+
+
+def _require_string(value: Any, label: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str):
+        raise ProposalError(f"{label} must be a string")
+    if not allow_empty and not value:
+        raise ProposalError(f"{label} must not be empty")
+    if "\x00" in value:
+        raise ProposalError(f"{label} must not contain NUL bytes")
+    return value
+
+
+def _string_tuple(value: Any, label: str) -> tuple[str, ...]:
+    if not isinstance(value, (list, tuple)):
+        raise ProposalError(f"{label} must be an array of strings")
+    return tuple(
+        _require_string(item, f"{label}[{index}]") for index, item in enumerate(value)
+    )
+
+
+def _canonical_id(value: Any, label: str, *, allow_empty: bool = False) -> str:
+    value = _require_string(value, label, allow_empty=allow_empty)
+    if value and any(character.isspace() for character in value):
+        raise ProposalError(f"{label} must not contain whitespace")
+    return value
+
+
+def _trace_target(value: Any) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ProposalError("trace_target must be an object")
+    unknown = sorted(set(value) - _TRACE_TARGET_FIELDS)
+    if unknown:
+        raise ProposalError(f"trace_target has unknown field(s): {', '.join(unknown)}")
+    missing = sorted({"id", "profile_id", "source"} - set(value))
+    if missing:
+        raise ProposalError(f"trace_target is missing field(s): {', '.join(missing)}")
+    try:
+        selection = TraceSelection.from_dict(dict(value))
+        _canonical_id(selection.id, "trace_target.id")
+        _canonical_id(selection.profile_id, "trace_target.profile_id", allow_empty=True)
+        _require_string(selection.source, "trace_target.source")
+        for name in ("start_ns", "end_ns"):
+            number = getattr(selection, name)
+            if number is not None and (
+                isinstance(number, bool) or not isinstance(number, int)
+            ):
+                raise ProposalError(f"trace_target.{name} must be an integer or null")
+        if (
+            selection.start_ns is not None
+            and selection.end_ns is not None
+            and selection.end_ns < selection.start_ns
+        ):
+            raise ProposalError("trace_target.end_ns must not precede start_ns")
+        for name in ("gpu_ids", "rank_ids", "stream_ids"):
+            numbers = getattr(selection, name)
+            if numbers is None:
+                continue
+            if not isinstance(numbers, (list, tuple)):
+                raise ProposalError(f"trace_target.{name} must be an array or null")
+            if any(isinstance(item, bool) or not isinstance(item, int) for item in numbers):
+                raise ProposalError(f"trace_target.{name} must contain only integers")
+        if selection.nvtx_path is not None:
+            _string_tuple(selection.nvtx_path, "trace_target.nvtx_path")
+        if selection.event_ids is not None:
+            _string_tuple(selection.event_ids, "trace_target.event_ids")
+        if selection.label is not None:
+            _require_string(selection.label, "trace_target.label", allow_empty=True)
+    except ProposalError:
+        raise
+    except (AttributeError, TypeError, ValueError) as exc:
+        raise ProposalError(f"trace_target is invalid: {exc}") from exc
+    return _snapshot_mapping(selection.to_dict(), "trace_target")
+
+
+@dataclass(frozen=True)
+class ExpectedImpact:
+    """Measured opportunity copied from a Finding, not a predicted gain."""
+
+    headroom_ms: float
+    headroom_basis: str
+
+    def __post_init__(self) -> None:
+        value = self.headroom_ms
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value < 0
+        ):
+            raise ProposalError("expected_impact.headroom_ms must be finite and non-negative")
+        object.__setattr__(self, "headroom_ms", float(value))
+        _require_string(self.headroom_basis, "expected_impact.headroom_basis")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "kind": "measured_headroom",
+            "headroom_ms": self.headroom_ms,
+            "headroom_basis": self.headroom_basis,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Any) -> ExpectedImpact:
+        if not isinstance(payload, Mapping):
+            raise ProposalError("expected_impact must be an object or null")
+        expected = {"kind", "headroom_ms", "headroom_basis"}
+        if set(payload) != expected:
+            raise ProposalError("expected_impact requires only kind, headroom_ms, headroom_basis")
+        if payload.get("kind") != "measured_headroom":
+            raise ProposalError("expected_impact.kind must be 'measured_headroom'")
+        return cls(payload["headroom_ms"], payload["headroom_basis"])
+
+
+@dataclass(frozen=True)
+class Proposal:
+    """A versioned, round-trippable proposal or explicit abstention."""
+
+    proposal_id: str
+    source_finding_id: str
+    source_profile_id: str
+    summary: str
+    suggested_actions: tuple[str, ...]
+    trace_target: Mapping[str, Any] | None
+    expected_impact: ExpectedImpact | None
+    confidence: float | None
+    verification: RunSpec | None
+    limitations: tuple[str, ...]
+    abstained: bool
+    abstention_reason: str | None
+
+    def __post_init__(self) -> None:
+        _require_string(self.proposal_id, "proposal_id")
+        _canonical_id(self.source_finding_id, "source_finding_id", allow_empty=True)
+        _canonical_id(self.source_profile_id, "source_profile_id", allow_empty=True)
+        _require_string(self.summary, "summary", allow_empty=True)
+        object.__setattr__(
+            self,
+            "suggested_actions",
+            _string_tuple(self.suggested_actions, "suggested_actions"),
+        )
+        if self.trace_target is not None:
+            object.__setattr__(self, "trace_target", _trace_target(self.trace_target))
+            if self.trace_target["profile_id"] != self.source_profile_id:
+                raise ProposalError("trace_target.profile_id must equal source_profile_id")
+        if self.expected_impact is not None and not isinstance(
+            self.expected_impact, ExpectedImpact
+        ):
+            raise ProposalError("expected_impact must be an ExpectedImpact or null")
+        if self.confidence is not None:
+            confidence = self.confidence
+            if (
+                isinstance(confidence, bool)
+                or not isinstance(confidence, (int, float))
+                or not math.isfinite(confidence)
+                or not 0 <= confidence <= 1
+            ):
+                raise ProposalError("confidence must be between 0 and 1 or null")
+            object.__setattr__(self, "confidence", float(confidence))
+        if self.verification is not None and not isinstance(self.verification, RunSpec):
+            raise ProposalError("verification must be a RunSpec or null")
+        object.__setattr__(self, "limitations", _string_tuple(self.limitations, "limitations"))
+        if not isinstance(self.abstained, bool):
+            raise ProposalError("abstained must be a boolean")
+        if self.abstained:
+            _require_string(self.abstention_reason, "abstention_reason")
+        elif self.abstention_reason is not None:
+            raise ProposalError("abstention_reason must be null when abstained is false")
+        if not self.abstained and (
+            not self.source_finding_id
+            or not self.source_profile_id
+            or not self.summary
+            or not self.suggested_actions
+            or self.trace_target is None
+            or self.verification is None
+        ):
+            raise ProposalError("non-abstained Proposal is missing a required proposal input")
+        expected_id = _proposal_id(self._identity_payload())
+        if self.proposal_id != expected_id:
+            raise ProposalError(
+                f"proposal_id does not match artifact content; expected {expected_id}"
+            )
+
+    def _identity_payload(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROPOSAL_SCHEMA_VERSION,
+            "source_finding_id": self.source_finding_id,
+            "source_profile_id": self.source_profile_id,
+            "summary": self.summary,
+            "suggested_actions": list(self.suggested_actions),
+            "trace_target": _thaw_json(self.trace_target),
+            "expected_impact": (
+                self.expected_impact.to_dict() if self.expected_impact is not None else None
+            ),
+            "confidence": self.confidence,
+            "verification": (
+                {"kind": "runspec", "runspec": self.verification.to_dict()}
+                if self.verification is not None
+                else None
+            ),
+            "limitations": list(self.limitations),
+            "abstained": self.abstained,
+            "abstention_reason": self.abstention_reason,
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"proposal_id": self.proposal_id, **self._identity_payload()}
+
+    def canonical_json_bytes(self) -> bytes:
+        return _canonical_json_bytes(self.to_dict(), "Proposal")
+
+    @classmethod
+    def from_dict(cls, payload: Any) -> Proposal:
+        if not isinstance(payload, Mapping):
+            raise ProposalError("Proposal must be an object")
+        allowed = {
+            "schema_version",
+            "proposal_id",
+            "source_finding_id",
+            "source_profile_id",
+            "summary",
+            "suggested_actions",
+            "trace_target",
+            "expected_impact",
+            "confidence",
+            "verification",
+            "limitations",
+            "abstained",
+            "abstention_reason",
+        }
+        unknown = sorted(set(payload) - allowed)
+        if unknown:
+            raise ProposalError(f"Proposal has unknown field(s): {', '.join(unknown)}")
+        missing = sorted(allowed - set(payload))
+        if missing:
+            raise ProposalError(f"Proposal is missing field(s): {', '.join(missing)}")
+        version = payload["schema_version"]
+        if version != PROPOSAL_SCHEMA_VERSION:
+            raise UnsupportedProposalVersionError(
+                f"unsupported Proposal schema_version {version!r}; "
+                f"expected {PROPOSAL_SCHEMA_VERSION!r}"
+            )
+        verification_payload = payload["verification"]
+        verification = None
+        if verification_payload is not None:
+            if not isinstance(verification_payload, Mapping):
+                raise ProposalError("verification must be an object or null")
+            if set(verification_payload) != {"kind", "runspec"}:
+                raise ProposalError("verification requires only kind and runspec")
+            if verification_payload.get("kind") != "runspec":
+                raise ProposalError("verification.kind must be 'runspec'")
+            try:
+                verification = RunSpec.from_dict(verification_payload["runspec"])
+            except RunSpecError as exc:
+                raise ProposalError(f"invalid verification RunSpec: {exc}") from exc
+        impact_payload = payload["expected_impact"]
+        impact = ExpectedImpact.from_dict(impact_payload) if impact_payload is not None else None
+        return cls(
+            proposal_id=payload["proposal_id"],
+            source_finding_id=payload["source_finding_id"],
+            source_profile_id=payload["source_profile_id"],
+            summary=payload["summary"],
+            suggested_actions=payload["suggested_actions"],
+            trace_target=payload["trace_target"],
+            expected_impact=impact,
+            confidence=payload["confidence"],
+            verification=verification,
+            limitations=payload["limitations"],
+            abstained=payload["abstained"],
+            abstention_reason=payload["abstention_reason"],
+        )
+
+    @classmethod
+    def from_json_bytes(cls, payload: bytes | str) -> Proposal:
+        try:
+            data = json.loads(payload)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            raise ProposalError(f"invalid Proposal JSON: {exc}") from exc
+        return cls.from_dict(data)
+
+
+def _proposal_id(payload: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256(_canonical_json_bytes(dict(payload), "Proposal")).hexdigest()
+    return _PROPOSAL_ID_PREFIX + digest
+
+
+def _clean_strings(values: Any, label: str) -> tuple[str, ...]:
+    if values is None:
+        return ()
+    if not isinstance(values, (list, tuple)):
+        raise ProposalError(f"{label} must be an array of strings or null")
+    cleaned: list[str] = []
+    for index, item in enumerate(values):
+        _require_string(item, f"{label}[{index}]", allow_empty=True)
+        if item.strip():
+            cleaned.append(item.strip())
+    return tuple(cleaned)
+
+
+def _derive_fields(finding: Finding, verification: RunSpec | None) -> dict[str, Any]:
+    selection = finding.selection
+    finding_id = "" if finding.id is None else _canonical_id(
+        finding.id, "source finding id", allow_empty=True
+    )
+    profile_id = ""
+    target = None
+    if selection is not None:
+        if not isinstance(selection, TraceSelection):
+            raise ProposalError("source finding selection must be a TraceSelection")
+        _canonical_id(selection.id, "source finding selection.id")
+        profile_id = _canonical_id(
+            selection.profile_id,
+            "source finding selection.profile_id",
+            allow_empty=True,
+        )
+        target = _thaw_json(_trace_target(selection.to_dict()))
+    actions = _clean_strings(finding.suggested_actions, "source finding suggested_actions")
+    if finding.explanation is not None:
+        _require_string(finding.explanation, "source finding explanation", allow_empty=True)
+    _require_string(finding.label, "source finding label", allow_empty=True)
+    summary = (finding.explanation or "").strip() or finding.label.strip()
+    reasons: list[str] = []
+    if not finding_id:
+        reasons.append("source finding has no id")
+    if selection is None:
+        reasons.append("source finding has no trace selection")
+    elif not profile_id:
+        reasons.append("source finding selection has no profile id")
+    if not actions:
+        reasons.append("source finding has no suggested action")
+    if verification is None:
+        reasons.append("verification RunSpec is required")
+    if not summary:
+        reasons.append("source finding has no summary")
+    limitations = [
+        *_BASE_LIMITATIONS,
+        *_clean_strings(
+            finding.false_positive_notes, "source finding false_positive_notes"
+        ),
+    ]
+    if verification is not None:
+        limitations.extend(verification.compatibility_limitations())
+    impact = None
+    if finding.headroom_ms is not None and (
+        isinstance(finding.headroom_ms, bool)
+        or not isinstance(finding.headroom_ms, (int, float))
+        or not math.isfinite(finding.headroom_ms)
+        or finding.headroom_ms < 0
+    ):
+        raise ProposalError("source finding headroom_ms must be finite and non-negative")
+    if finding.headroom_basis is not None:
+        _require_string(
+            finding.headroom_basis,
+            "source finding headroom_basis",
+            allow_empty=True,
+        )
+    if finding.headroom_ms is not None and finding.headroom_basis:
+        impact = ExpectedImpact(finding.headroom_ms, finding.headroom_basis)
+    elif finding.headroom_ms is not None:
+        limitations.append("Source headroom has no basis and was not copied.")
+    return {
+        "source_finding_id": finding_id,
+        "source_profile_id": profile_id,
+        "summary": summary,
+        "suggested_actions": actions,
+        "trace_target": target,
+        "expected_impact": impact,
+        "confidence": _finding_confidence(finding.confidence),
+        "limitations": tuple(limitations),
+        "abstained": bool(reasons),
+        "abstention_reason": "; ".join(reasons) if reasons else None,
+    }
+
+
+def _identity(fields: Mapping[str, Any], verification: RunSpec | None) -> dict[str, Any]:
+    return {
+        "schema_version": PROPOSAL_SCHEMA_VERSION,
+        "source_finding_id": fields["source_finding_id"],
+        "source_profile_id": fields["source_profile_id"],
+        "summary": fields["summary"],
+        "suggested_actions": list(fields["suggested_actions"]),
+        "trace_target": fields["trace_target"],
+        "expected_impact": (
+            fields["expected_impact"].to_dict()
+            if fields["expected_impact"] is not None
+            else None
+        ),
+        "confidence": fields["confidence"],
+        "verification": (
+            {"kind": "runspec", "runspec": verification.to_dict()}
+            if verification is not None
+            else None
+        ),
+        "limitations": list(fields["limitations"]),
+        "abstained": fields["abstained"],
+        "abstention_reason": fields["abstention_reason"],
+    }
+
+
+def _secret_scan_identity(identity: Mapping[str, Any]) -> dict[str, Any]:
+    payload = dict(identity)
+    verification = identity.get("verification")
+    if verification is not None:
+        runspec = dict(verification["runspec"])
+        environment = dict(runspec["environment"])
+        environment["secrets"] = []
+        runspec["environment"] = environment
+        payload["verification"] = {"kind": "runspec", "runspec": runspec}
+    return payload
+
+
+def _finding_confidence(value: Any) -> float | None:
+    if value is None:
+        return None
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+        or not 0 <= value <= 1
+    ):
+        raise ProposalError("source finding confidence must be between 0 and 1 or null")
+    return float(value)
+
+
+def generate_proposal(
+    finding: Finding,
+    verification: RunSpec | None,
+    *,
+    resolved_secrets: Mapping[str, str] | None = None,
+) -> Proposal:
+    """Derive a Proposal without IO or storing the resolved-secret mapping.
+
+    Before ID construction, resolved values are checked against every emitted
+    string key and value except the intentionally persisted declaration names.
+    Non-string measurements are not converted to text for this check.
+    """
+    if not isinstance(finding, Finding):
+        raise ProposalError("finding must be a Finding")
+    if verification is not None and not isinstance(verification, RunSpec):
+        raise ProposalError("verification must be a RunSpec or null")
+    if verification is None and resolved_secrets is not None:
+        raise ProposalError("resolved_secrets requires a verification RunSpec")
+    resolved = {} if resolved_secrets is None else resolved_secrets
+    if verification is not None:
+        validate_secret_boundaries(verification, resolved)
+    fields = _derive_fields(finding, verification)
+    identity = _identity(fields, verification)
+    # Resolved values are never stored. Scan all persisted user-controlled
+    # string keys and values without textualizing numeric measurements.
+    validate_persisted_secret_strings(_secret_scan_identity(identity), resolved)
+    return Proposal(
+        proposal_id=_proposal_id(identity),
+        source_finding_id=fields["source_finding_id"],
+        source_profile_id=fields["source_profile_id"],
+        summary=fields["summary"],
+        suggested_actions=fields["suggested_actions"],
+        trace_target=fields["trace_target"],
+        expected_impact=fields["expected_impact"],
+        confidence=fields["confidence"],
+        verification=verification,
+        limitations=fields["limitations"],
+        abstained=fields["abstained"],
+        abstention_reason=fields["abstention_reason"],
+    )

--- a/src/nsys_ai/runspec.py
+++ b/src/nsys_ai/runspec.py
@@ -504,3 +504,43 @@ def validate_secret_boundaries(
                 raise RunSpecError(
                     f"declared secret {secret_name} appears in {location}{suffix}"
                 )
+
+
+def validate_persisted_secret_strings(
+    payload: Any, resolved_secrets: Mapping[str, str]
+) -> None:
+    """Reject resolved secrets in persisted string keys and string values.
+
+    Diagnostics identify only the validated secret declaration. They never
+    include the secret value or keys from the user-controlled payload.
+    Callers must remove secret-name declaration fields before invoking this
+    scanner because declaration names are intentionally persistable. Numeric,
+    boolean, and null measurements are not converted to text: a secret such as
+    ``"1"`` does not make an unrelated integer measurement unsafe.
+    """
+    values = _require_mapping(resolved_secrets, "resolved_secrets")
+    for name in values:
+        EnvironmentSpec._validate_name(name)
+
+    def strings(value: Any):
+        if isinstance(value, Mapping):
+            for key, nested in value.items():
+                if not isinstance(key, str):
+                    raise RunSpecError("persisted payload mapping keys must be strings")
+                yield key
+                yield from strings(nested)
+        elif isinstance(value, (list, tuple)):
+            for nested in value:
+                yield from strings(nested)
+        elif isinstance(value, str):
+            yield value
+
+    persisted = tuple(strings(payload))
+    for secret_name in sorted(values):
+        secret_value = values[secret_name]
+        if not isinstance(secret_value, str):
+            raise RunSpecError(f"resolved secret {secret_name} must be a string")
+        if secret_value and any(secret_value in value for value in persisted):
+            raise RunSpecError(
+                f"declared secret {secret_name} appears in a persisted string"
+            )

--- a/tests/test_proposal.py
+++ b/tests/test_proposal.py
@@ -1,0 +1,376 @@
+import json
+
+import pytest
+
+from nsys_ai.annotation import Finding, TraceSelection
+from nsys_ai.profile_runner import LocalProfileRunner
+from nsys_ai.proposal import (
+    PROPOSAL_SCHEMA_VERSION,
+    Proposal,
+    ProposalError,
+    UnsupportedProposalVersionError,
+    generate_proposal,
+)
+from nsys_ai.runspec import EnvironmentSpec, RunSpec, RunSpecError
+
+
+def _finding(**overrides):
+    values = {
+        "type": "region",
+        "label": "Exposed communication",
+        "start_ns": 100,
+        "end_ns": 200,
+        "id": "overlap-exposed-0",
+        "confidence": 0.84,
+        "explanation": "Communication is exposed in the backward pass.",
+        "suggested_actions": ["Test moving the all-reduce earlier."],
+        "false_positive_notes": ["Confirm the workload is representative."],
+        "headroom_ms": 12.5,
+        "headroom_basis": "capture_total",
+        "selection": TraceSelection(
+            id="selection-0",
+            profile_id="nsys1:sha256:profile",
+            source="skill:overlap_breakdown",
+            start_ns=100,
+            end_ns=200,
+            gpu_ids=[0],
+            nvtx_path=["iteration", "backward"],
+        ),
+        "provenance": {"skill": "overlap_breakdown", "row": 0},
+    }
+    values.update(overrides)
+    return Finding(**values)
+
+
+def _runspec():
+    return RunSpec(
+        argv=("python", "train.py", "--steps", "4"),
+        repository="/work/training",
+        cwd="jobs",
+        environment=EnvironmentSpec(policy="clean", public={"MODE": "profile"}),
+        profile_steps=4,
+        seed=7,
+    )
+
+
+def test_proposal_round_trip_is_deterministic_and_projected():
+    finding = _finding()
+    spec = _runspec()
+
+    first = generate_proposal(finding, spec)
+    second = generate_proposal(finding, spec)
+    canonical = first.canonical_json_bytes()
+
+    assert not first.abstained
+    assert first.proposal_id == second.proposal_id
+    assert canonical == second.canonical_json_bytes()
+    assert Proposal.from_dict(first.to_dict()) == first
+    assert Proposal.from_json_bytes(canonical) == first
+
+    payload = json.loads(canonical)
+    assert payload["schema_version"] == PROPOSAL_SCHEMA_VERSION
+    assert payload["source_finding_id"] == finding.id
+    assert payload["source_profile_id"] == finding.selection.profile_id
+    assert "source_finding" not in payload
+    assert payload["trace_target"] == finding.selection.to_dict()
+    assert payload["trace_target"]["nvtx_path"] == ["iteration", "backward"]
+    assert payload["summary"] == finding.explanation
+    assert payload["suggested_actions"] == finding.suggested_actions
+    assert payload["expected_impact"] == {
+        "kind": "measured_headroom",
+        "headroom_ms": 12.5,
+        "headroom_basis": "capture_total",
+    }
+    assert payload["confidence"] == finding.confidence
+    assert payload["verification"] == {"kind": "runspec", "runspec": spec.to_dict()}
+    assert "source file" in " ".join(payload["limitations"])
+    assert "gain" in " ".join(payload["limitations"])
+    assert "file" not in payload["trace_target"]
+    assert "line" not in payload["trace_target"]
+    assert "patch" not in payload
+
+
+def test_generated_proposal_copies_projected_mutable_inputs():
+    finding = _finding()
+    proposal = generate_proposal(finding, _runspec())
+    before = proposal.canonical_json_bytes()
+
+    finding.suggested_actions.append("A later mutation")
+    finding.selection.nvtx_path.append("later")
+    finding.provenance["row"] = 99
+
+    assert proposal.canonical_json_bytes() == before
+    with pytest.raises(TypeError):
+        proposal.trace_target["label"] = "changed"
+
+
+@pytest.mark.parametrize(
+    ("finding", "spec", "reason"),
+    [
+        (_finding(id=None), _runspec(), "no id"),
+        (_finding(selection=None), _runspec(), "no trace selection"),
+        (
+            _finding(
+                selection=TraceSelection(id="selection-0", profile_id="", source="skill:x")
+            ),
+            _runspec(),
+            "no profile id",
+        ),
+        (_finding(suggested_actions=[]), _runspec(), "no suggested action"),
+        (_finding(), None, "verification RunSpec is required"),
+    ],
+)
+def test_missing_required_input_produces_round_trippable_abstention(finding, spec, reason):
+    proposal = generate_proposal(finding, spec)
+
+    assert proposal.abstained
+    assert reason in proposal.abstention_reason
+    assert Proposal.from_json_bytes(proposal.canonical_json_bytes()) == proposal
+
+
+def test_missing_selection_abstention_keeps_exact_finding_pointer():
+    finding = _finding(selection=None)
+    proposal = generate_proposal(finding, _runspec())
+    payload = proposal.to_dict()
+
+    assert payload["source_finding_id"] == finding.id
+    assert payload["source_profile_id"] == ""
+    assert payload["trace_target"] is None
+
+
+def test_unquantified_impact_and_confidence_stay_null():
+    proposal = generate_proposal(
+        _finding(headroom_ms=None, headroom_basis=None, confidence=None),
+        _runspec(),
+    )
+
+    assert not proposal.abstained
+    assert proposal.expected_impact is None
+    assert proposal.confidence is None
+    assert proposal.to_dict()["expected_impact"] is None
+    assert proposal.to_dict()["confidence"] is None
+
+
+def test_runspec_comparability_limitations_are_preserved():
+    spec = RunSpec(
+        argv=("python", "train.py"),
+        environment=EnvironmentSpec(policy="inherit", secrets=("TOKEN",)),
+    )
+    proposal = generate_proposal(
+        _finding(), spec, resolved_secrets={"TOKEN": "not-persisted"}
+    )
+
+    assert "inherited_environment_unresolved" in proposal.limitations
+    assert "secret_environment_values_unresolved" in proposal.limitations
+
+
+def test_changed_artifact_content_is_rejected_by_proposal_id():
+    payload = generate_proposal(_finding(), _runspec()).to_dict()
+    payload["proposal_id"] = "proposal1:sha256:" + "0" * 64
+
+    with pytest.raises(ProposalError, match="proposal_id does not match"):
+        Proposal.from_dict(payload)
+
+
+def test_unsupported_version_and_unknown_fields_are_rejected():
+    payload = generate_proposal(_finding(), _runspec()).to_dict()
+    payload["schema_version"] = "9.0"
+    with pytest.raises(UnsupportedProposalVersionError, match="9.0.*expected '0.1'"):
+        Proposal.from_dict(payload)
+
+    payload = generate_proposal(_finding(), _runspec()).to_dict()
+    payload["source_patch"] = "not allowed"
+    with pytest.raises(ProposalError, match="unknown field.*source_patch"):
+        Proposal.from_dict(payload)
+
+
+def test_invalid_finding_and_verification_types_are_rejected():
+    with pytest.raises(ProposalError, match="finding must be"):
+        generate_proposal({}, _runspec())
+    with pytest.raises(ProposalError, match="verification must be"):
+        generate_proposal(_finding(), "python train.py")
+
+
+@pytest.mark.parametrize("missing", ["expected_impact", "confidence"])
+def test_writer_fields_are_required_on_read(missing):
+    payload = generate_proposal(_finding(), _runspec()).to_dict()
+    del payload[missing]
+
+    with pytest.raises(ProposalError, match=f"missing field.*{missing}"):
+        Proposal.from_dict(payload)
+
+
+def test_runner_rejected_secret_cannot_be_persisted_in_proposal(tmp_path, monkeypatch):
+    secret = "sentinel-secret-value"
+    monkeypatch.setenv("RUNNER_SECRET", secret)
+    spec = RunSpec(
+        argv=("python", "train.py", f"--token={secret}"),
+        environment=EnvironmentSpec(secrets=("RUNNER_SECRET",)),
+    )
+
+    with pytest.raises(RunSpecError) as runner_error:
+        LocalProfileRunner(tmp_path / "runner-artifacts").run(spec)
+    with pytest.raises(RunSpecError) as proposal_error:
+        generate_proposal(
+            _finding(), spec, resolved_secrets={"RUNNER_SECRET": secret}
+        )
+
+    assert str(proposal_error.value) == str(runner_error.value)
+    assert secret not in str(proposal_error.value)
+    assert not (tmp_path / "runner-artifacts").exists()
+
+
+def test_resolved_secret_mapping_is_preflight_only():
+    secret = "sentinel-secret-value"
+    spec = RunSpec(
+        argv=("python", "train.py"),
+        environment=EnvironmentSpec(secrets=("RUNNER_SECRET",)),
+    )
+
+    payload = generate_proposal(
+        _finding(), spec, resolved_secrets={"RUNNER_SECRET": secret}
+    ).to_dict()
+
+    environment = payload["verification"]["runspec"]["environment"]
+    assert environment == {
+        "policy": "inherit",
+        "public": {},
+        "secrets": ["RUNNER_SECRET"],
+    }
+    assert "resolved_secrets" not in payload
+
+
+def test_secret_in_projected_finding_text_is_rejected_without_echo():
+    secret = "sentinel-secret-value"
+    spec = RunSpec(
+        argv=("python", "train.py"),
+        environment=EnvironmentSpec(secrets=("RUNNER_SECRET",)),
+    )
+
+    with pytest.raises(RunSpecError) as exc_info:
+        generate_proposal(
+            _finding(explanation=f"Do not persist {secret}"),
+            spec,
+            resolved_secrets={"RUNNER_SECRET": secret},
+        )
+
+    assert "persisted string" in str(exc_info.value)
+    assert secret not in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "provenance",
+    [
+        {"sentinel-secret-value": "safe"},
+        {"safe": "sentinel-secret-value"},
+    ],
+)
+def test_non_projected_provenance_is_not_persisted(provenance):
+    secret = "sentinel-secret-value"
+    spec = RunSpec(
+        argv=("python", "train.py"),
+        environment=EnvironmentSpec(secrets=("RUNNER_SECRET",)),
+    )
+
+    proposal = generate_proposal(
+        _finding(provenance=provenance),
+        spec,
+        resolved_secrets={"RUNNER_SECRET": secret},
+    )
+    baseline = generate_proposal(
+        _finding(provenance={}),
+        spec,
+        resolved_secrets={"RUNNER_SECRET": secret},
+    )
+
+    assert proposal.canonical_json_bytes() == baseline.canonical_json_bytes()
+    assert "provenance" not in proposal.to_dict()
+
+
+@pytest.mark.parametrize("invalid", [[], (), ""])
+def test_falsey_non_mapping_resolved_secrets_are_rejected(invalid):
+    with pytest.raises(RunSpecError, match="resolved_secrets must be an object"):
+        generate_proposal(_finding(), _runspec(), resolved_secrets=invalid)
+
+
+def test_non_finite_finding_number_is_not_serialized():
+    with pytest.raises(ProposalError, match="confidence must be between"):
+        generate_proposal(_finding(confidence=float("nan")), _runspec())
+
+
+def test_malformed_nested_trace_target_error_is_wrapped():
+    payload = generate_proposal(_finding(), _runspec()).to_dict()
+    payload["trace_target"] = "not-an-object"
+
+    with pytest.raises(ProposalError, match="trace_target must be an object"):
+        Proposal.from_dict(payload)
+
+
+@pytest.mark.parametrize("field", ["suggested_actions", "false_positive_notes"])
+def test_string_container_finding_fields_reject_scalar_strings(field):
+    with pytest.raises(ProposalError, match=f"source finding {field} must be an array"):
+        generate_proposal(_finding(**{field: "abc"}), _runspec())
+
+
+def test_suggested_actions_reject_non_string_members():
+    with pytest.raises(ProposalError, match=r"suggested_actions\[1\] must be a string"):
+        generate_proposal(
+            _finding(suggested_actions=["valid", 7]),
+            _runspec(),
+        )
+
+
+def test_malformed_trace_selection_shape_is_rejected():
+    selection = TraceSelection(
+        id="selection-0",
+        profile_id="nsys1:sha256:profile",
+        source="skill:test",
+        nvtx_path="iteration",
+    )
+
+    with pytest.raises(ProposalError, match="nvtx_path must be an array"):
+        generate_proposal(_finding(selection=selection), _runspec())
+
+
+@pytest.mark.parametrize(
+    ("finding_id", "profile_id", "message"),
+    [
+        (" finding-0", "nsys1:sha256:profile", "source finding id"),
+        ("finding-0", "nsys1:sha256: profile", "selection.profile_id"),
+    ],
+)
+def test_provenance_ids_with_whitespace_are_rejected(finding_id, profile_id, message):
+    selection = TraceSelection(id="selection-0", profile_id=profile_id, source="skill:test")
+
+    with pytest.raises(ProposalError, match=message):
+        generate_proposal(_finding(id=finding_id, selection=selection), _runspec())
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"type": 7},
+        {"start_ns": "later"},
+        {"end_ns": False},
+        {"provenance": []},
+    ],
+)
+def test_non_projected_finding_fields_do_not_expand_proposal_schema(overrides):
+    baseline = generate_proposal(_finding(), _runspec()).canonical_json_bytes()
+
+    assert generate_proposal(
+        _finding(**overrides), _runspec()
+    ).canonical_json_bytes() == baseline
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"confidence": -1}, "confidence must be between"),
+        ({"headroom_basis": 7}, "headroom_basis must be a string"),
+        ({"explanation": 7}, "explanation must be a string"),
+    ],
+)
+def test_malformed_projected_finding_fields_are_rejected(overrides, message):
+    with pytest.raises(ProposalError, match=message):
+        generate_proposal(_finding(**overrides), _runspec())

--- a/tests/test_runspec.py
+++ b/tests/test_runspec.py
@@ -9,6 +9,7 @@ from nsys_ai.runspec import (
     RunSpecError,
     UnsupportedRunSpecVersionError,
     build_nsys_profile_argv,
+    validate_persisted_secret_strings,
     validate_secret_boundaries,
 )
 
@@ -291,6 +292,33 @@ def test_secret_preflight_checks_public_mapping_keys_without_echoing_them():
     message = str(exc_info.value)
     assert secret_value not in message
     assert public_name not in message
+
+
+def test_persisted_secret_string_scanner_never_echoes_payload_keys():
+    secret_value = "private-key-fragment"
+    user_key = f"prefix-{secret_value}-suffix"
+
+    with pytest.raises(RunSpecError) as exc_info:
+        validate_persisted_secret_strings(
+            {user_key: "safe"}, {"HF_TOKEN": secret_value}
+        )
+
+    message = str(exc_info.value)
+    assert "HF_TOKEN" in message
+    assert secret_value not in message
+    assert user_key not in message
+
+
+def test_persisted_secret_string_scanner_ignores_numeric_coincidence():
+    validate_persisted_secret_strings(
+        {"count": 1, "enabled": True, "missing": None},
+        {"HF_TOKEN": "1"},
+    )
+
+
+def test_persisted_secret_string_scanner_rejects_non_string_keys():
+    with pytest.raises(RunSpecError, match="mapping keys must be strings"):
+        validate_persisted_secret_strings({1: "safe"}, {"HF_TOKEN": "private"})
 
 
 def test_public_value_error_does_not_echo_its_user_controlled_key():


### PR DESCRIPTION
Part of #352.

## Summary

- add a versioned, deterministic Proposal v0 artifact derived from one Finding and verification RunSpec
- point provenance to the exact `(source_profile_id, source_finding_id)` in the canonical findings artifact
- copy only evidence-backed summary, actions, trace target, measured headroom, confidence, and limitations
- emit explicit abstention when the finding lacks an ID, trace selection, action, summary, profile provenance, or verification RunSpec
- reject declared secret values from every persisted Proposal string key/value before computing the proposal ID
- keep resolved secret values outside the Proposal object, identity, and serialized artifact

## Validation

- focused Proposal, RunSpec, annotation, and profile-runner tests: 193 passed
- full suite: 1687 passed, 146 skipped, 1 known local coverage-gate failure because `NSYS_TEST_PROFILE` is unset
- Ruff, Bandit, and `git diff --check`: passed
- four adversarial review rounds completed; final verdict: APPROVE

## Scope

This PR owns only the Proposal model and pure generator. Session persistence remains in #268, and CLI/Web/TUI integration remains open in #352. No LLM, source patch, file/line attribution, working-tree mutation, or predicted realized gain is added.
