### PR TITLE
feat: add read-only local profile references

### DIFF
--- a/docs/agent_skills/commands/evidence_schema.md
+++ b/docs/agent_skills/commands/evidence_schema.md
@@ -108,7 +108,7 @@ Findings should encode **conclusions**, not raw data. The agent must reason abou
   "producer": "nsys-ai",
   "producer_version": "0.2.2",
   "title": "Human-readable title for the report",
-  "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
+  "profile_id": "nsys2:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "profile_path": "path/to/profile.sqlite",
   "findings": [ ... ],
   "skipped": [
@@ -125,7 +125,7 @@ Findings should encode **conclusions**, not raw data. The agent must reason abou
 - `producer`: Always `"nsys-ai"` for reports emitted by this tool.
 - `producer_version`: Version of the `nsys-ai` package that wrote the report.
 - `title`: Displayed at the top of the evidence sidebar.
-- `profile_id`: Content-derived stable identifier produced by `fingerprint.get_profile_id`. Format: `nsys1:sha256:<64-hex>` (or `nsys1:path:<64-hex>` fallback when the source carries no Nsight metadata, e.g. a parquetdir-only backend). Two surfaces looking at the same profile agree on this value without depending on the filesystem path. **Every `TraceSelection.profile_id` produced during the same build carries the same value** — readers can join across surfaces by equality.
+- `profile_id`: Content-derived stable identifier produced by `fingerprint.get_profile_id`. Format: `nsys2:sha256:<64-hex>` (or `nsys2:path:<64-hex>` fallback when the source carries no Nsight metadata, e.g. a parquetdir-only backend). Two surfaces looking at the same profile agree on this value without depending on the filesystem path. **Every `TraceSelection.profile_id` produced during the same build carries the same value** — readers can join across surfaces by equality.
 - `profile_path`: Filesystem path the producer opened. Reference only — not an identifier.
 - `findings`: Array of Finding objects (see above).
 - `skipped`: Array of analyses that could not run on this profile, and why. A Finding says something about the profile's performance; an entry here says something about the analysis's *coverage*, which is why the two are separate arrays rather than one ranked list. Each entry carries `analyzer` (the name `evidence build --analyzers` accepts), `skill` (the name `skill run` accepts — several analyzers can share one skill), and `reason` (the text the skill passed to `abstain`). **The key is always emitted, empty array included**: `"skipped": []` means nothing was skipped, while a missing key means the producer predates the field. Do not read an empty array as a clean bill of health without checking that the key was present.
@@ -178,7 +178,7 @@ A region of a profile. All location fields are optional — a selection may be t
 ```json
 {
   "id": "sel_idle_gap_gpu0_stream7_500",
-  "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
+  "profile_id": "nsys2:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "source": "skill:gpu_idle_gaps",
   "start_ns": 500,
   "end_ns": 12500500,
@@ -190,7 +190,7 @@ A region of a profile. All location fields are optional — a selection may be t
 ```
 
 - `id`: Stable id for this selection.
-- `profile_id`: Content-derived stable identifier — matches the enclosing `EvidenceReport.profile_id` and is sourced from `fingerprint.get_profile_id`. Format: `nsys1:sha256:<64-hex>` (or `nsys1:path:<64-hex>` fallback when no Nsight metadata is reachable). Treated by readers as an equality key — two surfaces looking at the same profile agree on the value without depending on the filesystem path.
+- `profile_id`: Content-derived stable identifier — matches the enclosing `EvidenceReport.profile_id` and is sourced from `fingerprint.get_profile_id`. Format: `nsys2:sha256:<64-hex>` (or `nsys2:path:<64-hex>` fallback when no Nsight metadata is reachable). Treated by readers as an equality key — two surfaces looking at the same profile agree on the value without depending on the filesystem path.
 - `source`: Who produced the selection — `"skill:<name>"`, `"gui"`, `"user"`, or `"diff"`.
 - `start_ns` / `end_ns`: Time window (nanoseconds, absolute from profile epoch).
 - `gpu_ids` / `rank_ids` / `stream_ids`: Location lists. Empty list (`[]`) means "no GPUs/ranks/streams" — distinct from omission, which means "unspecified".
@@ -207,7 +207,7 @@ Set on findings that originated from a before/after diff comparison.
   "diff_id": "diff_20260512",
   "role": "regression",
   "rank": 1,
-  "baseline_profile_id": "nsys1:sha256:6b1f9a0e0b3e2c7a8b8d5f0e1b2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d"
+  "baseline_profile_id": "nsys2:sha256:6b1f9a0e0b3e2c7a8b8d5f0e1b2d3e4f5a6b7c8d9e0f1a2b3c4d5e6f7a8b9c0d"
 }
 ```
 
@@ -250,7 +250,7 @@ Same finding as the [Quick Example](#quick-example-minimal--legacy-fields-only) 
   "producer": "nsys-ai",
   "producer_version": "0.2.2",
   "title": "Pipeline Parallelism Bubble Analysis",
-  "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
+  "profile_id": "nsys2:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
   "profile_path": "fastvideo.sqlite",
   "findings": [
     {
@@ -274,7 +274,7 @@ Same finding as the [Quick Example](#quick-example-minimal--legacy-fields-only) 
       ],
       "selection": {
         "id": "sel_pp_bubble_iter142",
-        "profile_id": "nsys1:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
+        "profile_id": "nsys2:sha256:7d2f6013fb98855bda6a5448a91af563553cc2c013f42ca6d9cdbb3b737ac738",
         "source": "skill:gpu_idle_gaps",
         "start_ns": 89000000000,
         "end_ns": 110000000000,

--- a/docs/doctor.md
+++ b/docs/doctor.md
@@ -100,7 +100,7 @@ and profile health in one place.
   "producer": "nsys-ai",
   "producer_version": "0.2.3",
   "profile_path": "profile.sqlite",
-  "profile_id": "nsys1:sha256:...",
+  "profile_id": "nsys2:sha256:...",
   "sections": [
     {"name": "System", "checks": [{"name": "Python", "status": "ok", "detail": "3.12.3", "hint": null, "sub": false}]}
   ],

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -14,7 +14,7 @@ import re
 import typing
 from dataclasses import dataclass, field
 
-from .connection import DB_ERRORS, wrap_connection
+from .connection import DB_ERRORS, is_safe_identifier, wrap_connection
 
 # Characters kept when trace-derived text is placed into prompt context or a
 # report: word characters, whitespace and light punctuation. Anything else
@@ -263,8 +263,8 @@ def get_fingerprint(conn: typing.Any) -> ProfileFingerprint:
 # profile_id — stable content-derived identifier
 # ---------------------------------------------------------------------------
 
-PROFILE_ID_VERSION = "nsys1"
-"""Algorithm tag for :func:`get_profile_id`. Bump (``nsys2``, …) if the
+PROFILE_ID_VERSION = "nsys2"
+"""Algorithm tag for :func:`get_profile_id`. Bump (``nsys3``, …) if the
 contributing columns or the canonical serialisation change."""
 
 
@@ -285,7 +285,7 @@ def get_profile_id(
         ``TARGET_INFO_CUDA_DEVICE`` and that contribution degrades to
         empty rather than failing
       - distinct ``ANALYSIS_FILE.globalPid`` values
-      - ``CUPTI_ACTIVITY_KIND_KERNEL`` row count
+      - resolved ``CUPTI_ACTIVITY_KIND_KERNEL[_Vn]`` row count
 
     Each contribution is JSON-encoded as a ``(label, value)`` pair before
     hashing, so values containing ``|`` / ``;`` / ``\\n`` can never collide
@@ -293,8 +293,8 @@ def get_profile_id(
 
     Format::
 
-        nsys1:sha256:<64-hex>   # preferred — content-derived
-        nsys1:path:<64-hex>     # fallback — when no Nsight metadata is reachable
+        nsys2:sha256:<64-hex>   # preferred — content-derived
+        nsys2:path:<64-hex>     # fallback — when no Nsight metadata is reachable
 
     The fallback fires for backends that expose only the parquet cache
     (``backend='parquetdir'``) where META_DATA / TARGET_INFO tables were
@@ -307,7 +307,7 @@ def get_profile_id(
 
     .. note::
        When *both* ``conn`` is None / empty and ``fallback_path`` is
-       None, the function returns ``nsys1:sha256:<sha256 of empty>``.
+       None, the function returns ``nsys2:sha256:<sha256 of empty>``.
        That is a recognisable null-id sentinel: every such caller
        collapses to the same value. Always pass ``fallback_path`` if
        cross-call distinguishability matters.
@@ -356,6 +356,18 @@ def get_profile_id(
             return [list(r) for r in adapter.execute(sql).fetchall() if r]
         except DB_ERRORS:
             return []
+
+    def _kernel_count() -> int | None:
+        """Count the kernel table selected by the shared schema resolver."""
+        try:
+            table = adapter.resolve_activity_tables().get("kernel")
+        except DB_ERRORS:
+            return None
+        if not table or not is_safe_identifier(table):
+            return None
+        # ``table`` is schema-derived and passed through the shared strict
+        # identifier validator immediately above.
+        return _scalar(f'SELECT COUNT(*) FROM "{table}"')  # nosec B608
 
     # NULLS LAST: SQLite defaults to NULLS FIRST, DuckDB to NULLS LAST —
     # pin it so two engine adapters on the same data hash identically.
@@ -416,12 +428,7 @@ def get_profile_id(
                 "ORDER BY globalPid NULLS LAST"
             ),
         ),
-        # literal-table-ok: this is a hash input, not a reader. Resolving the
-        # name would make a _V2 / _V3 export hash differently than it does
-        # today, and get_profile_id is a stable content identifier — that is an
-        # algorithm change, which the _PROFILE_ID_ALGO tag exists to version.
-        # Tracked separately; do not "fix" this without bumping the tag.
-        ("kernel_count", _scalar("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_KERNEL")),
+        ("kernel_count", _kernel_count()),
     ]
 
     # If every contribution is missing/empty the conn carries no Nsight

--- a/src/nsys_ai/profile_reference.py
+++ b/src/nsys_ai/profile_reference.py
@@ -1,0 +1,203 @@
+"""Strict local profile references shared by runners and session storage."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+from dataclasses import dataclass
+from pathlib import Path
+
+from .fingerprint import PROFILE_ID_VERSION
+
+LOCAL_PROFILE_ID_PATTERN = re.compile(
+    rf"{re.escape(PROFILE_ID_VERSION)}:sha256:[0-9a-f]{{64}}"
+)
+
+
+@dataclass(frozen=True)
+class LocalProfileReference:
+    """Validated identity and schema metadata for a local SQLite export."""
+
+    path: str
+    profile_id: str
+    schema_version: str | None
+    product_version: str | None
+    kernel_count: int
+
+
+def profile_stat_signature(metadata: os.stat_result) -> tuple[int, ...]:
+    """Return the fields used to detect a profile path or inode swap."""
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_mode,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+        metadata.st_ctime_ns,
+    )
+
+
+def _open_profile_parent_chain(
+    profile_path: Path,
+) -> tuple[int, tuple[tuple[int, ...], ...]]:
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+    descriptor = -1
+    signatures: list[tuple[int, ...]] = []
+    try:
+        descriptor = os.open(profile_path.anchor, flags)
+        signatures.append(profile_stat_signature(os.fstat(descriptor)))
+        for component in profile_path.parts[1:-1]:
+            child = os.open(component, flags, dir_fd=descriptor)
+            os.close(descriptor)
+            descriptor = child
+            signatures.append(profile_stat_signature(os.fstat(descriptor)))
+        return descriptor, tuple(signatures)
+    except (OSError, ValueError):
+        if descriptor >= 0:
+            os.close(descriptor)
+        raise ValueError(
+            "local profile reference file parent cannot be inspected safely"
+        ) from None
+
+
+def _confirm_local_profile_leaf_is_missing(
+    profile_path: Path,
+    raw_path: str,
+) -> None:
+    if not profile_path.is_absolute() or os.path.normpath(raw_path) != raw_path:
+        raise ValueError("local profile reference path must be canonical")
+
+    first_descriptor = -1
+    second_descriptor = -1
+    try:
+        first_descriptor, first_signatures = _open_profile_parent_chain(profile_path)
+        try:
+            os.stat(
+                profile_path.name,
+                dir_fd=first_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            pass
+        else:
+            raise ValueError(
+                "local profile reference file changed while being inspected"
+            )
+
+        second_descriptor, second_signatures = _open_profile_parent_chain(profile_path)
+        if first_signatures != second_signatures:
+            raise ValueError(
+                "local profile reference file changed while being inspected"
+            )
+        try:
+            os.stat(
+                profile_path.name,
+                dir_fd=second_descriptor,
+                follow_symlinks=False,
+            )
+        except FileNotFoundError:
+            return
+        raise ValueError("local profile reference file changed while being inspected")
+    except ValueError:
+        raise
+    except OSError:
+        raise ValueError(
+            "local profile reference file cannot be inspected"
+        ) from None
+    finally:
+        if first_descriptor >= 0:
+            os.close(first_descriptor)
+        if second_descriptor >= 0:
+            os.close(second_descriptor)
+
+
+def inspect_local_profile_file(
+    path: str | Path,
+    *,
+    allow_missing: bool = False,
+) -> tuple[Path, os.stat_result] | None:
+    """Inspect one canonical, non-symlinked, non-empty regular profile file.
+
+    ``allow_missing`` permits only a path absent at the initial no-follow stat.
+    Once an inode is observed, every later inspection failure is treated as a
+    path mutation or unsafe file instead of being downgraded to absence.
+    """
+    raw_path = os.fspath(path)
+    profile_path = Path(raw_path)
+    try:
+        before = os.stat(profile_path, follow_symlinks=False)
+    except FileNotFoundError:
+        if allow_missing:
+            _confirm_local_profile_leaf_is_missing(profile_path, raw_path)
+            return None
+        raise ValueError("local profile reference file does not exist") from None
+    except (OSError, ValueError):
+        raise ValueError("local profile reference file cannot be inspected") from None
+
+    try:
+        resolved = profile_path.resolve(strict=True)
+        after = os.stat(profile_path, follow_symlinks=False)
+    except FileNotFoundError:
+        raise ValueError("local profile reference file changed while being inspected") from None
+    except (OSError, RuntimeError, ValueError):
+        raise ValueError("local profile reference file cannot be inspected") from None
+
+    if profile_stat_signature(before) != profile_stat_signature(after):
+        raise ValueError("local profile reference file changed while being inspected")
+    if resolved != profile_path or stat.S_ISLNK(after.st_mode):
+        raise ValueError(
+            "local profile reference path must be canonical and contain no symbolic links"
+        )
+    if not stat.S_ISREG(after.st_mode):
+        raise ValueError("local profile reference path is not a regular file")
+    if after.st_size <= 0:
+        raise ValueError("local profile reference file is empty")
+    return resolved, after
+
+
+def validate_local_profile_reference(
+    reference: LocalProfileReference,
+    *,
+    require_file: bool,
+) -> LocalProfileReference:
+    """Validate the single persisted contract for a local profile reference."""
+    if not isinstance(reference, LocalProfileReference):
+        raise TypeError("profile reference must be a LocalProfileReference")
+
+    path = reference.path
+    if (
+        not isinstance(path, str)
+        or not path
+        or "\x00" in path
+        or not Path(path).is_absolute()
+    ):
+        raise ValueError("local profile reference path must be an absolute path string")
+    if Path(path).suffix.lower() != ".sqlite":
+        raise ValueError("local profile reference path must name a .sqlite file")
+    inspect_local_profile_file(path, allow_missing=not require_file)
+
+    if not isinstance(reference.profile_id, str) or not LOCAL_PROFILE_ID_PATTERN.fullmatch(
+        reference.profile_id
+    ):
+        raise ValueError("local profile identity is invalid")
+    for name, value in (
+        ("schema_version", reference.schema_version),
+        ("product_version", reference.product_version),
+    ):
+        if value is not None and (not isinstance(value, str) or not value):
+            raise ValueError(
+                f"local profile reference {name} must be a non-empty string or null"
+            )
+    if isinstance(reference.kernel_count, bool) or not isinstance(
+        reference.kernel_count, int
+    ):
+        raise ValueError("local profile kernel count is invalid")
+    if reference.kernel_count <= 0:
+        raise ValueError("local profile contains no GPU kernel activity")
+    return reference

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -7,8 +7,11 @@ does not own CLI presentation, session layout, or remote execution.
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import signal
+import sqlite3
+import stat
 import subprocess  # nosec B404
 import time
 from collections.abc import Callable, Mapping
@@ -19,10 +22,22 @@ from pathlib import Path
 from typing import BinaryIO, Protocol
 
 from .connection import DB_ERRORS
-from .exceptions import NsysAiError
+from .exceptions import NsysAiError, ProfileError
 from .fingerprint import get_profile_id
 from .profile import Profile, resolve_profile_path
-from .runspec import RunSpec, RunSpecError, build_nsys_profile_argv, validate_secret_boundaries
+from .profile_reference import (
+    LocalProfileReference,
+    inspect_local_profile_file,
+    profile_stat_signature,
+    validate_local_profile_reference,
+)
+from .runspec import (
+    RunSpec,
+    RunSpecError,
+    build_nsys_profile_argv,
+    validate_persisted_secret_strings,
+    validate_secret_boundaries,
+)
 
 
 class RunStatus(str, Enum):
@@ -57,15 +72,187 @@ class RunProgress:
     elapsed_seconds: float
 
 
-@dataclass(frozen=True)
-class LocalProfileReference:
-    """Validated identity and schema metadata for a local SQLite export."""
+_ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
-    path: str
-    profile_id: str
-    schema_version: str | None
-    product_version: str | None
-    kernel_count: int
+
+def _open_profile_descriptor(profile_path: Path) -> tuple[int, os.stat_result]:
+    try:
+        resolved_path, path_metadata = inspect_local_profile_file(profile_path)
+    except ValueError as exc:
+        raise ProfileError(str(exc)) from None
+
+    flags = (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_NONBLOCK", 0)
+    )
+    try:
+        descriptor = os.open(resolved_path, flags)
+    except FileNotFoundError:
+        raise ProfileError("local profile path does not exist") from None
+    except OSError:
+        raise ProfileError("local profile path cannot be opened safely") from None
+    try:
+        descriptor_metadata = os.fstat(descriptor)
+        if not stat.S_ISREG(descriptor_metadata.st_mode):
+            raise ProfileError("local profile path is not a regular file")
+        if profile_stat_signature(path_metadata) != profile_stat_signature(
+            descriptor_metadata
+        ):
+            raise ProfileError("local profile changed while it was being opened")
+        return descriptor, descriptor_metadata
+    except Exception:
+        os.close(descriptor)
+        raise
+
+
+def _assert_profile_descriptor_unchanged(
+    descriptor: int,
+    profile_path: Path,
+    before: os.stat_result,
+) -> None:
+    try:
+        descriptor_after = os.fstat(descriptor)
+        resolved_after, path_after = inspect_local_profile_file(profile_path)
+    except (OSError, ValueError):
+        raise ProfileError("local profile changed during validation") from None
+    expected = profile_stat_signature(before)
+    if (
+        profile_stat_signature(descriptor_after) != expected
+        or profile_stat_signature(path_after) != expected
+        or resolved_after != profile_path
+        or not stat.S_ISREG(path_after.st_mode)
+    ):
+        raise ProfileError("local profile changed during validation")
+
+
+def build_local_profile_reference(
+    path: str | os.PathLike[str],
+    *,
+    resolved_secrets: Mapping[str, str] | None = None,
+) -> LocalProfileReference:
+    """Validate an existing SQLite export and return its local reference.
+
+    The source profile is opened in direct, read-only analysis mode. The
+    function does not export, copy, cache, or publish the profile or create a
+    session. ``resolved_secrets`` lets callers reject a declared secret that
+    would otherwise be persisted as part of the absolute local path.
+    """
+    path_conversion_failed = False
+    try:
+        raw_path = os.fspath(path)
+    except Exception:
+        path_conversion_failed = True
+        raw_path = None
+    if path_conversion_failed:
+        raise ProfileError("local profile path must be a path string")
+    if not isinstance(raw_path, str):
+        raise ProfileError("local profile path must be a path string")
+    if not raw_path:
+        raise ProfileError("local profile path must not be empty")
+    if "\x00" in raw_path:
+        raise ProfileError("local profile path must not contain NUL bytes")
+
+    try:
+        profile_path = Path(raw_path).expanduser().absolute()
+    except (OSError, RuntimeError):
+        raise ProfileError("local profile path cannot be normalized") from None
+    if profile_path.suffix.lower() != ".sqlite":
+        raise ProfileError("local profile path must name a .sqlite file")
+    secret_error_detail: str | None = None
+    try:
+        validate_persisted_secret_strings(
+            {"path": str(profile_path)},
+            resolved_secrets if resolved_secrets is not None else {},
+        )
+    except Exception:
+        declared_names: list[str] = []
+        try:
+            for name, value in (resolved_secrets or {}).items():
+                if (
+                    isinstance(name, str)
+                    and _ENVIRONMENT_NAME.fullmatch(name)
+                    and isinstance(value, str)
+                    and value
+                    and value in str(profile_path)
+                ):
+                    declared_names.append(name)
+        except Exception:
+            declared_names = []
+        detail = (
+            " " + ", ".join(sorted(declared_names))
+            if declared_names
+            else ""
+        )
+        secret_error_detail = detail
+    if secret_error_detail is not None:
+        raise ProfileError(
+            f"local profile path contains a resolved secret{secret_error_detail}"
+        )
+
+    descriptor, before = _open_profile_descriptor(profile_path)
+    connection: sqlite3.Connection | None = None
+    validation_succeeded = False
+    unexpected_error: Exception | None = None
+    kernel_count = None
+    profile_id = None
+    schema_version = None
+    product_version = None
+    try:
+        descriptor_uri = f"file:/proc/self/fd/{descriptor}?mode=ro&immutable=1"
+        connection = sqlite3.connect(
+            descriptor_uri,
+            uri=True,
+            check_same_thread=False,
+        )
+        connection.execute("PRAGMA query_only = ON")
+        with Profile._from_conn(connection) as profile:
+            kernel_count = profile.meta.kernel_count
+            profile_id = get_profile_id(
+                profile.conn, fallback_path=str(profile_path)
+            )
+            schema_version = profile.schema.schema_version
+            product_version = profile.schema.version
+        validation_succeeded = True
+    except (NsysAiError, OSError, *DB_ERRORS):
+        validation_succeeded = False
+    except Exception as exc:
+        unexpected_error = exc
+    finally:
+        if connection is not None:
+            try:
+                connection.close()
+            except (OSError, *DB_ERRORS):
+                validation_succeeded = False
+            except Exception as exc:
+                unexpected_error = unexpected_error or exc
+
+    changed_error = None
+    try:
+        _assert_profile_descriptor_unchanged(descriptor, profile_path, before)
+    except ProfileError as exc:
+        changed_error = exc
+    finally:
+        os.close(descriptor)
+    if changed_error is not None:
+        raise changed_error from None
+    if unexpected_error is not None:
+        raise unexpected_error
+    if not validation_succeeded:
+        raise ProfileError("local profile is not a valid Nsight SQLite export") from None
+
+    reference = LocalProfileReference(
+        path=str(profile_path),
+        profile_id=profile_id,
+        schema_version=schema_version,
+        product_version=product_version,
+        kernel_count=kernel_count,
+    )
+    try:
+        return validate_local_profile_reference(reference, require_file=True)
+    except (TypeError, ValueError) as exc:
+        raise ProfileError(str(exc)) from None
 
 
 @dataclass(frozen=True)
@@ -105,10 +292,6 @@ ProgressCallback = Callable[[RunProgress], None]
 
 _POLL_SECONDS = 0.05
 _TERMINATION_GRACE_SECONDS = 2.0
-
-
-class _EmptyProfileError(ValueError):
-    """A readable profile has no GPU kernel rows."""
 
 
 class _CaptureLaunchError(Exception):
@@ -348,19 +531,10 @@ class LocalProfileRunner:
         progress(RunStage.VALIDATING)
         validation_started = time.monotonic()
         try:
-            with Profile(str(sqlite_path), cache_mode="direct") as profile:
-                if profile.meta.kernel_count <= 0:
-                    raise _EmptyProfileError("profile contains no GPU kernel activity")
-                reference = LocalProfileReference(
-                    path=str(sqlite_path),
-                    profile_id=get_profile_id(
-                        profile.conn, fallback_path=str(sqlite_path.absolute())
-                    ),
-                    schema_version=profile.schema.schema_version,
-                    product_version=profile.schema.version,
-                    kernel_count=profile.meta.kernel_count,
-                )
-        except (NsysAiError, OSError, *DB_ERRORS, _EmptyProfileError) as exc:
+            reference = build_local_profile_reference(
+                sqlite_path, resolved_secrets=resolved_secrets
+            )
+        except (NsysAiError, OSError, *DB_ERRORS) as exc:
             validation_seconds = time.monotonic() - validation_started
             return result(
                 RunStatus.INVALID_PROFILE,

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -49,7 +49,7 @@ from .diff_decision import (
     write_diff_json_from_diff_dict,
 )
 from .exceptions import NsysAiError
-from .profile_runner import LocalProfileReference
+from .profile_reference import LocalProfileReference, validate_local_profile_reference
 from .proposal import (
     PROPOSAL_SCHEMA_VERSION,
     Proposal,
@@ -341,7 +341,7 @@ class SessionStore:
         """Atomically create the exact v0 session directory layout."""
         _validate_session_id(session_id)
         if before_profile is not None:
-            _validate_profile_reference(before_profile, require_file=True)
+            validate_local_profile_reference(before_profile, require_file=True)
         self._ensure_roots()
         with self._lock(session_id, "writer", exclusive=True, blocking=False):
             destination = self._session_dir(session_id)
@@ -680,7 +680,7 @@ class SessionWriter:
         if not isinstance(findings, EvidenceReport):
             raise TypeError("findings must be an EvidenceReport")
         if before_profile is not None:
-            _validate_profile_reference(before_profile, require_file=True)
+            validate_local_profile_reference(before_profile, require_file=True)
 
         try:
             payload = findings.to_dict()
@@ -720,7 +720,7 @@ class SessionWriter:
 
     def publish_after_profile(self, profile: LocalProfileReference) -> SessionState:
         self._ensure_open()
-        _validate_profile_reference(profile, require_file=True)
+        validate_local_profile_reference(profile, require_file=True)
         return self._update_state(phase="reprofile", after_profile=profile)
 
     def publish_proposal(self, proposal: Proposal) -> SessionState:
@@ -1117,7 +1117,7 @@ def _profile_reference_to_dict(
 ) -> dict[str, Any] | None:
     if reference is None:
         return None
-    _validate_profile_reference(reference, require_file=False)
+    validate_local_profile_reference(reference, require_file=False)
     return {
         "kind": "local",
         "path": reference.path,
@@ -1154,35 +1154,10 @@ def _profile_reference_from_dict(value: Any) -> LocalProfileReference | None:
             product_version=payload["product_version"],
             kernel_count=payload["kernel_count"],
         )
-        _validate_profile_reference(reference, require_file=False)
+        validate_local_profile_reference(reference, require_file=False)
     except (KeyError, TypeError, ValueError) as exc:
         raise SessionCorruptError(f"invalid local profile reference: {exc}") from exc
     return reference
-
-
-def _validate_profile_reference(
-    reference: LocalProfileReference, *, require_file: bool
-) -> None:
-    if not isinstance(reference, LocalProfileReference):
-        raise TypeError("profile reference must be a LocalProfileReference")
-    if not isinstance(reference.path, str) or not Path(reference.path).is_absolute():
-        raise ValueError("local profile reference path must be absolute")
-    if require_file and not Path(reference.path).is_file():
-        raise ValueError(f"local profile reference does not exist: {reference.path}")
-    if not isinstance(reference.profile_id, str) or not reference.profile_id:
-        raise ValueError("local profile reference profile_id must be non-empty")
-    for name, value in (
-        ("schema_version", reference.schema_version),
-        ("product_version", reference.product_version),
-    ):
-        if value is not None and (not isinstance(value, str) or not value):
-            raise ValueError(f"local profile reference {name} must be a string or null")
-    if isinstance(reference.kernel_count, bool) or not isinstance(
-        reference.kernel_count, int
-    ) or reference.kernel_count < 0:
-        raise ValueError("local profile reference kernel_count must be non-negative")
-
-
 def _diff_mapping(value: Any, label: str) -> Mapping[str, Any]:
     if not isinstance(value, Mapping):
         raise ValueError(f"{label} must be an object")

--- a/tests/test_analyze_format_json.py
+++ b/tests/test_analyze_format_json.py
@@ -54,7 +54,7 @@ class TestAnalyzeFormatJson:
         assert isinstance(payload["findings"], list)
         # v0.1 content-derived profile id
         assert isinstance(payload["profile_id"], str)
-        assert payload["profile_id"].startswith("nsys1:"), payload["profile_id"]
+        assert payload["profile_id"].startswith("nsys2:"), payload["profile_id"]
 
     def test_profile_path_present(self, minimal_nsys_db_path):
         """Envelope contains a profile_path string sourced from the opened Profile."""
@@ -74,7 +74,7 @@ class TestAnalyzeFormatJson:
         """Single source of truth: envelope profile_id matches every
         Finding.selection.profile_id inside the same payload.
 
-        ``profile_id`` is the content-derived hash (``nsys1:sha256:...``)
+        ``profile_id`` is the content-derived hash (``nsys2:sha256:...``)
         from ``fingerprint.get_profile_id`` — both the envelope and every
         ``TraceSelection`` produced during the same build must carry it.
         """
@@ -86,7 +86,7 @@ class TestAnalyzeFormatJson:
         payload = json.loads(stdout)
 
         envelope_id = payload["profile_id"]
-        assert envelope_id.startswith("nsys1:"), envelope_id
+        assert envelope_id.startswith("nsys2:"), envelope_id
         for f in payload["findings"]:
             sel = f.get("selection")
             if sel is None:

--- a/tests/test_annotation_models.py
+++ b/tests/test_annotation_models.py
@@ -779,15 +779,15 @@ class TestEvidenceReportEnvelope:
 
     def test_envelope_carries_profile_id(self):
         """When set, profile_id is serialized verbatim in the envelope."""
-        report = EvidenceReport(title="T", profile_id="nsys1:sha256:abc", profile_path="/p")
+        report = EvidenceReport(title="T", profile_id="nsys2:sha256:abc", profile_path="/p")
         d = report.to_dict()
-        assert d["profile_id"] == "nsys1:sha256:abc"
+        assert d["profile_id"] == "nsys2:sha256:abc"
 
     def test_from_dict_preserves_profile_id(self):
         restored = EvidenceReport.from_dict(
-            {"title": "T", "profile_id": "nsys1:sha256:deadbeef", "profile_path": "/p"}
+            {"title": "T", "profile_id": "nsys2:sha256:deadbeef", "profile_path": "/p"}
         )
-        assert restored.profile_id == "nsys1:sha256:deadbeef"
+        assert restored.profile_id == "nsys2:sha256:deadbeef"
 
     def test_from_dict_defaults_profile_id_when_missing(self):
         """Pre-profile_id payloads (no key) load with profile_id=''."""
@@ -826,7 +826,7 @@ class TestEvidenceReportEnvelope:
 
         # Positional binding of ``profile_id`` is forbidden:
         with pytest.raises(TypeError):
-            EvidenceReport("T", "/p", [], "nsys1:sha256:abc")  # type: ignore[misc]
+            EvidenceReport("T", "/p", [], "nsys2:sha256:abc")  # type: ignore[misc]
 
         # Old positional usage (title, profile_path[, findings]) still
         # binds to the same fields it always did.

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -52,7 +52,7 @@ def test_tag_round_trip(tmp_path, profile_a):
 
     # meta shape
     assert meta["name"] == "v1"
-    assert meta["profile_id"].startswith("nsys1:")
+    assert meta["profile_id"].startswith("nsys2:")
     assert meta["reason"] == "known good"
     assert meta["runspec"] is None
     assert meta["tagger"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -454,7 +454,7 @@ def test_baseline_tag_list_show_roundtrip(tmp_path):
     assert meta["name"] == "v1"
     assert meta["reason"] == "known good"
     assert meta["runspec"] is None
-    assert meta["profile_id"].startswith("nsys1:")
+    assert meta["profile_id"].startswith("nsys2:")
     assert meta["tagger"]
     assert meta["tagged_at"].endswith("Z")
 

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1004,8 +1004,8 @@ def test_diff_cli_accept_writes_stable_decision_json(tmp_path):
     assert record["verdict"] == stdout_payload["verdict"]
     assert record["comparability_confidence"] == stdout_payload["comparability_confidence"]
     assert record["category_attribution"] == stdout_payload["category_attribution"]
-    assert record["before"]["profile_id"].startswith("nsys1:")
-    assert record["after"]["profile_id"].startswith("nsys1:")
+    assert record["before"]["profile_id"].startswith("nsys2:")
+    assert record["after"]["profile_id"].startswith("nsys2:")
     assert record["decision"]["status"] == "accepted"
     assert record["decision"]["reason"] == "candidate is faster"
     assert record["decision"]["decider"] == "fallback-user"
@@ -1340,7 +1340,7 @@ def test_diff_tools_global_diff_payload_includes_selection(tmp_path):
     selection = payload["top_regressions"][0]["selection"]
     assert selection["id"].startswith("sel_diff_")
     assert selection["source"] == "diff"
-    assert selection["profile_id"].startswith("nsys1:")
+    assert selection["profile_id"].startswith("nsys2:")
     assert selection["gpu_ids"] == [0]
     assert "kA" in selection["label"]
 
@@ -2623,8 +2623,8 @@ def test_v01_diff_json_envelope_and_verdict(tmp_path):
     assert len(payload["diff_id"]) == len("diff1:sha256:") + 64
 
     # profile_id in each side, content-derived
-    assert payload["before"]["profile_id"].startswith("nsys1:")
-    assert payload["after"]["profile_id"].startswith("nsys1:")
+    assert payload["before"]["profile_id"].startswith("nsys2:")
+    assert payload["after"]["profile_id"].startswith("nsys2:")
 
     # Verdict + confidence
     assert payload["verdict"] in {

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -92,7 +92,7 @@ def test_health_section_on_minimal_profile(minimal_nsys_db_path):
     assert health is not None
     assert report.profile_path == minimal_nsys_db_path
     # profile_id is content-derived when Nsight metadata is reachable.
-    assert report.profile_id is None or report.profile_id.startswith("nsys1:")
+    assert report.profile_id is None or report.profile_id.startswith("nsys2:")
     by_name = {c.name: c for c in health.checks}
     assert "Duration" in by_name
     assert "GPUs" in by_name

--- a/tests/test_fingerprint.py
+++ b/tests/test_fingerprint.py
@@ -1,6 +1,7 @@
 """Tests for framework fingerprinting logic."""
 
 import re
+import shutil
 import sqlite3
 
 from nsys_ai.fingerprint import (
@@ -192,8 +193,8 @@ def test_distributed_payload_schema_takes_precedence_over_fallback():
 # ---------------------------------------------------------------------------
 
 
-_SHA256_RE = re.compile(r"^nsys1:sha256:[0-9a-f]{64}$")
-_PATH_RE = re.compile(r"^nsys1:path:[0-9a-f]{64}$")
+_SHA256_RE = re.compile(r"^nsys2:sha256:[0-9a-f]{64}$")
+_PATH_RE = re.compile(r"^nsys2:path:[0-9a-f]{64}$")
 
 
 def _nsight_meta_db(
@@ -233,11 +234,50 @@ def _nsight_meta_db(
 
 
 def test_get_profile_id_format():
-    """Default-shaped result is ``nsys1:sha256:<64-hex>``."""
+    """Default-shaped result is ``nsys2:sha256:<64-hex>``."""
     conn = _nsight_meta_db()
     pid = get_profile_id(conn)
     assert _SHA256_RE.match(pid), pid
     assert pid.startswith(f"{PROFILE_ID_VERSION}:sha256:")
+
+
+def test_get_profile_id_resolves_canonical_and_versioned_kernel_tables(
+    minimal_nsys_db_path, tmp_path
+):
+    identities = []
+    for suffix in ("", "_V2", "_V3"):
+        profile_path = tmp_path / f"kernel-table{suffix or '-canonical'}.sqlite"
+        shutil.copyfile(minimal_nsys_db_path, profile_path)
+        with sqlite3.connect(profile_path) as connection:
+            if suffix:
+                connection.execute(
+                    "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+                    f"RENAME TO CUPTI_ACTIVITY_KIND_KERNEL{suffix}"
+                )
+            identities.append(get_profile_id(connection, fallback_path=str(profile_path)))
+
+    assert len(set(identities)) == 1
+
+
+def test_get_profile_id_changes_with_versioned_kernel_content(
+    minimal_nsys_db_path, tmp_path
+):
+    identities = []
+    for kernel_rows in (1, 2):
+        profile_path = tmp_path / f"kernels-v3-{kernel_rows}.sqlite"
+        shutil.copyfile(minimal_nsys_db_path, profile_path)
+        with sqlite3.connect(profile_path) as connection:
+            connection.execute(
+                "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+                "RENAME TO CUPTI_ACTIVITY_KIND_KERNEL_V3"
+            )
+            connection.execute(
+                "DELETE FROM CUPTI_ACTIVITY_KIND_KERNEL_V3 WHERE rowid > ?",
+                (kernel_rows,),
+            )
+            identities.append(get_profile_id(connection, fallback_path=str(profile_path)))
+
+    assert identities[0] != identities[1]
 
 
 def test_get_profile_id_deterministic():
@@ -271,7 +311,7 @@ def test_get_profile_id_path_independent():
 
 
 def test_get_profile_id_missing_tables_falls_back_to_path():
-    """Empty conn (no Nsight tables) + fallback_path → nsys1:path:..."""
+    """Empty conn (no Nsight tables) + fallback_path → nsys2:path:..."""
     conn = sqlite3.connect(":memory:")
     pid = get_profile_id(conn, fallback_path="/some/profile.sqlite")
     assert _PATH_RE.match(pid), pid
@@ -288,7 +328,7 @@ def test_get_profile_id_missing_tables_without_fallback_is_null_sentinel():
     )
     # And they must both be the well-known empty-string SHA-256.
     empty_sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    assert pid == f"nsys1:sha256:{empty_sha}"
+    assert pid == f"nsys2:sha256:{empty_sha}"
 
 
 def test_get_profile_id_partial_metadata_still_content_path():
@@ -339,7 +379,7 @@ def test_get_profile_id_none_conn_without_fallback_is_null_sentinel():
     # The well-known SHA-256 of the empty string. If this constant ever
     # changes, hashlib has changed, not our algorithm.
     empty_sha = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-    assert pid == f"nsys1:sha256:{empty_sha}"
+    assert pid == f"nsys2:sha256:{empty_sha}"
 
 
 def test_get_profile_id_no_separator_collision():

--- a/tests/test_gpu_idle_gaps_findings.py
+++ b/tests/test_gpu_idle_gaps_findings.py
@@ -264,7 +264,7 @@ class TestSerialization:
 class TestEvidenceBuilderIntegration:
     def test_builder_passes_profile_id_to_idle_gaps(self, minimal_nsys_db_path):
         """Real DB integration: TraceSelections produced under EvidenceBuilder
-        carry the content-derived ``profile_id`` (``nsys1:sha256:...``)
+        carry the content-derived ``profile_id`` (``nsys2:sha256:...``)
         from ``fingerprint.get_profile_id``, *not* the filesystem path."""
         from nsys_ai.evidence_builder import EvidenceBuilder
         from nsys_ai.profile import Profile
@@ -275,7 +275,7 @@ class TestEvidenceBuilderIntegration:
 
         # The envelope must always be stamped with a content-derived id,
         # regardless of whether the fixture happened to produce findings.
-        assert report.profile_id.startswith("nsys1:"), report.profile_id
+        assert report.profile_id.startswith("nsys2:"), report.profile_id
         assert report.profile_id != str(minimal_nsys_db_path), (
             "profile_id must be a hash, not the filesystem path"
         )
@@ -323,7 +323,7 @@ class TestEvidenceBuilderIntegration:
         # builder coerces and ``EvidenceReport.__post_init__`` coerces
         # again as a belt-and-braces guarantee.
         assert isinstance(report.profile_path, str)
-        assert report.profile_id.startswith("nsys1:"), report.profile_id
+        assert report.profile_id.startswith("nsys2:"), report.profile_id
         # JSON-dumpable end-to-end (this is the failure mode if either
         # coercion regresses).
         json.dumps(report.to_dict())

--- a/tests/test_kernel_instances.py
+++ b/tests/test_kernel_instances.py
@@ -95,7 +95,7 @@ class TestKernelInstanceFindings:
     def test_compute_hotspot_has_v01_evidence_shape(self, ki_skill):
         findings = ki_skill.to_findings_fn(
             [_kernel_row()],
-            context={"profile_id": "nsys1:sha256:test"},
+            context={"profile_id": "nsys2:sha256:test"},
         )
         assert len(findings) == 1
         f = findings[0]
@@ -116,7 +116,7 @@ class TestKernelInstanceFindings:
         assert f.provenance == {"skill": "kernel_instances", "row_kind": "kernel_hotspot"}
 
         assert isinstance(f.selection, TraceSelection)
-        assert f.selection.profile_id == "nsys1:sha256:test"
+        assert f.selection.profile_id == "nsys2:sha256:test"
         assert f.selection.source == "skill:kernel_instances"
         assert f.selection.start_ns == 1_000
         assert f.selection.end_ns == 6_001_000

--- a/tests/test_overlap_breakdown.py
+++ b/tests/test_overlap_breakdown.py
@@ -238,7 +238,7 @@ def test_findings_note_includes_same_stream_pct(minimal_nsys_conn):
 def test_low_overlap_finding_has_v01_evidence_shape():
     findings = SKILL.to_findings_fn(
         [_overlap_row()],
-        context={"profile_id": "nsys1:sha256:test"},
+        context={"profile_id": "nsys2:sha256:test"},
     )
     low = [f for f in findings if f.id and f.id.startswith("overlap_low_gpu2_")]
     assert low, f"expected low-overlap finding, got {[f.label for f in findings]}"
@@ -259,7 +259,7 @@ def test_low_overlap_finding_has_v01_evidence_shape():
     assert f.provenance == {"skill": "overlap_breakdown", "row_kind": "low_overlap"}
 
     assert isinstance(f.selection, TraceSelection)
-    assert f.selection.profile_id == "nsys1:sha256:test"
+    assert f.selection.profile_id == "nsys2:sha256:test"
     assert f.selection.source == "skill:overlap_breakdown"
     assert f.selection.start_ns == 1_000
     assert f.selection.end_ns == 9_000

--- a/tests/test_profile_reference.py
+++ b/tests/test_profile_reference.py
@@ -1,0 +1,655 @@
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+import traceback
+from dataclasses import asdict, replace
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.exceptions import ProfileError
+from nsys_ai.fingerprint import PROFILE_ID_VERSION
+from nsys_ai.profile_reference import (
+    LocalProfileReference,
+    validate_local_profile_reference,
+)
+from nsys_ai.profile_runner import build_local_profile_reference
+
+VALID_PROFILE_ID = f"{PROFILE_ID_VERSION}:sha256:" + "0" * 64
+
+
+def _digest(path: str | Path) -> str:
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def _tree_digest(root: Path) -> dict[str, str]:
+    snapshot = {}
+    for path in sorted(root.rglob("*")):
+        relative = str(path.relative_to(root))
+        if path.is_symlink():
+            snapshot[relative] = f"symlink:{path.readlink()}"
+        elif path.is_dir():
+            snapshot[relative] = "directory"
+        elif path.is_file():
+            snapshot[relative] = f"file:{path.stat().st_size}:{_digest(path)}"
+        else:
+            snapshot[relative] = "special"
+    return snapshot
+
+
+def test_existing_profile_reference_matches_profile_and_evidence_identity(
+    minimal_nsys_db_path,
+):
+    from nsys_ai.evidence_builder import EvidenceBuilder
+    from nsys_ai.profile import Profile
+
+    reference = build_local_profile_reference(minimal_nsys_db_path)
+    with Profile(minimal_nsys_db_path, cache_mode="direct") as profile:
+        report = EvidenceBuilder(profile).build(only=[])
+        assert reference.profile_id == report.profile_id
+        assert reference.schema_version == profile.schema.schema_version
+        assert reference.product_version == profile.schema.version
+        assert reference.kernel_count == profile.meta.kernel_count
+
+    assert reference.path == str(Path(minimal_nsys_db_path).absolute())
+    assert reference.profile_id.startswith("nsys2:sha256:")
+    assert reference.kernel_count == 5
+
+
+def test_existing_profile_reference_has_no_local_artifact_or_cache_side_effects(
+    minimal_nsys_db_path, tmp_path
+):
+    profile = Path(minimal_nsys_db_path)
+    before_names = {item.relative_to(tmp_path) for item in tmp_path.rglob("*")}
+    before_size = profile.stat().st_size
+    before_digest = _digest(profile)
+
+    build_local_profile_reference(profile)
+
+    assert profile.stat().st_size == before_size
+    assert _digest(profile) == before_digest
+    assert {item.relative_to(tmp_path) for item in tmp_path.rglob("*")} == before_names
+    assert not (tmp_path / ".nsys-ai").exists()
+
+
+def test_relative_profile_path_is_normalized_without_copying(
+    minimal_nsys_db_path, monkeypatch
+):
+    profile = Path(minimal_nsys_db_path)
+    monkeypatch.chdir(profile.parent)
+
+    reference = build_local_profile_reference(profile.name)
+
+    assert reference.path == str(profile.absolute())
+    assert list(profile.parent.glob("*.sqlite")) == [profile]
+
+
+@pytest.mark.parametrize(
+    ("path_value", "message"),
+    [
+        ("", "must not be empty"),
+        (b"profile.sqlite", "must be a path string"),
+        ("profile.nsys-rep", "must name a .sqlite file"),
+        ("bad\x00.sqlite", "must not contain NUL bytes"),
+    ],
+)
+def test_profile_reference_rejects_invalid_path_contract(path_value, message):
+    with pytest.raises(ProfileError, match=message):
+        build_local_profile_reference(path_value)
+
+
+def test_profile_reference_rejects_missing_directory_empty_and_invalid_files(
+    tmp_path,
+):
+    missing = tmp_path / "missing.sqlite"
+    with pytest.raises(ProfileError, match="does not exist"):
+        build_local_profile_reference(missing)
+
+    directory = tmp_path / "directory.sqlite"
+    directory.mkdir()
+    with pytest.raises(ProfileError, match="not a regular file"):
+        build_local_profile_reference(directory)
+
+    empty = tmp_path / "empty.sqlite"
+    empty.touch()
+    with pytest.raises(ProfileError, match="file is empty"):
+        build_local_profile_reference(empty)
+
+    invalid = tmp_path / "invalid.sqlite"
+    invalid.write_bytes(b"not a sqlite database")
+    with pytest.raises(ProfileError, match="not a valid Nsight SQLite export"):
+        build_local_profile_reference(invalid)
+
+
+def test_profile_reference_rejects_symlink_and_special_file(
+    minimal_nsys_db_path, tmp_path
+):
+    symlink = tmp_path / "symlink.sqlite"
+    symlink.symlink_to(minimal_nsys_db_path)
+    with pytest.raises(ProfileError, match="symbolic link"):
+        build_local_profile_reference(symlink)
+
+    real_directory = tmp_path / "real-directory"
+    real_directory.mkdir()
+    nested_profile = real_directory / "nested.sqlite"
+    shutil.copyfile(minimal_nsys_db_path, nested_profile)
+    directory_symlink = tmp_path / "directory-symlink"
+    directory_symlink.symlink_to(real_directory, target_is_directory=True)
+    with pytest.raises(ProfileError, match="symbolic link"):
+        build_local_profile_reference(directory_symlink / nested_profile.name)
+
+    fifo = tmp_path / "special.sqlite"
+    os.mkfifo(fifo)
+    with pytest.raises(ProfileError, match="not a regular file"):
+        build_local_profile_reference(fifo)
+
+
+def test_same_inode_same_size_header_mutation_is_rejected(
+    minimal_nsys_db_path, monkeypatch
+):
+    import nsys_ai.profile_runner as profile_runner
+
+    profile = Path(minimal_nsys_db_path)
+    real_identity = profile_runner.get_profile_id
+    before = profile.stat()
+
+    def mutate_after_identity(*args, **kwargs):
+        identity = real_identity(*args, **kwargs)
+        descriptor = os.open(profile, os.O_RDWR)
+        try:
+            os.pwrite(descriptor, b"\x01\x02\x03\x04", 68)
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        os.utime(profile, ns=(before.st_atime_ns, before.st_mtime_ns))
+        return identity
+
+    monkeypatch.setattr(profile_runner, "get_profile_id", mutate_after_identity)
+
+    with pytest.raises(ProfileError, match="changed during validation"):
+        build_local_profile_reference(profile)
+
+    after = profile.stat()
+    assert (after.st_dev, after.st_ino, after.st_size, after.st_mtime_ns) == (
+        before.st_dev,
+        before.st_ino,
+        before.st_size,
+        before.st_mtime_ns,
+    )
+    assert after.st_ctime_ns != before.st_ctime_ns
+
+
+def test_path_replacement_during_validation_is_rejected(
+    minimal_nsys_db_path, tmp_path, monkeypatch
+):
+    import nsys_ai.profile_runner as profile_runner
+
+    profile = Path(minimal_nsys_db_path)
+    replacement = tmp_path / "replacement.sqlite"
+    shutil.copyfile(profile, replacement)
+    real_identity = profile_runner.get_profile_id
+    original_inode = profile.stat().st_ino
+
+    def replace_after_identity(*args, **kwargs):
+        identity = real_identity(*args, **kwargs)
+        os.replace(replacement, profile)
+        return identity
+
+    monkeypatch.setattr(profile_runner, "get_profile_id", replace_after_identity)
+
+    with pytest.raises(ProfileError, match="changed during validation"):
+        build_local_profile_reference(profile)
+
+    assert profile.stat().st_ino != original_inode
+
+
+def test_validation_closes_profile_descriptor_on_failure(tmp_path, monkeypatch):
+    import nsys_ai.profile_runner as profile_runner
+
+    invalid = tmp_path / "invalid.sqlite"
+    invalid.write_bytes(b"not a sqlite database")
+    real_open = profile_runner.os.open
+    descriptors: list[int] = []
+
+    def recording_open(*args, **kwargs):
+        descriptor = real_open(*args, **kwargs)
+        descriptors.append(descriptor)
+        return descriptor
+
+    monkeypatch.setattr(profile_runner.os, "open", recording_open)
+
+    with pytest.raises(ProfileError, match="not a valid Nsight SQLite export"):
+        build_local_profile_reference(invalid)
+
+    assert descriptors
+    for descriptor in descriptors:
+        with pytest.raises(OSError):
+            os.fstat(descriptor)
+
+
+def test_profile_reference_rejects_profile_without_kernel_activity(
+    minimal_nsys_db_path,
+):
+    with sqlite3.connect(minimal_nsys_db_path) as connection:
+        connection.execute("DELETE FROM CUPTI_ACTIVITY_KIND_KERNEL")
+
+    with pytest.raises(ProfileError, match="no GPU kernel activity"):
+        build_local_profile_reference(minimal_nsys_db_path)
+
+
+@pytest.mark.parametrize(
+    "invalid_identity",
+    [
+        "nsys1:sha256:" + "0" * 64,
+        f"{PROFILE_ID_VERSION}:path:" + "0" * 64,
+        "opaque-profile-id",
+        f"{PROFILE_ID_VERSION}:sha256:" + "A" * 64,
+        f"{PROFILE_ID_VERSION}:sha256:" + "0" * 63,
+        f"{PROFILE_ID_VERSION}:sha256:" + "0" * 65,
+    ],
+)
+def test_profile_reference_factory_rejects_noncanonical_identity(
+    minimal_nsys_db_path, monkeypatch, invalid_identity
+):
+    import nsys_ai.profile_runner as profile_runner
+
+    monkeypatch.setattr(
+        profile_runner,
+        "get_profile_id",
+        lambda *_args, **_kwargs: invalid_identity,
+    )
+
+    with pytest.raises(ProfileError, match="identity is invalid"):
+        build_local_profile_reference(minimal_nsys_db_path)
+
+
+def test_profile_reference_factory_calls_shared_validator(
+    minimal_nsys_db_path, monkeypatch
+):
+    import nsys_ai.profile_runner as profile_runner
+
+    calls = []
+    real_validator = profile_runner.validate_local_profile_reference
+
+    def recording_validator(reference, *, require_file):
+        calls.append((reference, require_file))
+        return real_validator(reference, require_file=require_file)
+
+    monkeypatch.setattr(
+        profile_runner,
+        "validate_local_profile_reference",
+        recording_validator,
+    )
+
+    reference = build_local_profile_reference(minimal_nsys_db_path)
+
+    assert calls == [(reference, True)]
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("path", "relative.sqlite", "absolute path string"),
+        ("path", "/tmp/profile.nsys-rep", "must name a .sqlite"),
+        ("path", "/tmp/bad\x00.sqlite", "absolute path string"),
+        ("schema_version", "", "schema_version"),
+        ("schema_version", 1, "schema_version"),
+        ("product_version", "", "product_version"),
+        ("kernel_count", 0, "no GPU kernel activity"),
+        ("kernel_count", True, "kernel count is invalid"),
+    ],
+)
+def test_shared_profile_reference_validator_rejects_invalid_fields(
+    field, value, message
+):
+    reference = LocalProfileReference(
+        path="/tmp/profile.sqlite",
+        profile_id=VALID_PROFILE_ID,
+        schema_version="3.25.0",
+        product_version="2026.2.1.106",
+        kernel_count=1,
+    )
+
+    with pytest.raises(ValueError, match=message):
+        validate_local_profile_reference(
+            replace(reference, **{field: value}),
+            require_file=False,
+        )
+
+
+def test_shared_file_inspection_detects_path_swap(tmp_path, monkeypatch):
+    import nsys_ai.profile_reference as profile_reference
+
+    profile = tmp_path / "profile.sqlite"
+    replacement = tmp_path / "replacement.sqlite"
+    profile.write_bytes(b"original")
+    replacement.write_bytes(b"replaced")
+    real_resolve = profile_reference.Path.resolve
+    swapped = False
+
+    def swap_then_resolve(path, *args, **kwargs):
+        nonlocal swapped
+        if path == profile and not swapped:
+            swapped = True
+            os.replace(replacement, profile)
+        return real_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(profile_reference.Path, "resolve", swap_then_resolve)
+
+    with pytest.raises(ValueError, match="changed while being inspected"):
+        profile_reference.inspect_local_profile_file(profile)
+
+
+def test_missing_file_inspection_detects_parent_swap(tmp_path, monkeypatch):
+    import nsys_ai.profile_reference as profile_reference
+
+    parent = tmp_path / "profile-parent"
+    parent.mkdir()
+    profile = parent / "missing.sqlite"
+    replaced_parent = tmp_path / "replaced-parent"
+    real_open_chain = profile_reference._open_profile_parent_chain
+    calls = 0
+
+    def swap_after_first_parent_walk(path):
+        nonlocal calls
+        result = real_open_chain(path)
+        calls += 1
+        if calls == 1:
+            parent.rename(replaced_parent)
+            parent.mkdir()
+        return result
+
+    monkeypatch.setattr(
+        profile_reference,
+        "_open_profile_parent_chain",
+        swap_after_first_parent_walk,
+    )
+
+    with pytest.raises(ValueError, match="changed while being inspected"):
+        profile_reference.inspect_local_profile_file(profile, allow_missing=True)
+
+
+@pytest.mark.parametrize(
+    "path_kind",
+    [
+        "parent_symlink",
+        "broken_parent_symlink",
+        "special_parent",
+        "final_symlink",
+        "broken_final_symlink",
+        "canonical_mismatch",
+        "missing_canonical_mismatch",
+        "empty",
+        "special",
+    ],
+)
+@pytest.mark.parametrize("require_file", [True, False])
+def test_shared_reference_file_contract_rejects_unsafe_existing_path(
+    tmp_path, path_kind, require_file
+):
+    valid = tmp_path / "valid.sqlite"
+    valid.write_bytes(b"profile")
+    if path_kind == "parent_symlink":
+        real_parent = tmp_path / "real-parent"
+        real_parent.mkdir()
+        target = real_parent / "profile.sqlite"
+        target.write_bytes(b"profile")
+        alias = tmp_path / "parent-alias"
+        alias.symlink_to(real_parent, target_is_directory=True)
+        path = alias / target.name
+    elif path_kind == "broken_parent_symlink":
+        alias = tmp_path / "broken-parent-alias"
+        alias.symlink_to(tmp_path / "missing-parent", target_is_directory=True)
+        path = alias / "profile.sqlite"
+    elif path_kind == "special_parent":
+        parent = tmp_path / "special-parent"
+        os.mkfifo(parent)
+        path = parent / "profile.sqlite"
+    elif path_kind == "final_symlink":
+        path = tmp_path / "final.sqlite"
+        path.symlink_to(valid)
+    elif path_kind == "broken_final_symlink":
+        path = tmp_path / "broken-final.sqlite"
+        path.symlink_to(tmp_path / "missing-target.sqlite")
+    elif path_kind == "canonical_mismatch":
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        path = nested / ".." / valid.name
+    elif path_kind == "missing_canonical_mismatch":
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        path = nested / ".." / "missing.sqlite"
+    elif path_kind == "empty":
+        path = tmp_path / "empty.sqlite"
+        path.touch()
+    else:
+        path = tmp_path / "special.sqlite"
+        os.mkfifo(path)
+    reference = LocalProfileReference(
+        path=str(path),
+        profile_id=VALID_PROFILE_ID,
+        schema_version="3.25.0",
+        product_version="2026.2.1.106",
+        kernel_count=1,
+    )
+
+    with pytest.raises(ValueError) as rejected:
+        validate_local_profile_reference(reference, require_file=require_file)
+
+    assert str(path) not in str(rejected.value)
+
+
+def test_shared_reference_contract_allows_only_a_truly_missing_optional_file(tmp_path):
+    reference = LocalProfileReference(
+        path=str(tmp_path / "missing.sqlite"),
+        profile_id=VALID_PROFILE_ID,
+        schema_version="3.25.0",
+        product_version="2026.2.1.106",
+        kernel_count=1,
+    )
+
+    assert (
+        validate_local_profile_reference(reference, require_file=False) is reference
+    )
+    with pytest.raises(ValueError, match="does not exist"):
+        validate_local_profile_reference(reference, require_file=True)
+
+
+def test_secret_bearing_path_is_rejected_without_disclosing_secret(
+    minimal_nsys_db_path, tmp_path
+):
+    secret = "private-profile-token"
+    secret_dir = tmp_path / secret
+    secret_dir.mkdir()
+    profile = secret_dir / "profile.sqlite"
+    shutil.copyfile(minimal_nsys_db_path, profile)
+    before_digest = _digest(profile)
+
+    with pytest.raises(ProfileError) as rejected:
+        build_local_profile_reference(
+            profile,
+            resolved_secrets={"RUNNER_SECRET": secret},
+        )
+
+    assert "RUNNER_SECRET" in str(rejected.value)
+    assert secret not in str(rejected.value)
+    assert _digest(profile) == before_digest
+    assert set(secret_dir.iterdir()) == {profile}
+
+
+def test_untrusted_pathlike_exception_has_no_secret_chain_or_log(caplog):
+    secret = "sentinel-fspath-secret"
+
+    class SecretPath:
+        def __fspath__(self):
+            raise RuntimeError(secret)
+
+    with pytest.raises(ProfileError) as rejected:
+        build_local_profile_reference(SecretPath())
+
+    rendered = "".join(
+        traceback.format_exception(rejected.type, rejected.value, rejected.tb)
+    )
+    assert rejected.value.__cause__ is None
+    assert rejected.value.__context__ is None
+    assert secret not in rendered
+    assert secret not in caplog.text
+
+
+def test_secret_validator_exception_has_no_secret_chain_or_log(
+    minimal_nsys_db_path, monkeypatch, caplog
+):
+    import nsys_ai.profile_runner as profile_runner
+
+    secret = "sentinel-validator-secret"
+
+    def fail_validation(*_args, **_kwargs):
+        try:
+            raise RuntimeError(secret)
+        except RuntimeError as exc:
+            raise profile_runner.RunSpecError(secret) from exc
+
+    monkeypatch.setattr(
+        profile_runner,
+        "validate_persisted_secret_strings",
+        fail_validation,
+    )
+
+    with pytest.raises(ProfileError) as rejected:
+        build_local_profile_reference(minimal_nsys_db_path)
+
+    rendered = "".join(
+        traceback.format_exception(rejected.type, rejected.value, rejected.tb)
+    )
+    assert rejected.value.__cause__ is None
+    assert rejected.value.__context__ is None
+    assert secret not in rendered
+    assert secret not in caplog.text
+
+
+def test_hot_rollback_journal_is_never_recovered_in_place(
+    minimal_nsys_db_path, tmp_path
+):
+    profile = Path(minimal_nsys_db_path)
+    crash_script = """
+import os
+import sqlite3
+import sys
+
+connection = sqlite3.connect(sys.argv[1])
+connection.execute("PRAGMA journal_mode=DELETE")
+connection.execute("PRAGMA synchronous=FULL")
+connection.execute("PRAGMA cache_size=1")
+connection.execute("PRAGMA cache_spill=ON")
+connection.execute("BEGIN IMMEDIATE")
+for index in range(256):
+    connection.execute(
+        "INSERT INTO StringIds(id, value) VALUES (?, ?)",
+        (1000 + index, "uncommitted-" + ("x" * 4096)),
+    )
+os._exit(0)
+"""
+    crashed = subprocess.run(
+        [sys.executable, "-c", crash_script, str(profile)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert crashed.returncode == 0, crashed.stderr
+    journal = Path(str(profile) + "-journal")
+    assert journal.is_file() and journal.stat().st_size > 512
+    before = _tree_digest(tmp_path)
+
+    reference = build_local_profile_reference(profile)
+
+    assert reference.kernel_count == 5
+    assert _tree_digest(tmp_path) == before
+
+
+def test_canonical_and_versioned_kernel_identity_is_content_based(
+    minimal_nsys_db_path, tmp_path
+):
+    from nsys_ai.evidence_builder import EvidenceBuilder
+    from nsys_ai.profile import Profile
+
+    equivalent_identities = []
+    for suffix in ("", "_V2", "_V3"):
+        profile_path = tmp_path / f"equivalent{suffix or '-canonical'}.sqlite"
+        shutil.copyfile(minimal_nsys_db_path, profile_path)
+        if suffix:
+            with sqlite3.connect(profile_path) as connection:
+                connection.execute(
+                    "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+                    f"RENAME TO CUPTI_ACTIVITY_KIND_KERNEL{suffix}"
+                )
+
+        reference = build_local_profile_reference(profile_path)
+        with Profile(str(profile_path), cache_mode="direct") as profile:
+            report = EvidenceBuilder(profile).build(only=[])
+        assert reference.profile_id == report.profile_id
+        equivalent_identities.append(reference.profile_id)
+
+    assert len(set(equivalent_identities)) == 1
+
+    content_identities = []
+    for kernel_rows in (1, 2):
+        profile_path = tmp_path / f"kernels-v3-{kernel_rows}.sqlite"
+        shutil.copyfile(minimal_nsys_db_path, profile_path)
+        with sqlite3.connect(profile_path) as connection:
+            connection.execute(
+                "ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL "
+                "RENAME TO CUPTI_ACTIVITY_KIND_KERNEL_V3"
+            )
+            connection.execute(
+                "DELETE FROM CUPTI_ACTIVITY_KIND_KERNEL_V3 WHERE rowid > ?",
+                (kernel_rows,),
+            )
+
+        reference = build_local_profile_reference(profile_path)
+        with Profile(str(profile_path), cache_mode="direct") as profile:
+            report = EvidenceBuilder(profile).build(only=[])
+        assert reference.profile_id == report.profile_id
+        assert reference.kernel_count == kernel_rows
+        content_identities.append(reference.profile_id)
+
+    assert content_identities[0] != content_identities[1]
+
+
+def test_profile_reference_is_stable_across_process_restart(
+    minimal_nsys_db_path, tmp_path
+):
+    profile = Path(minimal_nsys_db_path)
+    script = """
+import json
+import sys
+from dataclasses import asdict
+from nsys_ai.profile_runner import build_local_profile_reference
+print(json.dumps(asdict(build_local_profile_reference(sys.argv[1])), sort_keys=True))
+"""
+    environment = dict(os.environ)
+    source = str(Path(__file__).resolve().parents[1] / "src")
+    environment["PYTHONPATH"] = source
+    before_names = {item.relative_to(tmp_path) for item in tmp_path.rglob("*")}
+    before_digest = _digest(profile)
+
+    outputs = []
+    for _ in range(2):
+        result = subprocess.run(
+            [sys.executable, "-c", script, str(profile)],
+            cwd=tmp_path,
+            env=environment,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr
+        outputs.append(json.loads(result.stdout))
+
+    assert outputs[0] == outputs[1] == asdict(build_local_profile_reference(profile))
+    assert _digest(profile) == before_digest
+    assert {item.relative_to(tmp_path) for item in tmp_path.rglob("*")} == before_names

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -199,6 +199,27 @@ def test_success_returns_validated_reference_and_artifacts(tmp_path, fake_nsys):
         assert stat.S_IMODE(Path(private_path).stat().st_mode) == 0o600
 
 
+def test_runner_reuses_public_profile_reference_factory(
+    tmp_path, fake_nsys, monkeypatch
+):
+    import nsys_ai.profile_runner as profile_runner
+
+    calls = []
+    real_factory = profile_runner.build_local_profile_reference
+
+    def recording_factory(path, *, resolved_secrets=None):
+        calls.append((Path(path), dict(resolved_secrets or {})))
+        return real_factory(path, resolved_secrets=resolved_secrets)
+
+    monkeypatch.setattr(
+        profile_runner, "build_local_profile_reference", recording_factory
+    )
+    result = _run(tmp_path, fake_nsys)
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert calls == [(Path(result.sqlite_path), {})]
+
+
 @pytest.mark.parametrize(
     ("mode", "expected"),
     [

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -175,7 +175,7 @@ def test_success_returns_validated_reference_and_artifacts(tmp_path, fake_nsys):
     assert result.application_return_code is None
     assert result.profile is not None
     assert result.profile.kernel_count == 1
-    assert result.profile.profile_id.startswith("nsys1:sha256:")
+    assert result.profile.profile_id.startswith("nsys2:sha256:")
     assert result.profile.schema_version == "3.25.0"
     assert result.profile.product_version == "2026.2.1.106"
     assert Path(result.report_path).is_file()

--- a/tests/test_proposal.py
+++ b/tests/test_proposal.py
@@ -31,7 +31,7 @@ def _finding(**overrides):
         "headroom_basis": "capture_total",
         "selection": TraceSelection(
             id="selection-0",
-            profile_id="nsys1:sha256:profile",
+            profile_id="nsys2:sha256:profile",
             source="skill:overlap_breakdown",
             start_ns=100,
             end_ns=200,
@@ -345,7 +345,7 @@ def test_suggested_actions_reject_non_string_members():
 def test_malformed_trace_selection_shape_is_rejected():
     selection = TraceSelection(
         id="selection-0",
-        profile_id="nsys1:sha256:profile",
+        profile_id="nsys2:sha256:profile",
         source="skill:test",
         nvtx_path="iteration",
     )
@@ -357,8 +357,8 @@ def test_malformed_trace_selection_shape_is_rejected():
 @pytest.mark.parametrize(
     ("finding_id", "profile_id", "message"),
     [
-        (" finding-0", "nsys1:sha256:profile", "source finding id"),
-        ("finding-0", "nsys1:sha256: profile", "selection.profile_id"),
+        (" finding-0", "nsys2:sha256:profile", "source finding id"),
+        ("finding-0", "nsys2:sha256: profile", "selection.profile_id"),
     ],
 )
 def test_provenance_ids_with_whitespace_are_rejected(finding_id, profile_id, message):

--- a/tests/test_propose_command.py
+++ b/tests/test_propose_command.py
@@ -33,7 +33,7 @@ def _finding(finding_id: str, *, explanation: str | None = None) -> Finding:
         headroom_basis="capture_total",
         selection=TraceSelection(
             id=f"selection-{finding_id}",
-            profile_id="nsys1:sha256:profile",
+            profile_id="nsys2:sha256:" + "1" * 64,
             source="skill:overlap_breakdown",
             start_ns=100,
             end_ns=200,
@@ -47,7 +47,7 @@ def _write_evidence(path: Path, findings: list[Finding]) -> dict:
     payload = EvidenceReport(
         "Auto-Analysis",
         profile_path="/profiles/before.sqlite",
-        profile_id="nsys1:sha256:profile",
+        profile_id="nsys2:sha256:" + "1" * 64,
         findings=findings,
     ).to_dict()
     path.write_text(json.dumps(payload), encoding="utf-8")

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -4,13 +4,14 @@ import os
 import stat
 import subprocess
 import sys
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
 
 from nsys_ai.annotation import SCHEMA_VERSION as DIFF_SCHEMA_VERSION
 from nsys_ai.annotation import EvidenceReport, EvidenceRow, Finding, TraceSelection
-from nsys_ai.profile_runner import LocalProfileReference
+from nsys_ai.profile_reference import LocalProfileReference
 from nsys_ai.proposal import PROPOSAL_SCHEMA_VERSION, Proposal, generate_proposal
 from nsys_ai.runspec import EnvironmentSpec, RunSpec, RunSpecError
 from nsys_ai.session_store import (
@@ -18,16 +19,21 @@ from nsys_ai.session_store import (
     SessionConflictError,
     SessionCorruptError,
     SessionError,
+    SessionState,
     SessionStore,
     UnsupportedSessionVersionError,
 )
 
 
-def _profile_reference(path: Path, profile_id: str) -> LocalProfileReference:
+def _profile_id(seed: str) -> str:
+    return "nsys2:sha256:" + hashlib.sha256(seed.encode("utf-8")).hexdigest()
+
+
+def _profile_reference(path: Path, identity_seed: str) -> LocalProfileReference:
     path.write_bytes(b"profile bytes remain outside the session")
     return LocalProfileReference(
         path=str(path.absolute()),
-        profile_id=profile_id,
+        profile_id=_profile_id(identity_seed),
         schema_version="3.25.0",
         product_version="2026.2.1.106",
         kernel_count=7,
@@ -248,10 +254,10 @@ def _proposal_id_for_payload(payload: dict) -> str:
 
 def _reprofiled_session(tmp_path: Path, session_id: str):
     before = _profile_reference(
-        tmp_path / f"{session_id}-before.sqlite", f"nsys1:{session_id}:before"
+        tmp_path / f"{session_id}-before.sqlite", f"{session_id}:before"
     )
     after = _profile_reference(
-        tmp_path / f"{session_id}-after.sqlite", f"nsys1:{session_id}:after"
+        tmp_path / f"{session_id}-after.sqlite", f"{session_id}:after"
     )
     finding = _finding(before)
     spec = RunSpec(argv=("true",))
@@ -274,8 +280,8 @@ def _reprofiled_session(tmp_path: Path, session_id: str):
 
 def test_complete_session_round_trip_uses_exact_layout_and_local_references(tmp_path):
     sessions = tmp_path / ".nsys-ai" / "sessions"
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
-    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
+    after = _profile_reference(tmp_path / "after.sqlite", "after")
     store = SessionStore(sessions)
 
     state = store.create("run-001", before_profile=before)
@@ -405,8 +411,8 @@ def test_symlink_alias_cannot_bypass_the_single_writer_lock(tmp_path):
 
 def test_new_process_reloads_persisted_phase_and_profile_reference(tmp_path):
     store = SessionStore(tmp_path / "sessions")
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
-    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
+    after = _profile_reference(tmp_path / "after.sqlite", "after")
     finding = _finding(before)
     spec = RunSpec(argv=("true",))
     store.create("restart", before_profile=before)
@@ -438,7 +444,7 @@ print(json.dumps({"phase": snapshot.state.phase, "profile_id": snapshot.state.af
     )
     assert json.loads(result.stdout) == {
         "phase": "reprofile",
-        "profile_id": "nsys1:after",
+        "profile_id": after.profile_id,
     }
 
 
@@ -697,8 +703,8 @@ def test_findings_producer_version_drift_remains_compatible(tmp_path):
 
 
 def test_findings_and_diff_must_match_session_profile_identities(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
-    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
+    after = _profile_reference(tmp_path / "after.sqlite", "after")
     store = SessionStore(tmp_path / "sessions")
     store.create("identity", before_profile=before)
     finding = _finding(before)
@@ -708,7 +714,7 @@ def test_findings_and_diff_must_match_session_profile_identities(tmp_path):
             writer.publish_findings(EvidenceReport("missing provenance"))
         with pytest.raises(ValueError, match="findings profile_id"):
             writer.publish_findings(
-                EvidenceReport("wrong", profile_id="nsys1:other")
+                EvidenceReport("wrong", profile_id=_profile_id("other"))
             )
         writer.publish_runspec(spec)
         writer.publish_findings(
@@ -722,7 +728,7 @@ def test_findings_and_diff_must_match_session_profile_identities(tmp_path):
         writer.publish_proposal(generate_proposal(finding, spec))
         writer.publish_after_profile(after)
         mismatched = _diff(before, after)
-        mismatched["after"]["profile_id"] = "nsys1:other"
+        mismatched["after"]["profile_id"] = _profile_id("other")
         with pytest.raises(ValueError, match="diff after profile_id"):
             writer.publish_diff(mismatched)
 
@@ -732,7 +738,7 @@ def test_findings_and_diff_must_match_session_profile_identities(tmp_path):
 
 
 def test_malformed_typed_findings_are_rejected_before_publication(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     malformed = [
         Finding(type=None, label="missing type", start_ns=1),
         Finding(
@@ -774,7 +780,7 @@ def test_malformed_typed_findings_are_rejected_before_publication(tmp_path):
 
 
 def test_malformed_findings_payload_is_rejected_on_restart(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     report = EvidenceReport(
         "diagnosis",
         profile_path=before.path,
@@ -803,7 +809,7 @@ def test_malformed_findings_payload_is_rejected_on_restart(tmp_path):
 
 
 def test_wrong_nested_evidence_scalar_and_container_types_are_rejected(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     malformed = [
         Finding(type=123, label="wrong scalar", start_ns=1),
         Finding(
@@ -847,7 +853,7 @@ def test_wrong_nested_evidence_scalar_and_container_types_are_rejected(tmp_path)
 def test_nested_finding_selection_must_match_before_profile_on_publish_and_load(
     tmp_path,
 ):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     finding = _finding(before)
     report = EvidenceReport(
         "diagnosis",
@@ -860,7 +866,7 @@ def test_nested_finding_selection_must_match_before_profile_on_publish_and_load(
     session_dir = store.root / "selection-profile"
     manifest_before = (session_dir / "session.json").read_bytes()
 
-    finding.selection.profile_id = "nsys1:other"
+    finding.selection.profile_id = _profile_id("other")
     with store.writer("selection-profile") as writer:
         with pytest.raises(ValueError, match="selection profile_id"):
             writer.publish_findings(report)
@@ -872,7 +878,7 @@ def test_nested_finding_selection_must_match_before_profile_on_publish_and_load(
         writer.publish_findings(report)
     findings_path = session_dir / "findings.json"
     payload = json.loads(findings_path.read_text())
-    payload["findings"][0]["selection"]["profile_id"] = "nsys1:other"
+    payload["findings"][0]["selection"]["profile_id"] = _profile_id("other")
     findings_path.write_text(json.dumps(payload))
     manifest_path = session_dir / "session.json"
     manifest = json.loads(manifest_path.read_text())
@@ -886,8 +892,8 @@ def test_nested_finding_selection_must_match_before_profile_on_publish_and_load(
 
 
 def test_diff_requires_reprofile_phase(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
-    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
+    after = _profile_reference(tmp_path / "after.sqlite", "after")
     store = SessionStore(tmp_path / "sessions")
     store.create("missing-refs")
     with store.writer("missing-refs") as writer:
@@ -1201,7 +1207,7 @@ def test_directional_diff_invariants_are_revalidated_on_restart(
     ("side", "field", "wrong_value"),
     [
         ("before", "path", "/tmp/not-the-before-profile.sqlite"),
-        ("after", "profile_id", "nsys1:not-after"),
+        ("after", "profile_id", _profile_id("not-after")),
         ("before", "schema_version", "9.9"),
         ("after", "product_version", "2099.1"),
     ],
@@ -1230,7 +1236,7 @@ def test_diff_side_metadata_must_match_session_references_before_publication(
     ("side", "field", "wrong_value"),
     [
         ("before", "path", "/tmp/not-the-before-profile.sqlite"),
-        ("after", "profile_id", "nsys1:not-after"),
+        ("after", "profile_id", _profile_id("not-after")),
         ("before", "schema_version", "9.9"),
         ("after", "product_version", "2099.1"),
     ],
@@ -1327,7 +1333,7 @@ def test_runspec_secret_preflight_happens_before_publication(tmp_path):
 
 
 def test_proposal_future_version_is_rejected_by_manifest_contract(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     store = SessionStore(tmp_path / "sessions")
     store.create("proposal", before_profile=before)
     finding = _finding(before)
@@ -1361,7 +1367,7 @@ def test_proposal_future_version_is_rejected_by_manifest_contract(tmp_path):
 
 
 def test_invented_proposal_projection_is_rejected_on_publish_and_reload(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     finding = _finding(before)
     report = EvidenceReport(
         "diagnosis",
@@ -1399,7 +1405,7 @@ def test_invented_proposal_projection_is_rejected_on_publish_and_reload(tmp_path
 
 
 def test_missing_selection_abstention_round_trips_without_weakening_identity(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     finding = _finding(before, "missing-selection")
     finding.selection = None
     report = EvidenceReport(
@@ -1428,7 +1434,7 @@ def test_missing_selection_abstention_round_trips_without_weakening_identity(tmp
         writer.publish_proposal(proposal)
         with pytest.raises(ValueError, match="non-abstained proposal"):
             writer.publish_after_profile(
-                _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+                _profile_reference(tmp_path / "after.sqlite", "after")
             )
 
     snapshot = store.load("missing-selection")
@@ -1439,8 +1445,8 @@ def test_missing_selection_abstention_round_trips_without_weakening_identity(tmp
 
 
 def test_proposal_requires_session_profile_and_exactly_one_finding(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
-    other = _profile_reference(tmp_path / "other.sqlite", "nsys1:other")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
+    other = _profile_reference(tmp_path / "other.sqlite", "other")
     known = _finding(before, "known")
     unknown = _finding(before, "unknown")
     wrong_profile = _finding(other, "known")
@@ -1473,7 +1479,7 @@ def test_interrupted_proposal_manifest_update_recovers_previous_proposal(
 ):
     import nsys_ai.session_store as session_store
 
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     first_finding = _finding(before, "f1", action="First action")
     second_finding = _finding(before, "f2", action="Second action")
     report = EvidenceReport(
@@ -1516,10 +1522,10 @@ def test_interrupted_proposal_manifest_update_recovers_previous_proposal(
 
 
 def test_dependent_overwrites_cannot_break_proposal_or_diff_references(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
-    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
+    after = _profile_reference(tmp_path / "after.sqlite", "after")
     replacement_after = _profile_reference(
-        tmp_path / "replacement.sqlite", "nsys1:replacement"
+        tmp_path / "replacement.sqlite", "replacement"
     )
     finding = _finding(before)
     report = EvidenceReport(
@@ -1771,7 +1777,7 @@ def test_load_rejects_noncanonical_diff_decisions(tmp_path, decision):
 
 
 def test_runspec_and_proposal_verification_cannot_diverge(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     finding = _finding(before)
     first_spec = RunSpec(argv=("true", "--mode=first"))
     second_spec = RunSpec(argv=("true", "--mode=second"))
@@ -1808,7 +1814,7 @@ def test_runspec_and_proposal_verification_cannot_diverge(tmp_path):
 
 
 def test_null_verification_abstention_requires_null_session_runspec(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
     finding = _finding(before)
     report = EvidenceReport(
         "diagnosis",
@@ -1827,7 +1833,7 @@ def test_null_verification_abstention_requires_null_session_runspec(tmp_path):
             writer.publish_runspec(RunSpec(argv=("true",)))
         with pytest.raises(ValueError, match="non-abstained proposal"):
             writer.publish_after_profile(
-                _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+                _profile_reference(tmp_path / "after.sqlite", "after")
             )
 
     snapshot = store.load("null-verification")
@@ -1866,8 +1872,8 @@ def test_non_finite_json_values_are_rejected_before_publication(tmp_path):
 
 
 def test_closed_writer_rejects_every_publication_method(tmp_path):
-    before = _profile_reference(tmp_path / "before.sqlite", "nsys1:before")
-    after = _profile_reference(tmp_path / "after.sqlite", "nsys1:after")
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
+    after = _profile_reference(tmp_path / "after.sqlite", "after")
     store = SessionStore(tmp_path / "sessions")
     store.create("closed", before_profile=before)
     writer = store.writer("closed")
@@ -1905,12 +1911,380 @@ def test_malformed_or_unsupported_json_is_rejected_as_corrupt(tmp_path):
         store.load("future")
 
 
-def test_profile_reference_rejects_remote_kind_and_is_not_revalidated_on_restart(tmp_path):
-    profile = _profile_reference(tmp_path / "profile.sqlite", "nsys1:profile")
+@pytest.mark.parametrize(
+    ("field", "manifest_field", "value"),
+    [
+        ("profile_id", "profile_id", "nsys1:sha256:" + "0" * 64),
+        ("profile_id", "profile_id", "nsys2:path:" + "0" * 64),
+        ("profile_id", "profile_id", "opaque-profile-id"),
+        ("profile_id", "profile_id", "nsys2:sha256:" + "A" * 64),
+        ("profile_id", "profile_id", "nsys2:sha256:" + "0" * 63),
+        ("profile_id", "profile_id", "nsys2:sha256:" + "0" * 65),
+        ("kernel_count", "kernel_count", 0),
+        ("kernel_count", "kernel_count", True),
+        ("path", "path", "relative.sqlite"),
+        ("path", "path", "/tmp/profile.nsys-rep"),
+        ("schema_version", "export_schema_version", ""),
+        ("product_version", "product_version", ""),
+    ],
+)
+def test_every_session_reference_boundary_rejects_invalid_contract(
+    tmp_path, field, manifest_field, value
+):
+    valid = _profile_reference(tmp_path / "valid.sqlite", "valid")
+    invalid = replace(valid, **{field: value})
+    store = SessionStore(tmp_path / "sessions")
+
+    with pytest.raises((TypeError, ValueError)):
+        store.create("invalid-create", before_profile=invalid)
+
+    store.create("invalid-publish")
+    with store.writer("invalid-publish") as writer:
+        with pytest.raises((TypeError, ValueError)):
+            writer.publish_findings(
+                EvidenceReport("invalid reference"),
+                before_profile=invalid,
+            )
+        with pytest.raises((TypeError, ValueError)):
+            writer.publish_after_profile(invalid)
+
+    state_payload = SessionState(
+        session_id="invalid-from-dict",
+        before_profile=valid,
+    ).to_dict()
+    state_payload["profiles"]["before"][manifest_field] = value
+    with pytest.raises(SessionCorruptError, match="invalid local profile reference"):
+        SessionState.from_dict(state_payload)
+
+    store.create("invalid-load", before_profile=valid)
+    manifest_path = store.root / "invalid-load" / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["profiles"]["before"][manifest_field] = value
+    manifest_path.write_text(json.dumps(manifest))
+    with pytest.raises(SessionCorruptError, match="invalid local profile reference"):
+        store.load("invalid-load")
+
+
+def test_session_reference_validation_error_does_not_disclose_path(tmp_path):
+    secret = "sentinel-private-profile-path"
+    valid = _profile_reference(tmp_path / "valid.sqlite", "valid")
+    missing = replace(
+        valid,
+        path=str(tmp_path / secret / "missing.sqlite"),
+    )
+
+    with pytest.raises(ValueError) as rejected:
+        SessionStore(tmp_path / "sessions").create(
+            "missing",
+            before_profile=missing,
+        )
+
+    assert secret not in str(rejected.value)
+
+
+@pytest.mark.parametrize(
+    "path_kind",
+    [
+        "parent_symlink",
+        "broken_parent_symlink",
+        "special_parent",
+        "final_symlink",
+        "broken_final_symlink",
+        "canonical_mismatch",
+        "missing_canonical_mismatch",
+        "empty",
+        "special",
+    ],
+)
+def test_session_publication_boundaries_reject_unsafe_profile_file(
+    tmp_path, path_kind
+):
+    valid = _profile_reference(tmp_path / "valid.sqlite", "valid")
+    if path_kind == "parent_symlink":
+        real_parent = tmp_path / "real-parent"
+        real_parent.mkdir()
+        target = real_parent / "profile.sqlite"
+        target.write_bytes(b"profile")
+        alias = tmp_path / "parent-alias"
+        alias.symlink_to(real_parent, target_is_directory=True)
+        path = alias / target.name
+    elif path_kind == "broken_parent_symlink":
+        alias = tmp_path / "broken-parent-alias"
+        alias.symlink_to(tmp_path / "missing-parent", target_is_directory=True)
+        path = alias / "profile.sqlite"
+    elif path_kind == "special_parent":
+        parent = tmp_path / "special-parent"
+        os.mkfifo(parent)
+        path = parent / "profile.sqlite"
+    elif path_kind == "final_symlink":
+        path = tmp_path / "final.sqlite"
+        path.symlink_to(valid.path)
+    elif path_kind == "broken_final_symlink":
+        path = tmp_path / "broken-final.sqlite"
+        path.symlink_to(tmp_path / "missing-target.sqlite")
+    elif path_kind == "canonical_mismatch":
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        path = nested / ".." / Path(valid.path).name
+    elif path_kind == "missing_canonical_mismatch":
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        path = nested / ".." / "missing.sqlite"
+    elif path_kind == "empty":
+        path = tmp_path / "empty.sqlite"
+        path.touch()
+    else:
+        path = tmp_path / "special.sqlite"
+        os.mkfifo(path)
+    invalid = replace(valid, path=str(path))
+    store = SessionStore(tmp_path / "sessions")
+
+    with pytest.raises(ValueError) as create_error:
+        store.create("unsafe-create", before_profile=invalid)
+    assert str(path) not in str(create_error.value)
+
+    store.create("unsafe-publish")
+    with store.writer("unsafe-publish") as writer:
+        with pytest.raises(ValueError):
+            writer.publish_findings(
+                EvidenceReport("unsafe reference"),
+                before_profile=invalid,
+            )
+        with pytest.raises(ValueError):
+            writer.publish_after_profile(invalid)
+
+
+@pytest.mark.parametrize(
+    "path_kind",
+    [
+        "parent_symlink",
+        "broken_parent_symlink",
+        "special_parent",
+        "final_symlink",
+        "broken_final_symlink",
+        "canonical_mismatch",
+        "missing_canonical_mismatch",
+        "empty",
+        "special",
+    ],
+)
+def test_load_rejects_unsafe_existing_profile_file(tmp_path, path_kind):
+    valid = _profile_reference(tmp_path / "valid.sqlite", "valid")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("unsafe-load", before_profile=valid)
+    if path_kind == "parent_symlink":
+        real_parent = tmp_path / "real-parent"
+        real_parent.mkdir()
+        target = real_parent / "profile.sqlite"
+        target.write_bytes(b"profile")
+        alias = tmp_path / "parent-alias"
+        alias.symlink_to(real_parent, target_is_directory=True)
+        path = alias / target.name
+    elif path_kind == "broken_parent_symlink":
+        alias = tmp_path / "broken-parent-alias"
+        alias.symlink_to(tmp_path / "missing-parent", target_is_directory=True)
+        path = alias / "profile.sqlite"
+    elif path_kind == "special_parent":
+        parent = tmp_path / "special-parent"
+        os.mkfifo(parent)
+        path = parent / "profile.sqlite"
+    elif path_kind == "final_symlink":
+        path = tmp_path / "final.sqlite"
+        path.symlink_to(valid.path)
+    elif path_kind == "broken_final_symlink":
+        path = tmp_path / "broken-final.sqlite"
+        path.symlink_to(tmp_path / "missing-target.sqlite")
+    elif path_kind == "canonical_mismatch":
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        path = nested / ".." / Path(valid.path).name
+    elif path_kind == "missing_canonical_mismatch":
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        path = nested / ".." / "missing.sqlite"
+    elif path_kind == "empty":
+        path = tmp_path / "empty.sqlite"
+        path.touch()
+    else:
+        path = tmp_path / "special.sqlite"
+        os.mkfifo(path)
+    manifest_path = store.root / "unsafe-load" / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["profiles"]["before"]["path"] = str(path)
+
+    with pytest.raises(SessionCorruptError) as deserialize_error:
+        SessionState.from_dict(manifest)
+    assert str(path) not in str(deserialize_error.value)
+
+    manifest_path.write_text(json.dumps(manifest))
+
+    with pytest.raises(SessionCorruptError) as rejected:
+        store.load("unsafe-load")
+
+    assert str(path) not in str(rejected.value)
+
+
+def test_load_rejects_profile_path_swapped_during_shared_inspection(
+    tmp_path, monkeypatch
+):
+    import nsys_ai.profile_reference as profile_reference
+
+    valid = _profile_reference(tmp_path / "valid.sqlite", "valid")
+    replacement = tmp_path / "replacement.sqlite"
+    replacement.write_bytes(b"replacement profile")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("swap-load", before_profile=valid)
+    real_resolve = profile_reference.Path.resolve
+    swapped = False
+
+    def swap_then_resolve(path, *args, **kwargs):
+        nonlocal swapped
+        if path == Path(valid.path) and not swapped:
+            swapped = True
+            os.replace(replacement, valid.path)
+        return real_resolve(path, *args, **kwargs)
+
+    monkeypatch.setattr(profile_reference.Path, "resolve", swap_then_resolve)
+
+    with pytest.raises(SessionCorruptError, match="changed while being inspected"):
+        store.load("swap-load")
+
+
+@pytest.mark.parametrize(
+    "path_kind",
+    [
+        "parent_symlink",
+        "broken_parent_symlink",
+        "special_parent",
+        "final_symlink",
+        "broken_final_symlink",
+        "canonical_mismatch",
+        "missing_canonical_mismatch",
+        "empty",
+        "special",
+    ],
+)
+def test_fresh_process_rejects_unsafe_existing_profile_file(tmp_path, path_kind):
+    valid = _profile_reference(tmp_path / "valid.sqlite", "valid")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("unsafe-restart", before_profile=valid)
+    if path_kind == "parent_symlink":
+        real_parent = tmp_path / "real-parent"
+        real_parent.mkdir()
+        target = real_parent / "profile.sqlite"
+        target.write_bytes(b"profile")
+        alias = tmp_path / "parent-alias"
+        alias.symlink_to(real_parent, target_is_directory=True)
+        path = alias / target.name
+    elif path_kind == "broken_parent_symlink":
+        alias = tmp_path / "broken-parent-alias"
+        alias.symlink_to(tmp_path / "missing-parent", target_is_directory=True)
+        path = alias / "profile.sqlite"
+    elif path_kind == "special_parent":
+        parent = tmp_path / "special-parent"
+        os.mkfifo(parent)
+        path = parent / "profile.sqlite"
+    elif path_kind == "final_symlink":
+        path = tmp_path / "final.sqlite"
+        path.symlink_to(valid.path)
+    elif path_kind == "broken_final_symlink":
+        path = tmp_path / "broken-final.sqlite"
+        path.symlink_to(tmp_path / "missing-target.sqlite")
+    elif path_kind == "canonical_mismatch":
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        path = nested / ".." / Path(valid.path).name
+    elif path_kind == "missing_canonical_mismatch":
+        nested = tmp_path / "nested"
+        nested.mkdir()
+        path = nested / ".." / "missing.sqlite"
+    elif path_kind == "empty":
+        path = tmp_path / "empty.sqlite"
+        path.touch()
+    else:
+        path = tmp_path / "special.sqlite"
+        os.mkfifo(path)
+    manifest_path = store.root / "unsafe-restart" / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["profiles"]["before"]["path"] = str(path)
+    manifest_path.write_text(json.dumps(manifest))
+    script = """
+from nsys_ai.session_store import SessionCorruptError, SessionStore
+try:
+    SessionStore(__import__('sys').argv[1]).load('unsafe-restart')
+except SessionCorruptError:
+    print('rejected')
+else:
+    raise SystemExit(2)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(store.root)],
+        cwd=tmp_path,
+        env=_subprocess_environment(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "rejected"
+    assert str(path) not in result.stdout + result.stderr
+
+
+def test_fresh_process_rejects_noncanonical_persisted_profile_identity(tmp_path):
+    store = SessionStore(tmp_path / "sessions")
+    valid = _profile_reference(tmp_path / "valid.sqlite", "valid")
+    store.create("restart-invalid", before_profile=valid)
+    manifest_path = store.root / "restart-invalid" / "session.json"
+    manifest = json.loads(manifest_path.read_text())
+    manifest["profiles"]["before"]["profile_id"] = "nsys1:sha256:" + "0" * 64
+    manifest_path.write_text(json.dumps(manifest))
+    script = """
+from nsys_ai.session_store import SessionCorruptError, SessionStore
+try:
+    SessionStore(__import__('sys').argv[1]).load('restart-invalid')
+except SessionCorruptError:
+    print('rejected')
+else:
+    raise SystemExit(2)
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(store.root)],
+        cwd=tmp_path,
+        env=_subprocess_environment(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "rejected"
+
+
+def test_profile_reference_allows_truly_missing_path_across_restart(tmp_path):
+    profile = _profile_reference(tmp_path / "profile.sqlite", "profile")
     store = SessionStore(tmp_path / "sessions")
     store.create("local", before_profile=profile)
     Path(profile.path).unlink()
     assert store.load("local").state.before_profile == profile
+
+    script = """
+from nsys_ai.session_store import SessionStore
+reference = SessionStore(__import__('sys').argv[1]).load('local').state.before_profile
+print(reference.profile_id)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script, str(store.root)],
+        cwd=tmp_path,
+        env=_subprocess_environment(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == profile.profile_id
 
     manifest_path = store.root / "local" / "session.json"
     manifest = json.loads(manifest_path.read_text())

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1025,7 +1025,7 @@ def test_diff_lineage_requires_exact_shape_types_and_parent_context(
     elif mutation == "baseline_type":
         lineage["baseline_profile_id"] = 1
     else:
-        lineage["baseline_profile_id"] = "nsys1:not-the-before-profile"
+        lineage["baseline_profile_id"] = "nsys2:sha256:" + "f" * 64
 
     with store.writer("diff-lineage-shape") as writer:
         with pytest.raises(ValueError, match="diff_lineage"):
@@ -1039,7 +1039,7 @@ def test_diff_lineage_requires_exact_shape_types_and_parent_context(
         ("diff_id", "another-diff"),
         ("role", "improvement"),
         ("rank", 1),
-        ("baseline_profile_id", "nsys1:not-the-before-profile"),
+        ("baseline_profile_id", "nsys2:sha256:" + "f" * 64),
     ],
 )
 def test_diff_lineage_context_is_revalidated_after_tamper_and_redigest(

--- a/tests/test_versioned_table_names.py
+++ b/tests/test_versioned_table_names.py
@@ -131,9 +131,8 @@ def test_get_region_kernels_agrees_across_both_table_names(runtime_v3):
 # ── The check that stops it coming back ─────────────────────────────────────
 
 
-# An escape hatch for the rare query that must keep the literal. It suppresses
-# the line that follows it, and it costs a written reason — see fingerprint.py,
-# where resolving the name would silently change a stable content hash.
+# An escape hatch for a rare query that must keep a literal. It suppresses the
+# line that follows it and costs a written reason at the call site.
 EXEMPTION = "literal-table-ok:"
 
 


### PR DESCRIPTION
Part of #268.

## Summary

- version profile content identity as `nsys2` and resolve canonical, `_V2`, and `_V3` kernel tables consistently
- add a reusable read-only `LocalProfileReference` factory for existing Nsight SQLite exports
- validate through a descriptor-bound `mode=ro&immutable=1` connection without copying, caching, recovering journals, or creating session artifacts
- make SessionStore create, publish, serialize, load, and restart share the same current profile-reference contract

## Correctness And Safety

- reject legacy/path/opaque IDs, zero-kernel references, final or parent symlinks, special/empty files, canonical mismatches, and path swaps
- allow a genuinely missing canonical path during restart while rejecting broken-symlink and noncanonical missing paths
- detect same-inode mutations and keep file descriptors stable across validation
- redact declared secrets from top-level errors, chained exceptions, tracebacks, and logs
- no `nsys1` compatibility shim; remaining `nsys1` literals are explicit legacy-rejection tests

## Verification

- five adversarial review rounds plus post-rebase review: final APPROVE
- pre-rebase approved tree: 1946 passed, 146 skipped; CI skip audit passed with the committed profile fixture
- post-rebase profile/proposal/diff/session overlap: 359 passed
- first identity commit standalone: 415 affected tests passed
- final reference/session slice: 586 focused and touched tests passed
- Ruff, Bandit, CLI smoke, and `git diff --check`: pass
- real profiles: 27 MB and 235 MB read-only smoke tests; the larger profile reported 228,740 kernels with a current content identity
- file-descriptor probe remained `4 -> 4`; profile bytes, journal state, directory entries, and tracked fixtures remained unchanged

This supplies the existing-profile reference prerequisite for headless `diagnose`. Web/TUI session adoption and the remaining #268 surface work stay open.
