### PR TITLE
fix(cache): decide auto cache mode on whether a cache can be written, not profile size

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,9 +294,14 @@ The build exports Parquet; the kernel-to-NVTX map is built separately by the
 first query that needs it, which is the "first NVTX query" column. Both are paid
 once per profile.
 
-On this workload the first run is already cheaper end to end than querying the
-export directly, at every size, so the build is the default. Two cases where it
-is not what you want:
+On this workload the first run is never slower end to end than querying the
+export directly, and always lighter on memory, so the build is the default. The
+middle two sizes are a clear win on time (23% and 26%); at 93 MB and 3.7 GB the
+time difference is 2-5%, inside run-to-run variance, and what those sizes gain
+is memory — 7.1 GB against 10.2 GB on the largest. Every command after the
+first is the warm row, which is where the cache pays for itself outright.
+
+Two cases where it is not what you want:
 
 - **One command against a very large profile, and no follow-up.** Set
   `NSYS_AI_CACHE_MODE=direct` to query the SQLite export in place — instant

--- a/README.md
+++ b/README.md
@@ -295,7 +295,9 @@ first query that needs it, which is the "first NVTX query" column. Both are paid
 once per profile.
 
 On this workload the first run is never slower end to end than querying the
-export directly, and always lighter on memory, so the build is the default. The
+export directly, and lighter on memory at all four sizes, so the build is the
+default — "this workload" being the eight skills above; a one-shot is a
+different trade, see below. The
 middle two sizes are a clear win on time (23% and 26%); at 93 MB and 3.7 GB the
 time difference is 2-5%, inside run-to-run variance, and what those sizes gain
 is memory — 7.1 GB against 10.2 GB on the largest. Every command after the

--- a/README.md
+++ b/README.md
@@ -270,6 +270,47 @@ via `--against` or as the `before` positional.
 
 Run `nsys-ai <command> --help` for flags.
 
+## Analysis cache
+
+The first command run against a profile builds a `<profile>.nsys-cache` directory
+next to it: the tables analysis needs, exported to Parquet and queried through
+DuckDB. Later commands reuse it and open in well under a second. The cache is
+rebuilt automatically when the profile changes; deleting the directory is safe.
+
+Measured on the reference captures (12 cores, 15 GB RAM), running eight skills:
+`top_kernels`, `gpu_idle_gaps`, `overlap_breakdown`, `memory_transfers`,
+`kernel_launch_overhead`, `stream_concurrency`, `tensor_core_usage`,
+`nvtx_layer_breakdown`. Reproduce with
+`python scripts/bench_cache.py <profile> --basket auto-policy`.
+
+| Profile | Build | First NVTX query | Cache size | Eight skills: direct query → cached query |
+|---------|-------|------------------|------------|-------------------------------------------|
+| 93 MB | 1.9 s | +3.7 s | 17 MB | 5.8 s → 0.6 s |
+| 235 MB | 2.6 s | +3.4 s | 22 MB | 11.2 s → 3.7 s |
+| 924 MB | 8.4 s | +11.2 s | 84 MB | 33.2 s → 8.5 s |
+| 3.7 GB | 27.4 s | +49.7 s | 277 MB | 83.4 s → 16.3 s |
+
+The build exports Parquet; the kernel-to-NVTX map is built separately by the
+first query that needs it, which is the "first NVTX query" column. Both are paid
+once per profile.
+
+On this workload the first run is already cheaper end to end than querying the
+export directly, at every size, so the build is the default. Two cases where it
+is not what you want:
+
+- **One command against a very large profile, and no follow-up.** Set
+  `NSYS_AI_CACHE_MODE=direct` to query the SQLite export in place — instant
+  start, slower queries, and no cache written. `nsys-ai skill run` also takes
+  `--no-cache` for the same effect. A light one-shot workload is also the case
+  where the build costs more memory than it saves, so prefer direct if you are
+  tight on RAM.
+- **A read-only or full disk.** No setting needed: nsys-ai checks before it
+  builds, says why it declined, and queries the export directly.
+
+`NSYS_AI_CACHE_MODE=parquet` forces the build in the other direction. Both
+values only decide whether a cache gets *built*: an existing valid cache is
+still used, so delete the directory if you want the export read in place.
+
 ## Skills
 
 Skills are self-contained analysis units that run without an LLM. nsys-ai ships

--- a/scripts/batch_audit_skills.py
+++ b/scripts/batch_audit_skills.py
@@ -2,10 +2,11 @@
 # ruff: noqa: E501
 """Run all built-in skills once against an Nsight profile (single DB connection).
 
-Uses the same ``open_auto_db()`` path as ``nsys-ai skill run`` (cache when one can
-be written, direct DuckDB-over-SQLite when it cannot, raw ``sqlite3`` only if both
-fail), so ``NSYS_AI_CACHE_MODE`` reaches this script exactly as it reaches the CLI.
-Writes per-skill JSON, logs, and ``_batch_summary.json``.
+Uses the same ``open_with_direct_fallback(open_auto_db)`` path as
+``nsys-ai skill run`` (cache when one can be written, direct DuckDB-over-SQLite
+when the build fails or cannot be afforded, raw ``sqlite3`` only if both DuckDB
+paths fail), so ``NSYS_AI_CACHE_MODE`` reaches this script exactly as it reaches
+the CLI. Writes per-skill JSON, logs, and ``_batch_summary.json``.
 
 Usage: python scripts/batch_audit_skills.py <profile.sqlite> [output_dir]
 
@@ -50,24 +51,21 @@ PRIORITY_FIRST = [
 
 
 def _open_skill_connection(profile_path: str):
-    """Match ``nsys-ai skill run`` connection setup (auto cache policy, else SQLite).
+    """Match ``nsys-ai skill run`` connection setup (three-tier auto policy).
 
-    ``open_auto_db``, not ``open_cached_db``: the handler behind ``skill run``
-    switched to the former in #317, and this script exists to reproduce what that
-    subcommand does. Calling the builder directly would silently ignore
-    ``NSYS_AI_CACHE_MODE`` and build a cache on profiles the CLI would have read
-    in place — an audit run that no longer audits the shipped path.
+    Same chain as the handler: ``open_auto_db`` → ``open_direct_sqlite`` → raw
+    ``sqlite3``, via ``open_with_direct_fallback``. Calling ``open_cached_db``
+    directly would silently ignore ``NSYS_AI_CACHE_MODE``; dropping straight to
+    raw ``sqlite3`` on a failed build would lose the enriched ``kernels`` view.
     """
     try:
-        import duckdb
-
-        from nsys_ai.parquet_cache import open_auto_db
+        from nsys_ai.parquet_cache import open_auto_db, open_with_direct_fallback
     except ImportError:
         return sqlite3.connect(profile_path)
-    try:
-        return open_auto_db(profile_path)
-    except (duckdb.Error, RuntimeError, OSError):
+    conn, _err = open_with_direct_fallback(profile_path, open_auto_db)
+    if conn is None:
         return sqlite3.connect(profile_path)
+    return conn
 
 
 def main() -> int:

--- a/scripts/batch_audit_skills.py
+++ b/scripts/batch_audit_skills.py
@@ -2,8 +2,10 @@
 # ruff: noqa: E501
 """Run all built-in skills once against an Nsight profile (single DB connection).
 
-Uses the same ``open_cached_db()`` path as ``nsys-ai skill run`` (DuckDB/Parquet
-with SQLite fallback). Writes per-skill JSON, logs, and ``_batch_summary.json``.
+Uses the same ``open_auto_db()`` path as ``nsys-ai skill run`` (cache when one can
+be written, direct DuckDB-over-SQLite when it cannot, raw ``sqlite3`` only if both
+fail), so ``NSYS_AI_CACHE_MODE`` reaches this script exactly as it reaches the CLI.
+Writes per-skill JSON, logs, and ``_batch_summary.json``.
 
 Usage: python scripts/batch_audit_skills.py <profile.sqlite> [output_dir]
 
@@ -48,15 +50,22 @@ PRIORITY_FIRST = [
 
 
 def _open_skill_connection(profile_path: str):
-    """Match ``nsys-ai skill run`` connection setup (cached DuckDB, else SQLite)."""
+    """Match ``nsys-ai skill run`` connection setup (auto cache policy, else SQLite).
+
+    ``open_auto_db``, not ``open_cached_db``: the handler behind ``skill run``
+    switched to the former in #317, and this script exists to reproduce what that
+    subcommand does. Calling the builder directly would silently ignore
+    ``NSYS_AI_CACHE_MODE`` and build a cache on profiles the CLI would have read
+    in place — an audit run that no longer audits the shipped path.
+    """
     try:
         import duckdb
 
-        from nsys_ai.parquet_cache import open_cached_db
+        from nsys_ai.parquet_cache import open_auto_db
     except ImportError:
         return sqlite3.connect(profile_path)
     try:
-        return open_cached_db(profile_path)
+        return open_auto_db(profile_path)
     except (duckdb.Error, RuntimeError, OSError):
         return sqlite3.connect(profile_path)
 

--- a/scripts/bench_cache.py
+++ b/scripts/bench_cache.py
@@ -8,9 +8,13 @@ Designed for the multi-phase cache-optimization plan. Measures:
 
 Usage:
   python scripts/bench_cache.py <profile.sqlite> [--no-rebuild] [--trim S E] [--out FILE]
+                                                 [--basket default|auto-policy]
 
 --no-rebuild reuses the existing cache (only measures query time).
 --trim narrows the analysis window for the skills (default: 400 420).
+--basket picks the skill set. ``auto-policy`` is the eight-skill battery that every
+figure in ``parquet_cache.open_auto_db`` and the README's cache table was measured
+over; the default basket is a different twelve and will not reproduce them.
 
 What the build column covers has changed, and comparing across that change is a
 mistake. ``nvtx_kernel_map`` is no longer produced by ``build_cache`` — it is
@@ -48,6 +52,33 @@ DEFAULT_SKILLS = [
     ("tensor_core_usage", [], "compute"),
     ("kernel_launch_pattern", [], "launch"),
 ]
+
+# The exact basket behind every number in ``parquet_cache.open_auto_db``'s decision
+# table and the README's "Analysis cache" table. It is NOT DEFAULT_SKILLS: this one
+# is eight skills, that one is twelve, and the two do not produce comparable rows.
+#
+# Named here rather than left implicit because the auto policy's whole argument is a
+# measurement, and a measurement whose workload is unstated cannot be reproduced or
+# challenged. Select it with ``--basket auto-policy``.
+#
+# The two ``-p device=0`` arguments are part of the definition: both skills abstain
+# without a device, so passing these names through bare ``--skills`` measures
+# something else entirely.
+AUTO_POLICY_SKILLS = [
+    ("top_kernels", [], "compute"),
+    ("gpu_idle_gaps", ["-p", "device=0"], "idle"),
+    ("overlap_breakdown", ["-p", "device=0"], "compute"),
+    ("memory_transfers", [], "mem"),
+    ("kernel_launch_overhead", [], "launch"),
+    ("stream_concurrency", [], "comms"),
+    ("tensor_core_usage", [], "compute"),
+    # Last on purpose: it is the only one that reaches nvtx_kernel_map, so on a cold
+    # cache it absorbs the deferred map build (3.7 / 3.4 / 11.2 / 49.7 s at 93 MB /
+    # 235 MB / 924 MB / 3.7 GB) and the ordering keeps that cost in one place.
+    ("nvtx_layer_breakdown", [], "nvtx"),
+]
+
+BASKETS = {"default": DEFAULT_SKILLS, "auto-policy": AUTO_POLICY_SKILLS}
 
 
 def _run(cmd: list[str], capture: bool = True, timeout: int = 900) -> tuple[int, str, str, float]:
@@ -132,7 +163,10 @@ def main() -> int:
     p.add_argument("--trim", nargs=2, type=float, default=(400.0, 420.0),
                    help="trim window (start end) in seconds; default 400 420")
     p.add_argument("--skills", nargs="*", default=None,
-                   help="override skill set; default = built-in basket")
+                   help="override skill set; default = the --basket selection")
+    p.add_argument("--basket", choices=sorted(BASKETS), default="default",
+                   help="named skill basket; 'auto-policy' is the eight skills behind "
+                        "the table in parquet_cache.open_auto_db")
     p.add_argument("--out", type=Path, default=None, help="JSON output path")
     p.add_argument("--label", default=None, help="label for this run (e.g. baseline / phase1)")
     args = p.parse_args()
@@ -145,7 +179,7 @@ def main() -> int:
     if args.skills:
         skills = [(s, [], "user") for s in args.skills]
     else:
-        skills = DEFAULT_SKILLS
+        skills = BASKETS[args.basket]
 
     report = {
         "label": args.label,

--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -308,12 +308,18 @@ def open_profile_readonly(path: str):
     a ``<profile_basename>.nsys-cache`` directory next to the profile before
     returning the connection.  While the query connection itself is read-only,
     the cache-building process performs disk writes.
+
+    That build goes through ``parquet_cache.open_auto_db``, so it obeys
+    ``NSYS_AI_CACHE_MODE`` and declines on a read-only or full disk rather than
+    failing into the ``sqlite3`` fallback below.  Calling ``open_cached_db``
+    here instead would silently exempt chat and region_mfu from the only
+    cache switch those entry points expose.
     """
     from nsys_ai import parquet_cache
     from nsys_ai.exceptions import ProfileNotFoundError
 
     try:
-        return parquet_cache.open_cached_db(path)
+        return parquet_cache.open_auto_db(path)
     except ProfileNotFoundError:
         # A missing file can't be salvaged by the SQLite fallback; surface the
         # clear not-found error instead of a vague "unable to open database".

--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -314,20 +314,21 @@ def open_profile_readonly(path: str):
     failing into the ``sqlite3`` fallback below.  Calling ``open_cached_db``
     here instead would silently exempt chat and region_mfu from the only
     cache switch those entry points expose.
+
+    A failed cache build falls back to ``open_direct_sqlite`` (DuckDB attached
+    read-only to the export — same middle tier as ``Profile`` and ``skill
+    run``) before raw ``sqlite3``. The direct attach keeps the enriched
+    ``kernels`` view; raw sqlite3 does not.
     """
     from nsys_ai import parquet_cache
-    from nsys_ai.exceptions import ProfileNotFoundError
 
-    try:
-        return parquet_cache.open_auto_db(path)
-    except ProfileNotFoundError:
-        # A missing file can't be salvaged by the SQLite fallback; surface the
-        # clear not-found error instead of a vague "unable to open database".
-        raise
-    except Exception as e:
-        _log.warning("Failed to open DuckDB cache for %s, falling back to SQLite: %s", path, e)
+    db, _err = parquet_cache.open_with_direct_fallback(
+        path, parquet_cache.open_auto_db, log=_log
+    )
+    if db is not None:
+        return db
 
-    # Fallback to SQLite
+    # Tier 3: raw SQLite, still read-only.
     uri = f"file:{path}?mode=ro"
     conn = sqlite3.connect(uri, uri=True)
     conn.row_factory = sqlite3.Row

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1592,7 +1592,7 @@ def _cmd_skill(args, _profile):
 
         import duckdb
 
-        from nsys_ai.parquet_cache import open_cached_db
+        from nsys_ai.parquet_cache import open_auto_db
 
         fmt = getattr(args, "format", "text")
         no_cache = getattr(args, "no_cache", False)
@@ -1602,7 +1602,11 @@ def _cmd_skill(args, _profile):
 
                 conn = open_direct_sqlite(args.profile)
             else:
-                conn = open_cached_db(args.profile)
+                # open_auto_db, not open_cached_db: this handler builds no
+                # Profile, and calling the builder directly made it the one
+                # subcommand where NSYS_AI_CACHE_MODE=direct did nothing — while
+                # the build banner printed that very instruction at the user.
+                conn = open_auto_db(args.profile)
         except (duckdb.Error, RuntimeError, OSError) as exc:
             # Fallback to raw SQLite if DuckDB/Parquet cache fails
             import logging

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1592,28 +1592,23 @@ def _cmd_skill(args, _profile):
 
         import duckdb
 
-        from nsys_ai.parquet_cache import open_auto_db
+        from nsys_ai.parquet_cache import (
+            open_auto_db,
+            open_direct_sqlite,
+            open_with_direct_fallback,
+        )
 
         fmt = getattr(args, "format", "text")
         no_cache = getattr(args, "no_cache", False)
-        try:
-            if no_cache:
-                from nsys_ai.parquet_cache import open_direct_sqlite
-
-                conn = open_direct_sqlite(args.profile)
-            else:
-                # open_auto_db, not open_cached_db: this handler builds no
-                # Profile, and calling the builder directly made it the one
-                # subcommand where NSYS_AI_CACHE_MODE=direct did nothing — while
-                # the build banner printed that very instruction at the user.
-                conn = open_auto_db(args.profile)
-        except (duckdb.Error, RuntimeError, OSError) as exc:
-            # Fallback to raw SQLite if DuckDB/Parquet cache fails
-            import logging
-
-            logging.getLogger("nsys_ai").warning(
-                "DuckDB cache unavailable (%s), falling back to raw SQLite", exc
-            )
+        # Same three-tier chain as Profile and open_profile_readonly: cache
+        # (or --no-cache direct), then open_direct_sqlite, then raw sqlite3.
+        # open_auto_db, not open_cached_db: this handler builds no Profile, and
+        # calling the builder directly made it the one subcommand where
+        # NSYS_AI_CACHE_MODE=direct did nothing — while the build banner
+        # printed that very instruction at the user.
+        primary = open_direct_sqlite if no_cache else open_auto_db
+        conn, _err = open_with_direct_fallback(args.profile, primary)
+        if conn is None:
             conn = sqlite3.connect(args.profile)
 
         # Build trim kwargs if --trim was provided

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -77,7 +77,7 @@ import shutil
 import sys
 import threading
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from hashlib import sha256
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -287,7 +287,12 @@ def invalidate_cache(sqlite_path: str) -> None:
         log.info("Removed cache: %s", cache_dir)
 
 
-def build_cache(sqlite_path: str, *, env_escape: bool = True) -> Path:
+def build_cache(
+    sqlite_path: str,
+    *,
+    env_escape: bool = True,
+    progress: Callable[[str, int, int], None] | None = None,
+) -> Path:
     """Build a Parquet cache from a SQLite profile (first-run ETL).
 
     Attaches the SQLite DB via DuckDB and exports the base tables to Parquet
@@ -311,6 +316,13 @@ def build_cache(sqlite_path: str, *, env_escape: bool = True) -> Path:
 
     ``env_escape`` is passed straight to :func:`_build_banner` and only picks
     which escape hatch that banner names; it changes nothing about the build.
+
+    ``progress``, when supplied, is called as ``progress(label, step, total)``
+    after each export step and suppresses all build writes to ``sys.stderr``
+    (banner, ``\\r`` redraws, and the final "Cache ready" line). Callers that
+    are not a terminal — notably a Textual app, whose ``sys.stderr.isatty()``
+    is unconditionally True — must pass one; without it the tty gate alone
+    cannot tell them apart from a real CLI tty.
 
     Returns the cache directory path.
     """
@@ -337,7 +349,9 @@ def build_cache(sqlite_path: str, *, env_escape: bool = True) -> Path:
             )
         )
         try:
-            _build_cache_into(sqlite_path, tmp_dir, env_escape=env_escape)
+            _build_cache_into(
+                sqlite_path, tmp_dir, env_escape=env_escape, progress=progress
+            )
         except BaseException:
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise
@@ -668,11 +682,19 @@ def _build_banner(sqlite_path: str, *, env_escape: bool = True) -> None:
     sys.stderr.flush()
 
 
-def _build_cache_into(sqlite_path: str, cache_dir: Path, *, env_escape: bool = True) -> Path:
+def _build_cache_into(
+    sqlite_path: str,
+    cache_dir: Path,
+    *,
+    env_escape: bool = True,
+    progress: Callable[[str, int, int], None] | None = None,
+) -> Path:
     """Internal: build the Parquet cache into the given directory."""
 
     log.info("Building analysis cache (first run only)...")
-    _build_banner(sqlite_path, env_escape=env_escape)
+    # A supplied progress callback owns reporting; do not also paint stderr.
+    if progress is None:
+        _build_banner(sqlite_path, env_escape=env_escape)
     t0 = time.monotonic()
 
     db = duckdb.connect()
@@ -736,6 +758,10 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path, *, env_escape: bool = T
         # arrive as one long line of fragments. Off a tty the banner and the
         # final "Cache ready" line carry the whole story.
         #
+        # When a progress callback is supplied it owns reporting and stderr
+        # stays quiet — required inside Textual, where sys.stderr.isatty() is
+        # True unconditionally (#332).
+        #
         # Single-threaded by construction: every caller is the build's own
         # thread, between DuckDB statements, so no write+flush pair can
         # interleave with another on the same fd.
@@ -752,7 +778,10 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path, *, env_escape: bool = T
         def _progress(name: str) -> None:
             step[0] += 1
             label[0] = name
-            _draw()
+            if progress is not None:
+                progress(name, step[0], total_steps)
+            else:
+                _draw()
 
         # ── Export pre-joined kernels table ────────────────────────────────
         # ORDER BY (deviceId, start) is critical: it lets DuckDB's parquet
@@ -882,14 +911,16 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path, *, env_escape: bool = T
         # _draw left on screen, so they belong to the same condition _draw does.
         # Emitted unconditionally they put a bare CR and 40 spaces into every
         # piped or redirected run — litter in exactly the case the tty gate was
-        # added to clean up.
+        # added to clean up. A progress callback replaces the whole stderr
+        # channel, so skip this line too.
         elapsed = time.monotonic() - t0
-        ready = f"[nsys-ai] Cache ready ({elapsed:.1f}s)"
-        if _stderr_is_tty():
-            sys.stderr.write("\r" + ready + " " * 40 + "\n")
-        else:
-            sys.stderr.write(ready + "\n")
-        sys.stderr.flush()
+        if progress is None:
+            ready = f"[nsys-ai] Cache ready ({elapsed:.1f}s)"
+            if _stderr_is_tty():
+                sys.stderr.write("\r" + ready + " " * 40 + "\n")
+            else:
+                sys.stderr.write(ready + "\n")
+            sys.stderr.flush()
 
         # ── Write version stamp ───────────────────────────────────────────
         meta = {
@@ -916,7 +947,12 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path, *, env_escape: bool = T
     return cache_dir
 
 
-def open_cached_db(sqlite_path: str, *, env_escape: bool = True) -> duckdb.DuckDBPyConnection:
+def open_cached_db(
+    sqlite_path: str,
+    *,
+    env_escape: bool = True,
+    progress: Callable[[str, int, int], None] | None = None,
+) -> duckdb.DuckDBPyConnection:
     """Open a DuckDB connection with views over the Parquet cache.
 
     If the cache doesn't exist or is stale, builds it first.
@@ -926,6 +962,8 @@ def open_cached_db(sqlite_path: str, *, env_escape: bool = True) -> duckdb.DuckD
     :class:`~nsys_ai.profile.Profile` with an explicit ``cache_mode="parquet"``
     passes it; ``open_auto_db`` leaves it at the default because on that path
     the variable really does work.
+
+    ``progress`` is forwarded to :func:`build_cache` when a build is needed.
 
     Returns a DuckDB connection with views named after each cached table:
       ``kernels``, ``nvtx``, ``runtime``, ``memcpy``, ``memset``,
@@ -938,7 +976,7 @@ def open_cached_db(sqlite_path: str, *, env_escape: bool = True) -> duckdb.DuckD
     """
     _require_profile_exists(sqlite_path)
     if not is_cache_valid(sqlite_path):
-        build_cache(sqlite_path, env_escape=env_escape)
+        build_cache(sqlite_path, env_escape=env_escape, progress=progress)
 
     cache_dir = _cache_dir_for(sqlite_path)
 
@@ -971,11 +1009,18 @@ def open_cached_db(sqlite_path: str, *, env_escape: bool = True) -> duckdb.DuckD
     return db
 
 
-def open_auto_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
+def open_auto_db(
+    sqlite_path: str,
+    *,
+    progress: Callable[[str, int, int], None] | None = None,
+) -> duckdb.DuckDBPyConnection:
     """Open a profile under the ``auto`` cache policy: cache if one can be had.
 
     Order: an existing valid cache, then the ``NSYS_AI_CACHE_MODE`` override,
     then "can a cache be written here at all", then build.
+
+    ``progress`` is forwarded to :func:`open_cached_db` / :func:`build_cache`
+    when a build runs.
 
     It lives here rather than on ``Profile`` because it is not only
     ``Profile``'s decision. ``nsys-ai skill run`` and ``open_profile_readonly``
@@ -1081,14 +1126,14 @@ def open_auto_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
     one, which will not reproduce these rows.
     """
     if is_cache_valid(sqlite_path):
-        return open_cached_db(sqlite_path)
+        return open_cached_db(sqlite_path, progress=progress)
 
     env_mode = os.environ.get("NSYS_AI_CACHE_MODE", "").strip().lower()
     if env_mode == "direct":
         log.info("NSYS_AI_CACHE_MODE=direct — querying the SQLite export in place.")
         return open_direct_sqlite(sqlite_path)
     if env_mode == "parquet":
-        return open_cached_db(sqlite_path)
+        return open_cached_db(sqlite_path, progress=progress)
     if env_mode:
         log.warning("Ignoring NSYS_AI_CACHE_MODE=%r; expected 'direct' or 'parquet'.", env_mode)
 
@@ -1112,7 +1157,7 @@ def open_auto_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
             reason,
         )
         return open_direct_sqlite(sqlite_path)
-    return open_cached_db(sqlite_path)
+    return open_cached_db(sqlite_path, progress=progress)
 
 
 def open_with_direct_fallback(

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1074,27 +1074,21 @@ def open_auto_db(
     table carries one.
 
     Total against total, a cold build is never *worse* than direct on the first
-    run, and never heavier on peak RSS. How much better splits in two, and
-    saying so is the point:
-
-    - 235 MB and 924 MB are real wins -- 23% and 26% on total, 2% and 21% on
-      peak RSS.
-    - 93 MB and 3734 MB are a **wash on time**: 5.1% and 2.7%, which is inside
-      run-to-run variance on a loaded box. What they do win is memory, and the
-      3734 MB row wins it decisively: 7.14 GB against 10.18 GB, a 30% cut on
-      the size where running out is a real outcome.
-
-    So the argument for building by default is not "always faster on the first
-    run". It is "never slower, sometimes much faster, and materially lighter on
-    the large profiles" -- plus the warm row, which is the one a user meets on
-    every command after the first.
+    run, and never heavier on peak RSS over this battery. So the argument for
+    building by default is not "always faster on the first run" -- it is "never
+    slower, sometimes much faster, and materially lighter on the large
+    profiles", plus the warm row, which is the one a user meets on every command
+    after the first.
 
     An earlier version of this docstring quoted a "runs-to-repay" ratio derived
     from the open/query split, which the #322 deferral made meaningless because
     the cold query now contains a build.
     Note also that the margins at 93 MB (6.17 vs 6.50) and 3734 MB (93.57 vs
     96.18) are 3-5%, and run-to-run spread on a loaded box is 15-25% — those
-    two sizes are a wash, not a win. The decisive gaps are in the middle.
+    two sizes are a wash on *time*, not a win. The decisive gaps are in the
+    middle. What the two ends win instead is memory, and at 3734 MB decisively:
+    7.14 GB against 10.18 GB, a 30% cut on the size where running out is a real
+    outcome.
 
     None of this is a property of the profile size: both sides of the trade
     scale together, which is exactly why size was the wrong axis. What does

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1073,11 +1073,25 @@ def open_auto_db(
     at the four sizes. The total is what the user experiences, which is why the
     table carries one.
 
-    Total against total, a cold build is already cheaper than direct on the
-    *first* run at all four sizes, and lighter on peak RSS at all four. Those
-    are the two claims worth making; an earlier version of this docstring
-    quoted a "runs-to-repay" ratio derived from the open/query split, which the
-    #322 deferral made meaningless because the cold query now contains a build.
+    Total against total, a cold build is never *worse* than direct on the first
+    run, and never heavier on peak RSS. How much better splits in two, and
+    saying so is the point:
+
+    - 235 MB and 924 MB are real wins -- 23% and 26% on total, 2% and 21% on
+      peak RSS.
+    - 93 MB and 3734 MB are a **wash on time**: 5.1% and 2.7%, which is inside
+      run-to-run variance on a loaded box. What they do win is memory, and the
+      3734 MB row wins it decisively: 7.14 GB against 10.18 GB, a 30% cut on
+      the size where running out is a real outcome.
+
+    So the argument for building by default is not "always faster on the first
+    run". It is "never slower, sometimes much faster, and materially lighter on
+    the large profiles" -- plus the warm row, which is the one a user meets on
+    every command after the first.
+
+    An earlier version of this docstring quoted a "runs-to-repay" ratio derived
+    from the open/query split, which the #322 deferral made meaningless because
+    the cold query now contains a build.
     Note also that the margins at 93 MB (6.17 vs 6.50) and 3734 MB (93.57 vs
     96.18) are 3-5%, and run-to-run spread on a loaded box is 15-25% — those
     two sizes are a wash, not a win. The decisive gaps are in the middle.

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -57,9 +57,12 @@ Environment (large profiles / DuckDB tuning):
   caller that does not ask for a specific mode. ``direct`` skips the build and
   queries the SQLite export in place (instant open, slower queries); ``parquet``
   forces the build even when the affordability check would have declined it.
-  It is the escape hatch for the entry points that expose no cache flag — the
-  TUI, the web server and every CLI subcommand except ``skill run``, which also
-  has ``--no-cache``. Note it is consulted only when no valid cache exists yet:
+  Every entry point honours it, including ``skill run`` — which is the point of
+  the variable, since the TUI, the timeline, the web server and the one-shot
+  subcommands expose no cache flag at all. ``skill run`` is the only one that
+  also takes ``--no-cache``.
+
+  Note it is consulted only when no valid cache exists yet:
   ``direct`` skips *building* one, it does not refuse an existing one.
 """
 
@@ -284,7 +287,7 @@ def invalidate_cache(sqlite_path: str) -> None:
         log.info("Removed cache: %s", cache_dir)
 
 
-def build_cache(sqlite_path: str) -> Path:
+def build_cache(sqlite_path: str, *, env_escape: bool = True) -> Path:
     """Build a Parquet cache from a SQLite profile (first-run ETL).
 
     Attaches the SQLite DB via DuckDB and exports the base tables to Parquet
@@ -305,6 +308,9 @@ def build_cache(sqlite_path: str) -> Path:
     file at all when the cache is already good. This matters for
     read-only profile directories (NFS / read-only mounts) where the
     cache is readable but the lock file cannot be created.
+
+    ``env_escape`` is passed straight to :func:`_build_banner` and only picks
+    which escape hatch that banner names; it changes nothing about the build.
 
     Returns the cache directory path.
     """
@@ -331,7 +337,7 @@ def build_cache(sqlite_path: str) -> Path:
             )
         )
         try:
-            _build_cache_into(sqlite_path, tmp_dir)
+            _build_cache_into(sqlite_path, tmp_dir, env_escape=env_escape)
         except BaseException:
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise
@@ -611,7 +617,7 @@ def _stderr_is_tty() -> bool:
         return False
 
 
-def _build_banner(sqlite_path: str) -> None:
+def _build_banner(sqlite_path: str, *, env_escape: bool = True) -> None:
     """Announce a long build before it starts, with the way out.
 
     The per-step progress line already exists, but it says nothing until the
@@ -627,6 +633,16 @@ def _build_banner(sqlite_path: str) -> None:
     ``materialize_cached_nvtx_kernel_map`` prints nothing at all. Instrumenting
     that build is the real fix and belongs with issue #300; saying it out loud
     is the floor.
+
+    ``env_escape`` picks which way out the last line names, because the two
+    callers do not have the same one. Reached through ``open_auto_db`` — every
+    entry point in this project — ``NSYS_AI_CACHE_MODE=direct`` genuinely skips
+    the build, including from its own ``=parquet`` branch. Reached through
+    ``open_cached_db`` directly, i.e. ``Profile(cache_mode="parquet")``, the
+    variable is never consulted and printing it would be advice that does
+    nothing; there the way out is the argument, so that is what it says.
+    Advertising an inert escape hatch is the exact defect #317 set out to fix
+    on ``skill run`` — narrowing it to one path is not fixing it.
     """
     try:
         size_mb = os.path.getsize(sqlite_path) / 1e6
@@ -634,6 +650,7 @@ def _build_banner(sqlite_path: str) -> None:
         return
     if size_mb < _BUILD_BANNER_MIN_MB:
         return
+    escape = "Set NSYS_AI_CACHE_MODE=direct" if env_escape else 'Pass cache_mode="direct"'
     # "4-5x" rather than the 3-9x range the docstring quotes: this banner only
     # fires at >=500 MB, and in that region direct-vs-warm-cached query time
     # measured 3.9x (924 MB) and 5.1x (3.7 GB). Quoting the whole-range figure
@@ -645,17 +662,17 @@ def _build_banner(sqlite_path: str) -> None:
         f"queries afterwards are 4-5x faster).\n"
         f"[nsys-ai] The first NVTX-attributing query then builds the kernel map "
         f"(~{size_mb / _MAP_BUILD_MB_PER_S:.0f}s more, also once per profile).\n"
-        f"[nsys-ai] Set NSYS_AI_CACHE_MODE=direct to skip the build and query "
+        f"[nsys-ai] {escape} to skip the build and query "
         f"the SQLite export in place.\n"
     )
     sys.stderr.flush()
 
 
-def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
+def _build_cache_into(sqlite_path: str, cache_dir: Path, *, env_escape: bool = True) -> Path:
     """Internal: build the Parquet cache into the given directory."""
 
     log.info("Building analysis cache (first run only)...")
-    _build_banner(sqlite_path)
+    _build_banner(sqlite_path, env_escape=env_escape)
     t0 = time.monotonic()
 
     db = duckdb.connect()
@@ -861,9 +878,17 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
                 "(set NSYS_AI_ALWAYS_BUILD_NVTX_KERNEL_MAP=1 to build it now)"
             )
 
-        # Clear progress line
+        # The CR and the padding exist only to overwrite the progress line
+        # _draw left on screen, so they belong to the same condition _draw does.
+        # Emitted unconditionally they put a bare CR and 40 spaces into every
+        # piped or redirected run — litter in exactly the case the tty gate was
+        # added to clean up.
         elapsed = time.monotonic() - t0
-        sys.stderr.write(f"\r[nsys-ai] Cache ready ({elapsed:.1f}s)" + " " * 40 + "\n")
+        ready = f"[nsys-ai] Cache ready ({elapsed:.1f}s)"
+        if _stderr_is_tty():
+            sys.stderr.write("\r" + ready + " " * 40 + "\n")
+        else:
+            sys.stderr.write(ready + "\n")
         sys.stderr.flush()
 
         # ── Write version stamp ───────────────────────────────────────────
@@ -891,10 +916,16 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
     return cache_dir
 
 
-def open_cached_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
+def open_cached_db(sqlite_path: str, *, env_escape: bool = True) -> duckdb.DuckDBPyConnection:
     """Open a DuckDB connection with views over the Parquet cache.
 
     If the cache doesn't exist or is stale, builds it first.
+
+    ``env_escape=False`` says the caller reached here without consulting
+    ``NSYS_AI_CACHE_MODE``, so the build banner must not advertise it. Only
+    :class:`~nsys_ai.profile.Profile` with an explicit ``cache_mode="parquet"``
+    passes it; ``open_auto_db`` leaves it at the default because on that path
+    the variable really does work.
 
     Returns a DuckDB connection with views named after each cached table:
       ``kernels``, ``nvtx``, ``runtime``, ``memcpy``, ``memset``,
@@ -907,7 +938,7 @@ def open_cached_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
     """
     _require_profile_exists(sqlite_path)
     if not is_cache_valid(sqlite_path):
-        build_cache(sqlite_path)
+        build_cache(sqlite_path, env_escape=env_escape)
 
     cache_dir = _cache_dir_for(sqlite_path)
 
@@ -1018,6 +1049,19 @@ def open_auto_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
       build (27.44 + 0.04). Direct still wins, but by 1.5x — before the #322
       deferral this comparison was 18.7 s against 79.2 s, so the advice is much
       weaker than it used to be.
+
+      Say plainly which callers those are, because the eight-skill basket did
+      not measure them and they inherit this default anyway: nothing in this
+      project passes ``cache_mode``, so the TUI, the timeline, the web server
+      and the one-shot subcommands (``info``, ``kernels``, ``export``) all land
+      on ``auto``. A TUI that used to open a 3.7 GB profile in ~13 s now waits
+      ~27 s at startup. That is a real regression for a one-shot user and a
+      real win for anyone who then queries, and the trade was chosen for the
+      latter. ``_build_banner`` is the mitigation, not a refutation: at
+      >=500 MB it says the wait is coming and how to opt out. If someone wants
+      this reversed for the interactive entry points, the honest fix is to
+      measure a TUI-shaped basket and let those callers pass ``cache_mode``,
+      not to put the size rule back.
     * **A light workload on a small profile, when RAM is tight.** The same
       93 MB capture queried with four cheap skills that never touch NVTX
       attribution (``top_kernels``, ``gpu_idle_gaps``, ``memory_transfers``,

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -52,6 +52,15 @@ Environment (large profiles / DuckDB tuning):
 
   ``NSYS_AI_DUCKDB_TEMP_DIRECTORY`` — optional spill directory for large aggregations
   (DuckDB ``temp_directory`` pragma).
+
+  ``NSYS_AI_CACHE_MODE=direct|parquet`` — read by ``open_auto_db``, i.e. by every
+  caller that does not ask for a specific mode. ``direct`` skips the build and
+  queries the SQLite export in place (instant open, slower queries); ``parquet``
+  forces the build even when the affordability check would have declined it.
+  It is the escape hatch for the entry points that expose no cache flag — the
+  TUI, the web server and every CLI subcommand except ``skill run``, which also
+  has ``--no-cache``. Note it is consulted only when no valid cache exists yet:
+  ``direct`` skips *building* one, it does not refuse an existing one.
 """
 
 from __future__ import annotations
@@ -61,6 +70,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 import threading
 import time
@@ -165,6 +175,60 @@ def _cache_dir_for(sqlite_path: str) -> Path:
     return Path(sqlite_path).with_suffix(".nsys-cache")
 
 
+# Headroom the affordability check demands, as a fraction of the SQLite size.
+# Measured cache/profile ratios (re-measured 2026-08-05 after #322; unchanged from
+# the 2026-08-03 figures, because deferring nvtx_kernel_map moves *when* it is
+# written, not whether):
+#   92.7 MB -> 16.7 MB (0.18), 235 MB -> 21.8 MB (0.093),
+#   924 MB -> 84.1 MB (0.091), 3734 MB -> 276.6 MB (0.074).
+# 0.25 is 1.4x the worst of those and 3.4x the large-profile ratio.
+#
+# Peak disk is *not* simply the final size, though it is close enough to sit
+# inside that margin. build_cache writes into a sibling temp dir and renames, so
+# the export itself never doubles; but since #322 the deferred map is staged in a
+# .nvtx_map_build_* directory *inside* the published cache dir before os.replace,
+# so peak = final + one copy of the map. On the 93 MB capture that is 3.3 MB of
+# 16.7 MB — the cache is 13.4 MB until an NVTX skill runs, measured — i.e. ~20%
+# of a ratio that already has 40% of slack above it.
+_CACHE_SIZE_FRACTION = 0.25
+_CACHE_MIN_FREE_BYTES = 128 * 1024 * 1024
+
+
+def cache_is_affordable(sqlite_path: str) -> tuple[bool, str]:
+    """Can a Parquet cache be built alongside this profile?
+
+    Returns ``(True, "")`` when the cache directory's parent is writable and has
+    room for the estimated cache, else ``(False, reason)`` with a reason short
+    enough to log verbatim.
+
+    This is the test ``open_auto_db`` uses in place of the old "profile is
+    larger than 50 MB" rule. Size is the wrong axis: build cost and query
+    speedup both scale with the profile, so a cold build comes out cheaper than
+    direct on the very first run at every size from 93 MB to 3.7 GB (see the
+    table in ``open_auto_db``). What actually stops a build is having nowhere to
+    put it, which is what this measures.
+
+    Estimates are deliberately generous — see ``_CACHE_SIZE_FRACTION``. A build
+    that overruns the estimate anyway fails inside ``build_cache``, which
+    discards its temp dir, and the caller falls back to direct SQLite.
+    """
+    cache_dir = _cache_dir_for(sqlite_path)
+    parent = cache_dir.parent
+    if not os.access(parent, os.W_OK):
+        return False, f"{parent} is not writable"
+    try:
+        needed = max(int(os.path.getsize(sqlite_path) * _CACHE_SIZE_FRACTION), _CACHE_MIN_FREE_BYTES)
+    except OSError as exc:
+        return False, f"size of {sqlite_path} could not be determined ({exc})"
+    try:
+        free = shutil.disk_usage(parent).free
+    except OSError as exc:
+        return False, f"free space on {parent} could not be determined ({exc})"
+    if free < needed:
+        return False, f"{parent} has {free / 1e6:.0f}MB free, cache needs ~{needed / 1e6:.0f}MB"
+    return True, ""
+
+
 def is_cache_valid(sqlite_path: str) -> bool:
     """Check whether the Parquet cache is up-to-date.
 
@@ -214,8 +278,6 @@ def is_cache_valid(sqlite_path: str) -> bool:
 
 def invalidate_cache(sqlite_path: str) -> None:
     """Remove the Parquet cache for a profile, forcing rebuild on next open."""
-    import shutil
-
     cache_dir = _cache_dir_for(sqlite_path)
     if cache_dir.exists():
         shutil.rmtree(cache_dir)
@@ -246,7 +308,6 @@ def build_cache(sqlite_path: str) -> Path:
 
     Returns the cache directory path.
     """
-    import shutil
     import tempfile
 
     cache_dir = _cache_dir_for(sqlite_path)
@@ -518,10 +579,83 @@ def _order_clause_for(
     return f"ORDER BY {cast}"
 
 
+# Build throughput measured on this repo's reference captures (2026-08-05, 12 cores):
+# 50 MB/s at 92.7 MB, 89 at 235 MB, 110 at 924 MB, 136 at 3734 MB. Throughput climbs with
+# size because a small build is dominated by fixed setup cost.
+#
+# Fitted to the >=500 MB end deliberately: _build_banner is the only consumer and it does
+# not fire below _BUILD_BANNER_MIN_MB, so the 50 and 89 MB/s rows are outside the range
+# this constant is ever asked about. 110 predicts 8 s at 924 MB (actual 8.4) and 34 s at
+# 3734 MB (actual 27.4) — i.e. it errs towards over-stating the wait, which is the right
+# direction for an ETA.
+#
+# These figures postdate #322, which moved nvtx_kernel_map out of the build and onto
+# first use. Any throughput number measured before that split described a build that also
+# produced the map and is 2-3x too pessimistic; re-measure rather than reconciling.
+_BUILD_MB_PER_S = 110.0
+# Below this the build is a few seconds and an ETA banner is just noise.
+_BUILD_BANNER_MIN_MB = 500.0
+# Throughput of the *deferred* nvtx_kernel_map sweep, which since #322 is no longer part
+# of the build and is paid by the first NVTX-attributing query instead. Measured the same
+# day, as cold-minus-warm time for nvtx_layer_breakdown: 11.2 s at 924 MB (82 MB/s) and
+# 49.7 s at 3734 MB (75 MB/s). Only the banner's size range matters here and it is tight
+# across it, so one constant is honest. Used solely to say how long the *second* wait is;
+# a profile with no NVTX data never pays it at all.
+_MAP_BUILD_MB_PER_S = 80.0
+
+
+def _stderr_is_tty() -> bool:
+    try:
+        return bool(sys.stderr.isatty())
+    except (AttributeError, ValueError):
+        return False
+
+
+def _build_banner(sqlite_path: str) -> None:
+    """Announce a long build before it starts, with the way out.
+
+    The per-step progress line already exists, but it says nothing until the
+    first step completes and nothing about how long the whole thing will take.
+    On a 3.7 GB profile that is ~27 s of a user not knowing whether to wait.
+
+    The ETA covers *this* build only, which since #322 is the Parquet export
+    and not the ``nvtx_kernel_map`` sweep — that is deferred to the first NVTX
+    query and costs a further 3.7 / 3.4 / 11.2 / 49.7 s at 93 MB / 235 MB /
+    924 MB / 3.7 GB. Naming the second wait is the point of the third line:
+    without it the banner promises ~34 s on the 3.7 GB capture and the user
+    then sits through another ~50 s of silence inside a skill, because
+    ``materialize_cached_nvtx_kernel_map`` prints nothing at all. Instrumenting
+    that build is the real fix and belongs with issue #300; saying it out loud
+    is the floor.
+    """
+    try:
+        size_mb = os.path.getsize(sqlite_path) / 1e6
+    except OSError:
+        return
+    if size_mb < _BUILD_BANNER_MIN_MB:
+        return
+    # "4-5x" rather than the 3-9x range the docstring quotes: this banner only
+    # fires at >=500 MB, and in that region direct-vs-warm-cached query time
+    # measured 3.9x (924 MB) and 5.1x (3.7 GB). Quoting the whole-range figure
+    # here would promise the small-profile speedup to the one audience that
+    # cannot get it.
+    sys.stderr.write(
+        f"[nsys-ai] Building analysis cache for a {size_mb:.0f}MB profile "
+        f"(~{size_mb / _BUILD_MB_PER_S:.0f}s, once per profile; "
+        f"queries afterwards are 4-5x faster).\n"
+        f"[nsys-ai] The first NVTX-attributing query then builds the kernel map "
+        f"(~{size_mb / _MAP_BUILD_MB_PER_S:.0f}s more, also once per profile).\n"
+        f"[nsys-ai] Set NSYS_AI_CACHE_MODE=direct to skip the build and query "
+        f"the SQLite export in place.\n"
+    )
+    sys.stderr.flush()
+
+
 def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
     """Internal: build the Parquet cache into the given directory."""
 
     log.info("Building analysis cache (first run only)...")
+    _build_banner(sqlite_path)
     t0 = time.monotonic()
 
     db = duckdb.connect()
@@ -579,13 +713,29 @@ def _build_cache_into(sqlite_path: str, cache_dir: Path) -> Path:
             total_steps += 1
         step = [0]
 
-        def _progress(name: str) -> None:
-            step[0] += 1
+        label = [""]
+
+        # \r redraws are only legible on a terminal; piped or redirected, they
+        # arrive as one long line of fragments. Off a tty the banner and the
+        # final "Cache ready" line carry the whole story.
+        #
+        # Single-threaded by construction: every caller is the build's own
+        # thread, between DuckDB statements, so no write+flush pair can
+        # interleave with another on the same fd.
+        def _draw() -> None:
+            if not _stderr_is_tty():
+                return
             elapsed = time.monotonic() - t0
             sys.stderr.write(
-                f"\r[nsys-ai] Building cache [{step[0]}/{total_steps}] {name} ({elapsed:.0f}s)"
+                f"\r[nsys-ai] Building cache [{step[0]}/{total_steps}] "
+                f"{label[0]} ({elapsed:.0f}s)" + " " * 8
             )
             sys.stderr.flush()
+
+        def _progress(name: str) -> None:
+            step[0] += 1
+            label[0] = name
+            _draw()
 
         # ── Export pre-joined kernels table ────────────────────────────────
         # ORDER BY (deviceId, start) is critical: it lets DuckDB's parquet
@@ -788,6 +938,137 @@ def open_cached_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
     register_cache_dir(db, cache_dir)
 
     return db
+
+
+def open_auto_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
+    """Open a profile under the ``auto`` cache policy: cache if one can be had.
+
+    Order: an existing valid cache, then the ``NSYS_AI_CACHE_MODE`` override,
+    then "can a cache be written here at all", then build.
+
+    It lives here rather than on ``Profile`` because it is not only
+    ``Profile``'s decision. ``nsys-ai skill run`` and ``open_profile_readonly``
+    (chat, region_mfu) open a connection with no ``Profile`` involved, and they
+    used to call ``open_cached_db`` directly — so the build banner advertised
+    ``NSYS_AI_CACHE_MODE=direct`` on a subcommand where setting it changed
+    nothing. One policy, one function, one place to change it.
+
+    Raises whatever ``open_cached_db`` and ``open_direct_sqlite`` raise; a
+    caller that wants a raw-``sqlite3`` last resort catches it itself.
+
+    Why the default is to build
+    ---------------------------
+
+    This used to send any profile over 50 MB to ``open_direct_sqlite``. That
+    was correct when it was written — the old interval-join map builder ran
+    past fifteen minutes on a 3.5 GB capture and OOM'd a 175 GB pod (#143) —
+    and it stopped being correct when the stack sweep replaced that join.
+
+    Measured on this machine (12 cores, 15 GB RAM, DuckDB 1.5.0, one process
+    per row, cache deleted before every cold run, 2026-08-05) over the
+    **eight-skill battery** named in ``scripts/bench_cache.py`` as
+    ``AUTO_POLICY_SKILLS`` — top_kernels, gpu_idle_gaps, overlap_breakdown,
+    memory_transfers, kernel_launch_overhead, stream_concurrency,
+    tensor_core_usage, nvtx_layer_breakdown. The basket is part of the result:
+    a different one moves these numbers a lot (see the light workload below),
+    so quoting them without it is not reproducible.
+
+    =========  =======  ==============  ========  =========  =======  ========
+    profile    SQLite   mode            open      query      total    peak RSS
+    =========  =======  ==============  ========  =========  =======  ========
+    nano_vllm    93MB   direct           0.75 s     5.75 s    6.50 s   1.03 GB
+                        parquet (cold)   1.86 s     4.31 s    6.17 s   0.96 GB
+                        parquet (warm)   0.04 s     0.63 s    0.67 s   0.33 GB
+    perf_sp1    235MB   direct           1.36 s    11.21 s   12.57 s   1.11 GB
+                        parquet (cold)   2.64 s     7.07 s    9.71 s   1.09 GB
+                        parquet (warm)   0.04 s     3.72 s    3.76 s   0.77 GB
+    mfu_l40s2   924MB   direct           4.68 s    33.17 s   37.85 s   2.67 GB
+                        parquet (cold)   8.37 s    19.66 s   28.03 s   2.12 GB
+                        parquet (warm)   0.05 s     8.49 s    8.54 s   1.39 GB
+    perf       3734MB   direct          12.75 s    83.43 s   96.18 s  10.18 GB
+                        parquet (cold)  27.44 s    66.13 s   93.57 s   7.14 GB
+                        parquet (warm)   0.06 s    16.27 s   16.33 s   1.78 GB
+    =========  =======  ==============  ========  =========  =======  ========
+
+    Read the cold row's ``query`` column carefully: since #322 the build no
+    longer produces ``nvtx_kernel_map``, so part of what used to be ``open``
+    now sits inside the first NVTX-attributing skill. Cold ``query`` minus warm
+    ``query`` for ``nvtx_layer_breakdown`` alone is 3.7 / 3.4 / 11.2 / 49.7 s
+    at the four sizes. The total is what the user experiences, which is why the
+    table carries one.
+
+    Total against total, a cold build is already cheaper than direct on the
+    *first* run at all four sizes, and lighter on peak RSS at all four. Those
+    are the two claims worth making; an earlier version of this docstring
+    quoted a "runs-to-repay" ratio derived from the open/query split, which the
+    #322 deferral made meaningless because the cold query now contains a build.
+    Note also that the margins at 93 MB (6.17 vs 6.50) and 3734 MB (93.57 vs
+    96.18) are 3-5%, and run-to-run spread on a loaded box is 15-25% — those
+    two sizes are a wash, not a win. The decisive gaps are in the middle.
+
+    None of this is a property of the profile size: both sides of the trade
+    scale together, which is exactly why size was the wrong axis. What does
+    discriminate is how much querying follows, and every consumer of this
+    project bar a one-shot skill is multi-query — the direct path re-pays its
+    cost on every later run forever, a build is paid once (warm total is 0.67 /
+    3.76 / 8.54 / 16.33 s). Two cases where that reasoning does not hold:
+
+    * **One cheap skill and nothing else.** On the 3.7 GB capture that is
+      ~19 s direct (12.75 open + 5.84 for ``top_kernels``) against ~27 s with a
+      build (27.44 + 0.04). Direct still wins, but by 1.5x — before the #322
+      deferral this comparison was 18.7 s against 79.2 s, so the advice is much
+      weaker than it used to be.
+    * **A light workload on a small profile, when RAM is tight.** The same
+      93 MB capture queried with four cheap skills that never touch NVTX
+      attribution (``top_kernels``, ``gpu_idle_gaps``, ``memory_transfers``,
+      ``kernel_launch_overhead``) is 0.73 + 1.65 s at 0.36 GB peak direct,
+      against 1.79 + 0.56 s at 0.74 GB cold. Wall clock is a dead heat
+      (2.38 vs 2.34 s) and the build costs twice the peak RSS, because its
+      working set is a fixed price a light run never earns back. So do *not*
+      read the table above as an unconditional peak-RSS win; issue #300 cares
+      about that ceiling.
+
+    Both are what ``NSYS_AI_CACHE_MODE=direct``, ``cache_mode="direct"`` and
+    ``skill run --no-cache`` are for.
+
+    If those numbers no longer hold, re-measure before nudging anything:
+    ``scripts/bench_cache.py --basket auto-policy`` is the harness and
+    reproduces this basket. Its *default* basket is a different, twelve-skill
+    one, which will not reproduce these rows.
+    """
+    if is_cache_valid(sqlite_path):
+        return open_cached_db(sqlite_path)
+
+    env_mode = os.environ.get("NSYS_AI_CACHE_MODE", "").strip().lower()
+    if env_mode == "direct":
+        log.info("NSYS_AI_CACHE_MODE=direct — querying the SQLite export in place.")
+        return open_direct_sqlite(sqlite_path)
+    if env_mode == "parquet":
+        return open_cached_db(sqlite_path)
+    if env_mode:
+        log.warning("Ignoring NSYS_AI_CACHE_MODE=%r; expected 'direct' or 'parquet'.", env_mode)
+
+    affordable, reason = cache_is_affordable(sqlite_path)
+    if not affordable:
+        # WARNING, not INFO, and the level is the whole mechanism. Nothing under
+        # src/nsys_ai/ ever calls basicConfig/dictConfig/addHandler, so the only
+        # sink for this record is logging.lastResort, a StreamHandler pinned at
+        # WARNING. At INFO the line was dropped: measured on a profile in a
+        # chmod 500 directory, `nsys-ai skill run top_kernels` wrote 2059 bytes
+        # to stdout and *zero* to stderr while silently taking the 3-9x slower
+        # path. Raising the level makes the same command print it.
+        #
+        # It also deserves the level on its merits: this is a silently degraded
+        # run, not a routine note. The `NSYS_AI_CACHE_MODE=direct` branch above
+        # stays at INFO on purpose — there the user asked for it, so silence is
+        # the correct outcome.
+        log.warning(
+            "Not building an analysis cache (%s); querying the SQLite export directly. "
+            "Queries will be several times slower.",
+            reason,
+        )
+        return open_direct_sqlite(sqlite_path)
+    return open_cached_db(sqlite_path)
 
 
 def open_parquetdir_db(parquetdir_path: str) -> duckdb.DuckDBPyConnection:
@@ -2227,12 +2508,22 @@ def open_direct_sqlite(sqlite_path: str) -> duckdb.DuckDBPyConnection:
     """Open DuckDB with SQLite directly attached — zero ETL latency.
 
     Uses DuckDB's sqlite_scanner to query the original SQLite file
-    in-place.  Analytical queries on large scans are slower than cached
-    Parquet, but startup is instant.  Best for:
+    in-place.  Analytical queries on large scans are slower than a warm cache
+    (3-9x on the four captures measured for issue #317, from 93 MB to 3.7 GB:
+    3.0x at 235 MB, 3.9x at 924 MB, 5.1x at 3.7 GB, 9.1x at 93 MB), but startup
+    is instant.  Used for:
 
-      - First access to large profiles (>50MB)
-      - One-off queries that only touch 1-2 tables
-      - ``--no-cache`` mode for quick diagnostics
+      - One-off queries that only touch 1-2 tables, where the build would not
+        repay itself: on a 3.7 GB profile one cheap skill costs ~19 s direct
+        against ~27 s including a build. That margin used to be 18.7 s against
+        79.2 s; #322 deferred nvtx_kernel_map out of the build, so direct now
+        wins this case by 1.5x rather than 4x
+      - ``cache_mode="direct"``, ``--no-cache`` and ``NSYS_AI_CACHE_MODE=direct``
+      - the fallback when a cache cannot be built or read — an unwritable
+        profile directory, no disk space, or a failed build
+
+    It is *not* the default for large profiles any more. That rule predated the
+    stack-sweep map builder and is gone; see ``open_auto_db``.
     """
     _require_profile_exists(sqlite_path)
     db = duckdb.connect()

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1115,6 +1115,53 @@ def open_auto_db(sqlite_path: str) -> duckdb.DuckDBPyConnection:
     return open_cached_db(sqlite_path)
 
 
+def open_with_direct_fallback(
+    sqlite_path: str,
+    primary,
+    *,
+    log: logging.Logger | None = None,
+) -> tuple[duckdb.DuckDBPyConnection | None, BaseException | None]:
+    """Open via ``primary``, then ``open_direct_sqlite``, then give up.
+
+    Shared three-tier policy used by ``Profile.__init__``,
+    ``open_profile_readonly`` (chat / region_mfu), and ``skill run``. Losing
+    the Parquet cache must not cost the DuckDB engine: a failed primary open
+    falls back to a direct SQLite attach (enriched ``kernels`` view intact)
+    and reaches raw ``sqlite3`` only when that fails too.
+
+    Returns ``(conn, primary_error)``:
+      - primary succeeded → ``(duckdb_conn, None)``
+      - primary failed, direct attach recovered → ``(duckdb_conn, primary_error)``
+      - both DuckDB paths failed → ``(None, primary_error)``; caller opens
+        raw ``sqlite3`` (read-only or not is the caller's choice)
+
+    ``ProfileNotFoundError`` is re-raised: a missing file cannot be salvaged.
+    ``open_direct_sqlite`` attaches ``READ_ONLY``, so the middle tier stays
+    compatible with read-only callers.
+    """
+    _log = log if log is not None else logging.getLogger(__name__)
+    try:
+        return primary(sqlite_path), None
+    except ProfileNotFoundError:
+        raise
+    except Exception as e:
+        try:
+            db = open_direct_sqlite(sqlite_path)
+            _log.warning(
+                "Parquet cache unavailable (%s); querying the SQLite export directly "
+                "through DuckDB.",
+                e,
+            )
+            return db, e
+        except Exception as direct_err:
+            _log.warning(
+                "DuckDB unavailable (cache: %s; direct: %s), falling back to sqlite3.",
+                e,
+                direct_err,
+            )
+            return None, e
+
+
 def open_parquetdir_db(parquetdir_path: str) -> duckdb.DuckDBPyConnection:
     """Open a DuckDB connection over an Nsight `parquetdir` export."""
     parquet_dir = Path(parquetdir_path)

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -348,28 +348,34 @@ class Profile:
                     # Original behaviour: block until cache is built
                     self.db = parquet_cache.open_cached_db(path)
                 else:
-                    # "auto" mode: use cache if valid, else smart fallback
-                    if parquet_cache.is_cache_valid(path):
-                        self.db = parquet_cache.open_cached_db(path)
-                    else:
-                        size_mb = os.path.getsize(path) / 1e6
-                        if size_mb > 50:
-                            self._log.info(
-                                "Large profile (%.0fMB), using direct query mode (instant startup).",
-                                size_mb,
-                            )
-                            self._log.info(
-                                "To build a Parquet cache for faster repeated queries, re-run with "
-                                "cache_mode='parquet' or pre-build the cache."
-                            )
-                            self.db = parquet_cache.open_direct_sqlite(path)
-                        else:
-                            # Small file — build cache now (seconds)
-                            self.db = parquet_cache.open_cached_db(path)
+                    # auto: cache when one can be had, direct SQLite when it
+                    # cannot. The policy (and the measurements behind it) lives
+                    # in parquet_cache.open_auto_db, because `skill run` and
+                    # open_profile_readonly reach it without a Profile.
+                    self.db = parquet_cache.open_auto_db(path)
             except Exception as e:
-                self._log.warning("DuckDB cache unavailable, falling back to SQLite: %s", e)
+
                 self.cache_error = e
-                self.db = None  # type: ignore[assignment]
+                # Losing the Parquet cache must not cost the DuckDB engine.
+                # The raw-sqlite3 fallback below is a third tier, not a
+                # synonym for this one: on it the `kernels` view and its
+                # tensor-core flags do not exist, so tensor_core_usage fails
+                # outright rather than running slower, and a 92.7MB profile
+                # queries in 8.15s against 5.62s on the direct attach.
+                try:
+                    self.db = parquet_cache.open_direct_sqlite(path)
+                    self._log.warning(
+                        "Parquet cache unavailable (%s); querying the SQLite export directly "
+                        "through DuckDB.",
+                        e,
+                    )
+                except Exception as direct_err:
+                    self._log.warning(
+                        "DuckDB unavailable (cache: %s; direct: %s), falling back to sqlite3.",
+                        e,
+                        direct_err,
+                    )
+                    self.db = None  # type: ignore[assignment]
         from .connection import wrap_connection
 
         self.adapter = wrap_connection(self.db if self.db is not None else self.conn)

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -358,7 +358,6 @@ class Profile:
                     # open_profile_readonly reach it without a Profile.
                     self.db = parquet_cache.open_auto_db(path)
             except Exception as e:
-
                 self.cache_error = e
                 # Losing the Parquet cache must not cost the DuckDB engine.
                 # The raw-sqlite3 fallback below is a third tier, not a

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -345,8 +345,12 @@ class Profile:
                     # Force direct SQLite via DuckDB — zero ETL, instant startup
                     self.db = parquet_cache.open_direct_sqlite(path)
                 elif cache_mode == "parquet":
-                    # Original behaviour: block until cache is built
-                    self.db = parquet_cache.open_cached_db(path)
+                    # Original behaviour: block until cache is built.
+                    # env_escape=False: this branch never reads
+                    # NSYS_AI_CACHE_MODE, so the build banner must not tell the
+                    # user to set it — on this path it does nothing. It names
+                    # cache_mode="direct" instead, which is the way out here.
+                    self.db = parquet_cache.open_cached_db(path, env_escape=False)
                 else:
                     # auto: cache when one can be had, direct SQLite when it
                     # cannot. The policy (and the measurements behind it) lives

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -314,7 +314,14 @@ class Profile:
     #: default in place.
     cache_error: Exception | None = None
 
-    def __init__(self, path: str, *, cache_mode: str = "auto", backend: str = "sqlite"):
+    def __init__(
+        self,
+        path: str,
+        *,
+        cache_mode: str = "auto",
+        backend: str = "sqlite",
+        progress: typing.Callable[[str, int, int], None] | None = None,
+    ):
         if cache_mode not in ("auto", "parquet", "direct"):
             raise ValueError(
                 f"Unknown cache_mode: {cache_mode!r}. Expected 'auto', 'parquet', or 'direct'."
@@ -353,13 +360,15 @@ class Profile:
                 # NSYS_AI_CACHE_MODE, so the build banner must not tell the
                 # user to set it — on this path it does nothing. It names
                 # cache_mode="direct" instead, which is the way out here.
-                primary = functools.partial(parquet_cache.open_cached_db, env_escape=False)
+                primary = functools.partial(
+                    parquet_cache.open_cached_db, env_escape=False, progress=progress
+                )
             else:
                 # auto: cache when one can be had, direct SQLite when it
                 # cannot. The policy (and the measurements behind it) lives
                 # in parquet_cache.open_auto_db, because `skill run` and
                 # open_profile_readonly reach it without a Profile.
-                primary = parquet_cache.open_auto_db
+                primary = functools.partial(parquet_cache.open_auto_db, progress=progress)
             self.db, err = parquet_cache.open_with_direct_fallback(
                 path, primary, log=self._log
             )
@@ -1162,7 +1171,13 @@ def get_first_gpu_name(conn) -> str:
     return (row[0] or "").strip() if row else ""
 
 
-def open(path: str, *, backend: str = "sqlite", cache_mode: str = "auto") -> Profile:
+def open(
+    path: str,
+    *,
+    backend: str = "sqlite",
+    cache_mode: str = "auto",
+    progress: typing.Callable[[str, int, int], None] | None = None,
+) -> Profile:
     """Open an Nsight Systems profile using the requested backend."""
     path = resolve_profile_path(path, backend=backend)
     # Heuristic: if the given path is an empty .sqlite stub but a sibling
@@ -1174,4 +1189,4 @@ def open(path: str, *, backend: str = "sqlite", cache_mode: str = "auto") -> Pro
         if os.path.exists(base) and os.path.getsize(base) > 0:
             path = base
 
-    return Profile(path, cache_mode=cache_mode, backend=backend)
+    return Profile(path, cache_mode=cache_mode, backend=backend, progress=progress)

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -340,45 +340,32 @@ class Profile:
         else:
             self.conn = sqlite3.connect(path, check_same_thread=False)
             self.conn.row_factory = sqlite3.Row
-            try:
-                if cache_mode == "direct":
-                    # Force direct SQLite via DuckDB — zero ETL, instant startup
-                    self.db = parquet_cache.open_direct_sqlite(path)
-                elif cache_mode == "parquet":
-                    # Original behaviour: block until cache is built.
-                    # env_escape=False: this branch never reads
-                    # NSYS_AI_CACHE_MODE, so the build banner must not tell the
-                    # user to set it — on this path it does nothing. It names
-                    # cache_mode="direct" instead, which is the way out here.
-                    self.db = parquet_cache.open_cached_db(path, env_escape=False)
-                else:
-                    # auto: cache when one can be had, direct SQLite when it
-                    # cannot. The policy (and the measurements behind it) lives
-                    # in parquet_cache.open_auto_db, because `skill run` and
-                    # open_profile_readonly reach it without a Profile.
-                    self.db = parquet_cache.open_auto_db(path)
-            except Exception as e:
-                self.cache_error = e
-                # Losing the Parquet cache must not cost the DuckDB engine.
-                # The raw-sqlite3 fallback below is a third tier, not a
-                # synonym for this one: on it the `kernels` view and its
-                # tensor-core flags do not exist, so tensor_core_usage fails
-                # outright rather than running slower, and a 92.7MB profile
-                # queries in 8.15s against 5.62s on the direct attach.
-                try:
-                    self.db = parquet_cache.open_direct_sqlite(path)
-                    self._log.warning(
-                        "Parquet cache unavailable (%s); querying the SQLite export directly "
-                        "through DuckDB.",
-                        e,
-                    )
-                except Exception as direct_err:
-                    self._log.warning(
-                        "DuckDB unavailable (cache: %s; direct: %s), falling back to sqlite3.",
-                        e,
-                        direct_err,
-                    )
-                    self.db = None  # type: ignore[assignment]
+            # Three-tier open (cache / direct attach / raw sqlite3) lives in
+            # parquet_cache.open_with_direct_fallback — also used by
+            # open_profile_readonly and skill run, so a failed build cannot
+            # drop only some entry points onto raw sqlite3 (issue #333).
+            if cache_mode == "direct":
+                # Force direct SQLite via DuckDB — zero ETL, instant startup
+                primary = parquet_cache.open_direct_sqlite
+            elif cache_mode == "parquet":
+                # Original behaviour: block until cache is built.
+                # env_escape=False: this branch never reads
+                # NSYS_AI_CACHE_MODE, so the build banner must not tell the
+                # user to set it — on this path it does nothing. It names
+                # cache_mode="direct" instead, which is the way out here.
+                primary = functools.partial(parquet_cache.open_cached_db, env_escape=False)
+            else:
+                # auto: cache when one can be had, direct SQLite when it
+                # cannot. The policy (and the measurements behind it) lives
+                # in parquet_cache.open_auto_db, because `skill run` and
+                # open_profile_readonly reach it without a Profile.
+                primary = parquet_cache.open_auto_db
+            self.db, err = parquet_cache.open_with_direct_fallback(
+                path, primary, log=self._log
+            )
+            if err is not None:
+                self.cache_error = err
+            # self.db is None → keep self.conn (raw sqlite3); already opened above
         from .connection import wrap_connection
 
         self.adapter = wrap_connection(self.db if self.db is not None else self.conn)

--- a/src/nsys_ai/timeline/app.py
+++ b/src/nsys_ai/timeline/app.py
@@ -271,7 +271,9 @@ class NsysTimelineApp(App):
         from ..nvtx_tree import build_nvtx_tree, to_json
 
         try:
-            with _profile.open(self._db_path) as prof:
+            with _profile.open(
+                self._db_path, progress=self._suppress_cache_progress
+            ) as prof:
                 # Auto-detect devices if none specified or single default 0
                 devices = self._devices
                 if not devices or devices == [0]:
@@ -364,6 +366,15 @@ class NsysTimelineApp(App):
             self._update_title()
         # Focus the canvas so App-level key bindings work.
         self.query_one("#canvas", TimelineCanvas).focus()
+
+    @staticmethod
+    def _suppress_cache_progress(label: str, step: int, total: int) -> None:
+        """Drop cache-build progress so Textual does not paint it on stderr.
+
+        Passing any callback silences the ``\\r`` redraw path inside ``build_cache``.
+        This one does nothing else: the build still runs synchronously on the
+        message loop, so the UI cannot update between steps (#332).
+        """
 
     def _push_canvas_state(self) -> None:
         if not self._is_mounted:

--- a/src/nsys_ai/tree/app.py
+++ b/src/nsys_ai/tree/app.py
@@ -212,12 +212,23 @@ class NsysTreeApp(App):
         # focus first and silently swallow key presses.
         self.query_one(DataTable).focus()
 
+    @staticmethod
+    def _suppress_cache_progress(label: str, step: int, total: int) -> None:
+        """Drop cache-build progress so Textual does not paint it on stderr.
+
+        Passing any callback silences the ``\\r`` redraw path inside ``build_cache``.
+        This one does nothing else: the build still runs synchronously on the
+        message loop, so the UI cannot update between steps (#332).
+        """
+
     def _load_from_db(self) -> None:
         from .. import profile as _profile
         from ..nvtx_tree import build_nvtx_tree, to_json
 
         try:
-            with _profile.open(self._db_path) as prof:
+            with _profile.open(
+                self._db_path, progress=self._suppress_cache_progress
+            ) as prof:
                 roots = build_nvtx_tree(prof, self._device, self._trim)
                 json_roots = to_json(roots)
 

--- a/src/nsys_ai/tui_textual.py
+++ b/src/nsys_ai/tui_textual.py
@@ -62,6 +62,15 @@ from textual.worker import NoActiveWorker, get_current_worker
 # ---------------------------------------------------------------------------
 
 
+def _suppress_cache_progress(label: str, step: int, total: int) -> None:
+    """Drop cache-build progress so Textual does not paint it on stderr.
+
+    Passing any callback silences the ``\\r`` redraw path inside ``build_cache``.
+    This one does nothing else: the build still runs synchronously on the
+    message loop, so the UI cannot update between steps (#332).
+    """
+
+
 def _load_top_kernels(sqlite_path: str, limit: int = 30) -> list[dict]:
     """Return top kernels by total GPU duration as a list of dicts.
 
@@ -71,7 +80,7 @@ def _load_top_kernels(sqlite_path: str, limit: int = 30) -> list[dict]:
     try:
         from .profile import open as open_profile
 
-        with open_profile(sqlite_path) as prof:
+        with open_profile(sqlite_path, progress=_suppress_cache_progress) as prof:
             aggs = prof.aggregate_kernels(device=None, limit=limit)
             return [
                 {

--- a/tests/test_analysis_memory.py
+++ b/tests/test_analysis_memory.py
@@ -34,9 +34,15 @@ direct / skills   6.62 MB   7.4 MB  dict instead of tuple buckets in
 direct / attrib   0.44 MB   0.9 MB  drop the ``LIMIT`` push-down -> 1.69 MB
 ===============  ========  =======  ==================================================
 
-``cache_mode="direct"`` is the second case because it is the path a real
-tens-of-GB capture takes: ``Profile.__init__`` sends anything over 50 MB to
-``open_direct_sqlite``, which does no ETL at all.
+``cache_mode="direct"`` is the second case because it is the path a run takes
+whenever no cache is built: the explicit opt-out (``cache_mode="direct"``,
+``--no-cache``, ``NSYS_AI_CACHE_MODE=direct``) and the fallback when the
+profile's directory is read-only or out of disk. It reaches
+``open_direct_sqlite``, which does no ETL at all. It stopped being the
+*default* for large captures in issue #317 — over an eight-skill run the cache
+came out cheaper on wall clock and on peak RSS at every size — but it is still
+the path a one-shot query on a tens-of-GB capture should take, so its ceilings
+still matter.
 
 The two cases used to be mirror images — the cached path spent its memory
 opening and almost none running skills, the direct path the reverse. They are

--- a/tests/test_chat_connection_threading.py
+++ b/tests/test_chat_connection_threading.py
@@ -187,10 +187,13 @@ def test_sqlite_fallback_connection_is_thread_affine(profile_copy, monkeypatch):
     """
     from nsys_ai import parquet_cache
 
-    def no_cache(_path):
+    def no_duckdb(_path):
         raise RuntimeError("forced fallback")
 
-    monkeypatch.setattr(parquet_cache, "open_cached_db", no_cache)
+    # Both DuckDB tiers must fail to reach raw sqlite3 — the middle tier
+    # (open_direct_sqlite) is what a failed cache build recovers through.
+    monkeypatch.setattr(parquet_cache, "open_cached_db", no_duckdb)
+    monkeypatch.setattr(parquet_cache, "open_direct_sqlite", no_duckdb)
 
     conn = chat_mod.open_profile_readonly(profile_copy)
     try:

--- a/tests/test_ci_coverage.py
+++ b/tests/test_ci_coverage.py
@@ -40,6 +40,12 @@ ACCEPTED_SKIP_REASONS = (
     "Profile not found: data/nsys-hero",
     "requires duckdb",
     "parquet cache unavailable",
+    # Environment-shaped, not fixture-shaped: the read-only-directory test in
+    # test_profile_modes.py cannot mean anything on Windows (no POSIX mode bits)
+    # or as root (which ignores the write bit). It runs on every CI job we have;
+    # the reason is registered so a container that happens to run as root fails
+    # loudly on nothing rather than on this.
+    "needs POSIX directory permissions and a non-root user",
 )
 
 

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -1310,11 +1310,15 @@ def test_an_empty_sweep_is_told_apart_from_a_missing_source(tmp_path, monkeypatc
 #
 # Everything below exists because none of it was reachable under test.
 # `_build_banner` returns early below _BUILD_BANNER_MIN_MB = 500 and the
-# largest fixture in this repo is 2.2 MB; `_draw` returns early unless stderr
-# is a tty, which it never is under pytest. Both bodies were verified
-# unreachable by mutating each to `raise AssertionError` — the whole
-# cache-test suite stayed green. So the size and the tty have to be faked, or
-# three lines of user-facing output and an ETA formula ship unpinned.
+# largest fixture in this repo is 2.2 MB; `_draw` returns early unless
+# stderr is a tty *and* no progress callback was supplied. Plain pytest is
+# not a tty, so the body is unreachable there — but a Textual app (see
+# tests/test_tui_chat_app.py) wraps stderr in `_PrintCapture` whose
+# `isatty()` is always True, so without a progress callback the redraws
+# *do* fire under pytest. Both bodies were verified unreachable by
+# mutating each to `raise AssertionError` — the whole cache-test suite
+# stayed green. So the size and the tty have to be faked, or three lines
+# of user-facing output and an ETA formula ship unpinned.
 
 
 class TestBuildBanner:

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -9,6 +9,24 @@ import pytest
 
 from nsys_ai import parquet_cache
 
+
+def _reads_sqlite_in_place(prof) -> bool:
+    """True when ``prof.db`` is DuckDB with the SQLite export attached directly.
+
+    The discriminator for "the cache was refused". Before issue #317 that state
+    was observable as ``prof.db is None`` — the fallback dropped to raw
+    ``sqlite3`` and lost the DuckDB engine with it. It now lands on
+    ``open_direct_sqlite``, which attaches the export as ``src``; a cached open
+    has no ``src`` in its catalog, and a raw-``sqlite3`` fallback has no
+    ``prof.db`` at all. All three are distinguishable, which is why the tests
+    below assert on this rather than on ``is None``.
+    """
+    if prof.db is None:
+        return False
+    rows = prof.db.execute("SELECT database_name FROM duckdb_databases()").fetchall()
+    return "src" in {r[0] for r in rows}
+
+
 # Minimal schema reused by tests that need to seed custom NVTX rows. Mirrors
 # the production CUPTI/NVTX layout; intentionally narrow — just enough for
 # build_cache() to produce kernels.parquet, runtime.parquet, nvtx.parquet,
@@ -353,7 +371,7 @@ class TestUnrecognisedKernelTable:
     def test_unrecognised_kernel_table_falls_back_instead_of_poisoning_cache(
         self, minimal_nsys_db_path
     ):
-        """A non-`_V` kernel suffix must leave no cache and open via sqlite3."""
+        """A non-`_V` kernel suffix must leave no cache and read the export in place."""
         from nsys_ai.profile import Profile
 
         conn = sqlite3.connect(minimal_nsys_db_path)
@@ -367,7 +385,7 @@ class TestUnrecognisedKernelTable:
         for _ in range(2):
             prof = Profile(minimal_nsys_db_path, cache_mode="auto")
             try:
-                assert prof.db is None  # sqlite3 fallback engaged
+                assert _reads_sqlite_in_place(prof)  # fallback engaged, cache refused
                 assert prof.schema.kernel_table == "CUPTI_ACTIVITY_KIND_KERNEL_X1"
                 assert prof.meta.kernel_count > 0
             finally:
@@ -465,7 +483,7 @@ class TestDamagedInput:
     def test_a_corrupt_kernels_parquet_falls_back_instead_of_failing(
         self, minimal_nsys_db_path
     ):
-        """A damaged cache file must degrade to sqlite3, not take the profile down.
+        """A damaged cache file must degrade, not take the profile down.
 
         Silent otherwise in the loudest possible way: the cache is an
         optimisation the user never asked for, so a byte-level fault inside it
@@ -484,20 +502,22 @@ class TestDamagedInput:
         (cache_dir / "kernels.parquet").write_bytes(b"NOTAPARQUET" * 100)
 
         with Profile(minimal_nsys_db_path, cache_mode="auto") as prof:
-            assert prof.db is None, "a corrupt cache file was accepted as a cache"
+            assert _reads_sqlite_in_place(prof), "a corrupt cache file was accepted as a cache"
             rows = get_skill("top_kernels").execute(prof.query_conn(), limit=3)
-        assert rows, "falling back to sqlite3 lost the kernel data"
+        assert rows, "falling back lost the kernel data"
 
     def test_a_corrupt_cache_is_never_repaired(self, minimal_nsys_db_path):
         """Pinned defect, not a virtue: the damage is permanent and invisible.
 
         ``is_cache_valid()`` checks for the cache directory and its manifest, not
         for readable Parquet, so a corrupt cache stays "valid" forever. Every
-        subsequent open pays the fallback and gets the degraded answer — the
-        sqlite3 path returns fewer columns than the cached one (``top_kernels``
-        loses ``tc_eligible``/``uses_tc``, ``nvtx_kernel_map`` loses demangled
-        names), so the user silently gets a thinner analysis on every run until
-        someone deletes the directory by hand.
+        subsequent open pays the fallback — since #317 that is DuckDB reading the
+        export in place, which keeps the enriched ``kernels`` view but loses the
+        precomputed ``nvtx_kernel_map``, so NVTX attribution is rebuilt from
+        scratch on every run until someone deletes the directory by hand. (Before
+        #317 the fallback was raw ``sqlite3`` and the loss was larger: no
+        ``kernels`` view at all, so ``top_kernels`` shed
+        ``tc_eligible``/``uses_tc`` and ``tensor_core_usage`` could not run.)
 
         This test exists so that fixing it — discard and rebuild on the first
         unreadable read — is a visible change to a stated behaviour rather than
@@ -516,7 +536,9 @@ class TestDamagedInput:
 
         for attempt in range(3):
             with Profile(minimal_nsys_db_path, cache_mode="auto") as prof:
-                assert prof.db is None, f"open #{attempt + 1} unexpectedly used the cache"
+                assert _reads_sqlite_in_place(prof), (
+                    f"open #{attempt + 1} unexpectedly used the cache"
+                )
 
         assert parquet_cache.is_cache_valid(minimal_nsys_db_path) is True, (
             "is_cache_valid now rejects a corrupt cache — good, but this test "

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -2,8 +2,10 @@
 
 import json
 import os
+import re
 import sqlite3
 from pathlib import Path
+from unittest import mock
 
 import pytest
 
@@ -704,7 +706,12 @@ class TestConcurrentBuild:
         count_lock = threading.Lock()
         original_build_into = parquet_cache._build_cache_into
 
-        def counting_build_into(sqlite_path: str, tmp_dir: Path) -> None:
+        # **kwargs, so this double keeps tracking _build_cache_into's real
+        # signature instead of pinning today's. It grew a keyword-only
+        # `env_escape` in #317 and a stub with a fixed parameter list turns
+        # that into a TypeError inside a worker thread, which surfaces here as
+        # "runners raised" rather than as anything to do with concurrency.
+        def counting_build_into(sqlite_path: str, tmp_dir: Path, **kwargs) -> None:
             nonlocal call_count
             with count_lock:
                 call_count += 1
@@ -713,7 +720,7 @@ class TestConcurrentBuild:
             # ETL on the minimal fixture is ~50ms; 0.5s sleep gives a
             # ~10× safety margin.
             time.sleep(0.5)
-            original_build_into(sqlite_path, tmp_dir)
+            original_build_into(sqlite_path, tmp_dir, **kwargs)
 
         monkeypatch.setattr(parquet_cache, "_build_cache_into", counting_build_into)
 
@@ -1299,3 +1306,151 @@ def test_an_empty_sweep_is_told_apart_from_a_missing_source(tmp_path, monkeypatc
         outcome, detail = parquet_cache.materialize_cached_nvtx_kernel_map_outcome(prof.db)
         assert outcome == parquet_cache.MAP_SOURCES_MISSING
         assert "runtime.parquet" in detail
+# ── Build-time terminal output (issue #317) ──────────────────────────
+#
+# Everything below exists because none of it was reachable under test.
+# `_build_banner` returns early below _BUILD_BANNER_MIN_MB = 500 and the
+# largest fixture in this repo is 2.2 MB; `_draw` returns early unless stderr
+# is a tty, which it never is under pytest. Both bodies were verified
+# unreachable by mutating each to `raise AssertionError` — the whole
+# cache-test suite stayed green. So the size and the tty have to be faked, or
+# three lines of user-facing output and an ETA formula ship unpinned.
+
+
+class TestBuildBanner:
+    """The >=500 MB announcement: when it fires, and what it promises."""
+
+    def test_it_fires_for_a_large_profile_and_names_both_waits(self, capsys):
+        """Both ETAs, the size, and the way out.
+
+        The numbers are pinned as literals rather than recomputed from
+        _BUILD_MB_PER_S / _MAP_BUILD_MB_PER_S on purpose. Recomputing would
+        pin the formula but let a constant drift silently, and those constants
+        are measured values carrying a provenance comment that says to
+        re-measure rather than reconcile. If a re-measurement moves them, this
+        test should go red and be updated deliberately.
+
+        3734 MB is the real `perf.sqlite` size from the decision table, chosen
+        over 500 so neither quotient lands on a .5 tie: 3734/110 = 33.9 -> 34,
+        3734/80 = 46.7 -> 47.
+        """
+        with mock.patch("os.path.getsize", return_value=3734.0 * 1e6):
+            parquet_cache._build_banner("/does/not/need/to/exist.sqlite")
+
+        err = capsys.readouterr().err
+        assert "Building analysis cache for a 3734MB profile" in err
+        assert "~34s" in err, f"build ETA is not 3734/{parquet_cache._BUILD_MB_PER_S}: {err!r}"
+        assert "~47s more" in err, (
+            f"map ETA is not 3734/{parquet_cache._MAP_BUILD_MB_PER_S}: {err!r}"
+        )
+        # The second wait is the whole reason the banner has a second line:
+        # without it the user is promised ~34s and then sits through ~47s more
+        # of silence inside a skill.
+        assert "first NVTX-attributing query" in err
+        assert "NSYS_AI_CACHE_MODE=direct" in err
+
+    def test_it_fires_exactly_at_the_threshold(self, capsys):
+        with mock.patch("os.path.getsize", return_value=500.0 * 1e6):
+            parquet_cache._build_banner("/x.sqlite")
+        assert "Building analysis cache" in capsys.readouterr().err
+
+    def test_it_is_silent_just_below_the_threshold(self, capsys):
+        """499 MB: a few seconds of build, and an ETA banner would be noise."""
+        with mock.patch("os.path.getsize", return_value=499.0 * 1e6):
+            parquet_cache._build_banner("/x.sqlite")
+        assert capsys.readouterr().err == "", "the banner fired below _BUILD_BANNER_MIN_MB"
+
+    def test_a_missing_file_is_not_an_error(self, capsys):
+        """getsize raises on a vanished path; announcing is never worth a crash."""
+        parquet_cache._build_banner("/nonexistent/profile.sqlite")
+        assert capsys.readouterr().err == ""
+
+    def test_it_names_the_escape_hatch_the_caller_actually_has(self, capsys):
+        """`Profile(cache_mode="parquet")` never reads NSYS_AI_CACHE_MODE.
+
+        Telling that caller's user to set it is advice that does nothing — the
+        same defect #317 fixed on `skill run`, which had a banner advertising a
+        variable the subcommand ignored. Narrowing it to one remaining path is
+        not fixing it, so the banner names the argument there instead.
+        """
+        with mock.patch("os.path.getsize", return_value=3734.0 * 1e6):
+            parquet_cache._build_banner("/x.sqlite", env_escape=False)
+
+        err = capsys.readouterr().err
+        assert 'Pass cache_mode="direct"' in err
+        assert "NSYS_AI_CACHE_MODE" not in err, (
+            "the banner advertised an environment variable on the one path that "
+            "never consults it"
+        )
+
+    def test_profile_parquet_mode_is_wired_to_that_branch(self, minimal_nsys_db_path, tmp_path):
+        """The wiring, not just the formatting: cache_mode="parquet" passes it.
+
+        Asserted on the call rather than on stderr because the fixture is 2.2 MB
+        and no real build in this repo can clear the 500 MB guard.
+        """
+        from nsys_ai.profile import Profile
+
+        db_path = tmp_path / "banner_wiring.sqlite"
+        db_path.write_bytes(Path(minimal_nsys_db_path).read_bytes())
+
+        with mock.patch.object(
+            parquet_cache, "_build_banner", wraps=parquet_cache._build_banner
+        ) as spy:
+            with Profile(str(db_path), cache_mode="parquet"):
+                pass
+
+        spy.assert_called_once()
+        assert spy.call_args.kwargs.get("env_escape") is False, (
+            "Profile(cache_mode='parquet') let the banner advertise NSYS_AI_CACHE_MODE, "
+            "which that path never reads"
+        )
+
+
+class TestBuildProgressOutput:
+    """The \\r-redrawn progress line, and what replaces it off a tty."""
+
+    def test_the_progress_line_renders_on_a_tty(self, minimal_nsys_db_path, tmp_path, capsys):
+        """Pins the f-string _draw's tty gate made unreachable under pytest.
+
+        Before the gate existed this was executed by every cache-building test;
+        gating it without adding this test would have been a net coverage loss
+        on the renderer.
+        """
+        db_path = tmp_path / "progress_tty.sqlite"
+        db_path.write_bytes(Path(minimal_nsys_db_path).read_bytes())
+
+        with mock.patch.object(parquet_cache, "_stderr_is_tty", return_value=True):
+            parquet_cache.build_cache(str(db_path))
+
+        err = capsys.readouterr().err
+        assert "\r[nsys-ai] Building cache [" in err, (
+            f"no progress line was drawn on a tty: {err!r}"
+        )
+        # "[n/total]" — the counter is the only part that says progress is
+        # being made at all, so pin its shape, not just the prefix.
+        assert re.search(r"\r\[nsys-ai\] Building cache \[\d+/\d+\] \S+ \(\d+s\)", err), (
+            f"the progress line lost its step counter or elapsed clock: {err!r}"
+        )
+        assert err.rstrip().endswith("s)"), "the final line should be 'Cache ready (…s)'"
+
+    def test_off_a_tty_nothing_draws_cursor_control(self, minimal_nsys_db_path, tmp_path, capsys):
+        """Piped or redirected, stderr must be plain lines.
+
+        `_draw` is gated on the tty, but the final "Cache ready" line used to
+        carry the \\r and the 40 spaces unconditionally — padding whose only job
+        is to erase a progress line that, off a tty, was never drawn. Measured
+        before the fix: a build with stderr redirected to a file produced
+        exactly b'\\r[nsys-ai] Cache ready (0.3s)' + 40 spaces + b'\\n'.
+        """
+        db_path = tmp_path / "progress_pipe.sqlite"
+        db_path.write_bytes(Path(minimal_nsys_db_path).read_bytes())
+
+        with mock.patch.object(parquet_cache, "_stderr_is_tty", return_value=False):
+            parquet_cache.build_cache(str(db_path))
+
+        err = capsys.readouterr().err
+        assert "\r" not in err, f"a carriage return reached a non-tty stderr: {err!r}"
+        assert "Cache ready" in err, "the one line that carries the story off a tty is missing"
+        for line in err.splitlines():
+            assert line == line.rstrip(), f"trailing erase-padding survived off a tty: {line!r}"

--- a/tests/test_profile_modes.py
+++ b/tests/test_profile_modes.py
@@ -1,7 +1,12 @@
+import os
+import stat
+import subprocess
+import sys
 from unittest import mock
 
 import pytest
 
+from nsys_ai import parquet_cache
 from nsys_ai.parquet_cache import _cache_dir_for
 from nsys_ai.profile import Profile
 
@@ -60,23 +65,271 @@ def test_cache_mode_auto_small(minimal_nsys_db_path, tmp_path):
     with Profile(str(db_path), cache_mode="auto"):
         pass
 
-    # small file (< 50MB) should build parquet
     cache_dir = _cache_dir_for(str(db_path))
     assert cache_dir.exists()
 
 
-def test_cache_mode_auto_large_mocked(minimal_nsys_db_path, tmp_path):
-    db_path = tmp_path / "test_auto_large.sqlite"
-    with open(minimal_nsys_db_path, "rb") as src, open(db_path, "wb") as dst:
-        dst.write(src.read())
+# ── The `auto` policy (issue #317) ───────────────────────────────────
+#
+# These pin what `auto` decides, in the order parquet_cache.open_auto_db asks:
+# size does not decide, the env override does, disk does, and a profile that
+# cannot be cached still gets a DuckDB engine rather than raw sqlite3. The last
+# one pins that the override reaches `skill run`, which opens its connection
+# without a Profile at all.
 
-    # Mock os.path.getsize to return 100MB
+
+def _copy_fixture(minimal_nsys_db_path, dest):
+    with open(minimal_nsys_db_path, "rb") as src, open(dest, "wb") as dst:
+        dst.write(src.read())
+    return dest
+
+
+def test_cache_mode_auto_builds_for_a_large_profile(minimal_nsys_db_path, tmp_path):
+    """Size alone must not send a profile to direct mode.
+
+    Replaces test_cache_mode_auto_large_mocked, which asserted the opposite for
+    the same 100 MB. The old 50 MB rule dated from the interval-join map builder
+    (>15 min on a 3.5 GB capture); against the stack sweep that replaced it, an
+    eight-skill run is faster end to end on a cold build at 93 MB, 235 MB,
+    924 MB and 3.7 GB alike — the table lives in parquet_cache.open_auto_db.
+
+    The patch below is global, and deliberately so. `mock.patch` on a dotted
+    path resolves through the `os` module object, which `nsys_ai.profile` and
+    `nsys_ai.parquet_cache` share with everything else, so patching
+    "nsys_ai.profile.os.path.getsize" patches posixpath.getsize — verified, it
+    is byte-for-byte the old test's "os.path.getsize". Nothing else consulted
+    during this open changes its answer at 100 MB: `is_cache_valid` reads
+    getmtime not getsize, `cache_is_affordable` clamps to the 128 MB floor
+    either way, the build banner needs 500 MB, and
+    `_should_defer_nvtx_kernel_map` returns True at any size unless
+    NSYS_AI_DEFER_NVTX_KERNEL_MAP_MB is set, which it is not here. So the
+    assertion below can only be satisfied by the size rule being gone.
+    """
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "auto_large.sqlite")
+
     with mock.patch("os.path.getsize", return_value=100.0 * 1e6):
         with Profile(str(db_path), cache_mode="auto") as prof:
-            # Large file should fallback to direct scanning and NOT build parquet
-            cache_dir = _cache_dir_for(str(db_path))
-            assert not cache_dir.exists()
-
-            # Alias views should still be accessible
             res = prof.db.execute("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME").fetchone()
             assert res[0] >= 0
+
+    assert _cache_dir_for(str(db_path)).exists(), (
+        "auto declined to build a cache for a 100MB profile — the size threshold is back"
+    )
+
+
+def test_cache_mode_auto_skips_build_when_disk_is_short(minimal_nsys_db_path, tmp_path):
+    """No room for the cache: query directly, do not fail and do not half-build."""
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "auto_nodisk.sqlite")
+    usage = mock.Mock(total=10**9, used=10**9, free=1024)
+
+    with mock.patch("nsys_ai.parquet_cache.shutil.disk_usage", return_value=usage):
+        with Profile(str(db_path), cache_mode="auto") as prof:
+            assert prof.db is not None, "a full disk must not cost the DuckDB engine"
+            res = prof.db.execute("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME").fetchone()
+            assert res[0] >= 0
+
+    assert not _cache_dir_for(str(db_path)).exists()
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or os.geteuid() == 0,
+    reason="needs POSIX directory permissions and a non-root user",
+)
+def test_cache_mode_auto_read_only_directory_builds_nothing(minimal_nsys_db_path, tmp_path):
+    """A profile on a read-only mount: no build *attempt*, and a working engine.
+
+    Before #317 this reached `_build_lock`, which fails at os.open(O_CREAT) with
+    PermissionError; Profile's blanket except then set `db = None`. Now the
+    affordability check declines up front, so nothing tries to write.
+
+    "Declines up front" is the whole point, so it is what the assertion has to
+    say. Checking only that the profile still opens does not distinguish this
+    from the build failing at the lock and the fallback rescuing it — that path
+    is already covered by test_failed_cache_build_falls_back_to_duckdb_not_sqlite3,
+    and a test that passes either way pins nothing here. Spying on build_cache
+    is the difference: it must never be reached.
+    """
+    ro_dir = tmp_path / "readonly"
+    ro_dir.mkdir()
+    db_path = _copy_fixture(minimal_nsys_db_path, ro_dir / "auto_ro.sqlite")
+    ro_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+    try:
+        with mock.patch(
+            "nsys_ai.parquet_cache.build_cache", wraps=parquet_cache.build_cache
+        ) as spy:
+            with Profile(str(db_path), cache_mode="auto") as prof:
+                assert prof.db is not None, (
+                    "a read-only profile directory dropped the profile to raw sqlite3"
+                )
+                res = prof.db.execute(
+                    "SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME"
+                ).fetchone()
+                assert res[0] >= 0
+        spy.assert_not_called()
+        assert not _cache_dir_for(str(db_path)).exists()
+    finally:
+        ro_dir.chmod(stat.S_IRWXU)
+
+
+def test_failed_cache_build_falls_back_to_duckdb_not_sqlite3(minimal_nsys_db_path, tmp_path):
+    """A cache that cannot be built costs the cache, not the query engine.
+
+    The old fallback set `self.db = None`, which drops the whole run onto raw
+    `sqlite3`. That is not "the same, without Parquet acceleration": the
+    enriched `kernels` view does not exist there, so tensor_core_usage fails
+    outright rather than running slower, and on a 93MB profile the eight-skill
+    query time was 8.15 s against 5.62 s on the direct DuckDB attach.
+
+    The assertion below is the difference, stated as SQL that only the DuckDB
+    path can answer.
+    """
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "auto_buildfail.sqlite")
+
+    def _boom(_path):
+        raise RuntimeError("simulated build failure (ENOSPC mid-COPY, unreadable source, ...)")
+
+    with mock.patch("nsys_ai.parquet_cache.open_cached_db", side_effect=_boom):
+        with Profile(str(db_path), cache_mode="auto") as prof:
+            assert prof.db is not None, (
+                "a failed cache build dropped the profile to raw sqlite3; the enriched "
+                "kernels view is gone and tensor_core_usage cannot run"
+            )
+            prof.db.execute("SELECT is_tc_eligible, uses_tc FROM kernels LIMIT 1").fetchall()
+
+
+def test_cache_mode_auto_env_override_direct(minimal_nsys_db_path, tmp_path, monkeypatch):
+    """The escape hatch for the entry points that expose no cache flag."""
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "auto_env.sqlite")
+    monkeypatch.setenv("NSYS_AI_CACHE_MODE", "direct")
+
+    with Profile(str(db_path), cache_mode="auto") as prof:
+        res = prof.db.execute("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME").fetchone()
+        assert res[0] >= 0
+
+    assert not _cache_dir_for(str(db_path)).exists()
+
+
+def test_cache_mode_auto_env_override_parquet_beats_affordability(
+    minimal_nsys_db_path, tmp_path, monkeypatch
+):
+    """`=parquet` is the override in the other direction: build anyway.
+
+    Pinned separately from `=direct` because it is the branch that has to win
+    against the affordability check, not just against the default.
+    """
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "auto_env_parquet.sqlite")
+    monkeypatch.setenv("NSYS_AI_CACHE_MODE", "parquet")
+    usage = mock.Mock(total=10**9, used=10**9, free=1024)
+
+    with mock.patch("nsys_ai.parquet_cache.shutil.disk_usage", return_value=usage):
+        with Profile(str(db_path), cache_mode="auto") as prof:
+            res = prof.db.execute("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME").fetchone()
+            assert res[0] >= 0
+
+    assert _cache_dir_for(str(db_path)).exists(), (
+        "NSYS_AI_CACHE_MODE=parquet did not override the affordability check"
+    )
+
+
+def test_cache_mode_auto_env_override_garbage_warns_and_uses_the_default(
+    minimal_nsys_db_path, tmp_path, monkeypatch, caplog
+):
+    """A typo must be loud and harmless, not silently read as `direct`."""
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "auto_env_junk.sqlite")
+    monkeypatch.setenv("NSYS_AI_CACHE_MODE", "sqlite")
+
+    with caplog.at_level("WARNING", logger="nsys_ai.parquet_cache"):
+        with Profile(str(db_path), cache_mode="auto"):
+            pass
+
+    assert _cache_dir_for(str(db_path)).exists(), "an unrecognised value silently disabled the cache"
+    assert any("Ignoring NSYS_AI_CACHE_MODE" in r.getMessage() for r in caplog.records), (
+        "an unrecognised NSYS_AI_CACHE_MODE was ignored without saying so"
+    )
+
+
+def test_skill_run_honours_the_cache_mode_override(minimal_nsys_db_path, tmp_path):
+    """`skill run` must obey the variable its own build banner advertises.
+
+    It is the one command that opens a connection without building a Profile,
+    so it used to call open_cached_db directly and build regardless — while
+    _build_banner, printed from inside that build, told the user to set
+    NSYS_AI_CACHE_MODE=direct to avoid it. Reproduced before the fix: the
+    variable was exported, the banner printed, the cache was built anyway.
+    """
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "skillrun_env.sqlite")
+    env = {**os.environ, "NSYS_AI_CACHE_MODE": "direct"}
+
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "skill", "run", "top_kernels", str(db_path)],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not _cache_dir_for(str(db_path)).exists(), (
+        "skill run built a cache with NSYS_AI_CACHE_MODE=direct set — the banner's "
+        "advice is wrong on the subcommand that prints it"
+    )
+
+
+def test_open_profile_readonly_honours_the_cache_mode_override(
+    minimal_nsys_db_path, tmp_path, monkeypatch
+):
+    """The chat / region_mfu entry point obeys the override too.
+
+    `open_profile_readonly` is the other place that opens a connection with no
+    Profile involved. It called `open_cached_db` directly, so the one escape
+    hatch those entry points expose — they take no cache flag at all — did
+    nothing there. Switching it to `open_auto_db` is a behaviour change, and
+    this is what goes red if anyone switches it back: mutating that one call
+    site makes this the only failing test across the profile-mode, tools,
+    threading and trajectory suites.
+    """
+    from nsys_ai.ai.backend.profile_db_tool import open_profile_readonly
+
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "readonly_env.sqlite")
+    monkeypatch.setenv("NSYS_AI_CACHE_MODE", "direct")
+
+    conn = open_profile_readonly(str(db_path))
+    try:
+        # Query something, so this cannot pass merely by failing to open.
+        res = conn.execute("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME").fetchone()
+        assert res[0] >= 0
+    finally:
+        conn.close()
+
+    assert not _cache_dir_for(str(db_path)).exists(), (
+        "open_profile_readonly built a cache with NSYS_AI_CACHE_MODE=direct set"
+    )
+
+
+def test_a_declined_cache_says_so_at_warning(minimal_nsys_db_path, tmp_path, caplog):
+    """A cache declined for disk reasons must be announced at WARNING, not INFO.
+
+    The level *is* the feature here, which is why this test pins the level and
+    not merely the text. Nothing under src/nsys_ai/ ever configures logging —
+    no basicConfig, no dictConfig, no addHandler anywhere — so the only sink a
+    record can reach is `logging.lastResort`, a StreamHandler fixed at WARNING.
+    An INFO record is therefore dropped on the floor, and the user silently
+    pays several times slower queries with nothing on stderr to say why.
+    Measured on a profile in a chmod 500 directory: `skill run top_kernels`
+    wrote 2059 bytes to stdout and 0 to stderr at INFO, 220 bytes at WARNING.
+
+    `caplog.at_level("WARNING", ...)` sets the logger's level, so an INFO call
+    is filtered out and the assertion below fails — which is exactly the
+    revert-detection this needs.
+    """
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "declined_warn.sqlite")
+    usage = mock.Mock(total=10**9, used=10**9, free=1024)
+
+    with caplog.at_level("WARNING", logger="nsys_ai.parquet_cache"):
+        with mock.patch("nsys_ai.parquet_cache.shutil.disk_usage", return_value=usage):
+            with Profile(str(db_path), cache_mode="auto") as prof:
+                assert prof.db is not None
+
+    assert any("Not building an analysis cache" in r.getMessage() for r in caplog.records), (
+        "the declined-cache notice did not reach WARNING, so lastResort drops it and a "
+        "silently degraded run produces nothing on stderr"
+    )

--- a/tests/test_profile_modes.py
+++ b/tests/test_profile_modes.py
@@ -2,6 +2,7 @@ import os
 import stat
 import subprocess
 import sys
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -332,4 +333,40 @@ def test_a_declined_cache_says_so_at_warning(minimal_nsys_db_path, tmp_path, cap
     assert any("Not building an analysis cache" in r.getMessage() for r in caplog.records), (
         "the declined-cache notice did not reach WARNING, so lastResort drops it and a "
         "silently degraded run produces nothing on stderr"
+    )
+
+
+def test_the_batch_audit_script_opens_the_same_way_skill_run_does():
+    """scripts/batch_audit_skills.py claims parity with `nsys-ai skill run`.
+
+    It exists to reproduce what that subcommand does across every registry
+    skill, and its module docstring says so. When `skill run` moved to
+    `open_auto_db` the script kept calling `open_cached_db`, so it silently
+    ignored NSYS_AI_CACHE_MODE and built caches on profiles the CLI would have
+    read in place — an audit of a path the CLI no longer takes, under a
+    docstring asserting the opposite.
+
+    This is the fourth time in this file's neighbourhood that prose one level
+    up from a change survived it and became false (#321, #325, #317). A grep
+    over call sites in src/ does not catch it, because the script is not in
+    src/. Pinning the two together in a test does.
+    """
+    root = Path(__file__).resolve().parent.parent
+    script = (root / "scripts" / "batch_audit_skills.py").read_text()
+    handlers = (root / "src" / "nsys_ai" / "cli" / "handlers.py").read_text()
+
+    # What `skill run` actually calls, read from the handler rather than
+    # assumed, so this test tracks the CLI instead of restating it.
+    assert "open_auto_db(args.profile)" in handlers, (
+        "`skill run` no longer calls open_auto_db — update this test and the "
+        "batch audit script together, they are supposed to agree"
+    )
+
+    assert "return open_auto_db(profile_path)" in script, (
+        "batch_audit_skills.py does not open the way `skill run` does; its "
+        "docstring claims it does, and NSYS_AI_CACHE_MODE does not reach it"
+    )
+    # The docstrings are the half that goes stale silently, so assert on them too.
+    assert "open_cached_db()" not in script, (
+        "batch_audit_skills.py still advertises the open_cached_db path it no longer takes"
     )

--- a/tests/test_profile_modes.py
+++ b/tests/test_profile_modes.py
@@ -198,6 +198,70 @@ def test_failed_cache_build_falls_back_to_duckdb_not_sqlite3(minimal_nsys_db_pat
             prof.db.execute("SELECT is_tc_eligible, uses_tc FROM kernels LIMIT 1").fetchall()
 
 
+def test_open_profile_readonly_failed_cache_keeps_duckdb_kernels(
+    minimal_nsys_db_path, tmp_path
+):
+    """chat / region_mfu must keep DuckDB when a cache build fails.
+
+    Profile already recovers via open_direct_sqlite. open_profile_readonly used
+    to drop straight to raw sqlite3 on the same failure, which loses the
+    enriched kernels view (``no such table: kernels``) and makes
+    tensor_core_usage fail outright. Force the cache open to raise, then
+    assert the handle is DuckDB and that kernels resolves.
+    """
+    import sqlite3
+
+    import duckdb
+
+    from nsys_ai.ai.backend.profile_db_tool import open_profile_readonly
+
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "readonly_buildfail.sqlite")
+
+    def _boom(_path):
+        raise RuntimeError("simulated build failure")
+
+    with mock.patch("nsys_ai.parquet_cache.open_cached_db", side_effect=_boom):
+        conn = open_profile_readonly(str(db_path))
+    try:
+        assert not isinstance(conn, sqlite3.Connection), (
+            "open_profile_readonly fell to raw sqlite3 after a cache build failure"
+        )
+        assert isinstance(conn, duckdb.DuckDBPyConnection)
+        conn.execute("SELECT is_tc_eligible, uses_tc FROM kernels LIMIT 1").fetchall()
+    finally:
+        conn.close()
+
+
+def test_skill_run_open_failed_cache_keeps_duckdb_kernels(minimal_nsys_db_path, tmp_path):
+    """skill run uses the same three-tier chain as Profile.
+
+    Mirrors the handler's open: open_with_direct_fallback(path, open_auto_db).
+    A test that only checked 'no exception' would have passed before the fix.
+    """
+    import sqlite3
+
+    import duckdb
+
+    from nsys_ai.parquet_cache import open_auto_db, open_with_direct_fallback
+
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "skillrun_buildfail.sqlite")
+
+    def _boom(_path):
+        raise RuntimeError("simulated build failure")
+
+    with mock.patch("nsys_ai.parquet_cache.open_cached_db", side_effect=_boom):
+        conn, err = open_with_direct_fallback(str(db_path), open_auto_db)
+    try:
+        assert err is not None
+        assert conn is not None, "skill-run open path returned None (raw sqlite3 tier)"
+        assert not isinstance(conn, sqlite3.Connection)
+        assert isinstance(conn, duckdb.DuckDBPyConnection)
+        conn.execute("SELECT is_tc_eligible, uses_tc FROM kernels LIMIT 1").fetchall()
+    finally:
+        if conn is not None:
+            conn.close()
+
+
 def test_cache_mode_auto_env_override_direct(minimal_nsys_db_path, tmp_path, monkeypatch):
     """The escape hatch for the entry points that expose no cache flag."""
     db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "auto_env.sqlite")
@@ -344,7 +408,8 @@ def test_the_batch_audit_script_opens_the_same_way_skill_run_does():
     `open_auto_db` the script kept calling `open_cached_db`, so it silently
     ignored NSYS_AI_CACHE_MODE and built caches on profiles the CLI would have
     read in place — an audit of a path the CLI no longer takes, under a
-    docstring asserting the opposite.
+    docstring asserting the opposite. Both now share
+    `open_with_direct_fallback` so a failed build keeps DuckDB too.
 
     This is the fourth time in this file's neighbourhood that prose one level
     up from a change survived it and became false (#321, #325, #317). A grep
@@ -357,12 +422,13 @@ def test_the_batch_audit_script_opens_the_same_way_skill_run_does():
 
     # What `skill run` actually calls, read from the handler rather than
     # assumed, so this test tracks the CLI instead of restating it.
-    assert "open_auto_db(args.profile)" in handlers, (
-        "`skill run` no longer calls open_auto_db — update this test and the "
-        "batch audit script together, they are supposed to agree"
+    assert "open_with_direct_fallback(args.profile, primary)" in handlers, (
+        "`skill run` no longer uses open_with_direct_fallback — update this "
+        "test and the batch audit script together, they are supposed to agree"
     )
+    assert "open_auto_db" in handlers and "open_direct_sqlite if no_cache else open_auto_db" in handlers
 
-    assert "return open_auto_db(profile_path)" in script, (
+    assert "open_with_direct_fallback(profile_path, open_auto_db)" in script, (
         "batch_audit_skills.py does not open the way `skill run` does; its "
         "docstring claims it does, and NSYS_AI_CACHE_MODE does not reach it"
     )

--- a/tests/test_tui_chat_app.py
+++ b/tests/test_tui_chat_app.py
@@ -369,3 +369,35 @@ async def test_a_stale_worker_with_no_worker_handle_stops_at_the_stream_loop(
         f"a stale worker kept pulling the stream: produced {produced}. Only the "
         "first chunk is unavoidable — the loop checks cancelled() after it."
     )
+
+
+@pytest.mark.asyncio
+async def test_cache_build_inside_textual_writes_no_cr_to_piped_stderr(profile_copy, tmp_path):
+    """Inside Textual, stderr.isatty() is True even when fd 2 is a pipe (#332).
+
+    Measured before the progress callback: a cold open painted thirteen
+    ``\\r`` redraws onto the redirected descriptor. The apps pass a callback
+    so ``build_cache`` writes nothing to stderr; this pins that, not merely
+    that the callback was invoked.
+    """
+    import os
+
+    from nsys_ai.tui_textual import NsysChatApp
+
+    err_path = tmp_path / "stderr.bin"
+    err_fd = os.open(str(err_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    saved = os.dup(2)
+    try:
+        os.dup2(err_fd, 2)
+        os.close(err_fd)
+        app = NsysChatApp(profile_copy)
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause()
+    finally:
+        os.dup2(saved, 2)
+        os.close(saved)
+
+    data = err_path.read_bytes()
+    assert b"\r" not in data, (
+        f"carriage returns reached piped stderr during a Textual cache build: {data!r}"
+    )


### PR DESCRIPTION
`cache_mode="auto"` decided on profile size: anything over 50 MB was sent to direct `sqlite_scanner` and never got a cache. That routed the largest profiles — the ones a cache helps most — onto the slower, hungrier path. This replaces the size rule with `cache_is_affordable()`, which decides on whether a cache can actually be *written*.

Closes #317. Closes #333.

## Measured — a 92 MB profile, `cache_mode="auto"`

| | `open()` | cache built |
|---|---:|---|
| before | 0.74 s | **no** |
| after | 1.82 s | **yes** |

One extra second on the first open. Every command after it opens in ~0.04 s instead of 0.74 s, and queries run 3–6× faster.

## What the auto policy is actually worth

Eight-skill battery, 12 cores / 15 GB RAM, cache deleted before every cold run. The full table is in `open_auto_db`'s docstring; the summary:

| profile | direct total | parquet cold total | peak RSS direct → parquet |
|---|---:|---:|---|
| 93 MB | 6.50 s | 6.17 s | 1.03 → 0.96 GB |
| 235 MB | 12.57 s | 9.71 s | 1.11 → 1.09 GB |
| 924 MB | 37.85 s | 28.03 s | 2.67 → 2.12 GB |
| 3.7 GB | 96.18 s | 93.57 s | 10.18 → 7.14 GB |

The claim this PR makes is deliberately narrower than the one it replaces: **never slower on the first run, never heavier on memory, sometimes much faster.** 235 MB and 924 MB are real wins on time (23 %, 26 %); 93 MB and 3.7 GB are 2–5 %, which is inside run-to-run variance. What those two win is memory, and at 3.7 GB it is decisive — 7.14 GB against 10.18 GB, on the size where running out is a real outcome.

An earlier draft of this text said "already cheaper end to end at every size". #336 item 4 flagged that as overstated and noted it would land with this PR; it has been corrected here in both the README and the docstring rather than carried forward.

## Also in this PR

### #333 — the fallback reached one of three entry points

The branch's guarantee is that losing the cache must not cost you the DuckDB engine: a failed build falls back to `open_direct_sqlite` and reaches raw `sqlite3` only if that fails too. That was implemented in `Profile.__init__` alone. `open_profile_readonly` (chat, region_mfu) and `skill run` still dropped straight to raw `sqlite3`, where the enriched `kernels` view does not exist.

Reproduced, then re-run after the fix:

```
main    open_profile_readonly -> sqlite3.Connection
           enriched kernels view: LOST — OperationalError: no such table: kernels
this    open_profile_readonly -> DuckDBPyConnection
           enriched kernels view: AVAILABLE (449,043 rows)
```

`no such table: kernels` is verbatim the failure #333 records. Now a shared `open_with_direct_fallback(path, primary)` carries the three-tier policy, used by `Profile.__init__`, `open_profile_readonly`, `skill run` and `scripts/batch_audit_skills.py`. The middle tier attaches `READ_ONLY`, so read-only callers stay read-only; tier three keeps `mode=ro`. `open_profile_readonly_for_worker` delegates to `open_profile_readonly`, so it is covered transitively.

### #332, first half — the tty gate cannot work inside Textual

`_stderr_is_tty()` cannot gate anything inside a Textual app: `sys.stderr` there is a `_PrintCapture` whose `isatty()` is documented upstream as *"Pretend we're a terminal"* and returns `True` unconditionally. #332 measured 13 `\r` redraws reaching a piped stderr.

`build_cache` now takes `progress: Callable[[str, int, int], None] | None`. When one is supplied it is called and **nothing** goes to stderr — not the redraw, not the banner. When it is not, today's behaviour is unchanged, gated on `_stderr_is_tty()`, which is correct on the CLI path and is why that function stays.

Verified with `isatty()` forced True in **both** runs, so the callback is the only variable:

```
no callback   (CLI path)      CR=11   bytes=695
with callback (Textual path)  CR= 0   bytes=  0
```

The three Textual apps pass a callback. **This does not make them responsive** — the build still runs synchronously on the message loop, and the docstrings say so. Moving it into a worker is the other half of #332 and stays open; this PR does not close that issue.

Also corrected: a comment in `tests/test_parquet_cache.py` asserted that `_draw` "returns early unless stderr is a tty, which it never is under pytest". `tests/test_tui_chat_app.py` falsifies that in the same suite.

## Verification

- `2034 passed, 146 skipped`. The one red is `test_ci_coverage.py::test_every_skip_has_a_known_reason`, which needs `NSYS_TEST_PROFILE`; CI sets it, a bare local shell does not.
- `ruff` clean, `bandit -c pyproject.toml -ll` clean.
- The NVTX map still builds byte-identically on the 3.5 GB reference capture after the rebase: 3,042,699 rows, matching content hash, all nine columns.
- New tests fail before the corresponding fix and pass after — shown for both #333 and #332.

Rebased onto `4009ebb`; the branch had drifted 21 commits behind while #344 rewrote `parquet_cache.py`.

## Left deliberately

`_suppress_cache_progress` is duplicated in the three Textual apps. Consolidating it would couple `tree` and `timeline` to the chat TUI module for a no-op function, and this diff is already large. It is the natural thing to fold in when #332's second half lands.
