### PR TITLE
fix(cli): make review answer exactly what diff answers, and add the diagnose verb

### DIFF
--- a/src/nsys_ai/ai/diff_narrative.py
+++ b/src/nsys_ai/ai/diff_narrative.py
@@ -64,6 +64,20 @@ def build_executive_summary(summary: ProfileDiffSummary) -> str:
     return " ".join(parts)
 
 
+def offline_diff_narrative(summary: ProfileDiffSummary) -> DiffNarrative:
+    """Narrative with the deterministic summary only — no LLM call, no warning.
+
+    Used by ``diff --no-ai`` and by every caller that never reaches an LLM, so
+    the non-AI report is byte-identical across those front doors.
+    """
+    return DiffNarrative(
+        executive_summary=build_executive_summary(summary),
+        ai_narrative=None,
+        model=None,
+        warning=None,
+    )
+
+
 def _build_narrative_prompt_payload(summary: ProfileDiffSummary) -> str:
     """Build a compact, numeric-only payload for the LLM (no raw kernel lists)."""
     lines: list[str] = []

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -35,6 +35,50 @@ def _cmd_propose(args, _profile):
     if exit_code:
         raise SystemExit(exit_code)
 
+
+def _cmd_diagnose(args, _profile):
+    """Thin front door: default evidence pack → session findings."""
+    from nsys_ai.diagnose_command import DiagnoseCommandError, run_diagnose
+
+    try:
+        exit_code = run_diagnose(
+            profile_path=getattr(args, "profile", None),
+            session_id=getattr(args, "session", None),
+            gpu=getattr(args, "gpu", 0) or 0,
+            trim=_parse_trim(args),
+            web=bool(getattr(args, "web", False)),
+            port=getattr(args, "port", 8144),
+            open_browser=not bool(getattr(args, "no_browser", False)),
+        )
+    except DiagnoseCommandError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    if exit_code:
+        raise SystemExit(exit_code)
+
+
+def _cmd_review(args, _profile):
+    """Thin front door: canonical before/after diff, or resume a session."""
+    from nsys_ai.review_command import ReviewCommandError, run_review
+
+    try:
+        exit_code = run_review(
+            before_path=getattr(args, "before", None),
+            after_path=getattr(args, "after", None),
+            session_id=getattr(args, "session", None),
+            gpu=getattr(args, "gpu", None),
+            trim=_parse_trim(args),
+            web=bool(getattr(args, "web", False)),
+            port=getattr(args, "port", 8144),
+            open_browser=not bool(getattr(args, "no_browser", False)),
+        )
+    except ReviewCommandError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    if exit_code:
+        raise SystemExit(exit_code)
+
+
 # ---------------------------------------------------------------------------
 # cutracer subcommand
 # ---------------------------------------------------------------------------
@@ -750,7 +794,11 @@ def _cmd_baseline_show(args, _profile):
 
 
 def _cmd_diff(args, _profile):
-    from nsys_ai.diff import STEP_TIME_REGRESSION_PCT, diff_profiles
+    from nsys_ai.diff import (
+        STEP_TIME_REGRESSION_PCT,
+        diff_profiles,
+        diff_profiles_all_gpus,
+    )
     from nsys_ai.diff_decision import write_diff_decision_json
     from nsys_ai.diff_render import (
         format_diff_markdown,
@@ -815,18 +863,12 @@ def _cmd_diff(args, _profile):
         if args.format not in ("terminal", "markdown"):
             return None
         from nsys_ai.ai.diff_narrative import (
-            DiffNarrative,
-            build_executive_summary,
             generate_diff_narrative,
+            offline_diff_narrative,
         )
 
         if no_ai:
-            return DiffNarrative(
-                executive_summary=build_executive_summary(summary),
-                ai_narrative=None,
-                model=None,
-                warning=None,
-            )
+            return offline_diff_narrative(summary)
         return generate_diff_narrative(summary)
 
     if getattr(args, "chat", False):
@@ -908,31 +950,17 @@ def _cmd_diff(args, _profile):
             else:
                 raise RuntimeError(f"Unknown format: {args.format}")
         else:
-            # Global (all GPUs) + per-GPU breakdown.
-            global_summary = diff_profiles(
+            # Global (all GPUs) + per-GPU breakdown. Shared with `review` so the
+            # two front doors cannot drift on devices or per-GPU top-k.
+            global_summary, per_gpu = diff_profiles_all_gpus(
                 before,
                 after,
-                gpu=None,
                 trim=trim,
                 limit=args.limit,
                 sort=args.sort,
                 regression_pct=regression_pct,
             )
             gate_summary = global_summary
-            # For per-GPU we keep top-k small to avoid overwhelming output.
-            per_gpu_limit = min(args.limit, 3)
-            devices = sorted(set(before.meta.devices) | set(after.meta.devices))
-            per_gpu = {}
-            for dev in devices:
-                per_gpu[dev] = diff_profiles(
-                    before,
-                    after,
-                    gpu=dev,
-                    trim=trim,
-                    limit=per_gpu_limit,
-                    sort=args.sort,
-                    regression_pct=regression_pct,
-                )
 
             narrative = _narrative_for(global_summary)
             if args.format == "terminal":

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -22,6 +22,7 @@ from .handlers import (
     _cmd_baseline_tag,
     _cmd_chat,
     _cmd_cutracer,
+    _cmd_diagnose,
     _cmd_diff,
     _cmd_diff_web,
     _cmd_doctor,
@@ -40,6 +41,7 @@ from .handlers import (
     _cmd_profile,
     _cmd_propose,
     _cmd_report,
+    _cmd_review,
     _cmd_root_cause,
     _cmd_search,
     _cmd_skill,
@@ -418,7 +420,7 @@ def _build_parser():
         dest="command",
         metavar=(
             "{open,web,timeline-web,loop,chat,ask,agent,agent-guide,"
-            "profile,propose,info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
+            "profile,propose,diagnose,review,info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
             "root-cause,help}"
         ),
     )
@@ -476,6 +478,123 @@ def _build_parser():
         ),
     )
     p.set_defaults(handler=_cmd_propose)
+
+    p = sub.add_parser(
+        "diagnose",
+        help="Run the default skill pack and publish ranked findings into a session",
+    )
+    p.add_argument(
+        "profile",
+        nargs="?",
+        default=None,
+        help="Path to profile (.sqlite or .nsys-rep); omit with --session --web",
+    )
+    p.add_argument(
+        "--gpu",
+        type=int,
+        default=0,
+        help="GPU device ID (default: 0; same as evidence build)",
+    )
+    p.add_argument(
+        "--trim",
+        nargs=2,
+        type=float,
+        metavar=("START_S", "END_S"),
+        default=None,
+        help="Time window in seconds",
+    )
+    p.add_argument(
+        "--session",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="ID",
+        help=(
+            "Session id to publish into (or reopen with --web). Omit ID to "
+            "derive it from the profile content id."
+        ),
+    )
+    p.add_argument(
+        "--web",
+        action="store_true",
+        help="Open timeline-web on the same session without regenerating state",
+    )
+    p.add_argument("--port", type=int, default=8144, help="HTTP port for --web")
+    p.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Don't auto-open a browser with --web",
+    )
+    p.set_defaults(handler=_cmd_diagnose)
+
+    p = sub.add_parser(
+        "review",
+        help=(
+            "Compare before/after profiles, or resume a session decision path"
+        ),
+        description=(
+            "Compare before/after profiles, or resume a session decision path. "
+            "The pair form is the canonical diff: stdout is byte-identical to "
+            "'nsys-ai diff <before> <after> --no-ai', including the per-GPU "
+            "overview and per-GPU regressions when --gpu is omitted. review "
+            "never calls an LLM, so the executive summary is the deterministic "
+            "one that --no-ai produces. Next-step hints are written to stderr, "
+            "so a redirected stdout holds exactly the diff report. review does "
+            "not create a session; --session resumes one."
+        ),
+    )
+    p.add_argument(
+        "before",
+        nargs="?",
+        default=None,
+        help="Before profile (.sqlite or .nsys-rep); omit with --session to resume",
+    )
+    p.add_argument(
+        "after",
+        nargs="?",
+        default=None,
+        help="After profile (.sqlite or .nsys-rep); omit with --session to resume",
+    )
+    p.add_argument(
+        "--gpu",
+        type=int,
+        default=None,
+        help=(
+            "GPU device ID (default: all GPUs, with the same per-GPU "
+            "breakdown diff prints)"
+        ),
+    )
+    p.add_argument(
+        "--trim",
+        nargs=2,
+        type=float,
+        metavar=("START_S", "END_S"),
+        default=None,
+        help="Time window in seconds (same as diff)",
+    )
+    p.add_argument(
+        "--session",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="ID",
+        help=(
+            "Resume an existing session and present its decision path. "
+            "Does not create a session; pair form is a comparison only."
+        ),
+    )
+    p.add_argument(
+        "--web",
+        action="store_true",
+        help="Open timeline-web on the same --session without regenerating state",
+    )
+    p.add_argument("--port", type=int, default=8144, help="HTTP port for --web")
+    p.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Don't auto-open a browser with --web",
+    )
+    p.set_defaults(handler=_cmd_review)
 
     # Public commands (simplified)
     p = sub.add_parser("open", help="Open profile quickly in Perfetto/web/TUI")

--- a/src/nsys_ai/diagnose_command.py
+++ b/src/nsys_ai/diagnose_command.py
@@ -1,0 +1,221 @@
+"""Headless ``nsys-ai diagnose`` — thin front door over EvidenceBuilder + SessionStore.
+
+Handlers unpack argparse Namespace values and call :func:`run_diagnose`. The
+analysis itself is the existing default skill pack; this module only composes
+publication and user-facing output.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TextIO
+
+from .exceptions import NsysAiError, ProfileError
+from .profile import Profile, resolve_profile_path
+from .profile_runner import build_local_profile_reference
+from .session_cli import publish_session_findings, resolve_session_id, session_dir
+from .session_store import SessionStore
+
+
+class DiagnoseCommandError(NsysAiError):
+    """The diagnose front door could not complete."""
+
+    error_code = "DIAGNOSE_COMMAND_FAILED"
+
+
+def run_diagnose(
+    *,
+    profile_path: str | os.PathLike[str] | None = None,
+    session_id: str | None = None,
+    gpu: int = 0,
+    trim: tuple[int, int] | None = None,
+    web: bool = False,
+    port: int = 8144,
+    open_browser: bool = True,
+    session_root: str | os.PathLike[str] = ".nsys-ai/sessions",
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    """Run the default evidence pack once and publish findings into a session.
+
+    Parameters are explicit (profile path, session id, gpu) so MCP and other
+    callers can reuse this path without fabricating an argparse Namespace.
+
+    Defaults match ``evidence build`` for the parameters this verb forwards
+    (``gpu`` defaults to 0). It does not forward ``--analyzers``, ``--format``,
+    or ``--output``: the default pack always runs, evidence prints to stdout,
+    and findings land in the session.
+
+    ``--web`` with only ``session_id`` opens the persisted session without
+    re-running analysis.
+    """
+    if profile_path is None:
+        if not web or not session_id:
+            raise DiagnoseCommandError(
+                "diagnose requires a profile, or --session <id> --web to reopen"
+            )
+        return _open_existing_session_web(
+            session_id=session_id,
+            port=port,
+            open_browser=open_browser,
+            session_root=session_root,
+            stderr=stderr,
+        )
+
+    if not os.fspath(profile_path):
+        raise DiagnoseCommandError("profile path is required")
+
+    raw = os.path.abspath(os.path.expanduser(os.fspath(profile_path)))
+    try:
+        sqlite_path = resolve_profile_path(raw)
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        raise DiagnoseCommandError(f"could not resolve profile: {exc}") from exc
+
+    from .evidence_builder import EvidenceBuilder
+
+    try:
+        with Profile(sqlite_path) as prof:
+            builder = EvidenceBuilder(prof, device=gpu, trim=trim)
+            # Analysis completes before any session writer lease is taken.
+            report = builder.build()
+            before = build_local_profile_reference(prof.path)
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        raise DiagnoseCommandError(f"diagnose failed: {exc}") from exc
+
+    resolved_id = resolve_session_id(
+        None if session_id == "" else session_id,
+        before=before,
+    )
+    try:
+        publish_session_findings(
+            session_id=resolved_id,
+            report=report,
+            before_profile=before,
+            root=session_root,
+        )
+    except (TypeError, ValueError, ProfileError) as exc:
+        raise DiagnoseCommandError(str(exc)) from exc
+
+    directory = session_dir(resolved_id, root=session_root)
+    print(f"Session: {resolved_id}", file=stdout)
+    print(f"Findings artifact: {directory / 'findings.json'}", file=stdout)
+    print(f"── Evidence Findings ({len(report.findings)}) ──", file=stdout)
+    sev_icons = {"critical": "🔴", "warning": "🟡", "info": "🔵"}
+    for finding in report.findings:
+        icon = sev_icons.get(finding.severity, "⚪")
+        dur_ms = (finding.end_ns - finding.start_ns) / 1e6 if finding.end_ns else 0
+        print(f"  {icon} [{finding.type}] {finding.label}  ({dur_ms:.1f}ms)", file=stdout)
+        if finding.note:
+            print(f"      {finding.note}", file=stdout)
+
+    if report.skipped:
+        print(f"── Limitations / skipped analyses ({len(report.skipped)}) ──", file=stdout)
+        for entry in report.skipped:
+            print(
+                f"  {entry.analyzer} ({entry.skill}) — skipped: {entry.reason}",
+                file=stdout,
+            )
+    else:
+        print("── Limitations / skipped analyses ──", file=stdout)
+        print("  (none)", file=stdout)
+
+    top_id = next((f.id for f in report.findings if f.id), None)
+    if top_id:
+        print(
+            "Next: nsys-ai propose --session "
+            f"{resolved_id} --finding-id {top_id} --runspec <runspec.json>",
+            file=stdout,
+        )
+    else:
+        print(
+            "Next: no actionable finding id to propose from; "
+            f"re-open with nsys-ai diagnose --session {resolved_id} --web",
+            file=stdout,
+        )
+    print(
+        f"Or open the same session: nsys-ai diagnose --session {resolved_id} --web",
+        file=stdout,
+    )
+
+    if web:
+        return _open_session_web(
+            before_path=before.path,
+            session_id=resolved_id,
+            gpu=gpu,
+            trim=trim,
+            port=port,
+            open_browser=open_browser,
+            session_root=session_root,
+            stderr=stderr,
+        )
+    return 0
+
+
+def _open_existing_session_web(
+    *,
+    session_id: str,
+    port: int,
+    open_browser: bool,
+    session_root: str | os.PathLike[str],
+    stderr: TextIO,
+) -> int:
+    store = SessionStore(session_root)
+    try:
+        snapshot = store.load(session_id)
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        raise DiagnoseCommandError(str(exc)) from exc
+    before = snapshot.state.before_profile
+    if before is None:
+        raise DiagnoseCommandError(
+            f"session {session_id} has no before profile to open in --web"
+        )
+    if snapshot.findings is None:
+        print(
+            f"Limitation: session {session_id} has no findings.json yet; "
+            "open will show an empty overlay until diagnose runs with a profile.",
+            file=stderr,
+        )
+    return _open_session_web(
+        before_path=before.path,
+        session_id=session_id,
+        gpu=0,
+        trim=None,
+        port=port,
+        open_browser=open_browser,
+        session_root=session_root,
+        stderr=stderr,
+    )
+
+
+def _open_session_web(
+    *,
+    before_path: str,
+    session_id: str,
+    gpu: int,
+    trim: tuple[int, int] | None,
+    port: int,
+    open_browser: bool,
+    session_root: str | os.PathLike[str],
+    stderr: TextIO,
+) -> int:
+    """Open timeline-web on an already-published session without re-analysis."""
+    from .web import serve_timeline
+
+    try:
+        with Profile(before_path) as prof:
+            devices = list(prof.meta.devices) if prof.meta.devices else [gpu]
+            serve_timeline(
+                prof,
+                devices,
+                trim,
+                port=port,
+                open_browser=open_browser,
+                loop_before=before_path,
+                session=session_id,
+                session_root=session_root,
+            )
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        print(f"Error: could not open session web view: {exc}", file=stderr)
+        return 2
+    return 0

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -1081,3 +1081,48 @@ def diff_profiles(
         step_time_delta_pct=step_time_delta_pct,
         diff_id=diff_id,
     )
+
+
+#: Per-device top-k used by the all-GPU view. The global section already lists
+#: the full top-k, so the per-GPU tables stay short.
+PER_GPU_TOP_K = 3
+
+
+def diff_profiles_all_gpus(
+    before_prof: Profile,
+    after_prof: Profile,
+    *,
+    trim: tuple[int, int] | None = None,
+    limit: int = 15,
+    sort: str = "delta",
+    regression_pct: float = STEP_TIME_REGRESSION_PCT,
+) -> tuple[ProfileDiffSummary, dict[int, ProfileDiffSummary]]:
+    """Compare two profiles across all GPUs: global summary + per-device breakdown.
+
+    This is the ``--gpu`` unset shape of ``nsys-ai diff``. Every caller that
+    renders an all-GPU comparison must go through here so the device set (union
+    of both profiles' devices) and the per-device top-k stay identical.
+    """
+    global_summary = diff_profiles(
+        before_prof,
+        after_prof,
+        gpu=None,
+        trim=trim,
+        limit=limit,
+        sort=sort,
+        regression_pct=regression_pct,
+    )
+    per_gpu_limit = min(limit, PER_GPU_TOP_K)
+    devices = sorted(set(before_prof.meta.devices) | set(after_prof.meta.devices))
+    per_gpu: dict[int, ProfileDiffSummary] = {}
+    for dev in devices:
+        per_gpu[dev] = diff_profiles(
+            before_prof,
+            after_prof,
+            gpu=dev,
+            trim=trim,
+            limit=per_gpu_limit,
+            sort=sort,
+            regression_pct=regression_pct,
+        )
+    return global_summary, per_gpu

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -1,0 +1,302 @@
+"""Headless ``nsys-ai review`` — thin front door over canonical diff + session resume.
+
+Handlers unpack argparse Namespace values and call :func:`run_review`.
+
+``review`` does not create a session. With ``--session`` it resumes an existing
+run and presents the decision path. With ``<before> <after>`` and no session it
+runs the canonical diff, prints the result to stdout and the next command to
+stderr, and leaves ``.nsys-ai/`` untouched. Diff analysis and the all-GPU shape
+stay in :func:`nsys_ai.diff.diff_profiles` /
+:func:`nsys_ai.diff.diff_profiles_all_gpus`; rendering stays in
+:mod:`nsys_ai.diff_render`. ``review <before> <after>`` stdout is byte-identical
+to ``diff <before> <after> --no-ai``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TextIO
+
+from .exceptions import NsysAiError, ProfileError
+from .profile import Profile
+from .profile import open as open_profile
+from .session_cli import project_loop_state, session_dir
+from .session_store import SessionSnapshot, SessionStore
+
+
+class ReviewCommandError(NsysAiError):
+    """The review front door could not complete."""
+
+    error_code = "REVIEW_COMMAND_FAILED"
+
+
+def run_review(
+    *,
+    before_path: str | os.PathLike[str] | None = None,
+    after_path: str | os.PathLike[str] | None = None,
+    session_id: str | None = None,
+    gpu: int | None = None,
+    trim: tuple[int, int] | None = None,
+    web: bool = False,
+    port: int = 8144,
+    open_browser: bool = True,
+    session_root: str | os.PathLike[str] = ".nsys-ai/sessions",
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+) -> int:
+    """Resume a session decision path, or compare a before/after pair without a session.
+
+    Pass either ``before_path`` + ``after_path`` (no session ownership), or
+    ``session_id`` to resume. Pair form ignores and does not invent a session.
+
+    Parameters forwarded from ``diff`` keep the same defaults: ``gpu`` is
+    ``None`` (all GPUs), ``trim`` optional. Not forwarded: ``--against``,
+    ``--iteration``, ``--marker``, ``--format``, ``--output``, ``--limit``,
+    ``--sort``, ``--no-ai``, ``--chat``, gates, or ``--accept``/``--reject``
+    (decision recording stays on the browser / ``publish_decision`` path).
+    Internal diff uses the same limit=15 and sort=delta defaults as ``diff``.
+
+    The pair form prints the terminal report ``diff`` prints, with no LLM call:
+    stdout equals ``diff <before> <after> --no-ai`` byte for byte, including the
+    all-GPU shape (executive summary, per-GPU overview, per-GPU top regressions)
+    when ``gpu`` is ``None``. Next-step hints are written to ``stderr`` so a
+    redirected stdout is exactly that report.
+    """
+    has_pair = before_path is not None or after_path is not None
+    if session_id is not None and not has_pair:
+        return _resume_review(
+            session_id=session_id,
+            web=web,
+            port=port,
+            open_browser=open_browser,
+            session_root=session_root,
+            stdout=stdout,
+            stderr=stderr,
+        )
+    if before_path is None or after_path is None:
+        raise ReviewCommandError(
+            "review requires <before> <after>, or --session <id> to resume"
+        )
+    if session_id is not None:
+        raise ReviewCommandError(
+            "review <before> <after> does not create or bind a session; "
+            "omit --session for a comparison, or pass --session <id> alone "
+            "to resume an existing run"
+        )
+    if web:
+        raise ReviewCommandError(
+            "review --web requires --session <id> so the browser opens the "
+            "same persisted session; pair form is a headless comparison only"
+        )
+
+    return _compare_pair(
+        before_path=before_path,
+        after_path=after_path,
+        gpu=gpu,
+        trim=trim,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _compare_pair(
+    *,
+    before_path: str | os.PathLike[str],
+    after_path: str | os.PathLike[str],
+    gpu: int | None,
+    trim: tuple[int, int] | None,
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int:
+    """Print the canonical diff report for a pair, byte-for-byte as ``diff --no-ai``.
+
+    The profile paths are opened with the caller's spelling (as ``diff`` does)
+    because that spelling is echoed in the report header. Next-step hints go to
+    ``stderr`` so redirected stdout stays exactly the diff report.
+    """
+    from .ai.diff_narrative import offline_diff_narrative
+    from .diff import STEP_TIME_REGRESSION_PCT, diff_profiles, diff_profiles_all_gpus
+    from .diff_render import format_diff_terminal, format_diff_terminal_multi
+
+    try:
+        with (
+            open_profile(os.fspath(before_path)) as before,
+            open_profile(os.fspath(after_path)) as after,
+        ):
+            # Defaults match ``nsys-ai diff`` (limit=15, sort=delta, gpu=None).
+            if gpu is not None:
+                summary = diff_profiles(
+                    before,
+                    after,
+                    gpu=gpu,
+                    trim=trim,
+                    limit=15,
+                    sort="delta",
+                    regression_pct=STEP_TIME_REGRESSION_PCT,
+                )
+                report = format_diff_terminal(
+                    summary, narrative=offline_diff_narrative(summary)
+                )
+            else:
+                global_summary, per_gpu = diff_profiles_all_gpus(
+                    before,
+                    after,
+                    trim=trim,
+                    limit=15,
+                    sort="delta",
+                    regression_pct=STEP_TIME_REGRESSION_PCT,
+                )
+                report = format_diff_terminal_multi(
+                    global_summary,
+                    per_gpu,
+                    narrative=offline_diff_narrative(global_summary),
+                )
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        raise ReviewCommandError(f"review diff failed: {exc}") from exc
+
+    print(report, end="", file=stdout)
+    before_abs = os.path.abspath(os.path.expanduser(os.fspath(before_path)))
+    print(
+        f"Next: nsys-ai diagnose {before_abs}  "
+        "# start a session when you need a recorded decision path",
+        file=stderr,
+    )
+    print(
+        "Or resume an existing run: nsys-ai review --session <id>",
+        file=stderr,
+    )
+    return 0
+
+
+def _resume_review(
+    *,
+    session_id: str,
+    web: bool,
+    port: int,
+    open_browser: bool,
+    session_root: str | os.PathLike[str],
+    stdout: TextIO,
+    stderr: TextIO,
+) -> int:
+    if not session_id:
+        raise ReviewCommandError(
+            "--session without an id requires an existing session id; "
+            "review does not derive or create a session from a profile pair"
+        )
+    store = SessionStore(session_root)
+    try:
+        snapshot = store.load(session_id)
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        raise ReviewCommandError(str(exc)) from exc
+
+    _print_decision_path(session_id, snapshot, session_root, stdout=stdout)
+
+    if web:
+        before = snapshot.state.before_profile
+        after = snapshot.state.after_profile
+        if before is None:
+            raise ReviewCommandError(
+                f"session {session_id} has no before profile to open in --web"
+            )
+        return _open_session_web(
+            before_path=before.path,
+            after_path=after.path if after is not None else None,
+            session_id=session_id,
+            gpu=None,
+            trim=None,
+            port=port,
+            open_browser=open_browser,
+            session_root=session_root,
+            stderr=stderr,
+        )
+    return 0
+
+
+def _print_decision_path(
+    session_id: str,
+    snapshot: SessionSnapshot,
+    session_root: str | os.PathLike[str],
+    *,
+    stdout: TextIO,
+) -> None:
+    directory = session_dir(session_id, root=session_root)
+    projected = project_loop_state(snapshot, session_dir_path=directory)
+    print(f"Session: {session_id}", file=stdout)
+    print(f"Phase: {projected.get('phase')}", file=stdout)
+    if snapshot.diff is not None:
+        print(f"Diff artifact: {directory / 'diff.json'}", file=stdout)
+        verdict = (snapshot.diff or {}).get("verdict", "unknown")
+        print(f"Verdict: {verdict}", file=stdout)
+    else:
+        print(f"Diff artifact: (none yet under {directory})", file=stdout)
+
+    decision = projected.get("decision")
+    if decision:
+        print(
+            f"Decision path: {decision} — recorded at {projected.get('decision_path')}",
+            file=stdout,
+        )
+        reason = projected.get("decision_reason") or ""
+        if reason:
+            print(f"Reason: {reason}", file=stdout)
+    elif snapshot.diff is not None:
+        print(
+            "Decision path: undecided. Record accept/reject in the browser "
+            f"via: nsys-ai review --session {session_id} --web",
+            file=stdout,
+        )
+    else:
+        top_id = None
+        if snapshot.findings is not None:
+            top_id = next((f.id for f in snapshot.findings.findings if f.id), None)
+        if top_id:
+            print(
+                "Decision path: no diff yet. Continue the loop with: "
+                f"nsys-ai propose --session {session_id} --finding-id {top_id} "
+                "--runspec <runspec.json>",
+                file=stdout,
+            )
+        else:
+            print(
+                "Decision path: no diff yet. Finish propose → reprofile → "
+                f"diff --session {session_id} before a decision can be recorded.",
+                file=stdout,
+            )
+
+
+def _open_session_web(
+    *,
+    before_path: str,
+    after_path: str | None,
+    session_id: str,
+    gpu: int | None,
+    trim: tuple[int, int] | None,
+    port: int,
+    open_browser: bool,
+    session_root: str | os.PathLike[str],
+    stderr: TextIO,
+) -> int:
+    from .web import serve_timeline
+
+    try:
+        with Profile(before_path) as prof:
+            if gpu is not None:
+                devices: list[int] = [gpu]
+            else:
+                devices = list(prof.meta.devices) if prof.meta.devices else [0]
+            serve_timeline(
+                prof,
+                devices,
+                trim,
+                port=port,
+                open_browser=open_browser,
+                loop_before=before_path,
+                loop_after=after_path,
+                session=session_id,
+                session_root=session_root,
+            )
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        print(f"Error: could not open session web view: {exc}", file=stderr)
+        return 2
+    return 0

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -792,6 +792,7 @@ def serve_timeline(
     loop_after: str | None = None,
     loop_h100_preset: bool = False,
     session: str | None = None,
+    session_root: str | os.PathLike[str] = ".nsys-ai/sessions",
 ):
     """Start a local HTTP server serving the horizontal timeline viewer.
 
@@ -802,6 +803,9 @@ def serve_timeline(
     If *session* is given (including empty string), open that SessionStore
     session; empty or omitted derives the id from the before profile content id
     (C1). SessionStore is always used — there is no in-memory loop state.
+    *session_root* is the SessionStore root the caller already published into;
+    default is ``.nsys-ai/sessions`` under the process CWD. Callers that used a
+    different root must pass it here so --web opens that same session.
     """
     from collections.abc import Sequence
 
@@ -822,7 +826,7 @@ def serve_timeline(
     _ViewerHandler._tile_nvtx_cache = {}
     _ViewerHandler._findings = findings_data or []
     _ViewerHandler._session_id = None
-    _ViewerHandler._session_root = ".nsys-ai/sessions"
+    _ViewerHandler._session_root = os.fspath(session_root)
     from .loop_state import detect_h100_replay_preset
 
     raw_path = prof.path if hasattr(prof, "path") else ""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -41,6 +41,8 @@ def test_subcommands():
         "agent",
         "agent-guide",
         "propose",
+        "diagnose",
+        "review",
         "info",
         "warm",
         "skill",
@@ -203,6 +205,33 @@ def test_propose_subcommand_help():
     assert "--finding-id" in result.stdout
     assert "--runspec" in result.stdout
     assert "--output" in result.stdout
+
+
+def test_diagnose_subcommand_help():
+    """diagnose should expose session publish and --web reopen flags."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diagnose", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--session" in result.stdout
+    assert "--web" in result.stdout
+
+
+def test_review_subcommand_help():
+    """review should expose before/after, --session resume, and --web."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "review", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--session" in result.stdout
+    assert "--web" in result.stdout
+    assert "before" in result.stdout
+    # gpu must default like diff (all GPUs), not silently to device 0
+    assert "default: all GPUs" in result.stdout
 
 
 def test_loop_missing_profile_has_friendly_error(tmp_path):

--- a/tests/test_diagnose_review.py
+++ b/tests/test_diagnose_review.py
@@ -1,0 +1,302 @@
+"""End-to-end coverage for the diagnose and review front doors."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from nsys_ai import web
+from nsys_ai.diagnose_command import run_diagnose
+from nsys_ai.session_cli import session_dir
+from nsys_ai.session_store import SessionStore
+
+ROOT = Path(__file__).resolve().parents[1]
+BEFORE = ROOT / "tests" / "fixtures" / "mfu_2gpu_before.sqlite"
+AFTER = ROOT / "tests" / "fixtures" / "mfu_2gpu_after.sqlite"
+SINGLE = ROOT / "tests" / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+def _subprocess_environment(**extra: str) -> dict[str, str]:
+    environment = dict(os.environ)
+    source = str(ROOT / "src")
+    current = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = source if not current else f"{source}{os.pathsep}{current}"
+    environment.update(extra)
+    return environment
+
+
+def _run_cli(
+    cwd: Path, *args: str, timeout: float = 180.0, **env: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "nsys_ai", *args],
+        cwd=cwd,
+        env=_subprocess_environment(**env),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def test_diagnose_then_review_pair_both_succeed(tmp_path: Path):
+    """diagnose then review <before> <after> must compose — the previous shape failed here."""
+    if not BEFORE.is_file() or not AFTER.is_file():
+        raise FileNotFoundError(f"missing fixture profiles: {BEFORE} / {AFTER}")
+    before = BEFORE.resolve()
+    after = AFTER.resolve()
+    session_id = "compose-e2e"
+
+    diagnose = _run_cli(
+        tmp_path,
+        "diagnose",
+        str(before),
+        "--gpu",
+        "0",
+        "--session",
+        session_id,
+    )
+    assert diagnose.returncode == 0, diagnose.stderr
+    assert f"Session: {session_id}" in diagnose.stdout
+    assert "Evidence Findings" in diagnose.stdout
+    assert (tmp_path / ".nsys-ai" / "sessions" / session_id / "findings.json").is_file()
+
+    review = _run_cli(tmp_path, "review", str(before), str(after))
+    assert review.returncode == 0, review.stderr
+    assert "Profile Diff" in review.stdout
+    assert "Next:" in review.stderr
+    # Pair form must not invent or mutate a session under .nsys-ai/
+    sessions_root = tmp_path / ".nsys-ai" / "sessions"
+    assert {path.name for path in sessions_root.iterdir()} == {session_id}
+    session_payload = json.loads(
+        (sessions_root / session_id / "session.json").read_text(encoding="utf-8")
+    )
+    assert session_payload["phase"] == "diagnose"
+    assert "mode" not in session_payload
+    assert not (sessions_root / session_id / "diff.json").exists()
+
+
+def test_review_pair_without_session_does_not_create_nsys_ai(tmp_path: Path):
+    if not BEFORE.is_file() or not AFTER.is_file():
+        raise FileNotFoundError(f"missing fixture profiles: {BEFORE} / {AFTER}")
+    before = BEFORE.resolve()
+    after = AFTER.resolve()
+
+    result = _run_cli(tmp_path, "review", str(before), str(after))
+    assert result.returncode == 0, result.stderr
+    assert "Next:" in result.stderr
+    assert not (tmp_path / ".nsys-ai").exists()
+
+
+def test_review_pair_stdout_is_byte_identical_to_diff_no_ai(tmp_path: Path):
+    """review <before> <after> IS the canonical diff, not a smaller rendering of it.
+
+    review's default (--gpu unset) must take the all-GPU shape diff takes:
+    executive summary, per-GPU overview and per-GPU regressions, with the GPU
+    label rendered as "all" rather than leaking the Python None.
+    """
+    if not BEFORE.is_file() or not AFTER.is_file():
+        raise FileNotFoundError(f"missing fixture profiles: {BEFORE} / {AFTER}")
+    before = BEFORE.resolve()
+    after = AFTER.resolve()
+
+    canonical = _run_cli(tmp_path, "diff", str(before), str(after), "--no-ai")
+    review = _run_cli(tmp_path, "review", str(before), str(after))
+    assert canonical.returncode == 0, canonical.stderr
+    assert review.returncode == 0, review.stderr
+
+    # Named sections first, so a regression reports which shape was lost.
+    for section in (
+        "Profile Diff (All GPUs)",
+        "Executive Summary",
+        "Per-GPU Overview",
+        "GPU:    all",
+    ):
+        assert section in review.stdout, f"review dropped section: {section}"
+    assert "GPU:    None" not in review.stdout
+    assert review.stdout == canonical.stdout
+
+    # Hints are an addition on stderr, never a substitution inside the report.
+    assert "Next: nsys-ai diagnose" in review.stderr
+    assert "Next:" not in review.stdout
+
+
+def test_review_gpu_scoped_stdout_is_byte_identical_to_diff_no_ai(tmp_path: Path):
+    """The --gpu path must stay on the same renderer as diff --gpu --no-ai."""
+    if not BEFORE.is_file() or not AFTER.is_file():
+        raise FileNotFoundError(f"missing fixture profiles: {BEFORE} / {AFTER}")
+    before = BEFORE.resolve()
+    after = AFTER.resolve()
+
+    canonical = _run_cli(tmp_path, "diff", str(before), str(after), "--no-ai", "--gpu", "1")
+    review = _run_cli(tmp_path, "review", str(before), str(after), "--gpu", "1")
+    assert canonical.returncode == 0, canonical.stderr
+    assert review.returncode == 0, review.stderr
+    assert "Executive Summary" in review.stdout
+    assert review.stdout == canonical.stdout
+
+
+def test_review_session_resumes_diagnose_session_decision_path(tmp_path: Path):
+    profile = SINGLE if SINGLE.is_file() else BEFORE
+    if not profile.is_file():
+        raise FileNotFoundError(f"missing fixture profile: {profile}")
+    profile = profile.resolve()
+    session_id = "resume-e2e"
+
+    diagnose = _run_cli(
+        tmp_path,
+        "diagnose",
+        str(profile),
+        "--gpu",
+        "0",
+        "--session",
+        session_id,
+    )
+    assert diagnose.returncode == 0, diagnose.stderr
+
+    resume = _run_cli(tmp_path, "review", "--session", session_id)
+    assert resume.returncode == 0, resume.stderr
+    assert f"Session: {session_id}" in resume.stdout
+    assert "Decision path:" in resume.stdout or "Phase:" in resume.stdout
+
+    directory = session_dir(session_id, root=tmp_path / ".nsys-ai" / "sessions")
+    store = SessionStore(tmp_path / ".nsys-ai" / "sessions")
+    snapshot = store.load(session_id)
+    assert snapshot.state.phase == "diagnose"
+    assert snapshot.findings is not None
+    assert snapshot.diff is None
+    assert (directory / "findings.json").is_file()
+
+
+def test_diagnose_publishes_findings_and_survives_a_second_process(tmp_path: Path):
+    profile = SINGLE if SINGLE.is_file() else BEFORE
+    if not profile.is_file():
+        raise FileNotFoundError(f"missing fixture profile: {profile}")
+    profile = profile.resolve()
+    session_id = "diagnose-e2e"
+
+    result = _run_cli(
+        tmp_path,
+        "diagnose",
+        str(profile),
+        "--gpu",
+        "0",
+        "--session",
+        session_id,
+    )
+    assert result.returncode == 0, result.stderr
+    assert f"Session: {session_id}" in result.stdout
+    assert "Limitations / skipped analyses" in result.stdout
+    assert "Next:" in result.stdout
+
+    directory = session_dir(session_id, root=tmp_path / ".nsys-ai" / "sessions")
+    assert (directory / "findings.json").is_file()
+    session_payload = json.loads((directory / "session.json").read_text(encoding="utf-8"))
+    assert "mode" not in session_payload
+
+    script = """
+import json, sys
+from nsys_ai.session_store import SessionStore
+snapshot = SessionStore(sys.argv[1]).load(sys.argv[2])
+print(json.dumps({
+    "phase": snapshot.state.phase,
+    "findings_count": len(snapshot.findings.findings),
+    "skipped_count": len(snapshot.findings.skipped),
+    "before_id": snapshot.state.before_profile.profile_id,
+}))
+"""
+    reloaded = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            script,
+            str(tmp_path / ".nsys-ai" / "sessions"),
+            session_id,
+        ],
+        cwd=tmp_path,
+        env=_subprocess_environment(),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert reloaded.returncode == 0, reloaded.stderr
+    payload = json.loads(reloaded.stdout)
+    assert payload["phase"] == "diagnose"
+    assert payload["findings_count"] >= 1
+    assert payload["before_id"]
+
+
+def test_diagnose_web_serves_the_caller_session_root(tmp_path: Path, monkeypatch):
+    """--web must open the session root diagnose published into, not cwd's default.
+
+    serve_timeline is driven for real; only the blocking serve step is replaced,
+    so the handler state under test is the state a browser would have seen.
+    """
+    profile_source = SINGLE if SINGLE.is_file() else BEFORE
+    if not profile_source.is_file():
+        raise FileNotFoundError(f"missing fixture profile: {profile_source}")
+    # Copy out of tests/fixtures/: serve_timeline writes a timeline cache next
+    # to the profile, which must not land on a committed fixture.
+    profile = tmp_path / "profile.sqlite"
+    shutil.copyfile(profile_source, profile)
+
+    root = tmp_path / "elsewhere" / "sessions"
+    session_id = "web-root-e2e"
+    published = run_diagnose(
+        profile_path=str(profile),
+        session_id=session_id,
+        gpu=0,
+        session_root=root,
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+    assert published == 0
+    assert (root / session_id / "findings.json").is_file()
+
+    captured: dict[str, object] = {}
+
+    def _capture_instead_of_serving(server, open_url, prof):
+        captured["session_root"] = web._ViewerHandler._session_root
+        captured["session_id"] = web._ViewerHandler._session_id
+        captured["findings"] = list(web._ViewerHandler._findings)
+        server.server_close()
+
+    monkeypatch.setattr(web, "_run_server", _capture_instead_of_serving)
+
+    workdir = tmp_path / "cwd"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    opened = run_diagnose(
+        profile_path=None,
+        session_id=session_id,
+        web=True,
+        port=0,
+        open_browser=False,
+        session_root=root,
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+    )
+    assert opened == 0
+    assert captured["session_root"] == os.fspath(root)
+    assert captured["session_id"] == session_id
+    assert captured["findings"], "findings from the custom session root were not loaded"
+    # The default root must never be created as a side effect of honouring a custom one.
+    assert not (workdir / ".nsys-ai").exists()
+    assert not (Path.cwd() / ".nsys-ai").exists()
+
+
+def test_review_gpu_default_matches_diff_all_gpus():
+    """Parser default for review --gpu must be None (all GPUs), like diff."""
+    from nsys_ai.cli.parsers import _build_parser
+
+    parser = _build_parser()
+    review = parser.parse_args(["review", "before.sqlite", "after.sqlite"])
+    diff = parser.parse_args(["diff", "before.sqlite", "after.sqlite"])
+    assert review.gpu is None
+    assert diff.gpu is None


### PR DESCRIPTION
Closes #267.

`review <before> <after>` rendered through `format_diff_terminal`, while `diff` renders through
`format_diff_terminal_multi` whenever `--gpu` is unset — which is `review`'s default. The two front
doors answered differently: 116 lines against 131, the literal Python `None` printed as the GPU label,
and the Executive Summary, Per-GPU Overview and per-GPU regression sections silently absent. The global
numbers matched, so nothing looked wrong; the answer was just smaller.

Both commands now share `diff_profiles_all_gpus` and `offline_diff_narrative`, so they cannot drift
apart again by editing one of them.

The acceptance bar was byte-identity, not inspection:

```
$ nsys-ai diff   before.sqlite after.sqlite --no-ai > d.txt
$ nsys-ai review before.sqlite after.sqlite         > r.txt
$ diff -u d.txt r.txt        # empty, 131 lines each
```

Verified identical for `--gpu 1`, `--gpu 0`, `--trim 0 0.5`, and for relative path spellings from a
different working directory. `review`'s hints go to stderr, so a redirected stdout holds exactly the
report.

Also here: `diagnose` and `review` as thin verbs over the session store, and `serve_timeline` widened to
take the session root so `--web` reopens the session the verb published instead of creating a second one
under the working directory. That handoff is the defect that got the previous attempt rejected and it now
has a test — replacing the parameter with the hardcoded default turns it red.

`review` does not create a session: the pair form is a comparison, and `--session` resumes. The issue text
says "creates or resumes" and should be updated to match.

Every test in the new file was checked by deleting the code it covers and confirming it fails. Full suite
2060 passed, 140 skipped, exit 0; ruff and bandit clean.
