### PR TITLE
chore: add issue forms for bug reports, findings, enhancements, and docs gaps

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.yml
@@ -1,0 +1,104 @@
+---
+name: Bug report
+description: nsys-ai does something wrong on a profile, on the CLI, or in a viewer
+title: "<subsystem>: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, please search **open and closed** issues — this repository has
+        found the same defect twice more than once.
+
+        Two things not to put in an issue:
+
+        - **Anything sensitive.** Kernel and NVTX names in a profile can carry internal
+          model, project, or customer names. Redact before pasting, and do not attach a
+          `.sqlite` you are not free to publish.
+        - **A large profile.** Attachments are capped and a multi-GB capture is not
+          reviewable. Describe its shape instead, or link a public one.
+
+        The title prefix is the subsystem, lowercase, followed by the specific thing that
+        is wrong — `cache: the lazy publish resurrects a stale cache and serves stale
+        data`. Not `feat:`/`fix:` (those are pull request prefixes), and not a task
+        (`improve the cache`).
+  - type: dropdown
+    attributes:
+      label: Subsystem
+      description: Where the problem shows up. Pick the closest.
+      options:
+        - cache (Parquet cache, warm, sweep)
+        - cli (argument parsing, a verb's behavior)
+        - skills (a builtin analysis skill or its SQL)
+        - agent (ask, chat, agent, propose)
+        - loop (loop, sessions, reprofile, verdict)
+        - tui (tree or timeline viewer)
+        - web (web, timeline-web, diff-web, export)
+        - diff (diff, baseline, comparability)
+        - evidence (evidence, report, root-cause)
+        - schema (Nsight table or column resolution)
+        - docs
+        - other / not sure
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: nsys-ai version
+      description: "`nsys-ai info --version`, or `pip show nsys-ai`. If running from a clone, the commit SHA."
+      placeholder: "0.2.3, or main @ 9617b50"
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Python version
+      options:
+        - "3.10"
+        - "3.11"
+        - "3.12"
+        - other (please say which in the description)
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Nsight Systems version that produced the profile
+      description: >
+        From `nsys --version`, or the exporter recorded in the profile. This matters more
+        than it looks: Nsight renames its activity tables between versions (`_V2` / `_V3`
+        suffixes), so a defect that only appears on one exporter version is a different
+        defect.
+      placeholder: "2024.5.1, or unknown"
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: What happened, and what you expected instead
+      description: State both. "It fails" without the expectation leaves the reader guessing which half is the bug.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How to reproduce
+      description: >
+        The exact command, and the output or traceback. Paste it rather than describing
+        it — a documented command that was never run is how several stale claims got into
+        this repo.
+      render: shell
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Profile shape
+      description: >
+        Optional, but it is usually the difference between reproducible and not: size on
+        disk, GPU count and model, framework (PyTorch, Megatron, vLLM), whether NVTX
+        ranges are present, whether NCCL was traced.
+      placeholder: "3.5 GB, 2x H100, Megatron, NVTX push/pop present, NCCL traced"
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Willingness to contribute
+      options:
+        - label: I can contribute a fix for this independently
+        - label: I would be willing to contribute a fix with guidance
+        - label: I cannot contribute a fix at this time

--- a/.github/ISSUE_TEMPLATE/2-finding.yml
+++ b/.github/ISSUE_TEMPLATE/2-finding.yml
@@ -1,0 +1,98 @@
+---
+name: Performance or correctness finding
+description: A defect found by reading or measuring the code, with the evidence attached
+title: "<subsystem>: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        For a finding you can point at in the code — a rescan, a stale cache, a missing
+        abstention, a contract nothing enforces. This is the shape most issues in this
+        repository take, and the shape that can be picked up without a conversation.
+
+        The sections below are the ones those issues use. Fill them and the issue is
+        implementable by someone who has never seen it; skip them and it is a note.
+  - type: textarea
+    attributes:
+      label: The mechanism
+      description: >
+        Name the function and the file, and say what it does today. Two or three
+        sentences, specific enough that a reader can go and look at it.
+      placeholder: >
+        `detect_iterations` scans the complete primary-thread runtime list from the
+        beginning for every detected iteration. Both inputs can be normalized into
+        ascending, non-overlapping windows, so one advancing cursor performs the same
+        correlation in O(N+M).
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Measured
+      description: >
+        Real numbers, in a table or a block: row counts, the excess factor, seconds,
+        memory peak, or a per-site table of observed behavior. Say what you measured it
+        on. If nothing can be measured, say precisely what you observed and how — an
+        issue asserting slowness without a number does not get picked up.
+      placeholder: |
+        Measured on a 3.5 GB capture:
+
+        primary-thread runtime rows = 1,696,160
+        iterations                  =       952
+        current inner-loop steps   ~= 558,521,628
+        single advancing scan      ~=   1,697,112
+                                          329x excess work
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What the fix must respect
+      description: >
+        Invariants a fix cannot break — ordering assumptions, the abstention contract,
+        the pure-SQLite fallback path, determinism of output. This is where a reviewer's
+        objection gets pre-empted.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Suggested
+      description: >
+        Candidate approaches when there is a choice, with the cheap per-site fix and the
+        structural fix distinguished, and which one you recommend. Do not present one
+        option as obvious when there are two.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Scope
+      description: >
+        What must **not** be folded into the pull request. Bundled work is the most common
+        review rejection here, and this field is what lets a reviewer tell an omission
+        from an oversight.
+      placeholder: >
+        This ticket changes the correlation loop only. Arrow/columnar loading and removal
+        of the 1.7 million Python dictionaries are separate memory work.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Done
+      description: >
+        Acceptance criteria as statements, not checkboxes and not "tests pass". What must
+        be true to close this, including how it is verified — oracle comparison, both
+        committed profile pairs identical, a test that fails if the invariant is violated.
+        A finding without this cannot carry `agent-ready`.
+      placeholder: |
+        - All 952 output rows compare field-for-field with the current implementation on the 3.5 GB oracle.
+        - Both committed profile pairs produce identical output.
+        - Tests cover zero iterations, one full-capture iteration, and multiple NVTX iterations.
+        - A test fails if the runtime iterable is restarted.
+        - The timing is recorded even if another skill remains the new bottleneck.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Related issues
+      description: "Real GitHub numbers only — roadmap handles (`#001`-`#094`, `§5.1`, `E#.#`) are not GitHub numbers."
+      placeholder: "Part of #300. Context: the note added in #340 points here."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/3-enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/3-enhancement.yml
@@ -1,0 +1,78 @@
+---
+name: Enhancement or feature request
+description: A capability nsys-ai does not have yet
+title: "<subsystem>: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Check `ROADMAP.md` first — the idea may already be queued there, in which case
+        this issue is the place to say what the roadmap entry does not cover.
+
+        Lead with the analysis you cannot do today, not with the feature. A request framed
+        as a question the tool cannot answer survives review; one framed as an
+        implementation usually gets rebuilt into something else.
+  - type: dropdown
+    attributes:
+      label: Subsystem
+      options:
+        - cache (Parquet cache, warm, sweep)
+        - cli (a new verb, or a flag on an existing one)
+        - skills (a new builtin analysis skill)
+        - agent (ask, chat, agent, propose)
+        - loop (loop, sessions, reprofile, verdict)
+        - tui (tree or timeline viewer)
+        - web (web, timeline-web, diff-web, export)
+        - diff (diff, baseline, comparability)
+        - evidence (evidence, report, root-cause)
+        - docs
+        - other / not sure
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: The question you cannot answer today
+      description: >
+        What are you trying to learn from a profile, and where does the current tool stop?
+        Name the command you reached for and what it gave you instead.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed surface
+      description: >
+        Concretely: a new verb, a flag, a builtin skill, a column in an existing table. If
+        it produces output, say what the output looks like — a skill returns rows with
+        named keys, and naming them here is most of the design.
+      placeholder: >
+        `nsys-ai skill run <name>` returning rows with keys `kernel_name: str,
+        stall_pct: float, device: int`, and a finding when stall_pct exceeds ...
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: What it must not need
+      description: >
+        Constraints that shape the design. New runtime dependencies are a high bar — SQL
+        analysis and the web server are stdlib on purpose, and AI features stay behind the
+        `[agent]` / `[chat]` extras and degrade cleanly when those are absent. Say whether
+        this works on a profile with no NVTX, no NCCL trace, or no Parquet cache.
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Prior art
+      description: >
+        Has another tool solved this — Nsight recipes, HTA, PyTorch Profiler, NAV? Link
+        the implementation rather than the README, and say what should and should not be
+        taken from it.
+    validations:
+      required: false
+  - type: checkboxes
+    attributes:
+      label: Willingness to contribute
+      options:
+        - label: I can implement this independently
+        - label: I would be willing to implement this with guidance
+        - label: I cannot implement this at this time

--- a/.github/ISSUE_TEMPLATE/4-docs.yml
+++ b/.github/ISSUE_TEMPLATE/4-docs.yml
@@ -1,0 +1,51 @@
+---
+name: Documentation gap
+description: A page is missing, wrong, or describes code that no longer exists
+title: "docs: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Worth knowing before writing the fix: `docs/01-cli-reference.md` through
+        `docs/08-focused-profiling.md` document **Nsight Systems and profiling technique**,
+        not this tool. They are domain knowledge and are not stale. `README.md` is where
+        most nsys-ai commands appear at all.
+
+        This repository has spent several issues removing prose that described code which
+        no longer existed, so a documentation claim is only as good as the command its
+        author actually ran.
+  - type: input
+    attributes:
+      label: Which page
+      description: Path, or "missing — there is no page for this".
+      placeholder: "docs/guided-loop-setup.md, or missing"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What it says, and what is actually true
+      description: >
+        Quote the passage and state the current behavior beside it. For a missing page, say
+        what a reader is trying to do and where they currently give up.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: How you know
+      description: >
+        The command you ran and its output, or the code that contradicts the page. A
+        documentation issue with a pasted failure is actionable; one asserting staleness
+        needs re-verifying before anyone can fix it.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Done
+      description: >
+        What must be true to close this. The standing bar for documentation here: reader
+        first, no emoji, no enumerating pull request numbers, every documented command
+        verified by running it, and nothing left alongside its own replacement.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,15 @@
+---
+# Blank issues stay enabled deliberately. The forms cover the common cases, but the
+# issues this project runs on are often prose with a measurement table and a Done
+# section, and a form is a worse container for that than an empty box.
+blank_issues_enabled: true
+contact_links:
+  - name: Roadmap — check whether it is already planned
+    url: https://github.com/GindaChen/nsys-ai/blob/main/ROADMAP.md
+    about: Prioritized work with issue links. A roadmap item number is not a GitHub issue number.
+  - name: Profiling and Nsight Systems guides
+    url: https://github.com/GindaChen/nsys-ai/tree/main/docs
+    about: How to capture a usable profile, NVTX annotation, NCCL tracing, container profiling.
+  - name: Book of Root Causes
+    url: https://github.com/GindaChen/nsys-ai/tree/main/docs/root-causes
+    about: Known GPU performance root causes and how they present in a profile.


### PR DESCRIPTION
## Summary

- Adds `.github/ISSUE_TEMPLATE/` — four GitHub issue forms and a `config.yml`. The repo
  had a pull request template but no issue template, so the conventions the existing
  issues already follow were nowhere a new contributor could see them.
- The forms encode what the issues in this repo actually do: a subsystem title prefix, a
  named mechanism, measured evidence, an explicit scope, and a `Done` section stating what
  must be true to close.
- Blank issues stay **enabled**. The forms cover the common cases, but this project's own
  findings are prose with a measurement table, and a form is a worse container for that
  than an empty box.

## Changes

- `1-bug_report.yml` — subsystem dropdown, nsys-ai version, Python version, and the
  Nsight Systems version that produced the profile (activity tables are `_V2`/`_V3`
  suffixed across exporter versions, so this is load-bearing rather than boilerplate).
  Required: what happened vs expected, and a pasted reproduction. Preamble warns against
  attaching a multi-GB capture or unredacted kernel/NVTX names, which can carry internal
  model and customer names.
- `2-finding.yml` — the shape most issues here take. Required: the mechanism (function and
  file), `Measured` (real numbers), and `Done`. Optional: invariants a fix must respect,
  suggested approaches with the cheap fix and the structural fix distinguished, and scope.
  Placeholders are drawn from #348 and #345.
- `3-enhancement.yml` — leads with the question a user cannot answer today rather than
  with a proposed implementation; asks for the output shape, the constraints (no new
  runtime dependency; behavior with no NVTX / no NCCL / no cache), and prior art.
- `4-docs.yml` — states up front that `docs/01`–`08` document Nsight Systems rather than
  this tool and are not stale, and asks for the command that was actually run.
- `config.yml` — `blank_issues_enabled: true`, plus contact links to `ROADMAP.md`, the
  profiling guides, and the Book of Root Causes.

Labels applied by the forms (`bug`, `enhancement`, `documentation`) all already exist.
Priority, pillar and `agent-*` labels are deliberately left to a maintainer — `agent-ready`
in particular is a claim that the issue can be implemented without a conversation, which
the form cannot verify.

## Backward compatibility

Yes. Additive, and blank issues remain available, so no existing way of filing an issue
stops working.

## Test plan

- [ ] Tests added or updated — n/a, no code change
- [x] All five files parse as YAML and satisfy the issue-forms schema rules: required
      top-level keys present, every `body` element a valid type, `markdown` elements carry
      `attributes.value` and no `validations`, every input carries `attributes.label`,
      dropdowns carry `options`, and no `checkboxes` element is marked required
- [x] `python3 -m nsys_ai --help` — CLI loads without error
- [x] `ruff check src/ tests/` clean
- [ ] `pytest tests/ -v --tb=short` — not run; no Python file is touched, left to CI
- [ ] Rendered form preview — cannot be verified from a fork; the forms only render from
      the default branch of the repository they live in, so this needs a look after merge

## Out of scope

- Does not touch `.github/PULL_REQUEST_TEMPLATE.md`, which already exists and is followed.
- Does not add a security-reporting policy (`SECURITY.md`); the bug form warns against
  pasting sensitive profile contents but there is no disclosure address to point at yet.
- Does not disable blank issues or enable Discussions.
