### PR TITLE
feat: add durable local session store

### DIFF
--- a/src/nsys_ai/annotation.py
+++ b/src/nsys_ai/annotation.py
@@ -24,6 +24,8 @@ tools can detect format compatibility.
 """
 
 import json
+import math
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field, fields
 from functools import cache
 from importlib.metadata import PackageNotFoundError
@@ -422,6 +424,249 @@ class DiffLineage:
     def from_dict(cls, d: dict) -> "DiffLineage":
         valid_keys = {f.name for f in cls.__dataclass_fields__.values()}
         return cls(**{k: v for k, v in d.items() if k in valid_keys})
+
+
+_FINDING_FIELDS = {item.name for item in fields(Finding)}
+_FINDING_REQUIRED_FIELDS = {"type", "label", "start_ns", "color", "severity", "note"}
+_SELECTION_FIELDS = {item.name for item in fields(TraceSelection)}
+_SELECTION_REQUIRED_FIELDS = {"id", "profile_id", "source"}
+_EVIDENCE_ROW_FIELDS = {item.name for item in fields(EvidenceRow)}
+_EVIDENCE_ROW_REQUIRED_FIELDS = {"id", "source_skill", "values", "units", "provenance"}
+_DIFF_LINEAGE_FIELDS = {item.name for item in fields(DiffLineage)}
+_REPORT_FIELDS = {
+    "schema_version",
+    "producer",
+    "producer_version",
+    "title",
+    "profile_id",
+    "profile_path",
+    "findings",
+    "skipped",
+}
+
+
+def _artifact_object(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    if any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{label} keys must be strings")
+    return value
+
+
+def _artifact_exact_keys(
+    value: Mapping[str, Any], allowed: set[str], required: set[str], label: str
+) -> None:
+    actual = set(value)
+    missing = required - actual
+    unknown = actual - allowed
+    if missing or unknown:
+        raise ValueError(
+            f"{label} fields do not match schema; "
+            f"missing={sorted(missing)}, unknown={sorted(unknown)}"
+        )
+
+
+def _artifact_string(value: Any, label: str, *, allow_empty: bool = False) -> str:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        qualifier = "a string" if allow_empty else "a non-empty string"
+        raise ValueError(f"{label} must be {qualifier}")
+    return value
+
+
+def _artifact_int(value: Any, label: str, *, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{label} must be an integer")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{label} must be at least {minimum}")
+    return value
+
+
+def _artifact_number(
+    value: Any,
+    label: str,
+    *,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+    ):
+        raise ValueError(f"{label} must be a finite number")
+    number = float(value)
+    if minimum is not None and number < minimum:
+        raise ValueError(f"{label} must be at least {minimum}")
+    if maximum is not None and number > maximum:
+        raise ValueError(f"{label} must be at most {maximum}")
+    return number
+
+
+def _artifact_string_list(value: Any, label: str) -> None:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ValueError(f"{label} must be an array of strings")
+
+
+def validate_trace_selection_payload(
+    payload: Any, *, label: str = "selection"
+) -> TraceSelection:
+    value = _artifact_object(payload, label)
+    _artifact_exact_keys(value, _SELECTION_FIELDS, _SELECTION_REQUIRED_FIELDS, label)
+    _artifact_string(value["id"], f"{label}.id")
+    _artifact_string(value["profile_id"], f"{label}.profile_id", allow_empty=True)
+    _artifact_string(value["source"], f"{label}.source")
+    for field_name in ("start_ns", "end_ns"):
+        if field_name in value:
+            _artifact_int(value[field_name], f"{label}.{field_name}", minimum=0)
+    if (
+        "start_ns" in value
+        and "end_ns" in value
+        and value["end_ns"] < value["start_ns"]
+    ):
+        raise ValueError(f"{label}.end_ns must not precede start_ns")
+    for field_name in ("gpu_ids", "rank_ids", "stream_ids"):
+        if field_name not in value:
+            continue
+        numbers = value[field_name]
+        if not isinstance(numbers, list):
+            raise ValueError(f"{label}.{field_name} must be an array")
+        for index, item in enumerate(numbers):
+            _artifact_int(item, f"{label}.{field_name}[{index}]", minimum=0)
+    for field_name in ("nvtx_path", "event_ids"):
+        if field_name in value:
+            _artifact_string_list(value[field_name], f"{label}.{field_name}")
+    if "label" in value:
+        _artifact_string(value["label"], f"{label}.label", allow_empty=True)
+    return TraceSelection.from_dict(dict(value))
+
+
+def validate_evidence_row_payload(
+    payload: Any, *, label: str = "evidence row"
+) -> EvidenceRow:
+    value = _artifact_object(payload, label)
+    _artifact_exact_keys(
+        value, _EVIDENCE_ROW_FIELDS, _EVIDENCE_ROW_REQUIRED_FIELDS, label
+    )
+    _artifact_string(value["id"], f"{label}.id")
+    _artifact_string(value["source_skill"], f"{label}.source_skill")
+    for field_name in ("values", "units", "provenance"):
+        _artifact_object(value[field_name], f"{label}.{field_name}")
+    if any(
+        not isinstance(key, str) or not isinstance(unit, str)
+        for key, unit in value["units"].items()
+    ):
+        raise ValueError(f"{label}.units must map strings to strings")
+    if "selection_id" in value:
+        _artifact_string(value["selection_id"], f"{label}.selection_id")
+    return EvidenceRow.from_dict(dict(value))
+
+
+def validate_finding_payload(payload: Any, *, label: str = "finding") -> Finding:
+    value = _artifact_object(payload, label)
+    _artifact_exact_keys(value, _FINDING_FIELDS, _FINDING_REQUIRED_FIELDS, label)
+    if value["type"] not in {"highlight", "region", "marker"}:
+        raise ValueError(f"{label}.type must be highlight, region, or marker")
+    _artifact_string(value["label"], f"{label}.label", allow_empty=True)
+    _artifact_int(value["start_ns"], f"{label}.start_ns", minimum=0)
+    if "end_ns" in value:
+        _artifact_int(value["end_ns"], f"{label}.end_ns", minimum=0)
+        if value["end_ns"] < value["start_ns"]:
+            raise ValueError(f"{label}.end_ns must not precede start_ns")
+    for field_name in ("stream", "color", "note"):
+        if field_name in value:
+            _artifact_string(value[field_name], f"{label}.{field_name}", allow_empty=True)
+    if "gpu_id" in value:
+        _artifact_int(value["gpu_id"], f"{label}.gpu_id", minimum=0)
+    if value["severity"] not in {"critical", "warning", "info"}:
+        raise ValueError(f"{label}.severity is invalid")
+    if "id" in value:
+        _artifact_string(value["id"], f"{label}.id", allow_empty=True)
+    if "category" in value and value["category"] not in {
+        "compute",
+        "communication",
+        "launch_overhead",
+        "idle",
+        "memory",
+        "sync",
+        "nvtx",
+        "profile_quality",
+        "kernel_internal",
+        "framework",
+    }:
+        raise ValueError(f"{label}.category is invalid")
+    if "confidence" in value:
+        _artifact_number(value["confidence"], f"{label}.confidence", minimum=0, maximum=1)
+    if "evidence" in value:
+        rows = value["evidence"]
+        if not isinstance(rows, list):
+            raise ValueError(f"{label}.evidence must be an array")
+        for index, row in enumerate(rows):
+            validate_evidence_row_payload(row, label=f"{label}.evidence[{index}]")
+    if "selection" in value:
+        validate_trace_selection_payload(value["selection"], label=f"{label}.selection")
+    for field_name in ("explanation", "headroom_basis"):
+        if field_name in value:
+            _artifact_string(value[field_name], f"{label}.{field_name}", allow_empty=True)
+    for field_name in ("suggested_actions", "false_positive_notes"):
+        if field_name in value:
+            _artifact_string_list(value[field_name], f"{label}.{field_name}")
+    if "provenance" in value:
+        _artifact_object(value["provenance"], f"{label}.provenance")
+    if "diff_lineage" in value:
+        lineage = _artifact_object(value["diff_lineage"], f"{label}.diff_lineage")
+        _artifact_exact_keys(
+            lineage,
+            _DIFF_LINEAGE_FIELDS,
+            _DIFF_LINEAGE_FIELDS,
+            f"{label}.diff_lineage",
+        )
+        for field_name in ("diff_id", "baseline_profile_id"):
+            _artifact_string(
+                lineage[field_name], f"{label}.diff_lineage.{field_name}"
+            )
+        if lineage["role"] not in {"regression", "improvement", "stable"}:
+            raise ValueError(f"{label}.diff_lineage.role is invalid")
+        _artifact_int(lineage["rank"], f"{label}.diff_lineage.rank", minimum=0)
+    if "headroom_ms" in value:
+        _artifact_number(value["headroom_ms"], f"{label}.headroom_ms", minimum=0)
+    return Finding.from_dict(dict(value))
+
+
+def validate_evidence_report_payload(payload: Any) -> EvidenceReport:
+    """Validate and rehydrate the current evidence artifact contract."""
+    value = _artifact_object(payload, "evidence report")
+    _artifact_exact_keys(value, _REPORT_FIELDS, _REPORT_FIELDS, "evidence report")
+    if value["schema_version"] != SCHEMA_VERSION:
+        raise ValueError(f"evidence report schema_version must be {SCHEMA_VERSION!r}")
+    if value["producer"] != PRODUCER:
+        raise ValueError(f"evidence report producer must be {PRODUCER!r}")
+    _artifact_string(value["producer_version"], "evidence report.producer_version")
+    for field_name in ("title", "profile_id", "profile_path"):
+        _artifact_string(
+            value[field_name], f"evidence report.{field_name}", allow_empty=True
+        )
+    findings = value["findings"]
+    if not isinstance(findings, list):
+        raise ValueError("evidence report.findings must be an array")
+    for index, finding in enumerate(findings):
+        validate_finding_payload(finding, label=f"findings[{index}]")
+    skipped = value["skipped"]
+    if not isinstance(skipped, list):
+        raise ValueError("evidence report.skipped must be an array")
+    for index, item in enumerate(skipped):
+        entry = _artifact_object(item, f"skipped[{index}]")
+        _artifact_exact_keys(
+            entry, {"analyzer", "skill", "reason"}, {"analyzer", "skill", "reason"}, f"skipped[{index}]"
+        )
+        for field_name in ("analyzer", "skill", "reason"):
+            _artifact_string(entry[field_name], f"skipped[{index}].{field_name}")
+
+    report = EvidenceReport.from_dict(dict(value))
+    regenerated = report.to_dict()
+    regenerated["producer_version"] = value["producer_version"]
+    if regenerated != dict(value):
+        raise ValueError("evidence report changes when rehydrated")
+    return report
 
 
 @dataclass

--- a/src/nsys_ai/artifact_io.py
+++ b/src/nsys_ai/artifact_io.py
@@ -1,0 +1,56 @@
+"""Crash-safe publication helpers for local JSON artifacts."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+def atomic_write_bytes(
+    path: str | os.PathLike[str], payload: bytes, *, mode: int = 0o600
+) -> Path:
+    """Publish bytes with flush/fsync followed by an atomic same-directory replace."""
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = -1
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, destination)
+        fsync_directory(destination.parent)
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+    return destination
+
+
+def atomic_write_json(path: str | os.PathLike[str], payload: Any) -> Path:
+    """Publish deterministic, human-readable JSON without exposing a torn file."""
+    encoded = (
+        json.dumps(payload, allow_nan=False, indent=2, sort_keys=True) + "\n"
+    ).encode("utf-8")
+    return atomic_write_bytes(path, encoded)
+
+
+def fsync_directory(path: Path) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    descriptor = os.open(path, flags)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)

--- a/src/nsys_ai/diff_decision.py
+++ b/src/nsys_ai/diff_decision.py
@@ -5,12 +5,12 @@ diff_decision.py - Persist auditable user decisions for profile diffs.
 from __future__ import annotations
 
 import copy
-import json
 import os
 import subprocess  # nosec B404
 from datetime import datetime, timezone
 from pathlib import Path
 
+from .artifact_io import atomic_write_json
 from .diff import MIN_COMPARABILITY_CONFIDENCE, ProfileDiffSummary
 from .diff_render import to_diff_dict
 
@@ -33,7 +33,11 @@ def resolve_decider_identity(cwd: str | os.PathLike[str] | None = None) -> str:
         if email:
             return email
 
-    return os.environ.get("USER") or os.environ.get("USERNAME") or "unknown"
+    for name in ("USER", "USERNAME"):
+        identity = os.environ.get(name, "").strip()
+        if identity:
+            return identity
+    return "unknown"
 
 
 def _utc_now_iso() -> str:
@@ -63,6 +67,13 @@ def build_diff_decision_record_from_diff_dict(
     if not normalized_reason:
         raise ValueError("--reason is required with --accept/--reject")
 
+    resolved_decider = decider if decider is not None else resolve_decider_identity()
+    if not isinstance(resolved_decider, str) or not resolved_decider.strip():
+        raise ValueError("decider must be a non-empty string when provided")
+    resolved_decided_at = decided_at if decided_at is not None else _utc_now_iso()
+    if not isinstance(resolved_decided_at, str) or not resolved_decided_at.strip():
+        raise ValueError("decided_at must be a non-empty string when provided")
+
     before_id = (diff_dict.get("before") or {}).get("profile_id")
     after_id = (diff_dict.get("after") or {}).get("profile_id")
     if not before_id or not after_id:
@@ -88,8 +99,8 @@ def build_diff_decision_record_from_diff_dict(
     payload["decision"] = {
         "status": normalized_decision,
         "reason": normalized_reason,
-        "decider": decider or resolve_decider_identity(),
-        "decided_at": decided_at or _utc_now_iso(),
+        "decider": resolved_decider,
+        "decided_at": resolved_decided_at,
     }
     return payload, advisory_warnings
 
@@ -113,14 +124,16 @@ def build_diff_decision_record(
 
 
 def _write_decision_payload(payload: dict, path: str | os.PathLike[str]) -> Path:
-    """Serialize a decision payload deterministically and write it to ``path``."""
-    out_path = Path(path)
-    if out_path.parent != Path("."):
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
-    with open(out_path, "w", encoding="utf-8", newline="\n") as f:
-        f.write(text)
-    return out_path
+    """Serialize a decision payload deterministically and publish it atomically."""
+    return atomic_write_json(path, payload)
+
+
+def write_diff_json_from_diff_dict(
+    diff_dict: dict, *, path: str | os.PathLike[str] = "diff.json"
+) -> tuple[Path, dict]:
+    """Publish a canonical diff payload without changing its shape."""
+    payload = copy.deepcopy(diff_dict)
+    return _write_decision_payload(payload, path), payload
 
 
 def write_diff_decision_json(

--- a/src/nsys_ai/proposal.py
+++ b/src/nsys_ai/proposal.py
@@ -539,7 +539,7 @@ def generate_proposal(
     # Resolved values are never stored. Scan all persisted user-controlled
     # string keys and values without textualizing numeric measurements.
     validate_persisted_secret_strings(_secret_scan_identity(identity), resolved)
-    return Proposal(
+    proposal = Proposal(
         proposal_id=_proposal_id(identity),
         source_finding_id=fields["source_finding_id"],
         source_profile_id=fields["source_profile_id"],
@@ -553,3 +553,26 @@ def generate_proposal(
         abstained=fields["abstained"],
         abstention_reason=fields["abstention_reason"],
     )
+    validate_proposal_against_finding(proposal, finding)
+    return proposal
+
+
+def validate_proposal_against_finding(
+    proposal: Proposal, finding: Finding
+) -> None:
+    """Require ``proposal`` to equal the deterministic projection of ``finding``.
+
+    The Proposal's own verification RunSpec is the verification input. This
+    semantic check does not resolve secrets or persist any additional data.
+    """
+    if not isinstance(proposal, Proposal):
+        raise ProposalError("proposal must be a Proposal")
+    if not isinstance(finding, Finding):
+        raise ProposalError("finding must be a Finding")
+    fields = _derive_fields(finding, proposal.verification)
+    identity = _identity(fields, proposal.verification)
+    expected = {"proposal_id": _proposal_id(identity), **identity}
+    if proposal.to_dict() != expected:
+        raise ProposalError(
+            "Proposal is not deterministically derived from the identified Finding"
+        )

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -1,0 +1,1654 @@
+"""Versioned local storage for the diagnose-to-verdict session loop.
+
+The store owns persistence only. Expensive diagnose, profile, and diff work is
+performed by callers before entering one of the short publication methods.
+Each JSON file is published untorn. A durable rollback journal protects the
+artifact-plus-manifest boundary: a restart after either file was replaced
+restores the prior coherent snapshot before returning it. This is recovery,
+not a claim that the operating system replaces multiple files atomically. A
+completed commit or rollback first renames the active journal to an inactive
+tombstone; deleting tombstones is best-effort and never gates snapshot loading.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import tempfile
+import uuid
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any, BinaryIO, Literal
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - nsys-ai profiling is supported on Linux
+    fcntl = None  # type: ignore[assignment]
+
+from .annotation import (
+    PRODUCER,
+    EvidenceReport,
+    validate_evidence_report_payload,
+    validate_trace_selection_payload,
+)
+from .annotation import (
+    SCHEMA_VERSION as EVIDENCE_SCHEMA_VERSION,
+)
+from .artifact_io import atomic_write_bytes, atomic_write_json, fsync_directory
+from .diff_decision import (
+    build_diff_decision_record_from_diff_dict,
+    write_diff_json_from_diff_dict,
+)
+from .exceptions import NsysAiError
+from .profile_runner import LocalProfileReference
+from .proposal import (
+    PROPOSAL_SCHEMA_VERSION,
+    Proposal,
+    ProposalError,
+    UnsupportedProposalVersionError,
+    validate_proposal_against_finding,
+)
+from .runspec import (
+    RUNSPEC_SCHEMA_VERSION,
+    RunSpec,
+    RunSpecError,
+    validate_secret_boundaries,
+)
+
+SESSION_SCHEMA_VERSION = "0.1"
+DIFF_SCHEMA_VERSION = EVIDENCE_SCHEMA_VERSION
+
+SessionPhase = Literal["diagnose", "propose", "reprofile", "diff", "accept"]
+_PHASES = frozenset({"diagnose", "propose", "reprofile", "diff", "accept"})
+_SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_ARTIFACT_PATHS = {
+    "runspec": "runspec.json",
+    "findings": "findings.json",
+    "proposal": "proposal.json",
+    "diff": "diff.json",
+}
+_TRANSACTION_DIR = ".transaction"
+_TRANSACTION_STAGING_PREFIX = ".transaction.stage."
+_TRANSACTION_CLEANUP_PREFIX = ".transaction.cleanup."
+_DIFF_FIELDS = {
+    "schema_version",
+    "decision",
+    "producer",
+    "producer_version",
+    "diff_id",
+    "verdict",
+    "comparability_confidence",
+    "step_time",
+    "category_attribution",
+    "communication_summary",
+    "idle_summary",
+    "before",
+    "after",
+    "warnings",
+    "top_regressions",
+    "top_improvements",
+    "nvtx_regressions",
+    "nvtx_improvements",
+    "overlap",
+}
+_DIFF_SIDE_FIELDS = {
+    "path",
+    "profile_id",
+    "gpu",
+    "schema_version",
+    "product_version",
+    "total_gpu_ns",
+}
+_DIFF_STEP_FIELDS = {"before_ms", "after_ms", "delta_ms", "delta_pct"}
+_DIFF_CATEGORY_FIELDS = {"category", *_DIFF_STEP_FIELDS}
+_DIFF_AXIS_FIELDS = {
+    "axis",
+    "title",
+    "total_basis",
+    *_DIFF_STEP_FIELDS,
+    "entries",
+}
+_DIFF_AXIS_ENTRY_FIELDS = {
+    "key",
+    "label",
+    *_DIFF_STEP_FIELDS,
+    "before_count",
+    "after_count",
+    "classification",
+    "selection",
+    "metadata",
+}
+_DIFF_KERNEL_FIELDS = {
+    "key",
+    "name",
+    "demangled",
+    "before_total_ns",
+    "after_total_ns",
+    "delta_ns",
+    "before_count",
+    "after_count",
+    "classification",
+    "before_share",
+    "after_share",
+    "delta_share",
+    "selection",
+}
+_DIFF_NVTX_FIELDS = {
+    "text",
+    "before_total_ns",
+    "after_total_ns",
+    "delta_ns",
+    "before_count",
+    "after_count",
+    "classification",
+}
+_OVERLAP_REQUIRED_FIELDS = {
+    "compute_only_ms",
+    "nccl_only_ms",
+    "overlap_ms",
+    "idle_ms",
+    "total_ms",
+    "overlap_pct",
+    "compute_kernels",
+    "nccl_kernels",
+}
+_OVERLAP_OPTIONAL_FIELDS = {
+    "launch_overhead_ms",
+    "span_start_ns",
+    "span_end_ns",
+}
+_OVERLAP_DELTA_FIELDS = {
+    "compute_only_ms",
+    "nccl_only_ms",
+    "overlap_ms",
+    "idle_ms",
+    "total_ms",
+    "overlap_pct",
+}
+
+
+class SessionError(NsysAiError):
+    """Base class for session persistence failures."""
+
+    error_code = "SESSION_ERROR"
+
+
+class SessionNotFoundError(SessionError):
+    error_code = "SESSION_NOT_FOUND"
+
+
+class SessionExistsError(SessionError):
+    error_code = "SESSION_EXISTS"
+
+
+class SessionConflictError(SessionError):
+    error_code = "SESSION_WRITER_CONFLICT"
+
+
+class SessionCorruptError(SessionError):
+    error_code = "SESSION_CORRUPT"
+
+
+class UnsupportedSessionVersionError(SessionError):
+    error_code = "SESSION_VERSION_UNSUPPORTED"
+
+
+@dataclass(frozen=True)
+class ArtifactReference:
+    path: str
+    schema_version: str
+    sha256: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "path": self.path,
+            "schema_version": self.schema_version,
+            "sha256": self.sha256,
+        }
+
+
+@dataclass(frozen=True)
+class SessionState:
+    session_id: str
+    phase: SessionPhase = "diagnose"
+    before_profile: LocalProfileReference | None = None
+    after_profile: LocalProfileReference | None = None
+    artifacts: Mapping[str, ArtifactReference] = dataclass_field(
+        default_factory=lambda: MappingProxyType({})
+    )
+
+    def __post_init__(self) -> None:
+        _validate_session_id(self.session_id)
+        if self.phase not in _PHASES:
+            raise SessionCorruptError(f"invalid session phase: {self.phase!r}")
+        refs = dict(self.artifacts)
+        unknown = sorted(set(refs) - set(_ARTIFACT_PATHS))
+        if unknown:
+            raise SessionCorruptError(
+                "session has unknown artifact reference(s): " + ", ".join(unknown)
+            )
+        object.__setattr__(self, "artifacts", MappingProxyType(refs))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SESSION_SCHEMA_VERSION,
+            "session_id": self.session_id,
+            "phase": self.phase,
+            "profiles": {
+                "before": _profile_reference_to_dict(self.before_profile),
+                "after": _profile_reference_to_dict(self.after_profile),
+            },
+            "artifacts": {
+                name: self.artifacts[name].to_dict() if name in self.artifacts else None
+                for name in _ARTIFACT_PATHS
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> SessionState:
+        _require_exact_keys(
+            payload,
+            {"schema_version", "session_id", "phase", "profiles", "artifacts"},
+            "session.json",
+        )
+        version = payload.get("schema_version")
+        if version != SESSION_SCHEMA_VERSION:
+            raise UnsupportedSessionVersionError(
+                f"unsupported session schema_version {version!r}; "
+                f"expected {SESSION_SCHEMA_VERSION!r}"
+            )
+        profiles = _require_mapping(payload.get("profiles"), "session profiles")
+        _require_exact_keys(profiles, {"before", "after"}, "session profiles")
+        artifacts_payload = _require_mapping(payload.get("artifacts"), "session artifacts")
+        _require_exact_keys(artifacts_payload, set(_ARTIFACT_PATHS), "session artifacts")
+        artifacts: dict[str, ArtifactReference] = {}
+        for name, value in artifacts_payload.items():
+            if value is None:
+                continue
+            artifact = _require_mapping(value, f"session artifact {name}")
+            _require_exact_keys(
+                artifact, {"path", "schema_version", "sha256"}, f"artifact {name}"
+            )
+            expected_path = _ARTIFACT_PATHS[name]
+            if artifact.get("path") != expected_path:
+                raise SessionCorruptError(
+                    f"artifact {name} path must be {expected_path!r}"
+                )
+            version_value = artifact.get("schema_version")
+            if not isinstance(version_value, str) or not version_value:
+                raise SessionCorruptError(
+                    f"artifact {name} schema_version must be a non-empty string"
+                )
+            digest = artifact.get("sha256")
+            if not isinstance(digest, str) or not re.fullmatch(r"[0-9a-f]{64}", digest):
+                raise SessionCorruptError(
+                    f"artifact {name} sha256 must be 64 lowercase hex characters"
+                )
+            artifacts[name] = ArtifactReference(expected_path, version_value, digest)
+        session_id = payload.get("session_id")
+        phase = payload.get("phase")
+        if not isinstance(session_id, str):
+            raise SessionCorruptError("session_id must be a string")
+        if not isinstance(phase, str):
+            raise SessionCorruptError("session phase must be a string")
+        return cls(
+            session_id=session_id,
+            phase=phase,  # type: ignore[arg-type]
+            before_profile=_profile_reference_from_dict(profiles.get("before")),
+            after_profile=_profile_reference_from_dict(profiles.get("after")),
+            artifacts=artifacts,
+        )
+
+
+@dataclass(frozen=True)
+class SessionSnapshot:
+    state: SessionState
+    runspec: RunSpec | None
+    findings: EvidenceReport | None
+    proposal: Proposal | None
+    diff: Mapping[str, Any] | None
+
+
+class SessionStore:
+    """Read and create sessions rooted at ``.nsys-ai/sessions``."""
+
+    def __init__(self, root: str | os.PathLike[str] = ".nsys-ai/sessions"):
+        self.root = Path(root).expanduser().resolve(strict=False)
+        self.lock_root = self.root.parent / "locks"
+
+    def create(
+        self,
+        session_id: str,
+        *,
+        before_profile: LocalProfileReference | None = None,
+    ) -> SessionState:
+        """Atomically create the exact v0 session directory layout."""
+        _validate_session_id(session_id)
+        if before_profile is not None:
+            _validate_profile_reference(before_profile, require_file=True)
+        self._ensure_roots()
+        with self._lock(session_id, "writer", exclusive=True, blocking=False):
+            destination = self._session_dir(session_id)
+            if destination.exists():
+                raise SessionExistsError(f"session already exists: {session_id}")
+            temporary = Path(tempfile.mkdtemp(prefix=f".{session_id}.", dir=self.root))
+            try:
+                (temporary / "logs").mkdir(mode=0o700)
+                state = SessionState(session_id=session_id, before_profile=before_profile)
+                atomic_write_json(temporary / "session.json", state.to_dict())
+                os.replace(temporary, destination)
+                fsync_directory(self.root)
+            except BaseException:
+                shutil.rmtree(temporary, ignore_errors=True)
+                raise
+            return state
+
+    def load(self, session_id: str) -> SessionSnapshot:
+        """Reload a coherent snapshot, rolling back an interrupted publication."""
+        _validate_session_id(session_id)
+        self._require_session(session_id)
+        with self._lock(session_id, "state", exclusive=True, blocking=True):
+            return self._load_unlocked(session_id)
+
+    def writer(self, session_id: str) -> SessionWriter:
+        """Claim the session's sole writer without waiting behind another process."""
+        _validate_session_id(session_id)
+        self._require_session(session_id)
+        handle = self._acquire_lock(session_id, "writer", exclusive=True, blocking=False)
+        try:
+            self.load(session_id)
+        except BaseException:
+            handle.close()
+            raise
+        return SessionWriter(self, session_id, handle)
+
+    def _load_unlocked(self, session_id: str) -> SessionSnapshot:
+        self._recover_transaction(session_id)
+        session_dir = self._session_dir(session_id)
+        state_payload = _read_json(session_dir / "session.json", "session.json")
+        state = SessionState.from_dict(_require_mapping(state_payload, "session.json"))
+        if state.session_id != session_id:
+            raise SessionCorruptError(
+                f"session directory {session_id!r} contains id {state.session_id!r}"
+            )
+
+        runspec = None
+        findings = None
+        proposal = None
+        diff = None
+        if "runspec" in state.artifacts:
+            self._check_artifact_version(state, "runspec", RUNSPEC_SCHEMA_VERSION)
+            self._verify_artifact(state, "runspec")
+            try:
+                runspec = RunSpec.from_dict(
+                    _require_mapping(
+                        _read_json(session_dir / "runspec.json", "runspec.json"),
+                        "runspec.json",
+                    )
+                )
+            except RunSpecError as exc:
+                raise SessionCorruptError(f"invalid runspec.json: {exc}") from exc
+        if "findings" in state.artifacts:
+            self._check_artifact_version(state, "findings", EVIDENCE_SCHEMA_VERSION)
+            self._verify_artifact(state, "findings")
+            payload = _require_mapping(
+                _read_json(session_dir / "findings.json", "findings.json"),
+                "findings.json",
+            )
+            if payload.get("schema_version") != state.artifacts["findings"].schema_version:
+                raise UnsupportedSessionVersionError(
+                    "findings.json schema_version does not match session.json: "
+                    f"{payload.get('schema_version')!r}"
+                )
+            findings = _rehydrate_evidence_payload(
+                dict(payload), error_type=SessionCorruptError
+            )
+            _validate_findings_provenance(
+                state.before_profile, findings, error_type=SessionCorruptError
+            )
+        if "proposal" in state.artifacts:
+            self._check_artifact_version(state, "proposal", PROPOSAL_SCHEMA_VERSION)
+            self._verify_artifact(state, "proposal")
+            try:
+                proposal = Proposal.from_dict(
+                    _require_mapping(
+                        _read_json(session_dir / "proposal.json", "proposal.json"),
+                        "proposal.json",
+                    )
+                )
+            except UnsupportedProposalVersionError as exc:
+                raise UnsupportedSessionVersionError(str(exc)) from exc
+            except ProposalError as exc:
+                raise SessionCorruptError(f"invalid proposal.json: {exc}") from exc
+            _validate_proposal_pointer(state, findings, proposal, error_type=SessionCorruptError)
+        if "diff" in state.artifacts:
+            self._check_artifact_version(state, "diff", DIFF_SCHEMA_VERSION)
+            self._verify_artifact(state, "diff")
+            diff_payload = _read_json(session_dir / "diff.json", "diff.json")
+            parsed_diff = dict(_require_mapping(diff_payload, "diff.json"))
+            if parsed_diff.get("schema_version") != DIFF_SCHEMA_VERSION:
+                raise UnsupportedSessionVersionError(
+                    "unsupported diff.json schema_version "
+                    f"{parsed_diff.get('schema_version')!r}"
+                )
+            try:
+                _validate_diff_payload(parsed_diff)
+            except (TypeError, ValueError) as exc:
+                raise SessionCorruptError(f"invalid diff.json: {exc}") from exc
+            diff = MappingProxyType(parsed_diff)
+            _validate_diff_references(state, diff, error_type=SessionCorruptError)
+        snapshot = SessionSnapshot(state, runspec, findings, proposal, diff)
+        _validate_snapshot_invariants(snapshot)
+        return snapshot
+
+    def _begin_transaction(self, session_id: str, artifact_name: str) -> None:
+        session_dir = self._session_dir(session_id)
+        journal = session_dir / _TRANSACTION_DIR
+        if journal.exists():
+            raise SessionCorruptError("session has an unrecovered publication journal")
+        staging = Path(
+            tempfile.mkdtemp(prefix=_TRANSACTION_STAGING_PREFIX, dir=session_dir)
+        )
+        artifact_path = session_dir / _ARTIFACT_PATHS[artifact_name]
+        try:
+            atomic_write_bytes(
+                staging / "session.json", _read_bytes(session_dir / "session.json", "session.json")
+            )
+            artifact_existed = artifact_path.is_file()
+            if artifact_existed:
+                atomic_write_bytes(
+                    staging / "artifact.json", _read_bytes(artifact_path, artifact_path.name)
+                )
+            atomic_write_json(
+                staging / "transaction.json",
+                {
+                    "artifact": artifact_name,
+                    "artifact_existed": artifact_existed,
+                },
+            )
+            fsync_directory(staging)
+            os.replace(staging, journal)
+            fsync_directory(session_dir)
+        except BaseException:
+            shutil.rmtree(staging, ignore_errors=True)
+            raise
+
+    def _finish_transaction(self, session_id: str) -> None:
+        session_dir = self._session_dir(session_id)
+        tombstone = self._deactivate_transaction(session_dir)
+        self._remove_inactive_transaction(session_dir, tombstone)
+
+    @staticmethod
+    def _deactivate_transaction(session_dir: Path) -> Path:
+        journal = session_dir / _TRANSACTION_DIR
+        tombstone = session_dir / (
+            _TRANSACTION_CLEANUP_PREFIX + uuid.uuid4().hex
+        )
+        os.replace(journal, tombstone)
+        fsync_directory(session_dir)
+        return tombstone
+
+    @staticmethod
+    def _remove_inactive_transaction(session_dir: Path, path: Path) -> None:
+        try:
+            shutil.rmtree(path)
+            fsync_directory(session_dir)
+        except OSError:
+            pass
+
+    def _recover_transaction(self, session_id: str) -> None:
+        session_dir = self._session_dir(session_id)
+        journal = session_dir / _TRANSACTION_DIR
+        if journal.is_dir():
+            metadata = _require_mapping(
+                _read_json(journal / "transaction.json", "transaction journal"),
+                "transaction journal",
+            )
+            _require_exact_keys(
+                metadata,
+                {"artifact", "artifact_existed"},
+                "transaction journal",
+            )
+            artifact_name = metadata.get("artifact")
+            artifact_existed = metadata.get("artifact_existed")
+            if artifact_name not in _ARTIFACT_PATHS or not isinstance(
+                artifact_existed, bool
+            ):
+                raise SessionCorruptError("transaction journal metadata is invalid")
+            artifact_path = session_dir / _ARTIFACT_PATHS[artifact_name]
+            if artifact_existed:
+                atomic_write_bytes(
+                    artifact_path,
+                    _read_bytes(journal / "artifact.json", "journal artifact backup"),
+                )
+            else:
+                artifact_path.unlink(missing_ok=True)
+                fsync_directory(session_dir)
+            atomic_write_bytes(
+                session_dir / "session.json",
+                _read_bytes(journal / "session.json", "journal manifest backup"),
+            )
+            tombstone = self._deactivate_transaction(session_dir)
+            self._remove_inactive_transaction(session_dir, tombstone)
+        for pattern in (
+            f"{_TRANSACTION_STAGING_PREFIX}*",
+            f"{_TRANSACTION_CLEANUP_PREFIX}*",
+        ):
+            for inactive in session_dir.glob(pattern):
+                if inactive.is_dir():
+                    self._remove_inactive_transaction(session_dir, inactive)
+
+    def _verify_artifact(self, state: SessionState, name: str) -> None:
+        path = self._session_dir(state.session_id) / _ARTIFACT_PATHS[name]
+        actual = _sha256_file(path, f"{name}.json")
+        if actual != state.artifacts[name].sha256:
+            raise SessionCorruptError(
+                f"{name}.json does not match session.json; "
+                "a prior publication may have been interrupted"
+            )
+
+    @staticmethod
+    def _check_artifact_version(
+        state: SessionState, name: str, expected: str
+    ) -> None:
+        actual = state.artifacts[name].schema_version
+        if actual != expected:
+            raise UnsupportedSessionVersionError(
+                f"unsupported {name} artifact schema_version {actual!r}; expected {expected!r}"
+            )
+
+    def _require_session(self, session_id: str) -> None:
+        if not self._session_dir(session_id).is_dir():
+            raise SessionNotFoundError(f"session not found: {session_id}")
+
+    def _session_dir(self, session_id: str) -> Path:
+        return self.root / session_id
+
+    def _ensure_roots(self) -> None:
+        for directory in (self.root, self.lock_root):
+            directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+            directory.chmod(0o700)
+
+    @contextmanager
+    def _lock(
+        self, session_id: str, kind: str, *, exclusive: bool, blocking: bool
+    ) -> Iterator[BinaryIO]:
+        handle = self._acquire_lock(
+            session_id, kind, exclusive=exclusive, blocking=blocking
+        )
+        try:
+            yield handle
+        finally:
+            handle.close()
+
+    def _acquire_lock(
+        self, session_id: str, kind: str, *, exclusive: bool, blocking: bool
+    ) -> BinaryIO:
+        if fcntl is None:
+            raise SessionError("cross-process session locking requires POSIX fcntl")
+        self._ensure_roots()
+        path = self.lock_root / f"{session_id}.{kind}.lock"
+        descriptor = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
+        os.fchmod(descriptor, 0o600)
+        handle = os.fdopen(descriptor, "a+b", buffering=0)
+        operation = fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH
+        if not blocking:
+            operation |= fcntl.LOCK_NB
+        try:
+            fcntl.flock(handle.fileno(), operation)
+        except BlockingIOError as exc:
+            handle.close()
+            raise SessionConflictError(
+                f"session {session_id!r} already has an active writer"
+            ) from exc
+        return handle
+
+
+class SessionWriter:
+    """Exclusive writer lease whose publication methods hold only a short state lock."""
+
+    def __init__(self, store: SessionStore, session_id: str, handle: BinaryIO):
+        self.store = store
+        self.session_id = session_id
+        self._handle: BinaryIO | None = handle
+
+    def __enter__(self) -> SessionWriter:
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._handle is not None:
+            self._handle.close()
+            self._handle = None
+
+    def publish_runspec(
+        self,
+        runspec: RunSpec,
+        *,
+        resolved_secrets: Mapping[str, str] | None = None,
+    ) -> SessionState:
+        self._ensure_open()
+        if not isinstance(runspec, RunSpec):
+            raise TypeError("runspec must be a RunSpec")
+        validate_secret_boundaries(
+            runspec, resolved_secrets if resolved_secrets is not None else {}
+        )
+
+        def validate_snapshot(snapshot: SessionSnapshot) -> None:
+            if snapshot.state.phase != "diagnose" and snapshot.runspec != runspec:
+                raise ValueError("runspec.json cannot change after proposal phase")
+            if (
+                snapshot.proposal is not None
+                and snapshot.proposal.verification != runspec
+            ):
+                raise ValueError(
+                    "runspec.json must match the Proposal verification RunSpec"
+                )
+
+        return self._publish(
+            "runspec",
+            RUNSPEC_SCHEMA_VERSION,
+            lambda path: atomic_write_bytes(path, runspec.canonical_json_bytes()),
+            snapshot_validator=validate_snapshot,
+        )
+
+    def publish_findings(
+        self,
+        findings: EvidenceReport,
+        *,
+        before_profile: LocalProfileReference | None = None,
+    ) -> SessionState:
+        self._ensure_open()
+        if not isinstance(findings, EvidenceReport):
+            raise TypeError("findings must be an EvidenceReport")
+        if before_profile is not None:
+            _validate_profile_reference(before_profile, require_file=True)
+
+        try:
+            payload = findings.to_dict()
+        except (AttributeError, KeyError, TypeError, ValueError) as exc:
+            raise ValueError("findings cannot be serialized as EvidenceReport") from exc
+        _require_json_serializable(payload, "findings")
+        canonical_findings = _rehydrate_evidence_payload(payload, error_type=ValueError)
+
+        def validate_snapshot(snapshot: SessionSnapshot) -> None:
+            _require_phase(snapshot, {"diagnose"}, "publish findings")
+            state = self._replace_state(
+                snapshot.state, before_profile=before_profile
+            )
+            _validate_findings_provenance(
+                state.before_profile, canonical_findings, error_type=ValueError
+            )
+            if snapshot.proposal is not None:
+                _validate_proposal_pointer(
+                    state,
+                    canonical_findings,
+                    snapshot.proposal,
+                    error_type=ValueError,
+                )
+            if snapshot.diff is not None:
+                _validate_diff_references(
+                    state, snapshot.diff, error_type=ValueError
+                )
+
+        return self._publish(
+            "findings",
+            EVIDENCE_SCHEMA_VERSION,
+            lambda path: atomic_write_json(path, payload),
+            phase="diagnose",
+            before_profile=before_profile,
+            snapshot_validator=validate_snapshot,
+        )
+
+    def publish_after_profile(self, profile: LocalProfileReference) -> SessionState:
+        self._ensure_open()
+        _validate_profile_reference(profile, require_file=True)
+        return self._update_state(phase="reprofile", after_profile=profile)
+
+    def publish_proposal(self, proposal: Proposal) -> SessionState:
+        self._ensure_open()
+        if not isinstance(proposal, Proposal):
+            raise TypeError("proposal must be a Proposal")
+
+        def validate_snapshot(snapshot: SessionSnapshot) -> None:
+            _require_phase(
+                snapshot, {"diagnose", "propose"}, "publish a proposal"
+            )
+            if proposal.verification != snapshot.runspec:
+                raise ValueError(
+                    "Proposal verification RunSpec must match runspec.json"
+                )
+            _validate_proposal_pointer(
+                snapshot.state,
+                snapshot.findings,
+                proposal,
+                error_type=ValueError,
+            )
+
+        return self._publish(
+            "proposal",
+            PROPOSAL_SCHEMA_VERSION,
+            lambda path: atomic_write_bytes(path, proposal.canonical_json_bytes()),
+            phase="propose",
+            snapshot_validator=validate_snapshot,
+        )
+
+    def publish_diff(self, diff: Mapping[str, Any]) -> SessionState:
+        self._ensure_open()
+        if not isinstance(diff, Mapping):
+            raise TypeError("diff must be a mapping")
+        payload = dict(diff)
+        _validate_diff_payload(payload, require_undecided=True)
+
+        def validate_snapshot(snapshot: SessionSnapshot) -> None:
+            _require_phase(snapshot, {"reprofile", "diff"}, "publish a diff")
+            _validate_diff_references(
+                snapshot.state, payload, error_type=ValueError
+            )
+
+        return self._publish(
+            "diff",
+            DIFF_SCHEMA_VERSION,
+            lambda path: write_diff_json_from_diff_dict(payload, path=path)[0],
+            phase="diff",
+            snapshot_validator=validate_snapshot,
+        )
+
+    def publish_decision(
+        self,
+        decision: str,
+        reason: str,
+        *,
+        decider: str | None = None,
+        decided_at: str | None = None,
+    ) -> tuple[SessionState, Mapping[str, Any], tuple[str, ...]]:
+        self._ensure_open()
+        with self.store._lock(
+            self.session_id, "state", exclusive=True, blocking=True
+        ):
+            snapshot = self.store._load_unlocked(self.session_id)
+            _require_phase(snapshot, {"diff"}, "publish a decision")
+            if snapshot.diff is None:
+                raise ValueError("publish a diff before recording a decision")
+            if _validate_diff_decision(snapshot.diff):
+                raise ValueError("diff already has a decision")
+            status = decision.strip().lower()
+            if status in {"accept", "accepted"}:
+                status = "accepted"
+            elif status in {"reject", "rejected"}:
+                status = "rejected"
+            else:
+                raise ValueError("decision must be accept or reject")
+            candidate, warnings = build_diff_decision_record_from_diff_dict(
+                dict(snapshot.diff),
+                decision=status,
+                reason=reason,
+                decider=decider,
+                decided_at=decided_at,
+            )
+            _validate_diff_payload(candidate)
+            self.store._begin_transaction(self.session_id, "diff")
+            _path, payload = write_diff_json_from_diff_dict(
+                candidate,
+                path=self.store._session_dir(self.session_id) / "diff.json",
+            )
+            artifacts = dict(snapshot.state.artifacts)
+            artifacts["diff"] = ArtifactReference(
+                _ARTIFACT_PATHS["diff"],
+                DIFF_SCHEMA_VERSION,
+                _sha256_file(
+                    self.store._session_dir(self.session_id) / "diff.json", "diff.json"
+                ),
+            )
+            state = self._replace_state(
+                snapshot.state, phase="accept", artifacts=artifacts
+            )
+            atomic_write_json(
+                self.store._session_dir(self.session_id) / "session.json",
+                state.to_dict(),
+            )
+            self.store._finish_transaction(self.session_id)
+            return state, MappingProxyType(payload), tuple(warnings)
+
+    def _publish(
+        self,
+        name: str,
+        schema_version: str,
+        publisher,
+        *,
+        phase: SessionPhase | None = None,
+        before_profile: LocalProfileReference | None = None,
+        snapshot_validator: Callable[[SessionSnapshot], None] | None = None,
+    ) -> SessionState:
+        self._ensure_open()
+        with self.store._lock(
+            self.session_id, "state", exclusive=True, blocking=True
+        ):
+            snapshot = self.store._load_unlocked(self.session_id)
+            state = snapshot.state
+            if snapshot_validator is not None:
+                snapshot_validator(snapshot)
+            artifact_path = self.store._session_dir(self.session_id) / _ARTIFACT_PATHS[name]
+            self.store._begin_transaction(self.session_id, name)
+            publisher(artifact_path)
+            artifacts = dict(state.artifacts)
+            artifacts[name] = ArtifactReference(
+                _ARTIFACT_PATHS[name],
+                schema_version,
+                _sha256_file(artifact_path, f"{name}.json"),
+            )
+            state = self._replace_state(
+                state,
+                phase=phase,
+                before_profile=before_profile,
+                artifacts=artifacts,
+            )
+            atomic_write_json(
+                self.store._session_dir(self.session_id) / "session.json",
+                state.to_dict(),
+            )
+            self.store._finish_transaction(self.session_id)
+            return state
+
+    def _update_state(
+        self,
+        *,
+        phase: SessionPhase,
+        after_profile: LocalProfileReference,
+    ) -> SessionState:
+        self._ensure_open()
+        with self.store._lock(
+            self.session_id, "state", exclusive=True, blocking=True
+        ):
+            snapshot = self.store._load_unlocked(self.session_id)
+            _require_phase(
+                snapshot,
+                {"propose", "reprofile"},
+                "publish an after profile",
+            )
+            if snapshot.proposal is None or snapshot.proposal.abstained:
+                raise ValueError(
+                    "after profile publication requires a non-abstained proposal"
+                )
+            state = snapshot.state
+            state = self._replace_state(
+                state, phase=phase, after_profile=after_profile
+            )
+            if snapshot.diff is not None:
+                _validate_diff_references(
+                    state, snapshot.diff, error_type=ValueError
+                )
+            atomic_write_json(
+                self.store._session_dir(self.session_id) / "session.json",
+                state.to_dict(),
+            )
+            return state
+
+    @staticmethod
+    def _replace_state(
+        state: SessionState,
+        *,
+        phase: SessionPhase | None = None,
+        before_profile: LocalProfileReference | None = None,
+        after_profile: LocalProfileReference | None = None,
+        artifacts: Mapping[str, ArtifactReference] | None = None,
+    ) -> SessionState:
+        return SessionState(
+            session_id=state.session_id,
+            phase=phase or state.phase,
+            before_profile=before_profile or state.before_profile,
+            after_profile=after_profile or state.after_profile,
+            artifacts=artifacts or state.artifacts,
+        )
+
+    def _ensure_open(self) -> None:
+        if self._handle is None:
+            raise SessionError("session writer is closed")
+
+
+def _validate_session_id(session_id: str) -> None:
+    if not isinstance(session_id, str) or not _SESSION_ID.fullmatch(session_id):
+        raise ValueError(
+            "session_id must be 1-128 letters, digits, dots, underscores, or hyphens"
+        )
+
+
+def _normalized_local_path(path: str) -> str:
+    """Normalize local spelling without dereferencing a user-facing symlink path."""
+    return os.path.abspath(os.path.expanduser(path))
+
+
+def _rehydrate_evidence_payload(
+    payload: Mapping[str, Any], *, error_type: type[Exception]
+) -> EvidenceReport:
+    try:
+        rehydrated = validate_evidence_report_payload(payload)
+    except (AttributeError, KeyError, TypeError, ValueError) as exc:
+        raise error_type(
+            f"invalid findings.json: {exc}"
+        ) from exc
+    return rehydrated
+
+
+def _validate_findings_provenance(
+    before: LocalProfileReference | None,
+    findings: EvidenceReport,
+    *,
+    error_type: type[Exception],
+) -> None:
+    if before is None:
+        return
+    if not findings.profile_id:
+        raise error_type("findings profile_id is required with a before profile")
+    if findings.profile_id != before.profile_id:
+        raise error_type("findings profile_id does not match the before profile")
+    if not findings.profile_path:
+        raise error_type("findings profile_path is required with a before profile")
+    if _normalized_local_path(findings.profile_path) != _normalized_local_path(
+        before.path
+    ):
+        raise error_type("findings profile_path does not match the before profile")
+    for index, finding in enumerate(findings.findings):
+        selection = finding.selection
+        if selection is not None and selection.profile_id != before.profile_id:
+            raise error_type(
+                f"findings[{index}] selection profile_id does not match "
+                "the before profile"
+            )
+
+
+def _validate_proposal_pointer(
+    state: SessionState,
+    findings: EvidenceReport | None,
+    proposal: Proposal,
+    *,
+    error_type: type[Exception],
+) -> None:
+    before = state.before_profile
+    if before is None:
+        raise error_type("proposal publication requires a before profile reference")
+    if not proposal.source_finding_id:
+        raise error_type("proposal source_finding_id must be non-empty")
+    if findings is None:
+        raise error_type("proposal publication requires findings.json")
+    matches = [
+        finding for finding in findings.findings if finding.id == proposal.source_finding_id
+    ]
+    if len(matches) != 1:
+        raise error_type(
+            "proposal source_finding_id must identify exactly one session finding"
+        )
+    missing_selection_abstention = proposal.abstained and matches[0].selection is None
+    if missing_selection_abstention:
+        if proposal.source_profile_id:
+            raise error_type(
+                "proposal without a source selection must have an empty source_profile_id"
+            )
+    elif proposal.source_profile_id != before.profile_id:
+        raise error_type("proposal source_profile_id does not match the before profile")
+    try:
+        validate_proposal_against_finding(proposal, matches[0])
+    except ProposalError as exc:
+        raise error_type(str(exc)) from exc
+
+
+def _validate_diff_references(
+    state: SessionState,
+    diff: Mapping[str, Any],
+    *,
+    error_type: type[Exception],
+) -> None:
+    if state.before_profile is None or state.after_profile is None:
+        raise error_type(
+            "diff publication requires before and after session profile references"
+        )
+    for side, expected in (
+        ("before", state.before_profile),
+        ("after", state.after_profile),
+    ):
+        reference = diff[side]
+        comparisons = (
+            ("path", _normalized_local_path(reference["path"]), _normalized_local_path(expected.path)),
+            ("profile_id", reference["profile_id"], expected.profile_id),
+            ("schema_version", reference["schema_version"], expected.schema_version),
+            ("product_version", reference["product_version"], expected.product_version),
+        )
+        for field, actual, wanted in comparisons:
+            if actual != wanted:
+                raise error_type(
+                    f"diff {side} {field} does not match the session reference"
+                )
+
+
+def _validate_snapshot_invariants(snapshot: SessionSnapshot) -> None:
+    state = snapshot.state
+    phase = state.phase
+    proposal = snapshot.proposal
+    diff = snapshot.diff
+
+    if proposal is not None and proposal.verification != snapshot.runspec:
+        raise SessionCorruptError(
+            "proposal verification RunSpec does not match runspec.json"
+        )
+
+    if phase == "diagnose":
+        if proposal is not None or state.after_profile is not None or diff is not None:
+            raise SessionCorruptError(
+                "diagnose phase cannot retain proposal, after profile, or diff artifacts"
+            )
+        return
+
+    if proposal is None:
+        raise SessionCorruptError(f"{phase} phase requires proposal.json")
+    if phase == "propose":
+        if state.after_profile is not None or diff is not None:
+            raise SessionCorruptError(
+                "propose phase cannot retain an after profile or diff artifact"
+            )
+        return
+
+    if proposal.abstained:
+        raise SessionCorruptError(f"{phase} phase requires a non-abstained proposal")
+    if state.after_profile is None:
+        raise SessionCorruptError(f"{phase} phase requires an after profile reference")
+    if phase == "reprofile":
+        if diff is not None:
+            raise SessionCorruptError("reprofile phase cannot retain a diff artifact")
+        return
+
+    if diff is None:
+        raise SessionCorruptError(f"{phase} phase requires diff.json")
+    decided = _validate_diff_decision(diff)
+    if phase == "diff" and decided:
+        raise SessionCorruptError("diff phase requires an undecided diff.json")
+    if phase == "accept" and not decided:
+        raise SessionCorruptError("accept phase requires a decided diff.json")
+
+
+def _require_phase(
+    snapshot: SessionSnapshot,
+    allowed: set[SessionPhase],
+    action: str,
+) -> None:
+    if snapshot.state.phase not in allowed:
+        choices = ", ".join(sorted(allowed))
+        raise ValueError(
+            f"cannot {action} during {snapshot.state.phase} phase; expected {choices}"
+        )
+
+
+def _require_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise SessionCorruptError(f"{label} must be a JSON object")
+    return value
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any], expected: set[str], label: str
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise SessionCorruptError(
+            f"{label} fields do not match schema; "
+            f"missing={sorted(expected - actual)}, unknown={sorted(actual - expected)}"
+        )
+
+
+def _profile_reference_to_dict(
+    reference: LocalProfileReference | None,
+) -> dict[str, Any] | None:
+    if reference is None:
+        return None
+    _validate_profile_reference(reference, require_file=False)
+    return {
+        "kind": "local",
+        "path": reference.path,
+        "profile_id": reference.profile_id,
+        "export_schema_version": reference.schema_version,
+        "product_version": reference.product_version,
+        "kernel_count": reference.kernel_count,
+    }
+
+
+def _profile_reference_from_dict(value: Any) -> LocalProfileReference | None:
+    if value is None:
+        return None
+    payload = _require_mapping(value, "profile reference")
+    _require_exact_keys(
+        payload,
+        {
+            "kind",
+            "path",
+            "profile_id",
+            "export_schema_version",
+            "product_version",
+            "kernel_count",
+        },
+        "profile reference",
+    )
+    if payload.get("kind") != "local":
+        raise SessionCorruptError("profile reference kind must be 'local'")
+    try:
+        reference = LocalProfileReference(
+            path=payload["path"],
+            profile_id=payload["profile_id"],
+            schema_version=payload["export_schema_version"],
+            product_version=payload["product_version"],
+            kernel_count=payload["kernel_count"],
+        )
+        _validate_profile_reference(reference, require_file=False)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise SessionCorruptError(f"invalid local profile reference: {exc}") from exc
+    return reference
+
+
+def _validate_profile_reference(
+    reference: LocalProfileReference, *, require_file: bool
+) -> None:
+    if not isinstance(reference, LocalProfileReference):
+        raise TypeError("profile reference must be a LocalProfileReference")
+    if not isinstance(reference.path, str) or not Path(reference.path).is_absolute():
+        raise ValueError("local profile reference path must be absolute")
+    if require_file and not Path(reference.path).is_file():
+        raise ValueError(f"local profile reference does not exist: {reference.path}")
+    if not isinstance(reference.profile_id, str) or not reference.profile_id:
+        raise ValueError("local profile reference profile_id must be non-empty")
+    for name, value in (
+        ("schema_version", reference.schema_version),
+        ("product_version", reference.product_version),
+    ):
+        if value is not None and (not isinstance(value, str) or not value):
+            raise ValueError(f"local profile reference {name} must be a string or null")
+    if isinstance(reference.kernel_count, bool) or not isinstance(
+        reference.kernel_count, int
+    ) or reference.kernel_count < 0:
+        raise ValueError("local profile reference kernel_count must be non-negative")
+
+
+def _diff_mapping(value: Any, label: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{label} must be an object")
+    if any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{label} keys must be strings")
+    return value
+
+
+def _diff_exact_fields(
+    value: Mapping[str, Any], expected: set[str], label: str
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        raise ValueError(
+            f"{label} fields do not match canonical shape; "
+            f"missing={sorted(expected - actual)}, unknown={sorted(actual - expected)}"
+        )
+
+
+def _diff_string(value: Any, label: str, *, allow_empty: bool = False) -> None:
+    if not isinstance(value, str) or (not allow_empty and not value):
+        qualifier = "a string" if allow_empty else "a non-empty string"
+        raise ValueError(f"{label} must be {qualifier}")
+
+
+def _diff_integer(value: Any, label: str, *, non_negative: bool = False) -> None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{label} must be an integer")
+    if non_negative and value < 0:
+        raise ValueError(f"{label} must be non-negative")
+
+
+def _diff_number(value: Any, label: str, *, nullable: bool = False) -> None:
+    if nullable and value is None:
+        return
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, (int, float))
+        or not math.isfinite(value)
+    ):
+        suffix = " or null" if nullable else ""
+        raise ValueError(f"{label} must be a finite number{suffix}")
+
+
+def _validate_diff_measurements(value: Mapping[str, Any], label: str) -> None:
+    for field in ("before_ms", "after_ms", "delta_ms"):
+        _diff_number(value[field], f"{label}.{field}")
+    _diff_number(value["delta_pct"], f"{label}.delta_pct", nullable=True)
+
+
+def _validate_diff_selection(
+    value: Any,
+    *,
+    label: str,
+    expected_profile_id: str,
+    expected_source: str | None = None,
+) -> None:
+    if value is None:
+        return
+    try:
+        selection = validate_trace_selection_payload(value, label=label)
+    except ValueError as exc:
+        raise ValueError(str(exc)) from exc
+    if selection.profile_id != expected_profile_id:
+        raise ValueError(f"{label}.profile_id does not match its selected diff side")
+    if expected_source is not None and selection.source != expected_source:
+        raise ValueError(f"{label}.source must be {expected_source!r}")
+
+
+def _validate_diff_categories(payload: Mapping[str, Any]) -> None:
+    step_time = payload["step_time"]
+    if step_time is not None:
+        step = _diff_mapping(step_time, "diff step_time")
+        _diff_exact_fields(step, _DIFF_STEP_FIELDS, "diff step_time")
+        _validate_diff_measurements(step, "diff step_time")
+
+    categories = payload["category_attribution"]
+    allowed = {"compute", "communication", "launch_overhead", "idle"}
+    seen: set[str] = set()
+    for index, item in enumerate(categories):
+        label = f"diff category_attribution[{index}]"
+        category = _diff_mapping(item, label)
+        _diff_exact_fields(category, _DIFF_CATEGORY_FIELDS, label)
+        if category["category"] not in allowed or category["category"] in seen:
+            raise ValueError(f"{label}.category is invalid or duplicated")
+        seen.add(category["category"])
+        _validate_diff_measurements(category, label)
+
+
+def _validate_diff_axis(
+    value: Any,
+    *,
+    field_name: str,
+    axis_name: str,
+    total_basis: str,
+    before_profile_id: str,
+    after_profile_id: str,
+) -> None:
+    if value is None:
+        return
+    label = f"diff {field_name}"
+    axis = _diff_mapping(value, label)
+    _diff_exact_fields(axis, _DIFF_AXIS_FIELDS, label)
+    if axis["axis"] != axis_name or axis["total_basis"] != total_basis:
+        raise ValueError(f"{label} axis metadata is inconsistent")
+    _diff_string(axis["title"], f"{label}.title")
+    _validate_diff_measurements(axis, label)
+    entries = axis["entries"]
+    if not isinstance(entries, list):
+        raise ValueError(f"{label}.entries must be an array")
+    classifications = {
+        "regression",
+        "improvement",
+        "new",
+        "removed",
+        "neutral",
+        "grown",
+        "shrunk",
+    }
+    for index, item in enumerate(entries):
+        entry_label = f"{label}.entries[{index}]"
+        entry = _diff_mapping(item, entry_label)
+        _diff_exact_fields(entry, _DIFF_AXIS_ENTRY_FIELDS, entry_label)
+        for field in ("key", "label"):
+            _diff_string(entry[field], f"{entry_label}.{field}", allow_empty=True)
+        _validate_diff_measurements(entry, entry_label)
+        for field in ("before_count", "after_count"):
+            _diff_integer(entry[field], f"{entry_label}.{field}", non_negative=True)
+        if entry["classification"] not in classifications:
+            raise ValueError(f"{entry_label}.classification is invalid")
+        metadata = _diff_mapping(entry["metadata"], f"{entry_label}.metadata")
+        if axis_name == "communication":
+            _diff_exact_fields(
+                metadata, {"selection_side"}, f"{entry_label}.metadata"
+            )
+        else:
+            _diff_exact_fields(
+                metadata,
+                {
+                    "device_id",
+                    "stream_id",
+                    "before_kernel",
+                    "after_kernel",
+                    "selection_side",
+                },
+                f"{entry_label}.metadata",
+            )
+            for field in ("device_id", "stream_id"):
+                _diff_integer(
+                    metadata[field],
+                    f"{entry_label}.metadata.{field}",
+                    non_negative=True,
+                )
+            for field in ("before_kernel", "after_kernel"):
+                _diff_string(
+                    metadata[field],
+                    f"{entry_label}.metadata.{field}",
+                    allow_empty=True,
+                )
+        selection_side = metadata["selection_side"]
+        if selection_side not in {"before", "after"}:
+            raise ValueError(f"{entry_label}.metadata.selection_side is invalid")
+        expected_profile_id = (
+            before_profile_id if selection_side == "before" else after_profile_id
+        )
+        _validate_diff_selection(
+            entry["selection"],
+            label=f"{entry_label}.selection",
+            expected_profile_id=expected_profile_id,
+            expected_source=f"diff:{axis_name}_summary",
+        )
+
+
+def _validate_directional_diff_entry(
+    entry: Mapping[str, Any], *, field_name: str, label: str
+) -> None:
+    before = entry["before_total_ns"]
+    after = entry["after_total_ns"]
+    delta = entry["delta_ns"]
+    if delta != after - before:
+        raise ValueError(f"{label}.delta_ns must equal after_total_ns - before_total_ns")
+    if field_name.endswith("regressions"):
+        if delta <= 0:
+            raise ValueError(f"{label}.delta_ns must be positive")
+        expected_classification = "new" if before == 0 else "regression"
+    else:
+        if delta >= 0:
+            raise ValueError(f"{label}.delta_ns must be negative")
+        expected_classification = "removed" if after == 0 else "improvement"
+    if entry["classification"] != expected_classification:
+        raise ValueError(
+            f"{label}.classification must be {expected_classification!r} "
+            "for its totals and list"
+        )
+
+
+def _validate_diff_kernel_entries(payload: Mapping[str, Any]) -> None:
+    after_profile_id = payload["after"]["profile_id"]
+    seen_keys: set[str] = set()
+    for field_name in ("top_regressions", "top_improvements"):
+        for index, item in enumerate(payload[field_name]):
+            label = f"diff {field_name}[{index}]"
+            entry = _diff_mapping(item, label)
+            _diff_exact_fields(entry, _DIFF_KERNEL_FIELDS, label)
+            for field in ("key", "name", "demangled"):
+                _diff_string(entry[field], f"{label}.{field}", allow_empty=True)
+            for field in ("before_total_ns", "after_total_ns", "before_count", "after_count"):
+                _diff_integer(entry[field], f"{label}.{field}", non_negative=True)
+            _diff_integer(entry["delta_ns"], f"{label}.delta_ns")
+            for field in ("before_share", "after_share", "delta_share"):
+                _diff_number(entry[field], f"{label}.{field}")
+            if entry["key"] in seen_keys:
+                raise ValueError(f"{label}.key is duplicated across top kernel lists")
+            seen_keys.add(entry["key"])
+            _validate_directional_diff_entry(
+                entry, field_name=field_name, label=label
+            )
+            if entry["delta_share"] != entry["after_share"] - entry["before_share"]:
+                raise ValueError(
+                    f"{label}.delta_share must equal after_share - before_share"
+                )
+            _validate_diff_selection(
+                entry["selection"],
+                label=f"{label}.selection",
+                expected_profile_id=after_profile_id,
+                expected_source="diff",
+            )
+
+
+def _validate_diff_nvtx_entries(payload: Mapping[str, Any]) -> None:
+    seen_text: set[str] = set()
+    for field_name in ("nvtx_regressions", "nvtx_improvements"):
+        for index, item in enumerate(payload[field_name]):
+            label = f"diff {field_name}[{index}]"
+            entry = _diff_mapping(item, label)
+            _diff_exact_fields(entry, _DIFF_NVTX_FIELDS, label)
+            _diff_string(entry["text"], f"{label}.text", allow_empty=True)
+            for field in ("before_total_ns", "after_total_ns", "before_count", "after_count"):
+                _diff_integer(entry[field], f"{label}.{field}", non_negative=True)
+            _diff_integer(entry["delta_ns"], f"{label}.delta_ns")
+            if entry["text"] in seen_text:
+                raise ValueError(f"{label}.text is duplicated across NVTX lists")
+            seen_text.add(entry["text"])
+            _validate_directional_diff_entry(
+                entry, field_name=field_name, label=label
+            )
+
+
+def _validate_overlap_side(value: Any, label: str) -> None:
+    overlap = _diff_mapping(value, label)
+    if "error" in overlap:
+        allowed = {
+            "error",
+            "requested_device",
+            "requested_trim_ns",
+            "available_devices",
+            "hint",
+        }
+        unknown = set(overlap) - allowed
+        if unknown or "requested_device" not in overlap:
+            raise ValueError(f"{label} diagnostic fields are invalid")
+        _diff_string(overlap["error"], f"{label}.error")
+        device = overlap["requested_device"]
+        if device is not None:
+            _diff_integer(device, f"{label}.requested_device", non_negative=True)
+        if "requested_trim_ns" in overlap:
+            trim = overlap["requested_trim_ns"]
+            if not isinstance(trim, list) or len(trim) != 2:
+                raise ValueError(f"{label}.requested_trim_ns must contain two integers")
+            for index, item in enumerate(trim):
+                _diff_integer(item, f"{label}.requested_trim_ns[{index}]")
+        if "available_devices" in overlap:
+            devices = overlap["available_devices"]
+            if not isinstance(devices, Mapping):
+                raise ValueError(f"{label}.available_devices must be an object")
+            for device_id, count in devices.items():
+                if not str(device_id).isdigit():
+                    raise ValueError(f"{label}.available_devices keys must be GPU ids")
+                _diff_integer(count, f"{label}.available_devices[{device_id}]", non_negative=True)
+        if "hint" in overlap:
+            _diff_string(overlap["hint"], f"{label}.hint")
+        return
+
+    actual = set(overlap)
+    allowed = _OVERLAP_REQUIRED_FIELDS | _OVERLAP_OPTIONAL_FIELDS
+    if not _OVERLAP_REQUIRED_FIELDS <= actual or actual - allowed:
+        raise ValueError(f"{label} fields do not match canonical overlap shape")
+    for field in (
+        "compute_only_ms",
+        "nccl_only_ms",
+        "overlap_ms",
+        "idle_ms",
+        "total_ms",
+        "overlap_pct",
+        "launch_overhead_ms",
+    ):
+        if field in overlap:
+            _diff_number(overlap[field], f"{label}.{field}")
+    for field in ("compute_kernels", "nccl_kernels", "span_start_ns", "span_end_ns"):
+        if field in overlap:
+            _diff_integer(overlap[field], f"{label}.{field}", non_negative=True)
+
+
+def _validate_diff_overlap(value: Any) -> None:
+    overlap = _diff_mapping(value, "diff overlap")
+    _diff_exact_fields(overlap, {"before", "after", "delta"}, "diff overlap")
+    _validate_overlap_side(overlap["before"], "diff overlap.before")
+    _validate_overlap_side(overlap["after"], "diff overlap.after")
+    delta = _diff_mapping(overlap["delta"], "diff overlap.delta")
+    unknown = set(delta) - _OVERLAP_DELTA_FIELDS
+    if unknown:
+        raise ValueError(f"diff overlap.delta has unknown fields: {sorted(unknown)}")
+    for field, value in delta.items():
+        _diff_number(value, f"diff overlap.delta.{field}")
+
+
+def _validate_diff_payload(
+    payload: Mapping[str, Any], *, require_undecided: bool = False
+) -> None:
+    actual_fields = set(payload)
+    if actual_fields != _DIFF_FIELDS:
+        raise ValueError(
+            "diff fields do not match canonical to_diff_dict shape; "
+            f"missing={sorted(_DIFF_FIELDS - actual_fields)}, "
+            f"unknown={sorted(actual_fields - _DIFF_FIELDS)}"
+        )
+    _require_json_serializable(payload, "diff")
+    if payload.get("schema_version") != DIFF_SCHEMA_VERSION:
+        raise ValueError(f"diff schema_version must be {DIFF_SCHEMA_VERSION!r}")
+    if payload.get("producer") != PRODUCER:
+        raise ValueError(f"diff producer must be {PRODUCER!r}")
+    for field in ("producer_version", "diff_id"):
+        value = payload.get(field)
+        if not isinstance(value, str) or not value:
+            raise ValueError(f"diff {field} must be a non-empty string")
+    if payload.get("verdict") not in {
+        "improvement_likely",
+        "regression_likely",
+        "neutral",
+        "inconclusive",
+    }:
+        raise ValueError("diff verdict is not canonical")
+    confidence = payload.get("comparability_confidence")
+    if (
+        isinstance(confidence, bool)
+        or not isinstance(confidence, (int, float))
+        or not math.isfinite(confidence)
+        or not 0 <= confidence <= 1
+    ):
+        raise ValueError("diff comparability_confidence must be between 0 and 1")
+
+    for field in (
+        "category_attribution",
+        "warnings",
+        "top_regressions",
+        "top_improvements",
+        "nvtx_regressions",
+        "nvtx_improvements",
+    ):
+        if not isinstance(payload.get(field), list):
+            raise ValueError(f"diff {field} must be an array")
+    if any(not isinstance(warning, str) for warning in payload["warnings"]):
+        raise ValueError("diff warnings must contain only strings")
+    for field in ("step_time", "communication_summary", "idle_summary"):
+        value = payload.get(field)
+        if value is not None and not isinstance(value, Mapping):
+            raise ValueError(f"diff {field} must be an object or null")
+    for side in ("before", "after"):
+        reference = payload.get(side)
+        if not isinstance(reference, Mapping):
+            raise ValueError(f"diff {side} must be an object")
+        reference_fields = set(reference)
+        if reference_fields != _DIFF_SIDE_FIELDS:
+            raise ValueError(
+                f"diff {side} fields do not match canonical shape; "
+                f"missing={sorted(_DIFF_SIDE_FIELDS - reference_fields)}, "
+                f"unknown={sorted(reference_fields - _DIFF_SIDE_FIELDS)}"
+            )
+        for field in ("path", "profile_id"):
+            value = reference.get(field)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"diff {side} {field} must be a non-empty string")
+        if not Path(reference["path"]).is_absolute():
+            raise ValueError(f"diff {side} path must be absolute")
+        for field in ("schema_version", "product_version"):
+            value = reference.get(field)
+            if value is not None and (not isinstance(value, str) or not value):
+                raise ValueError(f"diff {side} {field} must be a string or null")
+        gpu = reference.get("gpu")
+        if gpu is not None and (isinstance(gpu, bool) or not isinstance(gpu, int)):
+            raise ValueError(f"diff {side} gpu must be an integer or null")
+        total_gpu_ns = reference.get("total_gpu_ns")
+        if (
+            isinstance(total_gpu_ns, bool)
+            or not isinstance(total_gpu_ns, int)
+            or total_gpu_ns < 0
+        ):
+            raise ValueError(f"diff {side} total_gpu_ns must be non-negative")
+
+    _validate_diff_categories(payload)
+    _validate_diff_axis(
+        payload["communication_summary"],
+        field_name="communication_summary",
+        axis_name="communication",
+        total_basis="exposed comm",
+        before_profile_id=payload["before"]["profile_id"],
+        after_profile_id=payload["after"]["profile_id"],
+    )
+    _validate_diff_axis(
+        payload["idle_summary"],
+        field_name="idle_summary",
+        axis_name="idle",
+        total_basis="wall-clock idle",
+        before_profile_id=payload["before"]["profile_id"],
+        after_profile_id=payload["after"]["profile_id"],
+    )
+    _validate_diff_kernel_entries(payload)
+    _validate_diff_nvtx_entries(payload)
+    _validate_diff_overlap(payload["overlap"])
+
+    decided = _validate_diff_decision(payload)
+    if require_undecided and decided:
+        raise ValueError(
+            "publish_diff requires decision to be null; use publish_decision"
+        )
+
+
+def _validate_diff_decision(diff: Mapping[str, Any]) -> bool:
+    decision = diff.get("decision")
+    if decision is None:
+        return False
+    if not isinstance(decision, Mapping):
+        raise ValueError("diff decision must be an object or null")
+    expected = {"status", "reason", "decider", "decided_at"}
+    if set(decision) != expected:
+        raise ValueError(
+            "diff decision requires only status, reason, decider, and decided_at"
+        )
+    if decision.get("status") not in {"accepted", "rejected"}:
+        raise ValueError("diff decision status must be accepted or rejected")
+    for field in ("reason", "decider", "decided_at"):
+        value = decision.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"diff decision {field} must be a non-empty string")
+    return True
+
+
+def _require_json_serializable(value: Any, label: str) -> None:
+    try:
+        json.dumps(value, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{label} must be JSON serializable: {exc}") from exc
+
+
+def _read_json(path: Path, label: str) -> Any:
+    try:
+        return json.loads(
+            _read_bytes(path, label),
+            parse_constant=_reject_non_finite_json,
+        )
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise SessionCorruptError(f"invalid {label}: {exc}") from exc
+
+
+def _reject_non_finite_json(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant {value}")
+
+
+def _read_bytes(path: Path, label: str) -> bytes:
+    try:
+        return path.read_bytes()
+    except FileNotFoundError as exc:
+        raise SessionCorruptError(f"missing {label}") from exc
+
+
+def _sha256_file(path: Path, label: str) -> str:
+    return hashlib.sha256(_read_bytes(path, label)).hexdigest()

--- a/tests/test_diff_json_shape.py
+++ b/tests/test_diff_json_shape.py
@@ -67,6 +67,30 @@ def test_deciding_adds_only_the_decision(undecided):
     assert decided["decision"]["status"] == "accepted"
 
 
+def test_whitespace_environment_identity_falls_back_before_building_decision(
+    monkeypatch,
+):
+    import nsys_ai.diff_decision as diff_decision
+
+    def unavailable_git(*_args, **_kwargs):
+        raise OSError("git unavailable")
+
+    monkeypatch.setattr(diff_decision.subprocess, "run", unavailable_git)
+    monkeypatch.setenv("USER", "   ")
+    monkeypatch.setenv("USERNAME", "\t")
+    payload, _warnings = diff_decision.build_diff_decision_record_from_diff_dict(
+        {
+            "before": {"profile_id": "before"},
+            "after": {"profile_id": "after"},
+            "warnings": [],
+        },
+        decision="accepted",
+        reason="verified",
+    )
+
+    assert payload["decision"]["decider"] == "unknown"
+
+
 def test_the_envelope_is_pinned(undecided):
     """A write-only artifact has no reader to reject a bad version, so the
     envelope is pinned here instead.
@@ -101,6 +125,12 @@ def test_it_is_json_serialisable(undecided):
     """The artifact is written to disk; a value that cannot serialise is a bug
     that would only surface at write time."""
     assert json.loads(json.dumps(undecided, default=str))["decision"] is None
+
+
+def test_canonical_diff_passes_the_session_artifact_validator(undecided):
+    from nsys_ai.session_store import _validate_diff_payload
+
+    _validate_diff_payload(undecided, require_undecided=True)
 
 
 # ── The two version constants are separate on purpose ───────────────────────

--- a/tests/test_proposal.py
+++ b/tests/test_proposal.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 
 import pytest
@@ -10,6 +11,7 @@ from nsys_ai.proposal import (
     ProposalError,
     UnsupportedProposalVersionError,
     generate_proposal,
+    validate_proposal_against_finding,
 )
 from nsys_ai.runspec import EnvironmentSpec, RunSpec, RunSpecError
 
@@ -170,6 +172,26 @@ def test_changed_artifact_content_is_rejected_by_proposal_id():
 
     with pytest.raises(ProposalError, match="proposal_id does not match"):
         Proposal.from_dict(payload)
+
+
+def test_semantic_validator_rejects_reidentified_invented_content():
+    finding = _finding()
+    payload = generate_proposal(finding, _runspec()).to_dict()
+    payload["summary"] = "Invented summary"
+    identity = dict(payload)
+    identity.pop("proposal_id")
+    canonical = json.dumps(
+        identity,
+        allow_nan=False,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    payload["proposal_id"] = "proposal1:sha256:" + hashlib.sha256(canonical).hexdigest()
+    invented = Proposal.from_dict(payload)
+
+    with pytest.raises(ProposalError, match="not deterministically derived"):
+        validate_proposal_against_finding(invented, finding)
 
 
 def test_unsupported_version_and_unknown_fields_are_rejected():

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1,0 +1,1771 @@
+import hashlib
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.annotation import SCHEMA_VERSION as DIFF_SCHEMA_VERSION
+from nsys_ai.annotation import EvidenceReport, EvidenceRow, Finding, TraceSelection
+from nsys_ai.profile_runner import LocalProfileReference
+from nsys_ai.proposal import PROPOSAL_SCHEMA_VERSION, Proposal, generate_proposal
+from nsys_ai.runspec import EnvironmentSpec, RunSpec, RunSpecError
+from nsys_ai.session_store import (
+    SESSION_SCHEMA_VERSION,
+    SessionConflictError,
+    SessionCorruptError,
+    SessionError,
+    SessionStore,
+    UnsupportedSessionVersionError,
+)
+
+
+def _profile_reference(path: Path, profile_id: str) -> LocalProfileReference:
+    path.write_bytes(b"profile bytes remain outside the session")
+    return LocalProfileReference(
+        path=str(path.absolute()),
+        profile_id=profile_id,
+        schema_version="3.25.0",
+        product_version="2026.2.1.106",
+        kernel_count=7,
+    )
+
+
+def _diff(before: LocalProfileReference, after: LocalProfileReference) -> dict:
+    return {
+        "schema_version": DIFF_SCHEMA_VERSION,
+        "decision": None,
+        "producer": "nsys-ai",
+        "producer_version": "test",
+        "diff_id": "diff-test",
+        "verdict": "improvement_likely",
+        "comparability_confidence": 0.9,
+        "step_time": None,
+        "category_attribution": [],
+        "communication_summary": None,
+        "idle_summary": None,
+        "warnings": [],
+        "before": {
+            "path": before.path,
+            "profile_id": before.profile_id,
+            "gpu": 0,
+            "schema_version": before.schema_version,
+            "product_version": before.product_version,
+            "total_gpu_ns": 10,
+        },
+        "after": {
+            "path": after.path,
+            "profile_id": after.profile_id,
+            "gpu": 0,
+            "schema_version": after.schema_version,
+            "product_version": after.product_version,
+            "total_gpu_ns": 9,
+        },
+        "top_regressions": [],
+        "top_improvements": [],
+        "nvtx_regressions": [],
+        "nvtx_improvements": [],
+        "overlap": {
+            "before": {
+                "compute_only_ms": 1.0,
+                "nccl_only_ms": 0.0,
+                "overlap_ms": 0.0,
+                "idle_ms": 0.0,
+                "total_ms": 1.0,
+                "overlap_pct": 0.0,
+                "compute_kernels": 1,
+                "nccl_kernels": 0,
+            },
+            "after": {
+                "compute_only_ms": 0.9,
+                "nccl_only_ms": 0.0,
+                "overlap_ms": 0.0,
+                "idle_ms": 0.0,
+                "total_ms": 0.9,
+                "overlap_pct": 0.0,
+                "compute_kernels": 1,
+                "nccl_kernels": 0,
+            },
+            "delta": {"compute_only_ms": -0.1},
+        },
+    }
+
+
+def _nested_diff(before: LocalProfileReference, after: LocalProfileReference) -> dict:
+    payload = _diff(before, after)
+    payload["step_time"] = {
+        "before_ms": 1.0,
+        "after_ms": 0.9,
+        "delta_ms": -0.1,
+        "delta_pct": -10.0,
+    }
+    payload["category_attribution"] = [
+        {
+            "category": "compute",
+            "before_ms": 1.0,
+            "after_ms": 0.9,
+            "delta_ms": -0.1,
+            "delta_pct": -10.0,
+        }
+    ]
+    selection = TraceSelection(
+        id="selection-diff",
+        profile_id=after.profile_id,
+        source="diff:communication_summary",
+        start_ns=1,
+        end_ns=2,
+        gpu_ids=[0],
+    ).to_dict()
+    payload["communication_summary"] = {
+        "axis": "communication",
+        "title": "Communication/NCCL Summary",
+        "total_basis": "exposed comm",
+        "before_ms": 1.0,
+        "after_ms": 0.9,
+        "delta_ms": -0.1,
+        "delta_pct": -10.0,
+        "entries": [
+            {
+                "key": "allreduce",
+                "label": "NCCL allreduce",
+                "before_ms": 1.0,
+                "after_ms": 0.9,
+                "delta_ms": -0.1,
+                "delta_pct": -10.0,
+                "before_count": 1,
+                "after_count": 1,
+                "classification": "improvement",
+                "selection": selection,
+                "metadata": {"selection_side": "after"},
+            }
+        ],
+    }
+    kernel_selection = TraceSelection(
+        id="selection-kernel",
+        profile_id=after.profile_id,
+        source="diff",
+        gpu_ids=[0],
+    ).to_dict()
+    payload["top_regressions"] = [
+        {
+            "key": "kernel",
+            "name": "kernel",
+            "demangled": "kernel",
+            "before_total_ns": 1,
+            "after_total_ns": 2,
+            "delta_ns": 1,
+            "before_count": 1,
+            "after_count": 1,
+            "classification": "regression",
+            "before_share": 0.5,
+            "after_share": 0.6,
+            "delta_share": 0.6 - 0.5,
+            "selection": kernel_selection,
+        }
+    ]
+    payload["nvtx_regressions"] = [
+        {
+            "text": "step",
+            "before_total_ns": 1,
+            "after_total_ns": 2,
+            "delta_ns": 1,
+            "before_count": 1,
+            "after_count": 1,
+            "classification": "regression",
+        }
+    ]
+    return payload
+
+
+def _finding(
+    profile: LocalProfileReference,
+    finding_id: str | None = "f1",
+    *,
+    action: str = "Test the change",
+) -> Finding:
+    return Finding(
+        type="region",
+        label="Idle region",
+        start_ns=10,
+        end_ns=20,
+        id=finding_id,
+        explanation="Reduce the measured idle region.",
+        suggested_actions=[action],
+        selection=TraceSelection(
+            id=f"selection-{finding_id or 'missing'}",
+            profile_id=profile.profile_id,
+            source="skill:test",
+            start_ns=10,
+            end_ns=20,
+        ),
+    )
+
+
+def _proposal_id_for_payload(payload: dict) -> str:
+    identity = dict(payload)
+    identity.pop("proposal_id", None)
+    canonical = json.dumps(
+        identity,
+        allow_nan=False,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return "proposal1:sha256:" + hashlib.sha256(canonical).hexdigest()
+
+
+def _reprofiled_session(tmp_path: Path, session_id: str):
+    before = _profile_reference(
+        tmp_path / f"{session_id}-before.sqlite", f"nsys1:{session_id}:before"
+    )
+    after = _profile_reference(
+        tmp_path / f"{session_id}-after.sqlite", f"nsys1:{session_id}:after"
+    )
+    finding = _finding(before)
+    spec = RunSpec(argv=("true",))
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    proposal = generate_proposal(finding, spec)
+    store = SessionStore(tmp_path / "sessions")
+    store.create(session_id, before_profile=before)
+    with store.writer(session_id) as writer:
+        writer.publish_runspec(spec)
+        writer.publish_findings(report)
+        writer.publish_proposal(proposal)
+        writer.publish_after_profile(after)
+    return store, before, after, finding, spec, proposal
+
+
+def test_complete_session_round_trip_uses_exact_layout_and_local_references(tmp_path):
+    sessions = tmp_path / ".nsys-ai" / "sessions"
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    store = SessionStore(sessions)
+
+    state = store.create("run-001", before_profile=before)
+    assert state.phase == "diagnose"
+    session_dir = sessions / "run-001"
+    assert {item.name for item in session_dir.iterdir()} == {"session.json", "logs"}
+    assert (tmp_path / ".nsys-ai" / "locks").is_dir()
+    assert stat.S_IMODE(sessions.stat().st_mode) == 0o700
+    assert stat.S_IMODE(session_dir.stat().st_mode) == 0o700
+    assert stat.S_IMODE((session_dir / "logs").stat().st_mode) == 0o700
+
+    runspec = RunSpec(argv=("python3", "train.py"), cwd=str(tmp_path))
+    finding = _finding(before)
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    proposal = generate_proposal(finding, runspec)
+    with store.writer("run-001") as writer:
+        writer.publish_runspec(runspec)
+        writer.publish_findings(report)
+        writer.publish_proposal(proposal)
+        writer.publish_after_profile(after)
+        writer.publish_diff(_diff(before, after))
+        state, decided, warnings = writer.publish_decision(
+            "accept",
+            "measured improvement",
+            decider="test@example.com",
+            decided_at="2026-08-06T00:00:00Z",
+        )
+
+    assert state.phase == "accept"
+    assert decided["decision"] == {
+        "status": "accepted",
+        "reason": "measured improvement",
+        "decider": "test@example.com",
+        "decided_at": "2026-08-06T00:00:00Z",
+    }
+    assert warnings == ()
+    assert {item.name for item in session_dir.iterdir()} == {
+        "session.json",
+        "runspec.json",
+        "findings.json",
+        "proposal.json",
+        "diff.json",
+        "logs",
+    }
+    assert not list(session_dir.rglob("*.sqlite"))
+    for artifact in session_dir.glob("*.json"):
+        assert stat.S_IMODE(artifact.stat().st_mode) == 0o600
+    for lock in (tmp_path / ".nsys-ai" / "locks").glob("*.lock"):
+        assert stat.S_IMODE(lock.stat().st_mode) == 0o600
+
+    restarted = SessionStore(sessions).load("run-001")
+    assert restarted.state.phase == "accept"
+    assert restarted.state.before_profile == before
+    assert restarted.state.after_profile == after
+    assert restarted.runspec == runspec
+    assert restarted.findings.to_dict() == report.to_dict()
+    assert restarted.proposal == proposal
+    assert restarted.diff["decision"]["status"] == "accepted"
+
+    manifest = json.loads((session_dir / "session.json").read_text())
+    assert manifest["schema_version"] == SESSION_SCHEMA_VERSION
+    assert manifest["profiles"]["before"] == {
+        "kind": "local",
+        "path": before.path,
+        "profile_id": before.profile_id,
+        "export_schema_version": before.schema_version,
+        "product_version": before.product_version,
+        "kernel_count": before.kernel_count,
+    }
+    assert manifest["artifacts"]["findings"]["schema_version"] == DIFF_SCHEMA_VERSION
+    assert manifest["artifacts"]["proposal"]["schema_version"] == (
+        PROPOSAL_SCHEMA_VERSION
+    )
+    assert json.loads((session_dir / "diff.json").read_text())["schema_version"] == (
+        DIFF_SCHEMA_VERSION
+    )
+
+
+def test_active_writer_conflict_is_observed_from_a_second_process(tmp_path):
+    store = SessionStore(tmp_path / "sessions")
+    store.create("conflict")
+    script = """
+import sys
+from nsys_ai.session_store import SessionStore
+store = SessionStore(sys.argv[1])
+with store.writer("conflict"):
+    print("LOCKED", flush=True)
+    sys.stdin.readline()
+"""
+    process = subprocess.Popen(
+        [sys.executable, "-c", script, str(store.root)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=_subprocess_environment(),
+    )
+    stderr = ""
+    try:
+        assert process.stdout.readline().strip() == "LOCKED"
+        with pytest.raises(SessionConflictError, match="active writer") as conflict:
+            store.writer("conflict")
+        assert conflict.value.error_code == "SESSION_WRITER_CONFLICT"
+    finally:
+        _stdout, stderr = process.communicate("\n", timeout=10)
+    assert process.returncode == 0, stderr
+
+
+def test_symlink_alias_cannot_bypass_the_single_writer_lock(tmp_path):
+    real_root = tmp_path / "real" / "sessions"
+    store = SessionStore(real_root)
+    store.create("alias-conflict")
+    alias_root = tmp_path / "alias-sessions"
+    alias_root.symlink_to(real_root, target_is_directory=True)
+    alias_store = SessionStore(alias_root)
+
+    assert alias_store.root == store.root
+    with store.writer("alias-conflict"):
+        with pytest.raises(SessionConflictError, match="active writer"):
+            alias_store.writer("alias-conflict")
+
+
+def test_new_process_reloads_persisted_phase_and_profile_reference(tmp_path):
+    store = SessionStore(tmp_path / "sessions")
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    finding = _finding(before)
+    spec = RunSpec(argv=("true",))
+    store.create("restart", before_profile=before)
+    with store.writer("restart") as writer:
+        writer.publish_runspec(spec)
+        writer.publish_findings(
+            EvidenceReport(
+                "diagnosis",
+                profile_path=before.path,
+                profile_id=before.profile_id,
+                findings=[finding],
+            )
+        )
+        writer.publish_proposal(generate_proposal(finding, spec))
+        writer.publish_after_profile(after)
+
+    script = """
+import json, sys
+from nsys_ai.session_store import SessionStore
+snapshot = SessionStore(sys.argv[1]).load("restart")
+print(json.dumps({"phase": snapshot.state.phase, "profile_id": snapshot.state.after_profile.profile_id}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(store.root)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_subprocess_environment(),
+    )
+    assert json.loads(result.stdout) == {
+        "phase": "reprofile",
+        "profile_id": "nsys1:after",
+    }
+
+
+def test_failed_atomic_replace_preserves_previous_artifact(monkeypatch, tmp_path):
+    import nsys_ai.artifact_io as artifact_io
+
+    store = SessionStore(tmp_path / "sessions")
+    store.create("atomic")
+    with store.writer("atomic") as writer:
+        writer.publish_findings(EvidenceReport("old"))
+        findings_path = store.root / "atomic" / "findings.json"
+        before = findings_path.read_bytes()
+        real_replace = artifact_io.os.replace
+
+        def fail_findings_replace(source, destination):
+            if Path(destination) == findings_path:
+                raise OSError("simulated publication failure")
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(artifact_io.os, "replace", fail_findings_replace)
+        with pytest.raises(OSError, match="publication failure"):
+            writer.publish_findings(EvidenceReport("new"))
+
+    assert findings_path.read_bytes() == before
+    monkeypatch.undo()
+    assert store.load("atomic").findings.title == "old"
+    assert not list(findings_path.parent.glob(".findings.json.*.tmp"))
+
+
+def test_manifest_failure_recovers_the_previous_snapshot(monkeypatch, tmp_path):
+    import nsys_ai.session_store as session_store
+
+    store = SessionStore(tmp_path / "sessions")
+    store.create("interrupted")
+    with store.writer("interrupted") as writer:
+        writer.publish_findings(EvidenceReport("old"))
+        manifest_path = store.root / "interrupted" / "session.json"
+        findings_path = store.root / "interrupted" / "findings.json"
+        manifest_before = json.loads(manifest_path.read_text())
+        real_atomic_write_json = session_store.atomic_write_json
+
+        def fail_manifest(path, payload):
+            if Path(path) == manifest_path:
+                raise OSError("simulated manifest failure")
+            return real_atomic_write_json(path, payload)
+
+        monkeypatch.setattr(session_store, "atomic_write_json", fail_manifest)
+        with pytest.raises(OSError, match="manifest failure"):
+            writer.publish_findings(EvidenceReport("new"))
+
+    assert json.loads(findings_path.read_text())["title"] == "new"
+    assert json.loads(manifest_path.read_text()) == manifest_before
+    assert manifest_before["phase"] == "diagnose"
+    recovered = SessionStore(store.root).load("interrupted")
+    assert recovered.findings.title == "old"
+    assert json.loads(findings_path.read_text())["title"] == "old"
+    assert not (store.root / "interrupted" / ".transaction").exists()
+
+
+def test_interruption_after_manifest_publication_recovers_in_a_new_process(
+    monkeypatch, tmp_path
+):
+    store = SessionStore(tmp_path / "sessions")
+    store.create("manifest-published")
+    with store.writer("manifest-published") as writer:
+        writer.publish_findings(EvidenceReport("old"))
+
+        def interrupt_cleanup(_session_id):
+            raise OSError("simulated crash after manifest publication")
+
+        monkeypatch.setattr(store, "_finish_transaction", interrupt_cleanup)
+        with pytest.raises(OSError, match="after manifest publication"):
+            writer.publish_findings(EvidenceReport("new"))
+
+    script = """
+import json, sys
+from nsys_ai.session_store import SessionStore
+snapshot = SessionStore(sys.argv[1]).load("manifest-published")
+print(json.dumps({"phase": snapshot.state.phase, "title": snapshot.findings.title}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(store.root)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_subprocess_environment(),
+    )
+    assert json.loads(result.stdout) == {"phase": "diagnose", "title": "old"}
+    assert not (store.root / "manifest-published" / ".transaction").exists()
+
+
+def test_committed_tombstone_cleanup_failure_does_not_affect_restart(
+    monkeypatch, tmp_path
+):
+    import nsys_ai.session_store as session_store
+
+    store = SessionStore(tmp_path / "sessions")
+    store.create("commit-tombstone")
+    with store.writer("commit-tombstone") as writer:
+        writer.publish_findings(EvidenceReport("old"))
+        real_rmtree = session_store.shutil.rmtree
+
+        def fail_tombstone_cleanup(path, *args, **kwargs):
+            if Path(path).name.startswith(".transaction.cleanup."):
+                raise OSError("simulated tombstone cleanup failure")
+            return real_rmtree(path, *args, **kwargs)
+
+        monkeypatch.setattr(session_store.shutil, "rmtree", fail_tombstone_cleanup)
+        writer.publish_findings(EvidenceReport("new"))
+
+    session_dir = store.root / "commit-tombstone"
+    assert not (session_dir / ".transaction").exists()
+    tombstone = next(session_dir.glob(".transaction.cleanup.*"))
+    (tombstone / "transaction.json").unlink()
+    monkeypatch.undo()
+
+    script = """
+import json, sys
+from nsys_ai.session_store import SessionStore
+snapshot = SessionStore(sys.argv[1]).load("commit-tombstone")
+print(json.dumps({"phase": snapshot.state.phase, "title": snapshot.findings.title}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(store.root)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_subprocess_environment(),
+    )
+    assert json.loads(result.stdout) == {"phase": "diagnose", "title": "new"}
+    assert not list(session_dir.glob(".transaction.cleanup.*"))
+
+
+def test_rollback_tombstone_cleanup_failure_does_not_affect_restart(
+    monkeypatch, tmp_path
+):
+    import nsys_ai.session_store as session_store
+
+    store = SessionStore(tmp_path / "sessions")
+    store.create("rollback-tombstone")
+    with store.writer("rollback-tombstone") as writer:
+        writer.publish_findings(EvidenceReport("old"))
+        manifest_path = store.root / "rollback-tombstone" / "session.json"
+        real_atomic_write_json = session_store.atomic_write_json
+
+        def fail_manifest(path, payload):
+            if Path(path) == manifest_path:
+                raise OSError("simulated manifest interruption")
+            return real_atomic_write_json(path, payload)
+
+        monkeypatch.setattr(session_store, "atomic_write_json", fail_manifest)
+        with pytest.raises(OSError, match="manifest interruption"):
+            writer.publish_findings(EvidenceReport("new"))
+    monkeypatch.undo()
+
+    real_rmtree = session_store.shutil.rmtree
+
+    def fail_tombstone_cleanup(path, *args, **kwargs):
+        if Path(path).name.startswith(".transaction.cleanup."):
+            raise OSError("simulated tombstone cleanup failure")
+        return real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(session_store.shutil, "rmtree", fail_tombstone_cleanup)
+    recovered = SessionStore(store.root).load("rollback-tombstone")
+    assert recovered.findings.title == "old"
+    session_dir = store.root / "rollback-tombstone"
+    assert not (session_dir / ".transaction").exists()
+    tombstone = next(session_dir.glob(".transaction.cleanup.*"))
+    (tombstone / "artifact.json").unlink()
+    monkeypatch.undo()
+
+    script = """
+import json, sys
+from nsys_ai.session_store import SessionStore
+snapshot = SessionStore(sys.argv[1]).load("rollback-tombstone")
+print(json.dumps({"phase": snapshot.state.phase, "title": snapshot.findings.title}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(store.root)],
+        check=True,
+        capture_output=True,
+        text=True,
+        env=_subprocess_environment(),
+    )
+    assert json.loads(result.stdout) == {"phase": "diagnose", "title": "old"}
+    assert not list(session_dir.glob(".transaction.cleanup.*"))
+
+
+def test_findings_unknown_schema_is_rejected_before_canonical_rehydration(tmp_path):
+    store = SessionStore(tmp_path / "sessions")
+    store.create("future-findings")
+    with store.writer("future-findings") as writer:
+        writer.publish_findings(EvidenceReport("future compatible"))
+
+    session_dir = store.root / "future-findings"
+    findings_path = session_dir / "findings.json"
+    payload = json.loads(findings_path.read_text())
+    payload["schema_version"] = "99"
+    findings_path.write_text(json.dumps(payload))
+    digest = hashlib.sha256(findings_path.read_bytes()).hexdigest()
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["findings"]["schema_version"] = "99"
+    manifest["artifacts"]["findings"]["sha256"] = digest
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(UnsupportedSessionVersionError, match="unsupported findings"):
+        store.load("future-findings")
+
+
+def test_findings_payload_version_must_match_manifest(tmp_path):
+    store = SessionStore(tmp_path / "sessions")
+    store.create("mismatch")
+    with store.writer("mismatch") as writer:
+        writer.publish_findings(EvidenceReport("mismatch"))
+
+    session_dir = store.root / "mismatch"
+    findings_path = session_dir / "findings.json"
+    payload = json.loads(findings_path.read_text())
+    payload["schema_version"] = "0.2"
+    findings_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["findings"]["sha256"] = hashlib.sha256(
+        findings_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(UnsupportedSessionVersionError, match="does not match"):
+        store.load("mismatch")
+
+
+def test_findings_producer_version_drift_remains_compatible(tmp_path):
+    store = SessionStore(tmp_path / "sessions")
+    store.create("producer-drift")
+    with store.writer("producer-drift") as writer:
+        writer.publish_findings(EvidenceReport("diagnosis"))
+
+    session_dir = store.root / "producer-drift"
+    findings_path = session_dir / "findings.json"
+    payload = json.loads(findings_path.read_text())
+    payload["producer_version"] = "99.7.3-compatible-writer"
+    findings_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["findings"]["sha256"] = hashlib.sha256(
+        findings_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    snapshot = store.load("producer-drift")
+    assert snapshot.findings.title == "diagnosis"
+    assert json.loads(findings_path.read_text())["producer_version"] == (
+        "99.7.3-compatible-writer"
+    )
+
+
+def test_findings_and_diff_must_match_session_profile_identities(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("identity", before_profile=before)
+    finding = _finding(before)
+    spec = RunSpec(argv=("true",))
+    with store.writer("identity") as writer:
+        with pytest.raises(ValueError, match="profile_id is required"):
+            writer.publish_findings(EvidenceReport("missing provenance"))
+        with pytest.raises(ValueError, match="findings profile_id"):
+            writer.publish_findings(
+                EvidenceReport("wrong", profile_id="nsys1:other")
+            )
+        writer.publish_runspec(spec)
+        writer.publish_findings(
+            EvidenceReport(
+                "diagnosis",
+                profile_path=before.path,
+                profile_id=before.profile_id,
+                findings=[finding],
+            )
+        )
+        writer.publish_proposal(generate_proposal(finding, spec))
+        writer.publish_after_profile(after)
+        mismatched = _diff(before, after)
+        mismatched["after"]["profile_id"] = "nsys1:other"
+        with pytest.raises(ValueError, match="diff after profile_id"):
+            writer.publish_diff(mismatched)
+
+    snapshot = store.load("identity")
+    assert snapshot.findings.findings[0].id == finding.id
+    assert snapshot.diff is None
+
+
+def test_malformed_typed_findings_are_rejected_before_publication(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    malformed = [
+        Finding(type=None, label="missing type", start_ns=1),
+        Finding(
+            type="region",
+            label="missing selection id",
+            start_ns=1,
+            selection=TraceSelection(
+                id=None,
+                profile_id=before.profile_id,
+                source="skill:test",
+            ),
+        ),
+        Finding(
+            type="region",
+            label="missing evidence id",
+            start_ns=1,
+            evidence=[EvidenceRow(id=None, source_skill="test")],
+        ),
+    ]
+    store = SessionStore(tmp_path / "sessions")
+    store.create("malformed-findings", before_profile=before)
+    session_dir = store.root / "malformed-findings"
+    manifest_before = (session_dir / "session.json").read_bytes()
+
+    with store.writer("malformed-findings") as writer:
+        for finding in malformed:
+            report = EvidenceReport(
+                "diagnosis",
+                profile_path=before.path,
+                profile_id=before.profile_id,
+                findings=[finding],
+            )
+            with pytest.raises(ValueError, match="fields do not match schema"):
+                writer.publish_findings(report)
+            assert not (session_dir / "findings.json").exists()
+            assert (session_dir / "session.json").read_bytes() == manifest_before
+
+    assert store.load("malformed-findings").findings is None
+
+
+def test_malformed_findings_payload_is_rejected_on_restart(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[_finding(before)],
+    )
+    store = SessionStore(tmp_path / "sessions")
+    store.create("malformed-findings-load", before_profile=before)
+    with store.writer("malformed-findings-load") as writer:
+        writer.publish_findings(report)
+
+    session_dir = store.root / "malformed-findings-load"
+    findings_path = session_dir / "findings.json"
+    payload = json.loads(findings_path.read_text())
+    payload["findings"][0].pop("type")
+    findings_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["findings"]["sha256"] = hashlib.sha256(
+        findings_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match="fields do not match schema"):
+        store.load("malformed-findings-load")
+
+
+def test_wrong_nested_evidence_scalar_and_container_types_are_rejected(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    malformed = [
+        Finding(type=123, label="wrong scalar", start_ns=1),
+        Finding(
+            type="region",
+            label="wrong selection container",
+            start_ns=1,
+            selection=TraceSelection(
+                id="selection",
+                profile_id=before.profile_id,
+                source="skill:test",
+                gpu_ids="0",
+            ),
+        ),
+        Finding(
+            type="region",
+            label="wrong evidence container",
+            start_ns=1,
+            evidence=[EvidenceRow(id="row", source_skill="test", units=[])],
+        ),
+    ]
+    store = SessionStore(tmp_path / "sessions")
+    store.create("typed-findings", before_profile=before)
+    session_dir = store.root / "typed-findings"
+    manifest_before = (session_dir / "session.json").read_bytes()
+
+    with store.writer("typed-findings") as writer:
+        for finding in malformed:
+            with pytest.raises(ValueError):
+                writer.publish_findings(
+                    EvidenceReport(
+                        "diagnosis",
+                        profile_path=before.path,
+                        profile_id=before.profile_id,
+                        findings=[finding],
+                    )
+                )
+            assert not (session_dir / "findings.json").exists()
+            assert (session_dir / "session.json").read_bytes() == manifest_before
+
+
+def test_nested_finding_selection_must_match_before_profile_on_publish_and_load(
+    tmp_path,
+):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    finding = _finding(before)
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    store = SessionStore(tmp_path / "sessions")
+    store.create("selection-profile", before_profile=before)
+    session_dir = store.root / "selection-profile"
+    manifest_before = (session_dir / "session.json").read_bytes()
+
+    finding.selection.profile_id = "nsys1:other"
+    with store.writer("selection-profile") as writer:
+        with pytest.raises(ValueError, match="selection profile_id"):
+            writer.publish_findings(report)
+    assert not (session_dir / "findings.json").exists()
+    assert (session_dir / "session.json").read_bytes() == manifest_before
+
+    finding.selection.profile_id = before.profile_id
+    with store.writer("selection-profile") as writer:
+        writer.publish_findings(report)
+    findings_path = session_dir / "findings.json"
+    payload = json.loads(findings_path.read_text())
+    payload["findings"][0]["selection"]["profile_id"] = "nsys1:other"
+    findings_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["findings"]["sha256"] = hashlib.sha256(
+        findings_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match="selection profile_id"):
+        store.load("selection-profile")
+
+
+def test_diff_requires_reprofile_phase(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("missing-refs")
+    with store.writer("missing-refs") as writer:
+        with pytest.raises(ValueError, match="expected diff, reprofile"):
+            writer.publish_diff(_diff(before, after))
+    assert store.load("missing-refs").diff is None
+
+
+@pytest.mark.parametrize("shape", ["minimal", "missing", "unknown"])
+def test_diff_publication_requires_exact_canonical_top_level_shape(tmp_path, shape):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "diff-shape"
+    )
+    payload = _diff(before, after)
+    if shape == "minimal":
+        payload = {
+            "schema_version": DIFF_SCHEMA_VERSION,
+            "before": {"profile_id": before.profile_id},
+            "after": {"profile_id": after.profile_id},
+            "decision": None,
+        }
+    elif shape == "missing":
+        payload.pop("top_regressions")
+    else:
+        payload["invented"] = True
+
+    session_dir = store.root / "diff-shape"
+    manifest_before = (session_dir / "session.json").read_bytes()
+    with store.writer("diff-shape") as writer:
+        with pytest.raises(ValueError, match="canonical to_diff_dict shape"):
+            writer.publish_diff(payload)
+
+    assert not (session_dir / "diff.json").exists()
+    assert (session_dir / "session.json").read_bytes() == manifest_before
+    assert store.load("diff-shape").state.phase == "reprofile"
+
+
+@pytest.mark.parametrize("shape", ["missing", "unknown"])
+def test_diff_canonical_top_level_shape_is_revalidated_on_restart(tmp_path, shape):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "diff-shape-load"
+    )
+    with store.writer("diff-shape-load") as writer:
+        writer.publish_diff(_diff(before, after))
+
+    session_dir = store.root / "diff-shape-load"
+    diff_path = session_dir / "diff.json"
+    payload = json.loads(diff_path.read_text())
+    if shape == "missing":
+        payload.pop("top_regressions")
+    else:
+        payload["invented"] = True
+    diff_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["diff"]["sha256"] = hashlib.sha256(
+        diff_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match="canonical to_diff_dict shape"):
+        store.load("diff-shape-load")
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "category_string",
+        "category_unknown",
+        "axis_selection_side",
+        "kernel_selection_profile",
+        "nvtx_count_string",
+        "overlap_metric_string",
+        "kernel_neutral",
+        "kernel_delta",
+        "kernel_wrong_list",
+        "nvtx_delta",
+        "nvtx_neutral",
+        "nvtx_duplicate",
+    ],
+)
+def test_diff_nested_schema_rejects_malformed_or_invented_data(tmp_path, mutation):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "nested-diff"
+    )
+    payload = _nested_diff(before, after)
+    if mutation == "category_string":
+        payload["category_attribution"] = "compute"
+    elif mutation == "category_unknown":
+        payload["category_attribution"][0]["invented"] = True
+    elif mutation == "axis_selection_side":
+        payload["communication_summary"]["entries"][0]["metadata"][
+            "selection_side"
+        ] = "before"
+    elif mutation == "kernel_selection_profile":
+        payload["top_regressions"][0]["selection"]["profile_id"] = before.profile_id
+    elif mutation == "nvtx_count_string":
+        payload["nvtx_regressions"][0]["before_count"] = "1"
+    elif mutation == "overlap_metric_string":
+        payload["overlap"]["before"]["compute_only_ms"] = "1.0"
+    elif mutation == "kernel_neutral":
+        payload["top_regressions"][0]["classification"] = "neutral"
+    elif mutation == "kernel_delta":
+        payload["top_regressions"][0]["delta_ns"] = 2
+    elif mutation == "kernel_wrong_list":
+        payload["top_improvements"] = payload.pop("top_regressions")
+        payload["top_regressions"] = []
+    elif mutation == "nvtx_delta":
+        payload["nvtx_regressions"][0]["delta_ns"] = 2
+    elif mutation == "nvtx_neutral":
+        payload["nvtx_regressions"][0]["classification"] = "neutral"
+    else:
+        payload["nvtx_improvements"] = [
+            dict(payload["nvtx_regressions"][0], delta_ns=-1, classification="removed")
+        ]
+
+    session_dir = store.root / "nested-diff"
+    manifest_before = (session_dir / "session.json").read_bytes()
+    with store.writer("nested-diff") as writer:
+        with pytest.raises(ValueError):
+            writer.publish_diff(payload)
+
+    assert not (session_dir / "diff.json").exists()
+    assert (session_dir / "session.json").read_bytes() == manifest_before
+    assert store.load("nested-diff").state.phase == "reprofile"
+
+
+def test_diff_nested_selection_side_binding_is_revalidated_on_restart(tmp_path):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "nested-diff-load"
+    )
+    with store.writer("nested-diff-load") as writer:
+        writer.publish_diff(_nested_diff(before, after))
+
+    session_dir = store.root / "nested-diff-load"
+    diff_path = session_dir / "diff.json"
+    payload = json.loads(diff_path.read_text())
+    payload["communication_summary"]["entries"][0]["metadata"][
+        "selection_side"
+    ] = "before"
+    diff_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["diff"]["sha256"] = hashlib.sha256(
+        diff_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match="selected diff side"):
+        store.load("nested-diff-load")
+
+
+@pytest.mark.parametrize("contradiction", ["kernel_delta", "nvtx_neutral"])
+def test_directional_diff_invariants_are_revalidated_on_restart(
+    tmp_path, contradiction
+):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "directional-diff-load"
+    )
+    with store.writer("directional-diff-load") as writer:
+        writer.publish_diff(_nested_diff(before, after))
+
+    session_dir = store.root / "directional-diff-load"
+    diff_path = session_dir / "diff.json"
+    payload = json.loads(diff_path.read_text())
+    if contradiction == "kernel_delta":
+        payload["top_regressions"][0]["delta_ns"] = 2
+    else:
+        payload["nvtx_regressions"][0]["classification"] = "neutral"
+    diff_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["diff"]["sha256"] = hashlib.sha256(
+        diff_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError):
+        store.load("directional-diff-load")
+
+
+@pytest.mark.parametrize(
+    ("side", "field", "wrong_value"),
+    [
+        ("before", "path", "/tmp/not-the-before-profile.sqlite"),
+        ("after", "profile_id", "nsys1:not-after"),
+        ("before", "schema_version", "9.9"),
+        ("after", "product_version", "2099.1"),
+    ],
+)
+def test_diff_side_metadata_must_match_session_references_before_publication(
+    tmp_path, side, field, wrong_value
+):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "diff-reference"
+    )
+    payload = _diff(before, after)
+    payload[side][field] = wrong_value
+    session_dir = store.root / "diff-reference"
+    manifest_before = (session_dir / "session.json").read_bytes()
+
+    with store.writer("diff-reference") as writer:
+        with pytest.raises(ValueError, match=f"diff {side} {field}"):
+            writer.publish_diff(payload)
+
+    assert not (session_dir / "diff.json").exists()
+    assert (session_dir / "session.json").read_bytes() == manifest_before
+    assert store.load("diff-reference").state.phase == "reprofile"
+
+
+@pytest.mark.parametrize(
+    ("side", "field", "wrong_value"),
+    [
+        ("before", "path", "/tmp/not-the-before-profile.sqlite"),
+        ("after", "profile_id", "nsys1:not-after"),
+        ("before", "schema_version", "9.9"),
+        ("after", "product_version", "2099.1"),
+    ],
+)
+def test_diff_side_metadata_is_revalidated_on_restart(
+    tmp_path, side, field, wrong_value
+):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "diff-load-reference"
+    )
+    with store.writer("diff-load-reference") as writer:
+        writer.publish_diff(_diff(before, after))
+
+    session_dir = store.root / "diff-load-reference"
+    diff_path = session_dir / "diff.json"
+    payload = json.loads(diff_path.read_text())
+    payload[side][field] = wrong_value
+    diff_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["diff"]["sha256"] = hashlib.sha256(
+        diff_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match=f"diff {side} {field}"):
+        store.load("diff-load-reference")
+
+
+def test_diff_paths_must_be_absolute_and_restart_is_cwd_independent(
+    monkeypatch, tmp_path
+):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "absolute-diff-paths"
+    )
+    relative = _diff(before, after)
+    relative["before"]["path"] = os.path.relpath(before.path, Path.cwd())
+    with store.writer("absolute-diff-paths") as writer:
+        with pytest.raises(ValueError, match="diff before path must be absolute"):
+            writer.publish_diff(relative)
+        writer.publish_diff(_diff(before, after))
+
+    other_cwd = tmp_path / "other-cwd"
+    other_cwd.mkdir()
+    monkeypatch.chdir(other_cwd)
+    snapshot = SessionStore(store.root).load("absolute-diff-paths")
+    assert snapshot.diff["before"]["path"] == before.path
+    assert snapshot.diff["after"]["path"] == after.path
+
+
+def test_diff_overlap_diagnostics_round_trip_numeric_device_keys(tmp_path):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "overlap-diagnostic"
+    )
+    payload = _diff(before, after)
+    diagnostic = {
+        "error": "no kernels found",
+        "requested_device": 7,
+        "available_devices": {0: 3},
+        "hint": "Try device 0",
+    }
+    payload["overlap"] = {
+        "before": diagnostic,
+        "after": diagnostic,
+        "delta": {},
+    }
+    with store.writer("overlap-diagnostic") as writer:
+        writer.publish_diff(payload)
+
+    snapshot = store.load("overlap-diagnostic")
+    assert snapshot.diff["overlap"]["before"]["available_devices"] == {"0": 3}
+
+
+def test_runspec_secret_preflight_happens_before_publication(tmp_path):
+    secret = "sentinel-secret-value"
+    environment = EnvironmentSpec(secrets=("RUNNER_SECRET",))
+    unsafe = RunSpec(argv=("python3", "train.py", f"--token={secret}"), environment=environment)
+    safe = RunSpec(argv=("python3", "train.py"), environment=environment)
+    store = SessionStore(tmp_path / "sessions")
+    store.create("secret-boundary")
+
+    with store.writer("secret-boundary") as writer:
+        with pytest.raises(RunSpecError) as rejected:
+            writer.publish_runspec(
+                unsafe, resolved_secrets={"RUNNER_SECRET": secret}
+            )
+        assert secret not in str(rejected.value)
+        assert store.load("secret-boundary").runspec is None
+        writer.publish_runspec(safe, resolved_secrets={"RUNNER_SECRET": secret})
+
+    runspec_bytes = (store.root / "secret-boundary" / "runspec.json").read_bytes()
+    assert secret.encode() not in runspec_bytes
+    assert store.load("secret-boundary").runspec == safe
+
+
+def test_proposal_future_version_is_rejected_by_manifest_contract(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("proposal", before_profile=before)
+    finding = _finding(before)
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    spec = RunSpec(argv=("true",))
+    with store.writer("proposal") as writer:
+        writer.publish_runspec(spec)
+        writer.publish_findings(report)
+        writer.publish_proposal(generate_proposal(finding, spec))
+
+    session_dir = store.root / "proposal"
+    proposal_path = session_dir / "proposal.json"
+    payload = json.loads(proposal_path.read_text())
+    payload["schema_version"] = "99"
+    proposal_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["proposal"]["schema_version"] = "99"
+    manifest["artifacts"]["proposal"]["sha256"] = hashlib.sha256(
+        proposal_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(UnsupportedSessionVersionError, match="unsupported proposal"):
+        store.load("proposal")
+
+
+def test_invented_proposal_projection_is_rejected_on_publish_and_reload(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    finding = _finding(before)
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    valid = generate_proposal(finding, RunSpec(argv=("true",)))
+    invented_payload = valid.to_dict()
+    invented_payload["summary"] = "Invented summary not present in the finding"
+    invented_payload["proposal_id"] = _proposal_id_for_payload(invented_payload)
+    invented = Proposal.from_dict(invented_payload)
+    store = SessionStore(tmp_path / "sessions")
+    store.create("semantic", before_profile=before)
+
+    with store.writer("semantic") as writer:
+        writer.publish_runspec(valid.verification)
+        writer.publish_findings(report)
+        with pytest.raises(ValueError, match="not deterministically derived"):
+            writer.publish_proposal(invented)
+        writer.publish_proposal(valid)
+
+    session_dir = store.root / "semantic"
+    proposal_path = session_dir / "proposal.json"
+    proposal_path.write_bytes(invented.canonical_json_bytes())
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["proposal"]["sha256"] = hashlib.sha256(
+        proposal_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match="not deterministically derived"):
+        store.load("semantic")
+
+
+def test_missing_selection_abstention_round_trips_without_weakening_identity(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    finding = _finding(before, "missing-selection")
+    finding.selection = None
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    spec = RunSpec(argv=("true",))
+    proposal = generate_proposal(finding, spec)
+    assert proposal.abstained
+    assert proposal.source_profile_id == ""
+
+    invented_payload = proposal.to_dict()
+    invented_payload["summary"] = "Invented abstention summary"
+    invented_payload["proposal_id"] = _proposal_id_for_payload(invented_payload)
+    invented = Proposal.from_dict(invented_payload)
+
+    store = SessionStore(tmp_path / "sessions")
+    store.create("missing-selection", before_profile=before)
+    with store.writer("missing-selection") as writer:
+        writer.publish_runspec(spec)
+        writer.publish_findings(report)
+        with pytest.raises(ValueError, match="not deterministically derived"):
+            writer.publish_proposal(invented)
+        writer.publish_proposal(proposal)
+        with pytest.raises(ValueError, match="non-abstained proposal"):
+            writer.publish_after_profile(
+                _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+            )
+
+    snapshot = store.load("missing-selection")
+    assert snapshot.state.phase == "propose"
+    assert snapshot.state.before_profile == before
+    assert snapshot.findings == report
+    assert snapshot.proposal == proposal
+
+
+def test_proposal_requires_session_profile_and_exactly_one_finding(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    other = _profile_reference(tmp_path / "other.sqlite", "nsys1:other")
+    known = _finding(before, "known")
+    unknown = _finding(before, "unknown")
+    wrong_profile = _finding(other, "known")
+    spec = RunSpec(argv=("true",))
+    store = SessionStore(tmp_path / "sessions")
+    store.create("proposal-pointer", before_profile=before)
+
+    with store.writer("proposal-pointer") as writer:
+        writer.publish_runspec(spec)
+        with pytest.raises(ValueError, match="requires findings.json"):
+            writer.publish_proposal(generate_proposal(known, spec))
+        writer.publish_findings(
+            EvidenceReport(
+                "diagnosis",
+                profile_path=before.path,
+                profile_id=before.profile_id,
+                findings=[known],
+            )
+        )
+        with pytest.raises(ValueError, match="exactly one session finding"):
+            writer.publish_proposal(generate_proposal(unknown, spec))
+        with pytest.raises(ValueError, match="does not match the before profile"):
+            writer.publish_proposal(generate_proposal(wrong_profile, spec))
+
+    assert store.load("proposal-pointer").proposal is None
+
+
+def test_interrupted_proposal_manifest_update_recovers_previous_proposal(
+    monkeypatch, tmp_path
+):
+    import nsys_ai.session_store as session_store
+
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    first_finding = _finding(before, "f1", action="First action")
+    second_finding = _finding(before, "f2", action="Second action")
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[first_finding, second_finding],
+    )
+    spec = RunSpec(argv=("true",))
+    first = generate_proposal(first_finding, spec)
+    second = generate_proposal(second_finding, spec)
+    store = SessionStore(tmp_path / "sessions")
+    store.create("proposal-interrupted", before_profile=before)
+
+    with store.writer("proposal-interrupted") as writer:
+        writer.publish_runspec(spec)
+        writer.publish_findings(report)
+        writer.publish_proposal(first)
+        session_dir = store.root / "proposal-interrupted"
+        manifest_path = session_dir / "session.json"
+        manifest_before = json.loads(manifest_path.read_text())
+        real_atomic_write_json = session_store.atomic_write_json
+
+        def fail_manifest(path, payload):
+            if Path(path) == manifest_path:
+                raise OSError("simulated proposal manifest failure")
+            return real_atomic_write_json(path, payload)
+
+        monkeypatch.setattr(session_store, "atomic_write_json", fail_manifest)
+        with pytest.raises(OSError, match="proposal manifest failure"):
+            writer.publish_proposal(second)
+
+    proposal_path = store.root / "proposal-interrupted" / "proposal.json"
+    assert Proposal.from_json_bytes(proposal_path.read_bytes()) == second
+    assert json.loads(manifest_path.read_text()) == manifest_before
+    assert manifest_before["phase"] == "propose"
+    recovered = SessionStore(store.root).load("proposal-interrupted")
+    assert recovered.proposal == first
+    assert Proposal.from_json_bytes(proposal_path.read_bytes()) == first
+
+
+def test_dependent_overwrites_cannot_break_proposal_or_diff_references(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    replacement_after = _profile_reference(
+        tmp_path / "replacement.sqlite", "nsys1:replacement"
+    )
+    finding = _finding(before)
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    proposal = generate_proposal(finding, RunSpec(argv=("true",)))
+    store = SessionStore(tmp_path / "sessions")
+    store.create("dependencies", before_profile=before)
+
+    with store.writer("dependencies") as writer:
+        writer.publish_runspec(proposal.verification)
+        writer.publish_findings(report)
+        writer.publish_proposal(proposal)
+        writer.publish_after_profile(after)
+        writer.publish_diff(_diff(before, after))
+        with pytest.raises(ValueError, match="cannot publish findings during diff"):
+            writer.publish_findings(
+                EvidenceReport(
+                    "replacement",
+                    profile_path=before.path,
+                    profile_id=before.profile_id,
+                    findings=[],
+                )
+            )
+        with pytest.raises(ValueError, match="cannot publish an after profile during diff"):
+            writer.publish_after_profile(replacement_after)
+        with pytest.raises(ValueError, match="cannot publish a proposal during diff"):
+            writer.publish_proposal(proposal)
+
+    snapshot = store.load("dependencies")
+    assert snapshot.findings.to_dict() == report.to_dict()
+    assert snapshot.proposal == proposal
+    assert snapshot.state.after_profile == after
+    assert snapshot.diff["after"]["profile_id"] == after.profile_id
+
+
+@pytest.mark.parametrize("phase", ["propose", "reprofile", "diff", "accept"])
+def test_manifest_cannot_claim_a_phase_without_required_artifacts(tmp_path, phase):
+    store = SessionStore(tmp_path / "sessions")
+    store.create(f"phase-{phase}")
+    manifest_path = store.root / f"phase-{phase}" / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["phase"] = phase
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match=f"{phase} phase requires proposal"):
+        store.load(f"phase-{phase}")
+
+
+def test_manifest_phase_and_diff_decision_must_agree(tmp_path):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "phase-decision"
+    )
+    with store.writer("phase-decision") as writer:
+        writer.publish_diff(_diff(before, after))
+
+    manifest_path = store.root / "phase-decision" / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["phase"] = "accept"
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(SessionCorruptError, match="accept phase requires a decided"):
+        store.load("phase-decision")
+
+    manifest["phase"] = "diff"
+    manifest_path.write_text(json.dumps(manifest))
+    with store.writer("phase-decision") as writer:
+        writer.publish_decision(
+            "accept",
+            "verified",
+            decider="test@example.com",
+            decided_at="2026-08-06T00:00:00Z",
+        )
+    with store.writer("phase-decision") as writer:
+        with pytest.raises(ValueError, match="during accept phase"):
+            writer.publish_decision("reject", "cannot overwrite")
+    decided_manifest = json.loads(manifest_path.read_text())
+    decided_manifest["phase"] = "diff"
+    manifest_path.write_text(json.dumps(decided_manifest))
+    with pytest.raises(SessionCorruptError, match="diff phase requires an undecided"):
+        store.load("phase-decision")
+
+
+@pytest.mark.parametrize(
+    ("metadata", "message"),
+    [
+        ({"decider": "   "}, "decider must be a non-empty string"),
+        ({"decided_at": "\t"}, "decided_at must be a non-empty string"),
+    ],
+)
+def test_blank_decision_metadata_cannot_corrupt_an_undecided_diff(
+    tmp_path, metadata, message
+):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "blank-decision-metadata"
+    )
+    with store.writer("blank-decision-metadata") as writer:
+        writer.publish_diff(_diff(before, after))
+
+    session_dir = store.root / "blank-decision-metadata"
+    diff_before = (session_dir / "diff.json").read_bytes()
+    manifest_before = (session_dir / "session.json").read_bytes()
+    with store.writer("blank-decision-metadata") as writer:
+        with pytest.raises(ValueError, match=message):
+            writer.publish_decision("accept", "verified", **metadata)
+
+    assert (session_dir / "diff.json").read_bytes() == diff_before
+    assert (session_dir / "session.json").read_bytes() == manifest_before
+    snapshot = store.load("blank-decision-metadata")
+    assert snapshot.state.phase == "diff"
+    assert snapshot.diff["decision"] is None
+
+
+@pytest.mark.parametrize("interruption", ["after_artifact", "after_manifest"])
+def test_interrupted_decision_publication_recovers_undecided_snapshot(
+    monkeypatch, tmp_path, interruption
+):
+    import nsys_ai.session_store as session_store
+
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "decision-recovery"
+    )
+    with store.writer("decision-recovery") as writer:
+        writer.publish_diff(_diff(before, after))
+
+    session_dir = store.root / "decision-recovery"
+    diff_before = (session_dir / "diff.json").read_bytes()
+    manifest_before = (session_dir / "session.json").read_bytes()
+    if interruption == "after_artifact":
+        manifest_path = session_dir / "session.json"
+        real_atomic_write_json = session_store.atomic_write_json
+
+        def fail_manifest(path, payload):
+            if Path(path) == manifest_path:
+                raise OSError("simulated crash after decision artifact")
+            return real_atomic_write_json(path, payload)
+
+        monkeypatch.setattr(session_store, "atomic_write_json", fail_manifest)
+    else:
+
+        def interrupt_cleanup(_session_id):
+            raise OSError("simulated crash after decision manifest")
+
+        monkeypatch.setattr(store, "_finish_transaction", interrupt_cleanup)
+
+    with store.writer("decision-recovery") as writer:
+        with pytest.raises(OSError, match="simulated crash"):
+            writer.publish_decision(
+                "accept",
+                "verified",
+                decider="test@example.com",
+                decided_at="2026-08-06T00:00:00Z",
+            )
+
+    recovered = SessionStore(store.root).load("decision-recovery")
+    assert recovered.state.phase == "diff"
+    assert recovered.diff["decision"] is None
+    assert (session_dir / "diff.json").read_bytes() == diff_before
+    assert (session_dir / "session.json").read_bytes() == manifest_before
+    assert not (session_dir / ".transaction").exists()
+
+
+def test_manifest_cannot_regress_while_retaining_downstream_artifacts(tmp_path):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "phase-regression"
+    )
+    manifest_path = store.root / "phase-regression" / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["phase"] = "diagnose"
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(SessionCorruptError, match="diagnose phase cannot retain"):
+        store.load("phase-regression")
+
+    manifest["phase"] = "reprofile"
+    manifest_path.write_text(json.dumps(manifest))
+    with store.writer("phase-regression") as writer:
+        writer.publish_diff(_diff(before, after))
+    manifest = json.loads(manifest_path.read_text())
+    manifest["phase"] = "reprofile"
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(SessionCorruptError, match="reprofile phase cannot retain"):
+        store.load("phase-regression")
+
+
+def test_publish_diff_rejects_prepopulated_decision(tmp_path):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "decided-input"
+    )
+    payload = _diff(before, after)
+    payload["decision"] = {
+        "status": "accepted",
+        "reason": "bypass",
+        "decider": "test@example.com",
+        "decided_at": "2026-08-06T00:00:00Z",
+    }
+    with store.writer("decided-input") as writer:
+        with pytest.raises(ValueError, match="requires decision to be null"):
+            writer.publish_diff(payload)
+    assert store.load("decided-input").state.phase == "reprofile"
+
+
+@pytest.mark.parametrize(
+    "decision",
+    [
+        {
+            "status": "maybe",
+            "reason": "reason",
+            "decider": "test@example.com",
+            "decided_at": "2026-08-06T00:00:00Z",
+        },
+        {
+            "status": "accepted",
+            "reason": "   ",
+            "decider": "test@example.com",
+            "decided_at": "2026-08-06T00:00:00Z",
+        },
+        {
+            "status": "rejected",
+            "reason": "reason",
+            "decider": "test@example.com",
+            "decided_at": "2026-08-06T00:00:00Z",
+            "extra": "not canonical",
+        },
+    ],
+)
+def test_load_rejects_noncanonical_diff_decisions(tmp_path, decision):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "bad-decision"
+    )
+    with store.writer("bad-decision") as writer:
+        writer.publish_diff(_diff(before, after))
+    session_dir = store.root / "bad-decision"
+    diff_path = session_dir / "diff.json"
+    payload = json.loads(diff_path.read_text())
+    payload["decision"] = decision
+    diff_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["phase"] = "accept"
+    manifest["artifacts"]["diff"]["sha256"] = hashlib.sha256(
+        diff_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match="invalid diff.json"):
+        store.load("bad-decision")
+
+
+def test_runspec_and_proposal_verification_cannot_diverge(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    finding = _finding(before)
+    first_spec = RunSpec(argv=("true", "--mode=first"))
+    second_spec = RunSpec(argv=("true", "--mode=second"))
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    store = SessionStore(tmp_path / "sessions")
+    store.create("runspec-consistency", before_profile=before)
+    with store.writer("runspec-consistency") as writer:
+        writer.publish_runspec(first_spec)
+        writer.publish_findings(report)
+        with pytest.raises(ValueError, match="must match runspec.json"):
+            writer.publish_proposal(generate_proposal(finding, second_spec))
+        first_proposal = generate_proposal(finding, first_spec)
+        writer.publish_proposal(first_proposal)
+        with pytest.raises(ValueError, match="cannot change after proposal"):
+            writer.publish_runspec(second_spec)
+        writer.publish_runspec(first_spec)
+
+    session_dir = store.root / "runspec-consistency"
+    runspec_path = session_dir / "runspec.json"
+    runspec_path.write_bytes(second_spec.canonical_json_bytes())
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["runspec"]["sha256"] = hashlib.sha256(
+        runspec_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(SessionCorruptError, match="does not match runspec.json"):
+        store.load("runspec-consistency")
+
+
+def test_null_verification_abstention_requires_null_session_runspec(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    finding = _finding(before)
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[finding],
+    )
+    proposal = generate_proposal(finding, None)
+    assert proposal.abstained
+    store = SessionStore(tmp_path / "sessions")
+    store.create("null-verification", before_profile=before)
+    with store.writer("null-verification") as writer:
+        writer.publish_findings(report)
+        writer.publish_proposal(proposal)
+        with pytest.raises(ValueError, match="cannot change after proposal"):
+            writer.publish_runspec(RunSpec(argv=("true",)))
+        with pytest.raises(ValueError, match="non-abstained proposal"):
+            writer.publish_after_profile(
+                _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+            )
+
+    snapshot = store.load("null-verification")
+    assert snapshot.runspec is None
+    assert snapshot.proposal == proposal
+    assert snapshot.state.phase == "propose"
+
+
+def test_non_finite_json_values_are_rejected_before_publication(tmp_path):
+    store = SessionStore(tmp_path / "sessions")
+    store.create("non-finite")
+    finding = Finding(
+        type="region",
+        label="bad value",
+        start_ns=1,
+        provenance={"measurement": float("nan")},
+    )
+    report = EvidenceReport("non-finite", findings=[finding])
+    with store.writer("non-finite") as writer:
+        with pytest.raises(TypeError, match="JSON serializable"):
+            writer.publish_findings(report)
+
+    session_dir = store.root / "non-finite"
+    assert not (session_dir / "findings.json").exists()
+    assert store.load("non-finite").state.phase == "diagnose"
+
+    reprofiled, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "non-finite-diff"
+    )
+    payload = _diff(before, after)
+    payload["comparability_confidence"] = float("inf")
+    with reprofiled.writer("non-finite-diff") as writer:
+        with pytest.raises(TypeError, match="JSON serializable"):
+            writer.publish_diff(payload)
+    assert not (reprofiled.root / "non-finite-diff" / "diff.json").exists()
+
+
+def test_closed_writer_rejects_every_publication_method(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("closed", before_profile=before)
+    writer = store.writer("closed")
+    writer.close()
+
+    actions = (
+        lambda: writer.publish_runspec(RunSpec(argv=("true",))),
+        lambda: writer.publish_findings(EvidenceReport("report")),
+        lambda: writer.publish_after_profile(after),
+        lambda: writer.publish_proposal(
+            generate_proposal(_finding(before), RunSpec(argv=("true",)))
+        ),
+        lambda: writer.publish_diff(_diff(before, after)),
+        lambda: writer.publish_decision("accept", "reason"),
+    )
+    for action in actions:
+        with pytest.raises(SessionError, match="writer is closed"):
+            action()
+
+
+def test_malformed_or_unsupported_json_is_rejected_as_corrupt(tmp_path):
+    store = SessionStore(tmp_path / "sessions")
+    store.create("broken")
+    manifest_path = store.root / "broken" / "session.json"
+    manifest_path.write_text('{"schema_version":')
+    with pytest.raises(SessionCorruptError, match="invalid session.json"):
+        store.load("broken")
+
+    store.create("future")
+    future_path = store.root / "future" / "session.json"
+    future = json.loads(future_path.read_text())
+    future["schema_version"] = "99"
+    future_path.write_text(json.dumps(future))
+    with pytest.raises(UnsupportedSessionVersionError, match="unsupported session"):
+        store.load("future")
+
+
+def test_profile_reference_rejects_remote_kind_and_is_not_revalidated_on_restart(tmp_path):
+    profile = _profile_reference(tmp_path / "profile.sqlite", "nsys1:profile")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("local", before_profile=profile)
+    Path(profile.path).unlink()
+    assert store.load("local").state.before_profile == profile
+
+    manifest_path = store.root / "local" / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["profiles"]["before"]["kind"] = "remote"
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(SessionCorruptError, match="kind must be 'local'"):
+        store.load("local")
+
+
+def _subprocess_environment() -> dict[str, str]:
+    environment = dict(os.environ)
+    source = str(Path(__file__).resolve().parents[1] / "src")
+    current = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = source if not current else f"{source}{os.pathsep}{current}"
+    return environment


### PR DESCRIPTION
## Summary

- Add the versioned local `.nsys-ai/sessions/<id>/` store for RunSpec, findings, proposal, profile references, canonical diff, decision, and phase state.
- Enforce one canonical writer across processes and path aliases, short state locks, private permissions, strict artifact schemas, provenance binding, proposal semantics, and secret boundaries.
- Publish JSON atomically and use a durable rollback journal so interruption between artifact and manifest publication recovers the previous coherent snapshot on the next process load.
- Reuse the existing diff decision writer and add shared atomic JSON publication helpers.

Part of #268.

This is the persistence foundation only. CLI, Web, Tree TUI, and Timeline TUI adoption remains in #268; this PR does not claim the cross-surface handoff is complete.

## Validation

- Four adversarial review rounds, including manual journal fault injection and symlink writer-conflict reproduction
- Final review gate: 122 passed; Ruff and `git diff --check` passed
- Post-rebase overlap gate against current main and #181: 222 passed
- Standard full suite: 1825 passed, 146 skipped; the only failure is the predeclared local `No test profile` skip-reason check when `NSYS_TEST_PROFILE` is unset
- Real 27 MB profile: persisted and reloaded in a new Python process with the same content-derived profile ID, absolute path, diagnose phase, findings title, and 11,162-kernel reference
- Ruff, scoped Bandit, py_compile, and committed diff check: passed

The only wider Bandit output is the existing trio of B608 warnings in `skills/base.py`; no file in this change introduces a Bandit finding.
