### PR TITLE
feat(diff): validate lineage through session persistence

### DIFF
--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import json
 
 from .ai.diff_narrative import DiffNarrative
-from .annotation import PRODUCER, SCHEMA_VERSION, _producer_version
+from .annotation import PRODUCER, SCHEMA_VERSION, DiffLineage, _producer_version
 from .diff import ProfileDiffSummary
 
 
@@ -83,6 +83,15 @@ _AXIS_ENTRY_FOOTNOTE = (
     "per-item values are raw component time and can exceed the total above when "
     "compute, communication, and idle overlap"
 )
+
+
+def _diff_lineage_to_dict(data: ProfileDiffSummary, role: str, rank: int) -> dict:
+    return DiffLineage(
+        diff_id=data.diff_id,
+        role=role,
+        rank=rank,
+        baseline_profile_id=data.before.profile_id,
+    ).to_dict()
 
 
 def format_diff_terminal(
@@ -631,8 +640,9 @@ def to_diff_dict(data: ProfileDiffSummary) -> dict:
                 "after_share": k.after_share,
                 "delta_share": k.delta_share,
                 "selection": k.selection.to_dict() if k.selection else None,
+                "diff_lineage": _diff_lineage_to_dict(data, "regression", rank),
             }
-            for k in data.top_regressions
+            for rank, k in enumerate(data.top_regressions)
         ],
         "top_improvements": [
             {
@@ -649,8 +659,9 @@ def to_diff_dict(data: ProfileDiffSummary) -> dict:
                 "after_share": k.after_share,
                 "delta_share": k.delta_share,
                 "selection": k.selection.to_dict() if k.selection else None,
+                "diff_lineage": _diff_lineage_to_dict(data, "improvement", rank),
             }
-            for k in data.top_improvements
+            for rank, k in enumerate(data.top_improvements)
         ],
         "nvtx_regressions": [
             {

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -35,6 +35,7 @@ except ImportError:  # pragma: no cover - nsys-ai profiling is supported on Linu
 
 from .annotation import (
     PRODUCER,
+    DiffLineage,
     EvidenceReport,
     validate_evidence_report_payload,
     validate_trace_selection_payload,
@@ -140,6 +141,13 @@ _DIFF_KERNEL_FIELDS = {
     "after_share",
     "delta_share",
     "selection",
+    "diff_lineage",
+}
+_DIFF_LINEAGE_FIELDS = {
+    "diff_id",
+    "role",
+    "rank",
+    "baseline_profile_id",
 }
 _DIFF_NVTX_FIELDS = {
     "text",
@@ -1371,10 +1379,42 @@ def _validate_directional_diff_entry(
         )
 
 
+def _validate_diff_lineage(
+    value: Any,
+    *,
+    label: str,
+    diff_id: str,
+    role: str,
+    rank: int,
+    baseline_profile_id: str,
+) -> None:
+    lineage_payload = _diff_mapping(value, label)
+    _diff_exact_fields(lineage_payload, _DIFF_LINEAGE_FIELDS, label)
+    for field in ("diff_id", "baseline_profile_id"):
+        _diff_string(lineage_payload[field], f"{label}.{field}")
+    if lineage_payload["role"] not in {"regression", "improvement", "stable"}:
+        raise ValueError(f"{label}.role is invalid")
+    _diff_integer(lineage_payload["rank"], f"{label}.rank", non_negative=True)
+
+    lineage = DiffLineage.from_dict(dict(lineage_payload))
+    expected = {
+        "diff_id": diff_id,
+        "role": role,
+        "rank": rank,
+        "baseline_profile_id": baseline_profile_id,
+    }
+    if lineage.to_dict() != expected:
+        raise ValueError(f"{label} does not match its parent diff entry")
+
+
 def _validate_diff_kernel_entries(payload: Mapping[str, Any]) -> None:
     after_profile_id = payload["after"]["profile_id"]
+    baseline_profile_id = payload["before"]["profile_id"]
     seen_keys: set[str] = set()
     for field_name in ("top_regressions", "top_improvements"):
+        expected_role = (
+            "regression" if field_name == "top_regressions" else "improvement"
+        )
         for index, item in enumerate(payload[field_name]):
             label = f"diff {field_name}[{index}]"
             entry = _diff_mapping(item, label)
@@ -1401,6 +1441,14 @@ def _validate_diff_kernel_entries(payload: Mapping[str, Any]) -> None:
                 label=f"{label}.selection",
                 expected_profile_id=after_profile_id,
                 expected_source="diff",
+            )
+            _validate_diff_lineage(
+                entry["diff_lineage"],
+                label=f"{label}.diff_lineage",
+                diff_id=payload["diff_id"],
+                role=expected_role,
+                rank=index,
+                baseline_profile_id=baseline_profile_id,
             )
 
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -999,6 +999,54 @@ def test_diff_cli_reject_writes_decision_status(tmp_path):
     assert record["decision"]["reason"] == "regression is too large"
 
 
+def test_diff_cli_decision_json_carries_lineage_for_top_regressions(tmp_path):
+    from nsys_ai.annotation import DiffLineage
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(
+        str(before),
+        kernels=[
+            (0, 10_000_000, 0, 7, 1, 1, 2),
+            (10_000_000, 20_000_000, 0, 7, 2, 3, 4),
+        ],
+    )
+    _make_profile(
+        str(after),
+        kernels=[
+            (0, 20_000_000, 0, 7, 1, 1, 2),
+            (20_000_000, 35_000_000, 0, 7, 2, 3, 4),
+        ],
+    )
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--format",
+        "json",
+        "--limit",
+        "2",
+        "--accept",
+        "--reason",
+        "regressions are expected",
+        cwd=tmp_path,
+        env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    record = json.loads((tmp_path / "diff.json").read_text(encoding="utf-8"))
+    regressions = record["top_regressions"]
+    assert len(regressions) == 2
+    for rank, row in enumerate(regressions):
+        lineage = row["diff_lineage"]
+        restored = DiffLineage.from_dict(lineage)
+        assert restored.to_dict() == lineage
+        assert lineage["diff_id"] == record["diff_id"]
+        assert lineage["role"] == "regression"
+        assert lineage["rank"] == rank
+        assert lineage["baseline_profile_id"] == record["before"]["profile_id"]
+
+
 def test_diff_cli_decision_missing_reason_is_refused(tmp_path):
     before = tmp_path / "before.sqlite"
     after = tmp_path / "after.sqlite"

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -580,6 +580,45 @@ def test_diff_without_top_regressions_has_empty_selection_lists(tmp_path):
     assert payload["top_improvements"] == []
 
 
+def test_diff_json_lineage_covers_regressions_and_improvements(tmp_path):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.diff_render import to_diff_dict
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(
+        str(before),
+        kernels=[
+            (0, 10_000_000, 0, 7, 1, 1, 2),
+            (20_000_000, 50_000_000, 0, 7, 2, 3, 4),
+        ],
+    )
+    _make_profile(
+        str(after),
+        kernels=[
+            (0, 30_000_000, 0, 7, 1, 1, 2),
+            (40_000_000, 50_000_000, 0, 7, 2, 3, 4),
+        ],
+    )
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        payload = to_diff_dict(diff_profiles(b, a, gpu=0, limit=10))
+
+    for field_name, role in (
+        ("top_regressions", "regression"),
+        ("top_improvements", "improvement"),
+    ):
+        assert payload[field_name]
+        for rank, entry in enumerate(payload[field_name]):
+            assert entry["diff_lineage"] == {
+                "diff_id": payload["diff_id"],
+                "role": role,
+                "rank": rank,
+                "baseline_profile_id": payload["before"]["profile_id"],
+            }
+
+
 def test_diff_cli_json_output(tmp_path):
     before = tmp_path / "before.sqlite"
     after = tmp_path / "after.sqlite"

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -164,6 +164,35 @@ def _nested_diff(before: LocalProfileReference, after: LocalProfileReference) ->
             "after_share": 0.6,
             "delta_share": 0.6 - 0.5,
             "selection": kernel_selection,
+            "diff_lineage": {
+                "diff_id": payload["diff_id"],
+                "role": "regression",
+                "rank": 0,
+                "baseline_profile_id": before.profile_id,
+            },
+        }
+    ]
+    payload["top_improvements"] = [
+        {
+            "key": "kernel-improved",
+            "name": "kernel-improved",
+            "demangled": "kernel-improved",
+            "before_total_ns": 2,
+            "after_total_ns": 1,
+            "delta_ns": -1,
+            "before_count": 1,
+            "after_count": 1,
+            "classification": "improvement",
+            "before_share": 0.6,
+            "after_share": 0.5,
+            "delta_share": 0.5 - 0.6,
+            "selection": kernel_selection,
+            "diff_lineage": {
+                "diff_id": payload["diff_id"],
+                "role": "improvement",
+                "rank": 0,
+                "baseline_profile_id": before.profile_id,
+            },
         }
     ]
     payload["nvtx_regressions"] = [
@@ -921,6 +950,134 @@ def test_diff_canonical_top_level_shape_is_revalidated_on_restart(tmp_path, shap
 
     with pytest.raises(SessionCorruptError, match="canonical to_diff_dict shape"):
         store.load("diff-shape-load")
+
+
+def test_diff_lineage_survives_publish_decision_and_restart(tmp_path):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "diff-lineage-round-trip"
+    )
+    payload = _nested_diff(before, after)
+    expected = {
+        field_name: [dict(entry["diff_lineage"]) for entry in payload[field_name]]
+        for field_name in ("top_regressions", "top_improvements")
+    }
+
+    with store.writer("diff-lineage-round-trip") as writer:
+        writer.publish_diff(payload)
+        _state, decided, _warnings = writer.publish_decision(
+            "accept",
+            "lineage stays attached to the measured diff",
+            decider="test@example.com",
+            decided_at="2026-08-06T00:00:00Z",
+        )
+
+    for field_name, lineages in expected.items():
+        assert [entry["diff_lineage"] for entry in decided[field_name]] == lineages
+
+    restarted = SessionStore(store.root).load("diff-lineage-round-trip")
+    assert restarted.diff["decision"]["status"] == "accepted"
+    for field_name, lineages in expected.items():
+        assert [entry["diff_lineage"] for entry in restarted.diff[field_name]] == lineages
+
+
+@pytest.mark.parametrize(
+    "mutation",
+    [
+        "not_object",
+        "missing_field",
+        "unknown_field",
+        "diff_id_type",
+        "diff_id_mismatch",
+        "role_type",
+        "role_mismatch",
+        "rank_type",
+        "rank_mismatch",
+        "baseline_type",
+        "baseline_mismatch",
+    ],
+)
+def test_diff_lineage_requires_exact_shape_types_and_parent_context(
+    tmp_path, mutation
+):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "diff-lineage-shape"
+    )
+    payload = _nested_diff(before, after)
+    lineage = payload["top_regressions"][0]["diff_lineage"]
+    if mutation == "not_object":
+        payload["top_regressions"][0]["diff_lineage"] = []
+    elif mutation == "missing_field":
+        lineage.pop("baseline_profile_id")
+    elif mutation == "unknown_field":
+        lineage["unknown"] = "value"
+    elif mutation == "diff_id_type":
+        lineage["diff_id"] = 1
+    elif mutation == "diff_id_mismatch":
+        lineage["diff_id"] = "another-diff"
+    elif mutation == "role_type":
+        lineage["role"] = 1
+    elif mutation == "role_mismatch":
+        lineage["role"] = "improvement"
+    elif mutation == "rank_type":
+        lineage["rank"] = True
+    elif mutation == "rank_mismatch":
+        lineage["rank"] = 1
+    elif mutation == "baseline_type":
+        lineage["baseline_profile_id"] = 1
+    else:
+        lineage["baseline_profile_id"] = "nsys1:not-the-before-profile"
+
+    with store.writer("diff-lineage-shape") as writer:
+        with pytest.raises(ValueError, match="diff_lineage"):
+            writer.publish_diff(payload)
+    assert store.load("diff-lineage-shape").state.phase == "reprofile"
+
+
+@pytest.mark.parametrize(
+    ("field", "wrong_value"),
+    [
+        ("diff_id", "another-diff"),
+        ("role", "improvement"),
+        ("rank", 1),
+        ("baseline_profile_id", "nsys1:not-the-before-profile"),
+    ],
+)
+def test_diff_lineage_context_is_revalidated_after_tamper_and_redigest(
+    tmp_path, field, wrong_value
+):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "diff-lineage-tamper"
+    )
+    with store.writer("diff-lineage-tamper") as writer:
+        writer.publish_diff(_nested_diff(before, after))
+
+    session_dir = store.root / "diff-lineage-tamper"
+    diff_path = session_dir / "diff.json"
+    payload = json.loads(diff_path.read_text())
+    payload["top_regressions"][0]["diff_lineage"][field] = wrong_value
+    diff_path.write_text(json.dumps(payload))
+    manifest_path = session_dir / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["artifacts"]["diff"]["sha256"] = hashlib.sha256(
+        diff_path.read_bytes()
+    ).hexdigest()
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError, match="diff_lineage"):
+        SessionStore(store.root).load("diff-lineage-tamper")
+
+
+def test_diff_lineage_validator_accepts_empty_top_lists(tmp_path):
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "diff-lineage-empty"
+    )
+    payload = _diff(before, after)
+    with store.writer("diff-lineage-empty") as writer:
+        writer.publish_diff(payload)
+
+    restarted = SessionStore(store.root).load("diff-lineage-empty")
+    assert restarted.diff["top_regressions"] == []
+    assert restarted.diff["top_improvements"] == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #179.

Supersedes #218 with its unique lineage patch carried forward onto current main.

## Summary

- add `diff_lineage` to top regression and improvement entries
- bind each lineage record to the enclosing diff ID, role, zero-based rank, and baseline profile ID
- extend strict session validation so malformed or context-divergent lineage is rejected on publish and restart
- preserve lineage when a diff decision is accepted or rejected

## Verification

- adversarial review: APPROVE
- diff/session/annotation focused suite: 259 passed
- additional reviewer coverage: 307 passed across production writer, session, loop, shape, annotation, and golden paths
- Ruff, Bandit, and `git diff --check`: pass
- post-rebase range-diff: patches unchanged against current `upstream/main`

## Notes

- empty top lists remain valid
- regressions and improvements are both covered
- tampered lineage is rejected even when the artifact digest is recomputed
