### PR TITLE
fix(agent): resolve the NVTX table name in the schema shown to the model

### DIFF
--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -18,8 +18,6 @@ DEFAULT_MAX_LIMIT = 50
 # Default maximum JSON length (characters) returned to the model.
 DEFAULT_MAX_JSON_CHARS = 8000
 
-# NVTX table name is stable; kernel table is detected by NsightSchema.
-NVTX_TABLE = "NVTX_EVENTS"
 # StringIds maps id -> value for kernel names (shortName, demangledName reference it).
 STRING_IDS_TABLE = "StringIds"
 
@@ -217,9 +215,15 @@ def get_profile_schema(
     """
     Return a short schema description for injection into the system prompt.
 
-    Uses NsightSchema to get the kernel table name, then fetches DDL from
-    sqlite_master for that table and NVTX_EVENTS (if present).
+    Uses NsightSchema to get the kernel table name and resolve_activity_tables
+    for the NVTX table (which newer exports suffix _V2/_V3), then fetches DDL
+    from sqlite_master for those tables. The DDL carries the resolved names, so
+    the model writes SQL against the tables that actually exist.
     """
+    from nsys_ai.connection import DB_ERRORS, DuckDBAdapter, wrap_connection
+
+    adapter = wrap_connection(conn)
+
     try:
         from nsys_ai.profile import NsightSchema
 
@@ -228,11 +232,15 @@ def get_profile_schema(
     except Exception:
         kernel_table = None
 
+    # Same path every other reader uses: a literal "NVTX_EVENTS" misses
+    # NVTX_EVENTS_V2/_V3 on raw sqlite3 (no parquet_cache alias view).
+    nvtx_table = adapter.resolve_activity_tables().get("nvtx")
+
     want = list(table_names) if table_names else []
     if kernel_table and kernel_table not in want:
         want.append(kernel_table)
-    if NVTX_TABLE not in want:
-        want.append(NVTX_TABLE)
+    if nvtx_table and nvtx_table not in want:
+        want.append(nvtx_table)
     if STRING_IDS_TABLE not in want:
         want.append(STRING_IDS_TABLE)
 
@@ -241,9 +249,6 @@ def get_profile_schema(
 
     parts = []
 
-    from nsys_ai.connection import DB_ERRORS, DuckDBAdapter, wrap_connection
-
-    adapter = wrap_connection(conn)
     is_duckdb = isinstance(adapter, DuckDBAdapter)
 
     if is_duckdb:

--- a/tests/test_nvtx_table_resolution.py
+++ b/tests/test_nvtx_table_resolution.py
@@ -187,3 +187,36 @@ def test_sqlite_blob_fallback_reads_the_versioned_table(versioned_profile):
         f"the SQLite blob fallback failed against a profile whose NVTX table is "
         f"{RENAMED} — the table name is not being resolved: {diagnostics}"
     )
+
+
+# ── profile_db_tool (get_profile_schema) ─────────────────────────────────────
+# The text-to-SQL system prompt is built from get_profile_schema on whatever
+# connection open_profile_readonly returned. On the DuckDB/cache path the
+# unversioned alias exists, so a literal still finds DDL. On the raw sqlite3
+# fallback it does not — and that is the path a read-only mount always takes.
+
+
+def test_get_profile_schema_includes_the_versioned_nvtx_table(versioned_profile):
+    """The assertion that fails while NVTX_TABLE is the literal NVTX_EVENTS.
+
+    Measured on this fixture: unrenamed schema is ~7034 chars and contains NVTX;
+    renamed under the literal is ~4710 chars and contains none. The model is
+    then asked to write SQL against a table it has not been shown.
+    """
+    from nsys_ai.ai.backend.profile_db_tool import get_profile_schema
+
+    conn = sqlite3.connect(versioned_profile)
+    try:
+        schema = get_profile_schema(conn)
+    finally:
+        conn.close()
+
+    assert RENAMED in schema, (
+        f"get_profile_schema omitted {RENAMED} from the model prompt on a raw "
+        f"sqlite3 connection — the NVTX table name is not being resolved"
+    )
+    # The DDL must teach the model the name that exists, not the unversioned
+    # literal it would invent from memory of older exports.
+    assert "CREATE TABLE" in schema and RENAMED in schema
+    assert "CREATE TABLE NVTX_EVENTS\n" not in schema
+    assert "CREATE TABLE NVTX_EVENTS (" not in schema


### PR DESCRIPTION
`get_profile_schema` hardcoded `NVTX_EVENTS` when building the schema description handed to the model. On a profile whose export names that table `NVTX_EVENTS_V2` or `_V3`, the model was shown a schema without it — and the model is what writes the SQL.

Closes #294.

## Reproduced, then fixed

Measured on a copy of `tests/fixtures/h100_2gpu_1s.sqlite` with `NVTX_EVENTS` renamed to `NVTX_EVENTS_V3`, over a raw `sqlite3` connection:

| | schema length | contains the NVTX table |
|---|---:|---|
| unrenamed fixture | 7,034 chars | yes |
| renamed, before this change | 4,710 chars | **no** |
| renamed, after | 7,039 chars | yes, as `NVTX_EVENTS_V3` |

The table simply vanished from what the model could see, so any NVTX question became unanswerable without the model being told why.

## Why only the sqlite3 tier is tested

The DuckDB path cannot reach this bug: `parquet_cache` aliases the versioned export under the unversioned name, so `NVTX_EVENTS` resolves there whatever the file calls it. The test therefore opens the raw `sqlite3` connection, which is the tier where the failure is reachable. `tests/test_nvtx_table_resolution.py` already carried `test_duckdb_reader_is_not_the_broken_one` as the tripwire for that asymmetry, and this asymmetry is documented in the module rather than left implicit.

## Verification

The new test asserts on the returned schema string, not on source text. That distinction is why it exists in this form: #288 shipped a source-text assertion for a related fix which kept passing while the fix itself was inert, and the module docstring records that.

Checked by hand rather than taken from a report — `git checkout upstream/main -- src/`, run, restore, run:

```
before the fix   1 failed, 6 passed
after            7 passed
```

Full suite with `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`: **2046 passed, 140 skipped, zero failures**. `ruff` clean.

## Known imprecision, not introduced here

`get_profile_schema`'s docstring says it "fetches DDL from `sqlite_master`". That is true of the sqlite3 branch only; the DuckDB branch runs `DESCRIBE` per table and synthesises the `CREATE TABLE` text. The sentence predates this change and this change did not make it worse, but a reader should know before relying on it.
