### PR TITLE
docs(scripts): add a portable CUDA axpy workload for local real captures

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,94 @@
+# scripts/
+
+Developer utilities for local workflows. Some scripts under this directory are used by CI
+(see `.github/workflows/plugin-smoke.yml` for `smoke_test.sh` and `build_fixture.py`).
+The CUDA axpy workload below is not.
+
+## CUDA axpy workload (`axpy.cu`)
+
+A tiny CUDA program that launches the same `axpy` kernel N times. It exists so a developer
+with a GPU can produce a real nsys capture and exercise `nsys-ai profile`, `diff`, and related
+paths against genuine GPU activity — the kind of coverage issue #289 measured as missing
+(committed fixtures are small; CI has no GPU).
+
+Source only is committed. Do not check in the binary or any capture. This workload is for a
+developer machine with `nvcc`, a CUDA GPU, and `nsys` on `PATH`. It is not wired into CI.
+
+### Build
+
+```bash
+nvcc -O2 -o /tmp/axpy scripts/axpy.cu
+/tmp/axpy 5
+```
+
+Example output:
+
+```text
+axpy done: launches=5 n=1048576
+```
+
+Launch count defaults to 5 when omitted; pass an integer to control how many kernels run.
+
+### Capture a before/after pair
+
+`-o` / `--output` is a fresh artifact **directory**. The SQLite export lands at
+`<dir>/profile.sqlite`. A path like `<dir>.sqlite` does not exist and fails with
+`PROFILE_NOT_FOUND`.
+
+With the package installed (`pip install -e '.[dev]'`, per the README):
+
+```bash
+mkdir -p /tmp/axpy-captures
+
+nsys-ai profile -o /tmp/axpy-captures/before -- /tmp/axpy 5
+nsys-ai profile -o /tmp/axpy-captures/after  -- /tmp/axpy 40
+```
+
+Example capture output (5 launches):
+
+```text
+[preparing] 0.0s
+[capturing] 0.0s
+[exporting] 2.2s
+[validating] 2.2s
+[finished] 2.2s
+Report: /tmp/axpy-captures/before/profile.nsys-rep
+SQLite: /tmp/axpy-captures/before/profile.sqlite
+RunSpec: /tmp/axpy-captures/before/runspec.json
+Profile ID: nsys2:sha256:<content hash of your capture>
+Export schema: 3.25.0
+Nsight version: <whatever your nsys reports>
+Kernels: 5
+```
+
+A successful capture prints `Kernels: <n>` matching the launch count (here `Kernels: 5`,
+then `Kernels: 40`).
+
+Wrong path (sibling `.sqlite` instead of `<dir>/profile.sqlite`):
+
+```bash
+nsys-ai diff \
+  /tmp/axpy-captures/before/profile.sqlite \
+  /tmp/axpy-captures/after/profile.sqlite
+```
+
+```text
+Error [PROFILE_NOT_FOUND]: profile not found: /tmp/axpy-captures/before/profile.sqlite
+```
+
+Correct compare:
+
+```bash
+nsys-ai diff \
+  /tmp/axpy-captures/before/profile.sqlite \
+  /tmp/axpy-captures/after/profile.sqlite
+```
+
+Example kernel regression line:
+
+```text
+ +706.54us  |         5->40 | axpy
+```
+
+Varying the launch count on one binary is enough to get a measurable kernel-time diff
+(for example 5 vs 40 launches).

--- a/scripts/axpy.cu
+++ b/scripts/axpy.cu
@@ -1,0 +1,72 @@
+// Minimal CUDA axpy workload for local nsys-ai profile captures.
+//
+// Build (needs nvcc; a GPU is needed to run it, not to compile it):
+//   nvcc -O2 -o /tmp/axpy scripts/axpy.cu
+//
+// Usage:
+//   /tmp/axpy [launches]
+//
+// Launch count is a CLI argument (default 5) so one binary produces both a
+// before and an after capture (e.g. 5 vs 40). See scripts/README.md.
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cuda_runtime.h>
+
+__global__ void axpy(float a, float* x, float* y, int n) {
+    int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) y[i] = a * x[i] + y[i];
+}
+
+static void check(cudaError_t err, const char* what) {
+    if (err != cudaSuccess) {
+        std::fprintf(stderr, "%s: %s\n", what, cudaGetErrorString(err));
+        std::exit(1);
+    }
+}
+
+static const long kMaxLaunches = 1000000;
+
+int main(int argc, char** argv) {
+    long launches = 5;
+    if (argc >= 2) {
+        char* end = nullptr;
+        errno = 0;
+        launches = std::strtol(argv[1], &end, 10);
+        // errno/ERANGE matters: without it strtol saturates at LONG_MAX and every
+        // other condition here passes, so an out-of-range argument becomes an
+        // effectively unbounded launch loop under a capture with no timeout.
+        if (end == argv[1] || *end != '\0' || errno == ERANGE
+            || launches < 1 || launches > kMaxLaunches) {
+            std::fprintf(stderr, "launches must be an integer in 1..%ld\n", kMaxLaunches);
+            return 2;
+        }
+    }
+
+    const int n = 1 << 20;
+    const float a = 2.0f;
+    const int threads = 256;
+    const int blocks = (n + threads - 1) / threads;
+
+    float* x = nullptr;
+    float* y = nullptr;
+    check(cudaMalloc(&x, n * sizeof(float)), "cudaMalloc x");
+    check(cudaMalloc(&y, n * sizeof(float)), "cudaMalloc y");
+    check(cudaMemset(x, 0, n * sizeof(float)), "cudaMemset x");
+    // The kernel reads y before writing it; leaving it uninitialised would be an
+    // uninitialised device read in a file that is otherwise fully error-checked.
+    check(cudaMemset(y, 0, n * sizeof(float)), "cudaMemset y");
+
+    for (long i = 0; i < launches; ++i) {
+        axpy<<<blocks, threads>>>(a, x, y, n);
+        check(cudaGetLastError(), "axpy launch");
+    }
+    check(cudaDeviceSynchronize(), "cudaDeviceSynchronize");
+
+    check(cudaFree(x), "cudaFree x");
+    check(cudaFree(y), "cudaFree y");
+
+    std::printf("axpy done: launches=%ld n=%d\n", launches, n);
+    return 0;
+}


### PR DESCRIPTION
A ~70-line CUDA program under `scripts/`, so a developer with a GPU can produce a real capture and exercise the runner and the loop end to end. Two source files, no `src/` changes.

Refs #289.

## Why

#289 measured the gap: of ~1379 tests, 11 need a real profile and **none of them runs in CI**. The largest committed fixture is 2.6 MB. Several defects only appear at real scale, and one was found this week by doing exactly what this makes repeatable — capturing a real profile and running the loop by hand:

```
$ nsys-ai diff before.sqlite after.sqlite --session
Error: diff before path must be absolute
```

Relative paths, the normal way to invoke a CLI, failed. Every test in `test_session_cli.py` passed `.resolve()`d paths, which is why none of them caught it. Fixed in #365.

The runner had 25 tests and 71 mock sites and had never been run against a real `nsys` until then.

## What it is

`axpy` over 2^20 floats, launch count as an argument, so one binary produces both sides of a diff:

```bash
nvcc -O2 -o /tmp/axpy scripts/axpy.cu
nsys-ai profile -o /tmp/axpy-captures/before -- /tmp/axpy 5
nsys-ai profile -o /tmp/axpy-captures/after  -- /tmp/axpy 40
nsys-ai diff /tmp/axpy-captures/before/profile.sqlite /tmp/axpy-captures/after/profile.sqlite
```

Every command above was run as written before being documented:

```
Kernels: 5
Kernels: 40
 +701.68us  |  5->40  | axpy
```

That last check matters more than it looks. An earlier draft documented the diff against `<dir>.sqlite`, which does not exist — `-o` names a directory and the export lands at `<dir>/profile.sqlite`. Run as written it failed with `PROFILE_NOT_FOUND`. The doc now carries both the working form and the wrong one, with the error it produces.

## Deliberately not

- **Not wired into CI.** CI has no GPU. Claiming otherwise would be false, and the doc says plainly it is for a developer with one.
- **No binary and no capture committed.** Source only.
- **No `src/` changes.** An earlier attempt at this bundled an edit to `src/nsys_ai/runspec.py` and was blocked: it swapped `--discard-environment=true` for `--inherit-environment=false` on the false premise that nsys rejects the former, and the resulting capture recorded 75 environment rows including `SSH_CLIENT` and auth tokens while `runspec.json` still claimed they were discarded. That is now #366. Nothing of it is here.

## Portability

Plain `nvcc`, standard headers, no pinned CUDA version and no hardcoded `nsys` path — so it can be built inside a container image when #272 wants a remote provider. That property rests on inspection, not on a container build: nothing here exercises it.

## Review findings from the first pass, all fixed

- `strtol` overflow was unchecked, so `axpy 99999999999999999999` saturated at `LONG_MAX` and ran an unbounded launch loop under a capture with no timeout — while the error message promised "a positive integer". Now `errno`/`ERANGE` and an explicit upper bound; that input exits 2.
- `y` was `cudaMalloc`'d but never initialised while the kernel reads it. Now `cudaMemset`, in a file that is otherwise fully error-checked.
- The header said building needs a GPU. Building needs `nvcc`; the GPU is for running — and the distinction is the portability property above.
- The doc pasted one machine's `Profile ID` and Nsight version as if reproducible. Replaced with placeholders.
- The doc told the reader to set `PYTHONPATH` to "this worktree's src". A committed doc has no "this worktree"; it now uses the installed entry point, as README.md and CLAUDE.md do.
