### PR TITLE
feat: add strict proposal artifact command

### DIFF
--- a/src/nsys_ai/artifact_io.py
+++ b/src/nsys_ai/artifact_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +46,66 @@ def atomic_write_json(path: str | os.PathLike[str], payload: Any) -> Path:
         json.dumps(payload, allow_nan=False, indent=2, sort_keys=True) + "\n"
     ).encode("utf-8")
     return atomic_write_bytes(path, encoded)
+
+
+def atomic_write_bytes_at(
+    directory_fd: int,
+    name: str,
+    payload: bytes,
+    *,
+    mode: int = 0o600,
+) -> None:
+    """Atomically publish one file relative to an already-open directory.
+
+    Holding ``directory_fd`` across validation and publication prevents a
+    symlinked pathname from being redirected to another directory between the
+    two operations. ``name`` is deliberately a single leaf: callers own parent
+    traversal and policy checks before invoking this low-level seam.
+    """
+    if not isinstance(name, str) or not name or name in {".", ".."}:
+        raise ValueError("artifact name must be a non-empty file name")
+    if os.path.basename(name) != name or os.sep in name or (
+        os.altsep is not None and os.altsep in name
+    ):
+        raise ValueError("artifact name must not contain path separators")
+
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    descriptor = -1
+    temporary_name = ""
+    for _attempt in range(16):
+        candidate = f".{name}.{uuid.uuid4().hex}.tmp"
+        try:
+            descriptor = os.open(candidate, flags, mode, dir_fd=directory_fd)
+        except FileExistsError:
+            continue
+        temporary_name = candidate
+        break
+    if descriptor < 0:
+        raise FileExistsError("could not allocate a temporary artifact file")
+
+    try:
+        os.fchmod(descriptor, mode)
+        with os.fdopen(descriptor, "wb") as stream:
+            descriptor = -1
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(
+            temporary_name,
+            name,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        os.fsync(directory_fd)
+    except BaseException:
+        if descriptor >= 0:
+            os.close(descriptor)
+        try:
+            os.unlink(temporary_name, dir_fd=directory_fd)
+        except FileNotFoundError:
+            pass
+        raise
 
 
 def fsync_directory(path: Path) -> None:

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -61,6 +61,7 @@ def show_help():
     print("  Skills & Agent:")
     print("    nsys-ai skill list                       List analysis skills")
     print("    nsys-ai skill run <name> <profile>       Run a specific skill")
+    print("    nsys-ai propose findings.json --finding-id ID   Generate proposal.json")
     print("    nsys-ai agent analyze <profile>           Full auto-analysis")
     print('    nsys-ai agent ask <profile> "question"   Ask about a profile')
     print("    nsys-ai agent-guide                      Print agent System Prompt")

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -26,6 +26,15 @@ def _cmd_profile(args, _profile):
     if exit_code:
         raise SystemExit(exit_code)
 
+
+def _cmd_propose(args, _profile):
+    """Generate a deterministic proposal artifact from one finding."""
+    from nsys_ai.propose_command import run_propose_command
+
+    exit_code = run_propose_command(args)
+    if exit_code:
+        raise SystemExit(exit_code)
+
 # ---------------------------------------------------------------------------
 # cutracer subcommand
 # ---------------------------------------------------------------------------

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -38,6 +38,7 @@ from .handlers import (
     _cmd_overlap,
     _cmd_perfetto,
     _cmd_profile,
+    _cmd_propose,
     _cmd_report,
     _cmd_root_cause,
     _cmd_search,
@@ -406,12 +407,35 @@ def _build_parser():
         dest="command",
         metavar=(
             "{open,web,timeline-web,loop,chat,ask,agent,agent-guide,"
-            "profile,info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
+            "profile,propose,info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
             "root-cause,help}"
         ),
     )
 
     _register_profile_parser(sub)
+
+    p = sub.add_parser(
+        "propose",
+        help="Generate a deterministic proposal artifact from one finding",
+    )
+    p.add_argument("findings", help="Path to a v0.1 findings.json artifact")
+    p.add_argument(
+        "--finding-id",
+        required=True,
+        help="Stable Finding.id to select",
+    )
+    p.add_argument(
+        "--runspec",
+        default=None,
+        help="Optional RunSpec artifact used as the verification path",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        default="proposal.json",
+        help="Proposal artifact path (default: proposal.json)",
+    )
+    p.set_defaults(handler=_cmd_propose)
 
     # Public commands (simplified)
     p = sub.add_parser("open", help="Open profile quickly in Perfetto/web/TUI")

--- a/src/nsys_ai/propose_command.py
+++ b/src/nsys_ai/propose_command.py
@@ -1,0 +1,378 @@
+"""Strict CLI orchestration for deterministic Proposal artifacts."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import stat
+import sys
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, TextIO
+
+from .annotation import EvidenceReport, Finding, validate_evidence_report_payload
+from .artifact_io import atomic_write_bytes_at
+from .exceptions import NsysAiError
+from .proposal import Proposal, generate_proposal
+from .runspec import RunSpec, RunSpecError, validate_persisted_secret_strings
+from .session_store import SessionState
+
+
+class ProposeCommandError(NsysAiError):
+    """The propose command received an invalid input or output target."""
+
+    error_code = "PROPOSE_COMMAND_INVALID"
+
+
+_SESSION_MANIFEST_MAX_BYTES = 256 * 1024
+_SESSION_TOP_LEVEL_SIGNATURE = frozenset(
+    {"schema_version", "session_id", "phase", "profiles", "artifacts"}
+)
+_SESSION_PROFILE_SIGNATURE = frozenset({"before", "after"})
+_SESSION_ARTIFACT_SIGNATURE = frozenset(
+    {"runspec", "findings", "proposal", "diff"}
+)
+_SESSION_CONTROL_KEYS = frozenset({"session_id", "phase"})
+_SESSION_STRUCTURE_KEYS = frozenset({"profiles", "artifacts"})
+
+
+@dataclass(frozen=True)
+class _InputArtifact:
+    payload: Any
+    device: int
+    inode: int
+
+
+def _read_json(path: Path, label: str) -> _InputArtifact:
+    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0)
+    descriptor = -1
+    try:
+        descriptor = os.open(path, flags)
+        metadata = os.fstat(descriptor)
+        with os.fdopen(descriptor, "rb") as stream:
+            descriptor = -1
+            encoded = stream.read()
+    except OSError as exc:
+        raise ProposeCommandError(
+            f"could not read {label} artifact ({type(exc).__name__})"
+        ) from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    try:
+        payload = json.loads(encoded)
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise ProposeCommandError(f"invalid {label} JSON") from exc
+    return _InputArtifact(payload, metadata.st_dev, metadata.st_ino)
+
+
+def _redact_message(message: str, resolved_secrets: Mapping[str, str]) -> str:
+    values = sorted(
+        {value for value in resolved_secrets.values() if value},
+        key=len,
+        reverse=True,
+    )
+    for value in values:
+        if value:
+            message = message.replace(value, "<redacted>")
+    return message
+
+
+def _select_finding(report: EvidenceReport, finding_id: str) -> Finding:
+    if not finding_id or any(character.isspace() for character in finding_id):
+        raise ProposeCommandError("--finding-id must be a non-empty stable ID without whitespace")
+    matches = [finding for finding in report.findings if finding.id == finding_id]
+    if not matches:
+        raise ProposeCommandError("requested finding ID was not found in the evidence report")
+    if len(matches) > 1:
+        raise ProposeCommandError("requested finding ID is duplicated in the evidence report")
+    return matches[0]
+
+
+def _resolve_declared_secrets(
+    spec: RunSpec, environment: Mapping[str, str]
+) -> dict[str, str]:
+    resolved: dict[str, str] = {}
+    for name in spec.environment.secrets:
+        if name not in environment:
+            raise RunSpecError(f"declared secret {name} is not set in the current environment")
+        value = environment[name]
+        if not isinstance(value, str):
+            raise RunSpecError(f"resolved secret {name} must be a string")
+        resolved[name] = value
+    return resolved
+
+
+def _read_bounded(descriptor: int, limit: int) -> bytes:
+    chunks = []
+    remaining = limit
+    while remaining:
+        chunk = os.read(descriptor, min(64 * 1024, remaining))
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _has_raw_session_signature(encoded: bytes) -> bool:
+    markers = {
+        name
+        for name in _SESSION_TOP_LEVEL_SIGNATURE
+        if f'"{name}"'.encode("ascii") in encoded
+    }
+    if markers == _SESSION_TOP_LEVEL_SIGNATURE:
+        return True
+    nested_artifacts = all(
+        f'"{name}"'.encode("ascii") in encoded
+        for name in _SESSION_ARTIFACT_SIGNATURE
+    )
+    nested_profiles = all(
+        f'"{name}"'.encode("ascii") in encoded
+        for name in _SESSION_PROFILE_SIGNATURE
+    )
+    if "artifacts" in markers and nested_artifacts:
+        return True
+    has_control = bool(_SESSION_CONTROL_KEYS & markers)
+    has_structure = bool(_SESSION_STRUCTURE_KEYS & markers)
+    return has_control and (
+        ("schema_version" in markers and has_structure)
+        or nested_artifacts
+        or nested_profiles
+    )
+
+
+def _has_session_signature(payload: Any) -> bool:
+    if not isinstance(payload, Mapping):
+        return False
+    keys = set(payload)
+    if _SESSION_TOP_LEVEL_SIGNATURE <= keys:
+        return True
+    profiles = payload.get("profiles")
+    artifacts = payload.get("artifacts")
+    nested_signature = (
+        isinstance(profiles, Mapping)
+        and _SESSION_PROFILE_SIGNATURE <= set(profiles)
+        and isinstance(artifacts, Mapping)
+        and _SESSION_ARTIFACT_SIGNATURE <= set(artifacts)
+    )
+    has_control = bool(_SESSION_CONTROL_KEYS & keys)
+    has_structure = bool(_SESSION_STRUCTURE_KEYS & keys)
+    return has_control and (
+        ("schema_version" in keys and has_structure) or nested_signature
+    )
+
+
+def _has_session_logs_directory(directory_fd: int) -> bool:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        descriptor = os.open("logs", flags, dir_fd=directory_fd)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        if exc.errno in {errno.ELOOP, errno.ENOTDIR, errno.ENXIO}:
+            return False
+        raise ProposeCommandError(
+            f"could not inspect session logs directory ({type(exc).__name__})"
+        ) from exc
+    try:
+        return stat.S_ISDIR(os.fstat(descriptor).st_mode)
+    finally:
+        os.close(descriptor)
+
+
+def _session_marker(directory_fd: int) -> bool:
+    has_logs_directory = _has_session_logs_directory(directory_fd)
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        descriptor = os.open("session.json", flags, dir_fd=directory_fd)
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise ProposeCommandError(
+            f"could not inspect session manifest ({type(exc).__name__})"
+        ) from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(metadata.st_mode):
+            raise ProposeCommandError("session manifest is not a regular file")
+        if metadata.st_size > _SESSION_MANIFEST_MAX_BYTES:
+            raise ProposeCommandError(
+                "session manifest exceeds the safe inspection size limit"
+            )
+        encoded = _read_bounded(descriptor, _SESSION_MANIFEST_MAX_BYTES + 1)
+        if len(encoded) > _SESSION_MANIFEST_MAX_BYTES:
+            raise ProposeCommandError(
+                "session manifest exceeds the safe inspection size limit"
+            )
+        try:
+            payload = json.loads(encoded)
+        except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+            if not has_logs_directory and not _has_raw_session_signature(encoded):
+                return False
+            raise ProposeCommandError("session manifest is invalid") from exc
+        if not _has_session_signature(payload):
+            if has_logs_directory:
+                raise ProposeCommandError("session manifest is invalid")
+            return False
+        try:
+            SessionState.from_dict(payload)
+        except (NsysAiError, KeyError, TypeError, ValueError) as exc:
+            raise ProposeCommandError("session manifest is invalid") from exc
+        return True
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def _reject_session_ancestor(directory_fd: int) -> None:
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+    current = os.dup(directory_fd)
+    try:
+        while True:
+            if _session_marker(current):
+                raise ProposeCommandError(
+                    "session artifacts must be published through SessionWriter, "
+                    "not nsys-ai propose"
+                )
+            parent = os.open("..", flags, dir_fd=current)
+            current_stat = os.fstat(current)
+            parent_stat = os.fstat(parent)
+            if (current_stat.st_dev, current_stat.st_ino) == (
+                parent_stat.st_dev,
+                parent_stat.st_ino,
+            ):
+                os.close(parent)
+                return
+            os.close(current)
+            current = parent
+    finally:
+        os.close(current)
+
+
+def _reject_input_aliases(
+    directory_fd: int,
+    name: str,
+    inputs: tuple[_InputArtifact, ...],
+) -> None:
+    try:
+        output_stat = os.stat(name, dir_fd=directory_fd, follow_symlinks=True)
+    except FileNotFoundError:
+        return
+    output_identity = (output_stat.st_dev, output_stat.st_ino)
+    if any(output_identity == (item.device, item.inode) for item in inputs):
+        raise ProposeCommandError("output artifact must not alias an input artifact")
+
+
+def _open_output_directory(path: Path) -> int:
+    """Open/create an output directory while checking each bound directory."""
+    absolute = Path(os.path.abspath(os.fspath(path.expanduser())))
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_CLOEXEC", 0)
+    current = os.open(os.sep, flags)
+    try:
+        _reject_session_ancestor(current)
+        for component in absolute.parts[1:]:
+            try:
+                child = os.open(component, flags, dir_fd=current)
+            except FileNotFoundError:
+                try:
+                    os.mkdir(component, dir_fd=current)
+                except FileExistsError:
+                    pass
+                child = os.open(component, flags, dir_fd=current)
+            os.close(current)
+            current = child
+            _reject_session_ancestor(current)
+        return current
+    except BaseException:
+        os.close(current)
+        raise
+
+
+def _write_proposal(
+    path: Path,
+    proposal: Proposal,
+    inputs: tuple[_InputArtifact, ...],
+) -> Path:
+    destination = path.expanduser()
+    if not destination.name:
+        raise ProposeCommandError("proposal output must name a file")
+    try:
+        directory_fd = _open_output_directory(destination.parent)
+    except ProposeCommandError:
+        raise
+    except OSError as exc:
+        raise ProposeCommandError(
+            f"could not write proposal artifact ({type(exc).__name__})"
+        ) from exc
+    try:
+        _reject_session_ancestor(directory_fd)
+        _reject_input_aliases(directory_fd, destination.name, inputs)
+        atomic_write_bytes_at(
+            directory_fd,
+            destination.name,
+            proposal.canonical_json_bytes(),
+        )
+    except ProposeCommandError:
+        raise
+    except (OSError, ValueError) as exc:
+        raise ProposeCommandError(
+            f"could not write proposal artifact ({type(exc).__name__})"
+        ) from exc
+    finally:
+        os.close(directory_fd)
+    return destination
+
+
+def run_propose_command(
+    args: Any,
+    *,
+    stdout: TextIO = sys.stdout,
+    environment: Mapping[str, str] = os.environ,
+) -> int:
+    """Generate one Proposal from a strictly validated evidence artifact."""
+    runspec_input = _read_json(Path(args.runspec), "RunSpec") if args.runspec else None
+    if runspec_input is not None:
+        try:
+            runspec = RunSpec.from_dict(runspec_input.payload)
+        except (AttributeError, RunSpecError, TypeError, ValueError) as exc:
+            raise ProposeCommandError("invalid RunSpec artifact") from exc
+    else:
+        runspec = None
+    resolved_secrets = (
+        _resolve_declared_secrets(runspec, environment) if runspec is not None else None
+    )
+    findings_input = _read_json(Path(args.findings), "evidence")
+    try:
+        report = validate_evidence_report_payload(findings_input.payload)
+    except (TypeError, ValueError) as exc:
+        detail = _redact_message(str(exc), resolved_secrets or {})
+        raise ProposeCommandError(f"invalid evidence report: {detail}") from exc
+    finding = _select_finding(report, args.finding_id)
+    proposal = generate_proposal(
+        finding,
+        runspec,
+        resolved_secrets=resolved_secrets,
+    )
+    output = Path(args.output)
+    if resolved_secrets is not None:
+        validate_persisted_secret_strings([str(output)], resolved_secrets)
+    inputs = (findings_input,) + ((runspec_input,) if runspec_input is not None else ())
+    written = _write_proposal(output, proposal, inputs)
+    print(f"Proposal written to {written}", file=stdout)
+    if proposal.abstained:
+        print(f"Abstained: {proposal.abstention_reason}", file=stdout)
+    return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -40,6 +40,7 @@ def test_subcommands():
         "export",
         "agent",
         "agent-guide",
+        "propose",
         "info",
         "warm",
         "skill",
@@ -188,6 +189,20 @@ def test_loop_subcommand_help():
     assert "--after" in result.stdout
     assert "--surface" in result.stdout
     assert "--h100-preset" in result.stdout
+
+
+def test_propose_subcommand_help():
+    """propose should expose strict artifact inputs without session mutation."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "propose", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "findings" in result.stdout
+    assert "--finding-id" in result.stdout
+    assert "--runspec" in result.stdout
+    assert "--output" in result.stdout
 
 
 def test_loop_missing_profile_has_friendly_error(tmp_path):

--- a/tests/test_propose_command.py
+++ b/tests/test_propose_command.py
@@ -1,0 +1,861 @@
+import io
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import nsys_ai.propose_command as propose_command
+from nsys_ai.annotation import EvidenceReport, Finding, TraceSelection
+from nsys_ai.proposal import Proposal
+from nsys_ai.runspec import EnvironmentSpec, RunSpec
+from nsys_ai.session_store import SessionStore
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _finding(finding_id: str, *, explanation: str | None = None) -> Finding:
+    return Finding(
+        type="region",
+        label="Exposed communication",
+        start_ns=100,
+        end_ns=200,
+        id=finding_id,
+        confidence=0.84,
+        explanation=explanation or "Communication is exposed in the backward pass.",
+        suggested_actions=["Test moving the all-reduce earlier."],
+        false_positive_notes=["Confirm the workload is representative."],
+        headroom_ms=12.5,
+        headroom_basis="capture_total",
+        selection=TraceSelection(
+            id=f"selection-{finding_id}",
+            profile_id="nsys1:sha256:profile",
+            source="skill:overlap_breakdown",
+            start_ns=100,
+            end_ns=200,
+            gpu_ids=[0],
+            nvtx_path=["iteration", "backward"],
+        ),
+    )
+
+
+def _write_evidence(path: Path, findings: list[Finding]) -> dict:
+    payload = EvidenceReport(
+        "Auto-Analysis",
+        profile_path="/profiles/before.sqlite",
+        profile_id="nsys1:sha256:profile",
+        findings=findings,
+    ).to_dict()
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return payload
+
+
+def _write_runspec(
+    path: Path, *, secrets: tuple[str, ...] = (), argv: tuple[str, ...] = ("python", "train.py")
+) -> RunSpec:
+    spec = RunSpec(
+        argv=argv,
+        environment=EnvironmentSpec(policy="clean", secrets=secrets),
+    )
+    path.write_bytes(spec.canonical_json_bytes())
+    return spec
+
+
+def _run_cli(
+    cwd: Path,
+    *args: str,
+    environment: dict[str, str] | None = None,
+    timeout: float = 10.0,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(ROOT / "src"), env.get("PYTHONPATH", "")) if part
+    )
+    if environment is not None:
+        env.update(environment)
+    return subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "propose", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def test_cli_generates_round_trippable_proposal_selected_only_by_id(tmp_path):
+    findings = tmp_path / "findings.json"
+    runspec = tmp_path / "runspec.json"
+    output = tmp_path / "artifacts" / "proposal.json"
+    _write_evidence(findings, [_finding("other"), _finding("target")])
+    expected_spec = _write_runspec(runspec)
+
+    result = _run_cli(
+        tmp_path,
+        str(findings),
+        "--finding-id",
+        "target",
+        "--runspec",
+        str(runspec),
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 0, result.stderr
+    proposal = Proposal.from_json_bytes(output.read_bytes())
+    assert proposal.source_finding_id == "target"
+    assert proposal.verification == expected_spec
+    assert not proposal.abstained
+    assert stat.S_IMODE(output.stat().st_mode) == 0o600
+    assert str(output) in result.stdout
+    assert result.stderr == ""
+
+
+def test_missing_runspec_writes_formal_abstention_and_exits_zero(tmp_path):
+    findings = tmp_path / "findings.json"
+    _write_evidence(findings, [_finding("target")])
+
+    result = _run_cli(tmp_path, str(findings), "--finding-id", "target")
+
+    assert result.returncode == 0, result.stderr
+    proposal = Proposal.from_json_bytes((tmp_path / "proposal.json").read_bytes())
+    assert proposal.abstained
+    assert proposal.verification is None
+    assert "verification RunSpec is required" in proposal.abstention_reason
+    assert "Abstained:" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("findings", "finding_id", "message"),
+    [
+        ([_finding("known")], "unknown", "not found"),
+        ([_finding("duplicate"), _finding("duplicate")], "duplicate", "duplicated"),
+    ],
+)
+def test_unknown_and_duplicate_finding_ids_are_clear_input_errors(
+    tmp_path, findings, finding_id, message
+):
+    source = tmp_path / "findings.json"
+    _write_evidence(source, findings)
+
+    result = _run_cli(tmp_path, str(source), "--finding-id", finding_id)
+
+    assert result.returncode == 1
+    assert message in result.stderr
+    assert "Traceback" not in result.stderr
+    assert not (tmp_path / "proposal.json").exists()
+
+
+@pytest.mark.parametrize("mutation", ["legacy", "unknown", "nested"])
+def test_evidence_input_uses_strict_current_artifact_validation(tmp_path, mutation):
+    source = tmp_path / "findings.json"
+    payload = _write_evidence(source, [_finding("target")])
+    if mutation == "legacy":
+        del payload["schema_version"]
+    elif mutation == "unknown":
+        payload["extra"] = True
+    else:
+        payload["findings"][0]["selection"]["start_ns"] = "later"
+    source.write_text(json.dumps(payload), encoding="utf-8")
+    output = tmp_path / "proposal.json"
+    output.write_text("existing", encoding="utf-8")
+
+    result = _run_cli(tmp_path, str(source), "--finding-id", "target")
+
+    assert result.returncode == 1
+    assert "invalid evidence report" in result.stderr
+    assert output.read_text(encoding="utf-8") == "existing"
+
+
+def test_success_atomically_overwrites_an_existing_ordinary_artifact(tmp_path):
+    source = tmp_path / "findings.json"
+    output = tmp_path / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+    output.write_text("stale", encoding="utf-8")
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Proposal.from_json_bytes(output.read_bytes()).source_finding_id == "target"
+    assert not list(tmp_path.glob(".proposal.json.*.tmp"))
+
+
+def test_declared_secret_is_preflight_only_and_never_persisted_or_printed(tmp_path):
+    secret = "sentinel-propose-secret"
+    source = tmp_path / "findings.json"
+    runspec = tmp_path / "runspec.json"
+    output = tmp_path / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+    _write_runspec(runspec, secrets=("PROPOSE_SECRET",))
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "--runspec",
+        str(runspec),
+        "-o",
+        str(output),
+        environment={"PROPOSE_SECRET": secret},
+    )
+
+    assert result.returncode == 0, result.stderr
+    artifact = output.read_text(encoding="utf-8")
+    assert secret not in artifact
+    assert secret not in result.stdout
+    assert secret not in result.stderr
+    proposal = Proposal.from_json_bytes(artifact)
+    assert proposal.verification.environment.secrets == ("PROPOSE_SECRET",)
+    assert "secret_environment_values_unresolved" in proposal.limitations
+
+
+def test_secret_in_projected_finding_leaves_existing_output_unchanged(tmp_path):
+    secret = "sentinel-projected-secret"
+    source = tmp_path / "findings.json"
+    runspec = tmp_path / "runspec.json"
+    output = tmp_path / "proposal.json"
+    _write_evidence(source, [_finding("target", explanation=f"Do not persist {secret}")])
+    _write_runspec(runspec, secrets=("PROPOSE_SECRET",))
+    output.write_text("existing", encoding="utf-8")
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "--runspec",
+        str(runspec),
+        "-o",
+        str(output),
+        environment={"PROPOSE_SECRET": secret},
+    )
+
+    assert result.returncode == 1
+    assert "persisted string" in result.stderr
+    assert secret not in result.stderr
+    assert secret not in result.stdout
+    assert output.read_text(encoding="utf-8") == "existing"
+
+
+def test_strict_evidence_error_redacts_overlapping_declared_secrets(tmp_path):
+    short_secret = "sentinel-overlap"
+    long_secret = f"{short_secret}-longer"
+    source = tmp_path / "findings.json"
+    runspec = tmp_path / "runspec.json"
+    payload = _write_evidence(source, [_finding("target")])
+    payload[long_secret] = "unknown field"
+    source.write_text(json.dumps(payload), encoding="utf-8")
+    _write_runspec(runspec, secrets=("A_SHORT_SECRET", "Z_LONG_SECRET"))
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "--runspec",
+        str(runspec),
+        environment={
+            "A_SHORT_SECRET": short_secret,
+            "Z_LONG_SECRET": long_secret,
+        },
+    )
+
+    assert result.returncode == 1
+    assert "invalid evidence report" in result.stderr
+    assert short_secret not in result.stderr
+    assert long_secret not in result.stderr
+    assert "-longer" not in result.stderr
+    assert not (tmp_path / "proposal.json").exists()
+
+
+def test_missing_declared_secret_is_an_input_error_with_no_output(tmp_path, monkeypatch):
+    source = tmp_path / "findings.json"
+    runspec = tmp_path / "runspec.json"
+    _write_evidence(source, [_finding("target")])
+    _write_runspec(runspec, secrets=("DELIBERATELY_UNSET_PROPOSE_SECRET",))
+
+    monkeypatch.delenv("DELIBERATELY_UNSET_PROPOSE_SECRET", raising=False)
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "--runspec",
+        str(runspec),
+    )
+
+    assert result.returncode == 1
+    assert "declared secret DELIBERATELY_UNSET_PROPOSE_SECRET is not set" in result.stderr
+    assert not (tmp_path / "proposal.json").exists()
+
+
+def test_malformed_runspec_cannot_reflect_a_declared_secret(tmp_path):
+    secret = "sentinel-malformed-runspec-secret"
+    source = tmp_path / "findings.json"
+    runspec = tmp_path / "runspec.json"
+    output = tmp_path / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+    payload = _write_runspec(runspec, secrets=("PROPOSE_SECRET",)).to_dict()
+    payload[secret] = "unknown field"
+    runspec.write_text(json.dumps(payload), encoding="utf-8")
+    output.write_text("existing", encoding="utf-8")
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "--runspec",
+        str(runspec),
+        environment={"PROPOSE_SECRET": secret},
+    )
+
+    assert result.returncode == 1
+    assert "invalid RunSpec artifact" in result.stderr
+    assert secret not in result.stderr
+    assert secret not in result.stdout
+    assert output.read_text(encoding="utf-8") == "existing"
+
+
+def test_secret_in_output_path_is_rejected_without_echo(tmp_path):
+    secret = "sentinel-path-secret"
+    source = tmp_path / "findings.json"
+    runspec = tmp_path / "runspec.json"
+    output = tmp_path / secret / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+    _write_runspec(runspec, secrets=("PROPOSE_SECRET",))
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "--runspec",
+        str(runspec),
+        "-o",
+        str(output),
+        environment={"PROPOSE_SECRET": secret},
+    )
+
+    assert result.returncode == 1
+    assert "persisted string" in result.stderr
+    assert secret not in result.stderr
+    assert secret not in result.stdout
+    assert not output.exists()
+
+
+def test_session_named_directory_without_manifest_is_an_ordinary_output(tmp_path):
+    source = tmp_path / "findings.json"
+    output = tmp_path / ".nsys-ai" / "sessions" / "run-001" / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Proposal.from_json_bytes(output.read_bytes()).source_finding_id == "target"
+
+
+def test_unrelated_session_json_is_an_ordinary_output_ancestor(tmp_path):
+    source = tmp_path / "findings.json"
+    output_directory = tmp_path / "web-state"
+    output_directory.mkdir()
+    manifest = output_directory / "session.json"
+    ordinary_payload = {
+        "schema_version": "web-v1",
+        "profiles": {"theme": "dark"},
+        "artifacts": {"bundle": "app.js"},
+        "route": "/review",
+    }
+    manifest.write_text(json.dumps(ordinary_payload), encoding="utf-8")
+    manifest_before = manifest.read_bytes()
+    output = output_directory / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Proposal.from_json_bytes(output.read_bytes()).source_finding_id == "target"
+    assert manifest.read_bytes() == manifest_before
+
+
+@pytest.mark.parametrize("manifest_kind", ["empty", "object", "unrelated"])
+def test_true_logs_layout_rejects_unrecognized_session_manifest(
+    tmp_path, manifest_kind
+):
+    source = tmp_path / "findings.json"
+    session_root = tmp_path / "session-root"
+    SessionStore(session_root).create("run-001")
+    session = session_root / "run-001"
+    manifest = session / "session.json"
+    if manifest_kind == "empty":
+        encoded = b""
+    elif manifest_kind == "object":
+        encoded = b"{}"
+    else:
+        encoded = json.dumps(
+            {
+                "schema_version": "web-v1",
+                "profiles": {"theme": "dark"},
+                "artifacts": {"bundle": "app.js"},
+                "route": "/review",
+            }
+        ).encode("utf-8")
+    manifest.write_bytes(encoded)
+    output = session / "new" / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "session manifest is invalid" in result.stderr
+    assert manifest.read_bytes() == encoded
+    assert not output.parent.exists()
+
+
+def test_early_truncated_sessionstate_is_rejected_without_logs_evidence(tmp_path):
+    source = tmp_path / "findings.json"
+    session_root = tmp_path / "source-session-root"
+    SessionStore(session_root).create("run-001")
+    valid = (session_root / "run-001" / "session.json").read_bytes()
+    truncated = valid[: valid.index(b'"profiles"')]
+    output_directory = tmp_path / "no-logs-partial-session"
+    output_directory.mkdir()
+    manifest = output_directory / "session.json"
+    manifest.write_bytes(truncated)
+    output = output_directory / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "session manifest is invalid" in result.stderr
+    assert manifest.read_bytes() == truncated
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("missing_key", ["schema_version", "profiles", "artifacts"])
+def test_partial_sessionstate_object_is_rejected_without_logs_evidence(
+    tmp_path, missing_key
+):
+    source = tmp_path / "findings.json"
+    session_root = tmp_path / "source-session-root"
+    SessionStore(session_root).create("run-001")
+    payload = json.loads((session_root / "run-001" / "session.json").read_bytes())
+    del payload[missing_key]
+    output_directory = tmp_path / f"missing-{missing_key}"
+    output_directory.mkdir()
+    manifest = output_directory / "session.json"
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    manifest_before = manifest.read_bytes()
+    output = output_directory / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "session manifest is invalid" in result.stderr
+    assert manifest.read_bytes() == manifest_before
+    assert not output.exists()
+
+
+@pytest.mark.parametrize("logs_kind", ["symlink", "fifo"])
+def test_non_directory_logs_entry_is_not_followed_or_used_as_layout_evidence(
+    tmp_path, logs_kind
+):
+    source = tmp_path / "findings.json"
+    output_directory = tmp_path / f"ordinary-{logs_kind}-logs"
+    output_directory.mkdir()
+    manifest = output_directory / "session.json"
+    ordinary_payload = {"schema_version": "web-v1", "route": "/review"}
+    manifest.write_text(json.dumps(ordinary_payload), encoding="utf-8")
+    logs = output_directory / "logs"
+    target = tmp_path / "logs-target"
+    if logs_kind == "symlink":
+        target.mkdir()
+        sentinel = target / "sentinel"
+        sentinel.write_text("unchanged", encoding="utf-8")
+        logs.symlink_to(target, target_is_directory=True)
+    else:
+        os.mkfifo(logs)
+        sentinel = None
+    output = output_directory / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+        timeout=2.0,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert Proposal.from_json_bytes(output.read_bytes()).source_finding_id == "target"
+    if sentinel is not None:
+        assert sentinel.read_text(encoding="utf-8") == "unchanged"
+
+
+def test_fifo_session_manifest_fails_without_blocking(tmp_path):
+    source = tmp_path / "findings.json"
+    output_directory = tmp_path / "fifo-ancestor"
+    output_directory.mkdir()
+    manifest = output_directory / "session.json"
+    os.mkfifo(manifest)
+    output = output_directory / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+        timeout=2.0,
+    )
+
+    assert result.returncode == 1
+    assert "session manifest is not a regular file" in result.stderr
+    assert not output.exists()
+
+
+def test_symlink_session_manifest_is_not_followed(tmp_path):
+    source = tmp_path / "findings.json"
+    state_root = tmp_path / "state-source"
+    SessionStore(state_root).create("run-001")
+    target = state_root / "run-001" / "session.json"
+    target_before = target.read_bytes()
+    output_directory = tmp_path / "symlink-manifest-ancestor"
+    output_directory.mkdir()
+    (output_directory / "session.json").symlink_to(target)
+    output = output_directory / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "could not inspect session manifest" in result.stderr
+    assert target.read_bytes() == target_before
+    assert not output.exists()
+
+
+def test_oversized_recognizable_manifest_is_rejected_before_read(
+    tmp_path, monkeypatch
+):
+    source = tmp_path / "findings.json"
+    output_directory = tmp_path / "oversized-session"
+    output_directory.mkdir()
+    manifest = output_directory / "session.json"
+    prefix = (
+        b'{"artifacts":{},"phase":"diagnose","profiles":{},'
+        b'"schema_version":"0.1","session_id":"oversized","padding":"'
+    )
+    manifest.write_bytes(
+        prefix + b"x" * (propose_command._SESSION_MANIFEST_MAX_BYTES * 2) + b'"}'
+    )
+    manifest_before = manifest.stat().st_size
+    output = output_directory / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+    real_read = propose_command.os.read
+    requested: list[int] = []
+    returned = 0
+
+    def recording_read(descriptor, size):
+        nonlocal returned
+        requested.append(size)
+        chunk = real_read(descriptor, size)
+        returned += len(chunk)
+        return chunk
+
+    monkeypatch.setattr(propose_command.os, "read", recording_read)
+    args = SimpleNamespace(
+        findings=str(source),
+        finding_id="target",
+        runspec=None,
+        output=str(output),
+    )
+
+    with pytest.raises(propose_command.ProposeCommandError, match="safe inspection size"):
+        propose_command.run_propose_command(args, stdout=io.StringIO(), environment={})
+
+    assert not requested
+    assert returned == 0
+    assert manifest.stat().st_size == manifest_before
+    assert not output.exists()
+
+
+def test_alternate_root_session_output_is_rejected_without_mutation(tmp_path):
+    source = tmp_path / "findings.json"
+    session_root = tmp_path / "custom-session-root"
+    SessionStore(session_root).create("run-001")
+    session = session_root / "run-001"
+    manifest = session / "session.json"
+    manifest_before = manifest.read_bytes()
+    output = session / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "SessionWriter" in result.stderr
+    assert manifest.read_bytes() == manifest_before
+    assert not output.exists()
+
+
+def test_symlink_to_session_directory_is_rejected_without_mutation(tmp_path):
+    source = tmp_path / "findings.json"
+    session_root = tmp_path / "alternate-session-root"
+    SessionStore(session_root).create("run-001")
+    session = session_root / "run-001"
+    manifest = session / "session.json"
+    manifest_before = manifest.read_bytes()
+    alias = tmp_path / "ordinary-looking-output"
+    alias.symlink_to(session, target_is_directory=True)
+    output = alias / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "SessionWriter" in result.stderr
+    assert manifest.read_bytes() == manifest_before
+    assert not (session / "proposal.json").exists()
+
+
+def test_corrupt_alternate_root_session_is_rejected_before_creating_parent(tmp_path):
+    source = tmp_path / "findings.json"
+    session_root = tmp_path / "alternate-session-root"
+    SessionStore(session_root).create("run-001")
+    session = session_root / "run-001"
+    manifest = session / "session.json"
+    corrupt_manifest = manifest.read_bytes().rstrip()[:-1]
+    manifest.write_bytes(corrupt_manifest)
+    output = session / "new" / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "session manifest is invalid" in result.stderr
+    assert str(session) not in result.stderr
+    assert "Traceback" not in result.stderr
+    assert manifest.read_bytes() == corrupt_manifest
+    assert not output.parent.exists()
+
+
+@pytest.mark.parametrize("mutation", ["corrupt", "unsupported"])
+def test_recognizable_invalid_session_manifest_fails_closed(tmp_path, mutation):
+    source = tmp_path / "findings.json"
+    session_root = tmp_path / "recognizable-invalid-root"
+    SessionStore(session_root).create("run-001")
+    session = session_root / "run-001"
+    manifest = session / "session.json"
+    payload = json.loads(manifest.read_bytes())
+    if mutation == "corrupt":
+        payload["profiles"] = "not-an-object"
+    else:
+        payload["schema_version"] = "999"
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    manifest_before = manifest.read_bytes()
+    output = session / "new" / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "session manifest is invalid" in result.stderr
+    assert manifest.read_bytes() == manifest_before
+    assert not output.parent.exists()
+
+
+@pytest.mark.parametrize("source_name", ["findings", "runspec"])
+@pytest.mark.parametrize("alias_kind", ["exact", "relative", "symlink", "hardlink"])
+def test_output_alias_of_input_is_rejected_before_write(
+    tmp_path, source_name, alias_kind
+):
+    findings = tmp_path / "findings.json"
+    runspec = tmp_path / "runspec.json"
+    _write_evidence(findings, [_finding("target")])
+    _write_runspec(runspec)
+    source = findings if source_name == "findings" else runspec
+
+    if alias_kind == "exact":
+        output_arg = str(source)
+    elif alias_kind == "relative":
+        output_arg = source.name
+    else:
+        output = tmp_path / f"{source_name}-{alias_kind}.json"
+        if alias_kind == "symlink":
+            output.symlink_to(source)
+        else:
+            os.link(source, output)
+        output_arg = str(output)
+
+    findings_before = findings.read_bytes()
+    runspec_before = runspec.read_bytes()
+    result = _run_cli(
+        tmp_path,
+        str(findings),
+        "--finding-id",
+        "target",
+        "--runspec",
+        str(runspec),
+        "-o",
+        output_arg,
+    )
+
+    assert result.returncode == 1
+    assert "must not alias an input artifact" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert findings.read_bytes() == findings_before
+    assert runspec.read_bytes() == runspec_before
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_symlink_retarget_after_validation_writes_only_to_bound_directory(
+    tmp_path, monkeypatch
+):
+    findings = tmp_path / "findings.json"
+    _write_evidence(findings, [_finding("target")])
+    safe = tmp_path / "ordinary-output"
+    safe.mkdir()
+    session_root = tmp_path / "alternate-session-root"
+    SessionStore(session_root).create("run-001")
+    session = session_root / "run-001"
+    manifest = session / "session.json"
+    manifest_before = manifest.read_bytes()
+    alias = tmp_path / "output-alias"
+    alias.symlink_to(safe, target_is_directory=True)
+    real_atomic_write = propose_command.atomic_write_bytes_at
+
+    def retarget_then_write(directory_fd, name, payload, *, mode=0o600):
+        alias.unlink()
+        alias.symlink_to(session, target_is_directory=True)
+        real_atomic_write(directory_fd, name, payload, mode=mode)
+
+    monkeypatch.setattr(
+        propose_command,
+        "atomic_write_bytes_at",
+        retarget_then_write,
+    )
+    stdout = io.StringIO()
+    args = SimpleNamespace(
+        findings=str(findings),
+        finding_id="target",
+        runspec=None,
+        output=str(alias / "proposal.json"),
+    )
+
+    result = propose_command.run_propose_command(args, stdout=stdout, environment={})
+
+    assert result == 0
+    assert Proposal.from_json_bytes(
+        (safe / "proposal.json").read_bytes()
+    ).source_finding_id == "target"
+    assert not (session / "proposal.json").exists()
+    assert manifest.read_bytes() == manifest_before
+
+
+def test_output_io_failure_is_clean_and_preserves_the_directory(tmp_path):
+    source = tmp_path / "findings.json"
+    output = tmp_path / "proposal.json"
+    _write_evidence(source, [_finding("target")])
+    output.mkdir()
+
+    result = _run_cli(
+        tmp_path,
+        str(source),
+        "--finding-id",
+        "target",
+        "-o",
+        str(output),
+    )
+
+    assert result.returncode == 1
+    assert "could not write proposal artifact" in result.stderr
+    assert "Traceback" not in result.stderr
+    assert output.is_dir()


### PR DESCRIPTION
Part of #352.

## Summary

- add `nsys-ai propose findings.json --finding-id ID [--runspec runspec.json] [-o proposal.json]`
- select only by stable Finding ID and strictly validate EvidenceReport and RunSpec inputs
- emit a formal, round-trippable abstention when no verification RunSpec is available
- resolve declared secrets for generation without persisting or printing their values
- publish ordinary proposal artifacts atomically while refusing SessionStore directories and input aliases

## Trust Boundaries

- alternate SessionStore roots are identified from the persisted session layout, not path naming conventions
- descriptor-bound directory traversal and atomic replace prevent symlink retargeting between validation and publication
- session marker reads are nonblocking and bounded; unrelated project `session.json` files are not misclassified
- findings/RunSpec exact, relative, symlink, and hard-link output aliases are rejected before writing

## Verification

- three adversarial review rounds: final APPROVE
- proposal/session/CLI overlap after rebase: 213 passed
- full suite: 1913 passed, 146 skipped; the only failure is the existing `No test profile` skip-reason gate when `NSYS_TEST_PROFILE` is unset
- Ruff, Bandit, CLI smoke, and `git diff --check`: pass
- post-rebase range-diff: patch unchanged against current `upstream/main`

This PR completes the first production caller for the Proposal artifact. Web/TUI rendering and removal of the free-text proposal path remain open under #352/#268.
