### PR TITLE
feat: complete default analysis skill pack

### DIFF
--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -179,6 +179,7 @@ class Agent:
         12. kernel_overlap_matrix
         13. iteration_timing
         14. nvtx_layer_breakdown
+        15. nccl_compile_context_breakdown
 
         Returns:
             Formatted multi-section report with optional AI synthesis.
@@ -205,6 +206,7 @@ class Agent:
             "kernel_overlap_matrix",
             "iteration_timing",
             "nvtx_layer_breakdown",
+            "nccl_compile_context_breakdown",
         ]
 
         for skill_name in core_skills:

--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -87,6 +87,7 @@ class EvidenceBuilder:
         "h2d_spikes": ("h2d_distribution", {}),
         "kernel_launch_overhead": ("kernel_launch_overhead", {}),
         "nccl_breakdown": ("nccl_breakdown", {}),
+        "nccl_compile_context_breakdown": ("nccl_compile_context_breakdown", {}),
         # Profile-level bound class. Contributes the verdict only and reports
         # no headroom by design (the reasoning lives in
         # critical_path._to_findings). It therefore ranks below every
@@ -105,8 +106,7 @@ class EvidenceBuilder:
 
         Args:
             only: If provided, run only the named analyzers.
-                  Valid names: slow_iterations, idle_gaps, nccl_stalls,
-                  kernel_hotspots, overlap_ratio, memory_anomalies, h2d_spikes.
+                  Valid names are the keys in :attr:`_SKILL_PIPELINE`.
                   If None, run all analyzers.
         """
         from .fingerprint import get_profile_id

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -542,10 +542,9 @@ class Skill:
                 _log.debug("No profiler overhead data found (table absent or empty)")
             resolved["overhead_ns"] = overhead_ns
 
-        # Memoize per connection. One EvidenceBuilder.build() executes 29 skills
-        # for 14 distinct names, because the health manifest and root-cause
-        # matcher re-run skills the pipeline already ran. Eight of those are
-        # exact repeats.
+        # Memoize per connection. One EvidenceBuilder.build() reaches skills
+        # both directly and through the health manifest / root-cause matcher,
+        # which re-run some analyses already requested by the pipeline.
         #
         # The key includes the resolved parameters, not just the name. The
         # repeats are mostly NOT identical — gpu_idle_gaps is called at limit=1

--- a/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_compile_context_breakdown.py
@@ -10,6 +10,8 @@ fix path:
   - temporal_only     → leaf NVTX uninformative; reach for
                         ``nccl_payload_breakdown`` / ``overlap_breakdown``
 
+Exact ties are reported as mixed and do not select a bucket-specific fix path.
+
 Classifies by **leaf** label, not ancestor-path containment. See
 ``nvtx_kernel_map``'s module docstring for why (temporal vs lexical
 containment).
@@ -19,6 +21,29 @@ from ..base import Skill, requires_pushpop_nvtx
 
 _INDUCTOR_LEAF_MARKERS = ("## Call CompiledFxGraph",)
 _EAGER_LEAF_PREFIXES = ("c10d::", "nccl")
+_BUCKET_ORDER = ("eager", "inductor_captured", "temporal_only")
+_LIMITATIONS = [
+    "Classification covers only NCCL kernels attributed to a Push/Pop NVTX leaf; "
+    "NCCL kernels without an attributable leaf are excluded.",
+    "Classification aggregates attributable NCCL kernels across all captured devices; "
+    "the EvidenceBuilder device selection is not applied by this skill.",
+    "temporal_only means the leaf label did not identify eager or compiled context; "
+    "it does not prove that torch.compile was absent.",
+    "Call mode identifies where to investigate, not overlap quality or recoverable time.",
+]
+_ACTIONS_BY_BUCKET = {
+    "eager": [
+        "For eager NCCL calls, use async_op=True and a dedicated CUDA stream to enable overlap."
+    ],
+    "inductor_captured": [
+        "For inductor-captured NCCL calls, use functional collectives and evaluate "
+        "torch._inductor.config.reorder_for_compute_comm_overlap."
+    ],
+    "temporal_only": [
+        "For temporal-only attribution, run nccl_payload_breakdown and overlap_breakdown "
+        "to identify the collective and exposed communication."
+    ],
+}
 
 
 def _classify_leaf(leaf: str) -> str:
@@ -45,7 +70,6 @@ def _execute(conn, **kwargs):
     if guard:
         return guard
 
-
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")
     trim = (
@@ -63,13 +87,13 @@ def _execute(conn, **kwargs):
     )
 
     buckets: dict[str, dict[str, int]] = {
-        "eager": {"count": 0, "ns": 0},
-        "inductor_captured": {"count": 0, "ns": 0},
-        "temporal_only": {"count": 0, "ns": 0},
+        name: {"count": 0, "ns": 0} for name in _BUCKET_ORDER
     }
+    nccl_rows = []
     for r in rows:
         if not _is_nccl_kernel(r.get("kernel_name", "")):
             continue
+        nccl_rows.append(r)
         bucket = _classify_leaf(r.get("nvtx_text", "") or "")
         buckets[bucket]["count"] += 1
         buckets[bucket]["ns"] += int(r.get("k_dur_ns") or 0)
@@ -84,18 +108,157 @@ def _execute(conn, **kwargs):
         {
             "_summary": True,
             "total_nccl_kernels": total_count,
+            "total_nccl_ns": total_ns,
             "total_nccl_ms": round(total_ns / 1e6, 3),
+            "span_start_ns": min(int(r["k_start"]) for r in nccl_rows),
+            "span_end_ns": max(int(r["k_end"]) for r in nccl_rows),
+            "device_scope": "all_captured_devices",
         },
         *[
             {
                 "bucket": name,
                 "count": b["count"],
+                "ns": b["ns"],
                 "ms": round(b["ns"] / 1e6, 3),
                 "pct": round(b["count"] / total_count * 100, 1),
                 "ms_pct": round(b["ns"] / total_ns * 100, 1) if total_ns > 0 else 0.0,
             }
             for name, b in buckets.items()
         ],
+    ]
+
+
+def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
+    from nsys_ai.annotation import EvidenceRow, Finding, TraceSelection
+
+    if not rows or "error" in rows[0]:
+        return []
+
+    summary = rows[0]
+    buckets = {r.get("bucket"): r for r in rows[1:] if r.get("bucket") in _BUCKET_ORDER}
+    if not buckets or not summary.get("total_nccl_kernels"):
+        return []
+
+    total_ns = sum(int(buckets.get(name, {}).get("ns") or 0) for name in _BUCKET_ORDER)
+    dominant_basis = "duration" if total_ns > 0 else "count"
+    dominant_key = "ns" if dominant_basis == "duration" else "count"
+    max_value = max(int(buckets.get(name, {}).get(dominant_key) or 0) for name in _BUCKET_ORDER)
+    dominant_buckets = [
+        name
+        for name in _BUCKET_ORDER
+        if int(buckets.get(name, {}).get(dominant_key) or 0) == max_value
+    ]
+    dominant = dominant_buckets[0] if len(dominant_buckets) == 1 else "mixed"
+    start_ns = int(summary.get("span_start_ns") or 0)
+    end_ns = int(summary.get("span_end_ns") or start_ns)
+    finding_id = f"nccl_compile_context_{start_ns}"
+    profile_id = (context or {}).get("profile_id", "unknown")
+    selection = TraceSelection(
+        id=f"sel_{finding_id}",
+        profile_id=profile_id,
+        source="skill:nccl_compile_context_breakdown",
+        start_ns=start_ns,
+        end_ns=end_ns,
+        label="NCCL kernels classified by leaf NVTX call mode across all captured devices",
+    )
+
+    values = {
+        "total_nccl_kernels": int(summary["total_nccl_kernels"]),
+        "total_nccl_ns": total_ns,
+        "total_nccl_ms": float(summary.get("total_nccl_ms") or 0.0),
+        "dominant_bucket": dominant,
+        "dominant_buckets": dominant_buckets,
+        "dominant_basis": dominant_basis,
+        "device_scope": "all_captured_devices",
+    }
+    units = {
+        "total_nccl_kernels": "count",
+        "total_nccl_ns": "ns",
+        "total_nccl_ms": "ms",
+    }
+    for name in _BUCKET_ORDER:
+        bucket = buckets.get(name, {})
+        values.update(
+            {
+                f"{name}_count": int(bucket.get("count") or 0),
+                f"{name}_ns": int(bucket.get("ns") or 0),
+                f"{name}_ms": float(bucket.get("ms") or 0.0),
+                f"{name}_count_pct": float(bucket.get("pct") or 0.0),
+                f"{name}_ms_pct": float(bucket.get("ms_pct") or 0.0),
+            }
+        )
+        units.update(
+            {
+                f"{name}_count": "count",
+                f"{name}_ns": "ns",
+                f"{name}_ms": "ms",
+                f"{name}_count_pct": "percent",
+                f"{name}_ms_pct": "percent",
+            }
+        )
+
+    evidence_row = EvidenceRow(
+        id=f"ev_{finding_id}",
+        source_skill="nccl_compile_context_breakdown",
+        values=values,
+        units=units,
+        selection_id=selection.id,
+        provenance={
+            "row_kind": "call_mode_classification",
+            "classification_basis": "leaf_pushpop_nvtx",
+            "dominant_basis": dominant_basis,
+            "dominant_buckets": dominant_buckets,
+            "device_scope": "all_captured_devices",
+            "limitations": list(_LIMITATIONS),
+        },
+    )
+    bucket_summary = ", ".join(
+        f"{name}={values[f'{name}_count']} ({values[f'{name}_count_pct']:.1f}% of kernels, "
+        f"{values[f'{name}_ms_pct']:.1f}% of time)"
+        for name in _BUCKET_ORDER
+    )
+    if dominant == "mixed":
+        tied = ", ".join(dominant_buckets)
+        dominance_explanation = f"The {dominant_basis} signal is tied across {tied}."
+        suggested_actions = [
+            f"{dominant_basis.capitalize()} is tied across {tied}; investigate those call-mode "
+            "buckets separately with overlap_breakdown before selecting a fix path."
+        ]
+    else:
+        dominance_explanation = (
+            f"The dominant bucket by exact {dominant_basis} is {dominant}."
+        )
+        suggested_actions = list(_ACTIONS_BY_BUCKET[dominant])
+    return [
+        Finding(
+            type="region",
+            label=f"NCCL Call Mode (dominant: {dominant})",
+            start_ns=start_ns,
+            end_ns=end_ns,
+            severity="info",
+            note=bucket_summary,
+            id=finding_id,
+            category="communication",
+            evidence=[evidence_row],
+            selection=selection,
+            explanation=(
+                "Leaf Push/Pop NVTX labels classify the observed NCCL calls across all "
+                "captured devices as eager, inductor-captured, or temporally attributed "
+                f"only. {dominance_explanation}"
+            ),
+            suggested_actions=suggested_actions,
+            false_positive_notes=list(_LIMITATIONS),
+            provenance={
+                "skill": "nccl_compile_context_breakdown",
+                "row_kind": "call_mode_classification",
+                "classification_basis": "leaf_pushpop_nvtx",
+                "dominant_basis": dominant_basis,
+                "dominant_buckets": dominant_buckets,
+                "device_scope": "all_captured_devices",
+            },
+            headroom_ms=None,
+            headroom_basis=None,
+        )
     ]
 
 
@@ -106,6 +269,7 @@ def _format(rows):
     lines = [
         "── NCCL Call-Mode Breakdown (by leaf NVTX) ──",
         f"  Total NCCL kernels: {s['total_nccl_kernels']:,}  ({s['total_nccl_ms']:.3f} ms)",
+        "  Scope: all captured devices",
         "",
         f"  {'bucket':<20}  {'count':>8}  {'ms':>12}  {'count_pct':>10}  {'ms_pct':>10}",
         "  " + "─" * 66,
@@ -129,5 +293,6 @@ SKILL = Skill(
     category="communication",
     execute_fn=_execute,
     format_fn=_format,
+    to_findings_fn=_to_findings,
     tags=["nccl", "communication", "distributed", "torch-compile", "nvtx"],
 )

--- a/tests/test_evidence_build.py
+++ b/tests/test_evidence_build.py
@@ -1,5 +1,7 @@
 """Tests for evidence build CLI and EvidenceBuilder.only parameter."""
 
+from collections import Counter
+
 from nsys_ai.evidence_builder import EvidenceBuilder
 
 
@@ -65,3 +67,11 @@ class TestEvidenceBuilderOnly:
         for name, (skill_name, params) in EvidenceBuilder._SKILL_PIPELINE.items():
             skill = get_skill(skill_name)
             assert skill is not None, f"Missing skill {skill_name} for analyzer '{name}'"
+
+    def test_default_pipeline_includes_launch_and_compile_context_once(self):
+        skill_counts = Counter(
+            skill_name for skill_name, _params in EvidenceBuilder._SKILL_PIPELINE.values()
+        )
+
+        assert skill_counts["kernel_launch_overhead"] == 1
+        assert skill_counts["nccl_compile_context_breakdown"] == 1

--- a/tests/test_nccl_compile_context_breakdown.py
+++ b/tests/test_nccl_compile_context_breakdown.py
@@ -6,6 +6,7 @@ into eager / inductor_captured / temporal_only buckets — the lesson from
 """
 
 import sqlite3
+from types import SimpleNamespace
 
 import pytest
 
@@ -92,6 +93,35 @@ def three_bucket_conn():
     conn.close()
 
 
+def _classification_rows(bucket_ns):
+    bucket_order = ("eager", "inductor_captured", "temporal_only")
+    counts = {name: int(bucket_ns.get(name, 0) > 0) for name in bucket_order}
+    total_count = sum(counts.values())
+    total_ns = sum(bucket_ns.values())
+    return [
+        {
+            "_summary": True,
+            "total_nccl_kernels": total_count,
+            "total_nccl_ns": total_ns,
+            "total_nccl_ms": round(total_ns / 1e6, 3),
+            "span_start_ns": 10,
+            "span_end_ns": 20,
+            "device_scope": "all_captured_devices",
+        },
+        *[
+            {
+                "bucket": name,
+                "count": counts[name],
+                "ns": bucket_ns.get(name, 0),
+                "ms": round(bucket_ns.get(name, 0) / 1e6, 3),
+                "pct": round(counts[name] / total_count * 100, 1),
+                "ms_pct": round(bucket_ns.get(name, 0) / total_ns * 100, 1),
+            }
+            for name in bucket_order
+        ],
+    ]
+
+
 # ---------------------------------------------------------------------------
 # Unit tests on the classification helpers (no DB needed)
 # ---------------------------------------------------------------------------
@@ -156,6 +186,9 @@ def test_skill_classifies_three_buckets(three_bucket_conn):
     assert buckets["eager"]["count"] == 1
     assert buckets["inductor_captured"]["count"] == 1
     assert buckets["temporal_only"]["count"] == 1
+    assert buckets["eager"]["ns"] == 1_000_000
+    assert buckets["inductor_captured"]["ns"] == 4_000_000
+    assert buckets["temporal_only"]["ns"] == 10_000_000
 
     # Durations come from the seeded kernel spans.
     assert buckets["eager"]["ms"] == 1.0           # 6_000_000 → 7_000_000
@@ -165,6 +198,132 @@ def test_skill_classifies_three_buckets(three_bucket_conn):
     # Percentages sum to ~100 (count-pct and ms-pct independently).
     assert sum(b["pct"] for b in buckets.values()) == pytest.approx(100.0, abs=0.3)
     assert sum(b["ms_pct"] for b in buckets.values()) == pytest.approx(100.0, abs=0.3)
+
+
+def test_evidence_builder_reports_the_observed_classification(three_bucket_conn):
+    from nsys_ai.evidence_builder import EvidenceBuilder
+
+    class ProfileStub:
+        path = "three-bucket.sqlite"
+        conn = three_bucket_conn
+        meta = SimpleNamespace(time_range=(0, 100_000_000))
+
+        def query_conn(self):
+            return self.conn
+
+    report = EvidenceBuilder(ProfileStub()).build(only=["nccl_compile_context_breakdown"])
+
+    assert len(report.findings) == 1
+    finding = report.findings[0]
+    assert finding.category == "communication"
+    assert finding.label == "NCCL Call Mode (dominant: temporal_only)"
+    assert finding.start_ns == 6_000_000
+    assert finding.end_ns == 60_000_000
+    assert finding.headroom_ms is None
+    assert finding.selection is not None
+    assert finding.selection.profile_id == report.profile_id
+    assert finding.selection.source == "skill:nccl_compile_context_breakdown"
+    assert finding.selection.gpu_ids is None
+    assert "all captured devices" in finding.selection.label
+    assert finding.suggested_actions == [
+        "For temporal-only attribution, run nccl_payload_breakdown and overlap_breakdown "
+        "to identify the collective and exposed communication."
+    ]
+    assert any("device selection is not applied" in note for note in finding.false_positive_notes)
+    assert finding.provenance["device_scope"] == "all_captured_devices"
+
+    assert finding.evidence is not None
+    evidence = finding.evidence[0]
+    assert evidence.source_skill == "nccl_compile_context_breakdown"
+    assert evidence.values["eager_count"] == 1
+    assert evidence.values["eager_ns"] == 1_000_000
+    assert evidence.values["inductor_captured_count"] == 1
+    assert evidence.values["inductor_captured_ns"] == 4_000_000
+    assert evidence.values["temporal_only_count"] == 1
+    assert evidence.values["temporal_only_ns"] == 10_000_000
+    assert evidence.values["temporal_only_ms_pct"] == pytest.approx(66.7)
+    assert evidence.values["dominant_basis"] == "duration"
+    assert evidence.values["device_scope"] == "all_captured_devices"
+    assert evidence.provenance["classification_basis"] == "leaf_pushpop_nvtx"
+    assert evidence.provenance["device_scope"] == "all_captured_devices"
+    assert evidence.provenance["limitations"]
+
+
+@pytest.mark.parametrize(
+    ("dominant", "action_fragment"),
+    [
+        ("eager", "async_op=True"),
+        ("inductor_captured", "functional collectives"),
+        ("temporal_only", "nccl_payload_breakdown and overlap_breakdown"),
+    ],
+)
+def test_finding_action_follows_dominant_bucket(dominant, action_fragment):
+    from nsys_ai.skills.registry import get_skill
+
+    rows = _classification_rows({dominant: 1_000_000})
+
+    finding = get_skill("nccl_compile_context_breakdown").to_findings_fn(rows)[0]
+
+    assert finding.suggested_actions is not None
+    assert action_fragment in finding.suggested_actions[0]
+
+
+def test_finding_uses_exact_ns_when_display_ms_tie():
+    from nsys_ai.skills.registry import get_skill
+
+    rows = _classification_rows({"eager": 1_000_400, "inductor_captured": 1_000_499})
+    assert rows[1]["ms"] == rows[2]["ms"] == 1.0
+
+    finding = get_skill("nccl_compile_context_breakdown").to_findings_fn(rows)[0]
+
+    assert finding.label == "NCCL Call Mode (dominant: inductor_captured)"
+    assert finding.evidence[0].values["dominant_bucket"] == "inductor_captured"
+    assert finding.evidence[0].values["eager_ns"] == 1_000_400
+    assert finding.evidence[0].values["inductor_captured_ns"] == 1_000_499
+    assert "functional collectives" in finding.suggested_actions[0]
+
+
+def test_finding_discloses_exact_tie_without_prescribing_one_bucket():
+    from nsys_ai.skills.registry import get_skill
+
+    rows = _classification_rows({"eager": 1_000_499, "inductor_captured": 1_000_499})
+    finding = get_skill("nccl_compile_context_breakdown").to_findings_fn(rows)[0]
+    evidence = finding.evidence[0]
+
+    assert finding.label == "NCCL Call Mode (dominant: mixed)"
+    assert evidence.values["dominant_bucket"] == "mixed"
+    assert evidence.values["dominant_buckets"] == ["eager", "inductor_captured"]
+    assert "tied across eager, inductor_captured" in finding.explanation
+    assert "tied across eager, inductor_captured" in finding.suggested_actions[0]
+    assert "async_op=True" not in finding.suggested_actions[0]
+    assert "functional collectives" not in finding.suggested_actions[0]
+
+
+def test_agent_analyze_renders_the_observed_classification(three_bucket_conn, monkeypatch):
+    from nsys_ai.agent import loop as agent_loop
+    from nsys_ai.skills.registry import get_skill
+
+    classifier = get_skill("nccl_compile_context_breakdown")
+    monkeypatch.setattr(
+        agent_loop,
+        "get_skill",
+        lambda name: classifier if name == "nccl_compile_context_breakdown" else None,
+    )
+
+    agent = agent_loop.Agent.__new__(agent_loop.Agent)
+    agent.profile = SimpleNamespace(query_conn=lambda: three_bucket_conn)
+    agent._fallback_conn = None
+    agent._trim_kwargs = {}
+    agent._try_llm_synthesis = lambda *args, **kwargs: None
+
+    report = agent.analyze()
+
+    assert report.count("NCCL Call-Mode Breakdown (by leaf NVTX)") == 1
+    assert "eager" in report
+    assert "inductor_captured" in report
+    assert "temporal_only" in report
+    assert "Total NCCL kernels: 3" in report
+    assert "Scope: all captured devices" in report
 
 
 def test_skill_no_nccl_kernels_returns_error():

--- a/tests/test_skill_memo.py
+++ b/tests/test_skill_memo.py
@@ -1,8 +1,8 @@
 """Skill results are memoized per connection, keyed on the resolved parameters.
 
-One `EvidenceBuilder.build()` executed 29 skills for 14 distinct names, because
-the health manifest and the root-cause matcher re-run skills the pipeline has
-already run. Eight of those were exact repeats.
+An `EvidenceBuilder.build()` reaches skills both directly and through the
+health manifest and root-cause matcher, which re-run some skills the pipeline
+has already requested. Exact repeats should reuse the first result.
 
 The parameters are the reason this needs care rather than a dictionary keyed on
 the skill name. Most of the repeats are *not* identical — `gpu_idle_gaps` is
@@ -222,9 +222,9 @@ def test_the_build_executes_fewer_skills_without_changing_findings(profile):
     # the skill does not declare and does not read (`communicator_data` is
     # forwarded through `root_cause_matcher`), so three of the remaining
     # executions are semantically identical calls the memo fails to absorb.
-    # kernel_launch_overhead is now independently enrolled in the evidence
-    # pipeline, adding one distinct execution rather than a duplicate. Narrowing
-    # the key to declared parameters would take this to 19; that is a separate
-    # change with its own correctness surface.
+    # Both independently enrolled default-pack skills add one distinct execution
+    # rather than a duplicate. Narrowing the key to declared parameters would
+    # take this to 20; that is a separate change with its own correctness surface.
     assert counts["kernel_launch_overhead"] == 1
-    assert total <= 22, f"{total} skill executions — duplicates came back: {dict(counts)}"
+    assert counts["nccl_compile_context_breakdown"] == 1
+    assert total <= 23, f"{total} skill executions — duplicates came back: {dict(counts)}"


### PR DESCRIPTION
## Summary

- Add `nccl_compile_context_breakdown` to the default EvidenceBuilder pipeline and Agent analysis pack exactly once.
- Convert classifier output into grounded communication Findings with exact-nanosecond dominance, explicit mixed ties, capture-wide device scope, limitations, and bucket-specific verification actions.
- Keep memoized execution observable across the Agent and EvidenceBuilder surfaces and correct stale analyzer documentation.

Closes #181.

## Validation

- Focused suite: 221 passed
- Independent final review: 29 focused tests passed; Ruff and diff check passed
- Standard full suite: 1747 passed, 146 skipped; the only failure is the predeclared local `No test profile` skip-reason check when `NSYS_TEST_PROFILE` is unset
- Real 27 MB profile suite: 1750 passed, 140 skipped; four fixed integration timeouts (`analyze` x2, `export`, `export-csv`)
- Same cold real-profile analyze comparison: current main 85.36 s / 336 MB; this branch 81.27 s / 330 MB
- Real-profile classifier repeat: byte-identical explicit abstention because the capture contains no NCCL kernels
- Bandit, Ruff, CLI smoke, and `git diff --check`: passed

The real-profile timeout is not introduced by this change: current main already takes 85.36 seconds for the integration command's 30-second analyze budget, and the export paths are outside this diff.
