### PR TITLE
fix(tui): run cache builds on a worker so the app stays responsive

### DIFF
--- a/src/nsys_ai/timeline/app.py
+++ b/src/nsys_ai/timeline/app.py
@@ -48,16 +48,20 @@ Layout:
 
 from __future__ import annotations
 
-from textual import on
+from collections.abc import Callable
+
+from textual import on, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.reactive import reactive
 from textual.widgets import Footer, Header, Input
+from textual.worker import get_current_worker
 
 from .. import tui_actions
 from ..formatting import fmt_dur as _fmt_dur
 from ..formatting import fmt_ns as _fmt_ns
 from ..tree.chat import ChatPanel
+from ..tui_cache import CacheBuildProgress, format_cache_progress, post_cache_progress
 from ..tui_models import KernelEvent
 from .canvas import TimelineCanvas
 from .logic import (
@@ -269,57 +273,83 @@ class NsysTimelineApp(App):
             self._nvtx_spans.extend(spans)
         self._nvtx_max_depth = max(self._gpu_nvtx_max_depth.values(), default=0)
 
-    def _load_from_db(self) -> None:
+    def _fetch_gpu_data_from_db(
+        self, progress: Callable[[str, int, int], None]
+    ) -> dict:
+        """Open the profile and collect per-GPU data. Safe to call from a worker thread."""
         from .. import profile as _profile
         from ..nvtx_tree import build_nvtx_tree, to_json
 
-        try:
-            with _profile.open(
-                self._db_path, progress=self._suppress_cache_progress
-            ) as prof:
-                # Auto-detect devices if none specified or single default 0
-                devices = self._devices
-                if not devices or devices == [0]:
-                    if (
-                        hasattr(prof, "meta")
-                        and hasattr(prof.meta, "devices")
-                        and prof.meta.devices
-                    ):
-                        devices = prof.meta.devices
-                        self._devices = devices
-                for dev in devices:
-                    # All kernels from GPU table (not only those under NVTX)
-                    raw_kernels = prof.kernels(dev, self._trim)
-                    kernel_events = [
-                        KernelEvent(
-                            {
-                                "name": k["name"],
-                                "demangled": k.get("demangled", ""),
-                                "start_ns": k["start"],
-                                "end_ns": k["end"],
-                                "duration_ms": (k["end"] - k["start"]) / 1e6,
-                                "stream": str(k["streamId"]),
-                            }
-                        )
-                        for k in raw_kernels
-                    ]
-                    # NVTX spans from tree for overlay rows
-                    roots = build_nvtx_tree(prof, dev, self._trim)
-                    json_roots = to_json(roots)
-                    _, nvtx_spans = extract_events(json_roots)
-                    self._gpu_kernels[dev] = kernel_events
-                    streams = collect_streams(kernel_events)
-                    self._gpu_streams[dev] = streams if streams else ["?"]
-                    self._gpu_stream_kernels[dev] = build_stream_kernels(
-                        kernel_events, self._gpu_streams[dev]
+        gpu_kernels: dict[int, list[KernelEvent]] = {}
+        gpu_streams: dict[int, list[str]] = {}
+        gpu_stream_kernels: dict[int, dict[str, list[KernelEvent]]] = {}
+        gpu_nvtx_spans: dict[int, list] = {}
+        gpu_nvtx_max_depth: dict[int, int] = {}
+        devices = list(self._devices)
+
+        with _profile.open(self._db_path, progress=progress) as prof:
+            # Auto-detect devices if none specified or single default 0
+            if not devices or devices == [0]:
+                if (
+                    hasattr(prof, "meta")
+                    and hasattr(prof.meta, "devices")
+                    and prof.meta.devices
+                ):
+                    devices = list(prof.meta.devices)
+            for dev in devices:
+                # All kernels from GPU table (not only those under NVTX)
+                raw_kernels = prof.kernels(dev, self._trim)
+                kernel_events = [
+                    KernelEvent(
+                        {
+                            "name": k["name"],
+                            "demangled": k.get("demangled", ""),
+                            "start_ns": k["start"],
+                            "end_ns": k["end"],
+                            "duration_ms": (k["end"] - k["start"]) / 1e6,
+                            "stream": str(k["streamId"]),
+                        }
                     )
-                    self._gpu_nvtx_spans[dev] = nvtx_spans
-                    self._gpu_nvtx_max_depth[dev] = (
-                        max((s.depth for s in nvtx_spans), default=-1) + 1
-                    )
-        except Exception as e:
-            self.notify(f"Failed to load profile: {e}", severity="error")
+                    for k in raw_kernels
+                ]
+                # NVTX spans from tree for overlay rows
+                roots = build_nvtx_tree(prof, dev, self._trim)
+                json_roots = to_json(roots)
+                _, nvtx_spans = extract_events(json_roots)
+                gpu_kernels[dev] = kernel_events
+                streams = collect_streams(kernel_events)
+                gpu_streams[dev] = streams if streams else ["?"]
+                gpu_stream_kernels[dev] = build_stream_kernels(
+                    kernel_events, gpu_streams[dev]
+                )
+                gpu_nvtx_spans[dev] = nvtx_spans
+                gpu_nvtx_max_depth[dev] = max((s.depth for s in nvtx_spans), default=-1) + 1
+
+        return {
+            "devices": devices,
+            "gpu_kernels": gpu_kernels,
+            "gpu_streams": gpu_streams,
+            "gpu_stream_kernels": gpu_stream_kernels,
+            "gpu_nvtx_spans": gpu_nvtx_spans,
+            "gpu_nvtx_max_depth": gpu_nvtx_max_depth,
+        }
+
+    def _apply_gpu_data(self, payload: dict, error: str | None) -> None:
+        """Main-thread apply after a DB load."""
+        # See NsysTreeApp._apply_json_roots: covers the shutdown window where the
+        # worker passed its is_cancelled check before quit cleared ``_running``.
+        if not self.is_running:
             return
+        self.sub_title = ""
+        if error is not None:
+            self.notify(f"Failed to load profile: {error}", severity="error")
+            return
+        self._devices = payload["devices"]
+        self._gpu_kernels = payload["gpu_kernels"]
+        self._gpu_streams = payload["gpu_streams"]
+        self._gpu_stream_kernels = payload["gpu_stream_kernels"]
+        self._gpu_nvtx_spans = payload["gpu_nvtx_spans"]
+        self._gpu_nvtx_max_depth = payload["gpu_nvtx_max_depth"]
         self._rebuild_flattened()
         # initial zoom: fit full trace in ~100 columns
         self.ns_per_col = max(1, self._time_span // 100)
@@ -357,7 +387,7 @@ class NsysTimelineApp(App):
     def on_mount(self) -> None:
         self._is_mounted = True
         if not self._kernels and self._db_path:
-            self._load_from_db()
+            self._run_load_worker()
         else:
             self._rebuild_flattened()
             self.ns_per_col = max(1, self._time_span // 100)
@@ -370,14 +400,26 @@ class NsysTimelineApp(App):
         # Focus the canvas so App-level key bindings work.
         self.query_one("#canvas", TimelineCanvas).focus()
 
-    @staticmethod
-    def _suppress_cache_progress(label: str, step: int, total: int) -> None:
-        """Drop cache-build progress so Textual does not paint it on stderr.
+    def on_cache_build_progress(self, event: CacheBuildProgress) -> None:
+        if not self.is_running:
+            return
+        self.sub_title = format_cache_progress(event.label, event.step, event.total)
 
-        Passing any callback silences the ``\\r`` redraw path inside ``build_cache``.
-        This one does nothing else: the build still runs synchronously on the
-        message loop, so the UI cannot update between steps (#332).
-        """
+    @work(thread=True, exclusive=True, group="load")
+    def _run_load_worker(self) -> None:
+        """Build/open the profile off the message loop; apply results on the UI thread."""
+        worker = get_current_worker()
+        try:
+            payload = self._fetch_gpu_data_from_db(
+                lambda label, step, total: post_cache_progress(self, label, step, total)
+            )
+            error: str | None = None
+        except Exception as e:
+            payload = {}
+            error = str(e)
+        if worker.is_cancelled:
+            return
+        self.call_from_thread(self._apply_gpu_data, payload, error)
 
     def _push_canvas_state(self) -> None:
         if not self._is_mounted:

--- a/src/nsys_ai/tree/app.py
+++ b/src/nsys_ai/tree/app.py
@@ -22,13 +22,17 @@ Layout:
 
 from __future__ import annotations
 
-from textual import on
+from collections.abc import Callable
+
+from textual import on, work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.reactive import reactive
 from textual.widgets import DataTable, Footer, Header, Input
+from textual.worker import get_current_worker
 
 from .. import tui_actions
+from ..tui_cache import CacheBuildProgress, format_cache_progress, post_cache_progress
 from ..tui_models import TreeNode
 from .chat import ChatPanel
 from .logic import (
@@ -206,7 +210,7 @@ class NsysTreeApp(App):
     # -------------------------------------------------------------------------
     def on_mount(self) -> None:
         if not self._json_roots and self._db_path:
-            self._load_from_db()
+            self._run_load_worker()
         else:
             self._refresh_table()
         self._update_title()
@@ -215,68 +219,90 @@ class NsysTreeApp(App):
         # focus first and silently swallow key presses.
         self.query_one(DataTable).focus()
 
-    @staticmethod
-    def _suppress_cache_progress(label: str, step: int, total: int) -> None:
-        """Drop cache-build progress so Textual does not paint it on stderr.
+    def on_cache_build_progress(self, event: CacheBuildProgress) -> None:
+        if not self.is_running:
+            return
+        self.sub_title = format_cache_progress(event.label, event.step, event.total)
 
-        Passing any callback silences the ``\\r`` redraw path inside ``build_cache``.
-        This one does nothing else: the build still runs synchronously on the
-        message loop, so the UI cannot update between steps (#332).
-        """
+    @work(thread=True, exclusive=True, group="load")
+    def _run_load_worker(self) -> None:
+        """Build/open the profile off the message loop; apply results on the UI thread."""
+        worker = get_current_worker()
+        try:
+            json_roots = self._fetch_json_roots_from_db(
+                lambda label, step, total: post_cache_progress(self, label, step, total)
+            )
+            error: str | None = None
+        except Exception as e:
+            json_roots = []
+            error = str(e)
+        if worker.is_cancelled:
+            return
+        self.call_from_thread(self._apply_json_roots, json_roots, error)
 
-    def _load_from_db(self) -> None:
+    def _fetch_json_roots_from_db(
+        self, progress: Callable[[str, int, int], None]
+    ) -> list[dict]:
+        """Open the profile and build JSON roots. Safe to call from a worker thread."""
         from .. import profile as _profile
         from ..nvtx_tree import build_nvtx_tree, to_json
 
-        try:
-            with _profile.open(
-                self._db_path, progress=self._suppress_cache_progress
-            ) as prof:
-                roots = build_nvtx_tree(prof, self._device, self._trim)
-                json_roots = to_json(roots)
+        with _profile.open(self._db_path, progress=progress) as prof:
+            roots = build_nvtx_tree(prof, self._device, self._trim)
+            json_roots = to_json(roots)
 
-                # Add kernels not under any NVTX span as "(ungrouped)" root node
-                nvtx_starts = _kernel_starts_in_json(json_roots)
-                raw_kernels = prof.kernels(self._device, self._trim)
-                ungrouped_raw = [k for k in raw_kernels if k["start"] not in nvtx_starts]
-                if ungrouped_raw:
-                    children = []
-                    for k in ungrouped_raw:
-                        dur = (k["end"] - k["start"]) / 1e6
-                        children.append(
-                            {
-                                "name": k["name"],
-                                "type": "kernel",
-                                "duration_ms": round(dur, 3),
-                                "heat": 0.0,
-                                "relative_pct": 100.0,
-                                "start_ns": k["start"],
-                                "end_ns": k["end"],
-                                "stream": str(k["streamId"]),
-                                "demangled": k.get("demangled", ""),
-                            }
-                        )
-                    max_dur = max((c["duration_ms"] for c in children), default=1) or 1
-                    for c in children:
-                        c["heat"] = round(c["duration_ms"] / max_dur, 3)
-                    json_roots.append(
+            # Add kernels not under any NVTX span as "(ungrouped)" root node
+            nvtx_starts = _kernel_starts_in_json(json_roots)
+            raw_kernels = prof.kernels(self._device, self._trim)
+            ungrouped_raw = [k for k in raw_kernels if k["start"] not in nvtx_starts]
+            if ungrouped_raw:
+                children = []
+                for k in ungrouped_raw:
+                    dur = (k["end"] - k["start"]) / 1e6
+                    children.append(
                         {
-                            "name": "(ungrouped)",
-                            "type": "nvtx",
-                            "duration_ms": round(sum(c["duration_ms"] for c in children), 3),
+                            "name": k["name"],
+                            "type": "kernel",
+                            "duration_ms": round(dur, 3),
                             "heat": 0.0,
                             "relative_pct": 100.0,
-                            "start_ns": min(c["start_ns"] for c in children),
-                            "end_ns": max(c["end_ns"] for c in children),
-                            "path": "(ungrouped)",
-                            "children": children,
+                            "start_ns": k["start"],
+                            "end_ns": k["end"],
+                            "stream": str(k["streamId"]),
+                            "demangled": k.get("demangled", ""),
                         }
                     )
+                max_dur = max((c["duration_ms"] for c in children), default=1) or 1
+                for c in children:
+                    c["heat"] = round(c["duration_ms"] / max_dur, 3)
+                json_roots.append(
+                    {
+                        "name": "(ungrouped)",
+                        "type": "nvtx",
+                        "duration_ms": round(sum(c["duration_ms"] for c in children), 3),
+                        "heat": 0.0,
+                        "relative_pct": 100.0,
+                        "start_ns": min(c["start_ns"] for c in children),
+                        "end_ns": max(c["end_ns"] for c in children),
+                        "path": "(ungrouped)",
+                        "children": children,
+                    }
+                )
+            return json_roots
 
-                self._json_roots = json_roots
-        except Exception as e:
-            self.notify(f"Failed to load profile: {e}", severity="error")
+    def _apply_json_roots(self, json_roots: list[dict], error: str | None) -> None:
+        """Main-thread apply after a DB load."""
+        # Quit cancels workers before it clears ``_running``, so the worker's own
+        # ``is_cancelled`` check normally skips this. This covers the window where
+        # the worker passed that check first and ``call_from_thread`` is serviced
+        # while the app is shutting down.
+        if not self.is_running:
             return
+        self.sub_title = ""
+        if error is not None:
+            self.notify(f"Failed to load profile: {error}", severity="error")
+            return
+        self._json_roots = json_roots
         self._all_nodes = build_nodes(self._json_roots)
         self._total_kernels, self._total_gpu_ms, self._total_nvtx = compute_summary(
             self._json_roots
@@ -339,6 +365,13 @@ class NsysTreeApp(App):
         )
 
     def _update_detail_bar(self) -> None:
+        # App shutdown pops the screen and then drains the message queue, so a
+        # RowHighlighted queued just before quit is still dispatched here with
+        # #tree-table already gone. ``is_running`` is False by then; the widget's
+        # own ``is_mounted`` is not — Textual never sets it back to False — so
+        # gate on the app. A #tree-table id regression still raises while running.
+        if not self.is_running:
+            return
         dt = self.query_one("#tree-table", TreeTable)
         row = dt.cursor_row
         node = self._visible[row] if self._visible and 0 <= row < len(self._visible) else None
@@ -389,7 +422,7 @@ class NsysTreeApp(App):
                 if e_ns > s_ns:
                     self._trim = (s_ns, e_ns)
                     if self._db_path:
-                        self._load_from_db()
+                        self._run_load_worker()
                     self._update_title()
                     self.notify(f"Trim → {parts[0]}s – {parts[1]}s", timeout=2)
                 else:
@@ -573,7 +606,7 @@ class NsysTreeApp(App):
     # Actions — reload
     def action_reload(self) -> None:
         if self._db_path:
-            self._load_from_db()
+            self._run_load_worker()
             self.notify("Reloaded", timeout=2)
 
     # Actions — bookmarks
@@ -686,7 +719,7 @@ class NsysTreeApp(App):
             return
         self._trim = (int(start_s * 1e9), int(end_s * 1e9))
         if self._db_path:
-            self._load_from_db()
+            self._run_load_worker()
         self._update_title()
         self.notify(f"AI zoom → {start_s:.2f}s–{end_s:.2f}s", timeout=3)
 

--- a/src/nsys_ai/tui_cache.py
+++ b/src/nsys_ai/tui_cache.py
@@ -1,0 +1,48 @@
+"""Shared cache-build progress for Textual apps.
+
+``build_cache`` accepts a progress callback so Textual callers can silence the
+``\\r`` stderr redraw (Textual's stderr pretends to be a tty). The three apps
+share one Message type and one helper that posts it from a worker thread —
+replacing the three identical no-ops that only silenced stderr while the build
+still ran on the message loop (#332).
+"""
+
+from __future__ import annotations
+
+from textual.app import App
+from textual.message import Message
+from textual.worker import NoActiveWorker, get_current_worker
+
+
+class CacheBuildProgress(Message):
+    """One step of an in-progress parquet cache build."""
+
+    def __init__(self, label: str, step: int, total: int) -> None:
+        super().__init__()
+        self.label = label
+        self.step = step
+        self.total = total
+
+
+def post_cache_progress(app: App, label: str, step: int, total: int) -> None:
+    """Progress callback for ``build_cache``: post ``CacheBuildProgress``.
+
+    Honours worker cancellation — a cancelled thread worker cannot be
+    interrupted, so the callback itself must stop posting (#311 / #332).
+    Also skips when the app has already left ``is_running``, so a progress
+    step that races quit does not enqueue UI work against a torn-down screen.
+    """
+    try:
+        worker = get_current_worker()
+    except NoActiveWorker:
+        worker = None
+    if worker is not None and worker.is_cancelled:
+        return
+    if not app.is_running:
+        return
+    app.post_message(CacheBuildProgress(label, step, total))
+
+
+def format_cache_progress(label: str, step: int, total: int) -> str:
+    """Subtitle text for a cache-build progress step."""
+    return f"Building cache [{step}/{total}] {label}"

--- a/src/nsys_ai/tui_textual.py
+++ b/src/nsys_ai/tui_textual.py
@@ -12,6 +12,10 @@ Threading:
     stream_agent_loop runs in a @work(thread=True) worker.
     UI updates are dispatched via self.call_from_thread().
 
+    Load and stream workers use distinct ``group=`` values. Textual scopes
+    ``exclusive=True`` to a group, so without that a new stream turn would
+    cancel an in-flight cache load (and vice versa).
+
     A thread worker cannot be interrupted: Worker.cancel() only marks it
     cancelled, and all three ways a turn ends go through that same non-stopping
     path — cancel_all() on Ctrl+C, exclusive supersession by a new submit, and
@@ -47,6 +51,7 @@ Threading:
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 
 from textual import work
@@ -57,30 +62,30 @@ from textual.message import Message
 from textual.widgets import DataTable, Footer, Header, Input, Label, RichLog, Static
 from textual.worker import NoActiveWorker, get_current_worker
 
+from .tui_cache import CacheBuildProgress, format_cache_progress, post_cache_progress
+
 # ---------------------------------------------------------------------------
 # Profile helper — load top kernels without importing the full Profile class.
 # ---------------------------------------------------------------------------
 
 
-def _suppress_cache_progress(label: str, step: int, total: int) -> None:
-    """Drop cache-build progress so Textual does not paint it on stderr.
-
-    Passing any callback silences the ``\\r`` redraw path inside ``build_cache``.
-    This one does nothing else: the build still runs synchronously on the
-    message loop, so the UI cannot update between steps (#332).
-    """
-
-
-def _load_top_kernels(sqlite_path: str, limit: int = 30) -> list[dict]:
+def _load_top_kernels(
+    sqlite_path: str,
+    limit: int = 30,
+    *,
+    progress: Callable[[str, int, int], None] | None = None,
+) -> list[dict]:
     """Return top kernels by total GPU duration as a list of dicts.
 
     Each dict has: name, count, total_ms, avg_ms.
     Opens the file via accelerated Profile class; returns [] on any error.
+    ``progress`` is forwarded to the profile open so a Textual caller can
+    route cache-build steps to the UI instead of stderr.
     """
     try:
         from .profile import open as open_profile
 
-        with open_profile(sqlite_path, progress=_suppress_cache_progress) as prof:
+        with open_profile(sqlite_path, progress=progress) as prof:
             aggs = prof.aggregate_kernels(device=None, limit=limit)
             return [
                 {
@@ -242,17 +247,15 @@ class NsysChatApp(App):
     def on_mount(self) -> None:
         self.title = f"nsys-ai chat — {self.profile_name}"
         self._setup_table_columns()
-        self._load_and_populate_kernels()
         log = self.query_one("#chat-log", RichLog)
         log.write(f"[bold cyan]Profile:[/bold cyan] {self.profile_path}")
-        if self._kernels:
-            log.write(
-                f"[bold cyan]{len(self._kernels)} kernels loaded.[/bold cyan] "
-                "Ask anything about this GPU profile."
-            )
-        else:
-            log.write("[yellow]No kernels found. Profile may be empty or incompatible.[/yellow]")
-        log.write("[dim]─────────────────────────────────────────[/dim]")
+        log.write("[dim]Loading profile…[/dim]")
+        self._run_load_worker()
+
+    def on_cache_build_progress(self, event: CacheBuildProgress) -> None:
+        if not self.is_running:
+            return
+        self.sub_title = format_cache_progress(event.label, event.step, event.total)
 
     # ── Setup helpers ─────────────────────────────────────────────────────────
 
@@ -260,19 +263,42 @@ class NsysChatApp(App):
         table = self.query_one("#kernel-table", DataTable)
         table.add_columns("#", "Kernel", "ms (total)", "Calls")
 
-    def _load_and_populate_kernels(self) -> None:
-        """Synchronously load kernels from the profile DB and fill the DataTable."""
+    @work(thread=True, exclusive=True, group="load")
+    def _run_load_worker(self) -> None:
+        """Load kernels off the message loop; post progress and apply on the UI thread."""
+        worker = get_current_worker()
+
+        def progress(label: str, step: int, total: int) -> None:
+            post_cache_progress(self, label, step, total)
+
         try:
             from .profile import resolve_profile_path
 
             sqlite_path = resolve_profile_path(self.profile_path)
-            self._kernels = _load_top_kernels(sqlite_path)
+            kernels = _load_top_kernels(sqlite_path, progress=progress)
+            error: str | None = None
         except Exception as e:
-            self.query_one("#chat-log", RichLog).write(
-                f"[bold red]Error loading profile:[/bold red] {e}"
-            )
+            kernels = []
+            error = str(e)
+
+        if worker.is_cancelled:
+            return
+        self.call_from_thread(self._on_kernels_loaded, kernels, error)
+
+    def _on_kernels_loaded(self, kernels: list[dict], error: str | None) -> None:
+        """Main-thread apply after the load worker finishes."""
+        # See NsysTreeApp._apply_json_roots: covers the shutdown window where the
+        # worker passed its is_cancelled check before quit cleared ``_running``.
+        if not self.is_running:
+            return
+        self.sub_title = ""
+        log = self.query_one("#chat-log", RichLog)
+        if error is not None:
+            log.write(f"[bold red]Error loading profile:[/bold red] {error}")
+            log.write("[dim]─────────────────────────────────────────[/dim]")
             return
 
+        self._kernels = kernels
         table = self.query_one("#kernel-table", DataTable)
         self._kernel_name_to_row = {}
         for i, k in enumerate(self._kernels):
@@ -285,6 +311,15 @@ class NsysChatApp(App):
                 str(k.get("count", 0)),
             )
             self._kernel_name_to_row[name.lower()] = i
+
+        if self._kernels:
+            log.write(
+                f"[bold cyan]{len(self._kernels)} kernels loaded.[/bold cyan] "
+                "Ask anything about this GPU profile."
+            )
+        else:
+            log.write("[yellow]No kernels found. Profile may be empty or incompatible.[/yellow]")
+        log.write("[dim]─────────────────────────────────────────[/dim]")
 
     # ── Input handler ─────────────────────────────────────────────────────────
 
@@ -366,6 +401,12 @@ class NsysChatApp(App):
         self, name: str, total_ms: float, calls: int, avg_ms: float
     ) -> None:
         """Update the selected kernel info bar below the DataTable."""
+        # Same teardown race as NsysTreeApp._update_detail_bar: a RowHighlighted
+        # still bubbling at quit is dispatched after the screen is pruned, with
+        # #kernel-info-bar already gone. Gate on the app — the control's own
+        # is_mounted stays True once mounted and cannot see this.
+        if not self.is_running:
+            return
         bar = self.query_one("#kernel-info-bar", Static)
         bar.update(
             f"▶ [bold]{name}[/bold]  │  [magenta]{total_ms:,.1f}ms total[/magenta]  │  "
@@ -414,7 +455,7 @@ class NsysChatApp(App):
 
     # ── Background worker ─────────────────────────────────────────────────────
 
-    @work(thread=True, exclusive=True)
+    @work(thread=True, exclusive=True, group="stream")
     def _run_stream_worker(self, user_msg: str, gen: int) -> None:
         """Background thread: calls stream_agent_loop, posts UI updates via call_from_thread.
 

--- a/tests/test_tui_cache_responsiveness.py
+++ b/tests/test_tui_cache_responsiveness.py
@@ -1,0 +1,281 @@
+"""Headless tests: Textual apps stay responsive across a cache build (#332).
+
+A callback that only fires is not enough — that passed when the build still
+ran on the message loop. These assert the UI updates *between* progress
+steps while the worker is still parked inside the build.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import threading
+from pathlib import Path
+
+import pytest
+
+from nsys_ai import parquet_cache
+from nsys_ai.tui_cache import format_cache_progress
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+# Tree/timeline treat (0, 0) as the UI "full" sentinel but Profile.kernels
+# applies it as a real window; CLI always passes a concrete --trim range.
+FULL_TRIM = (0, 10**18)
+
+
+@pytest.fixture
+def profile_copy(tmp_path, monkeypatch):
+    """Cold profile copy in an isolated cwd (session store + cache stay local)."""
+    dest = tmp_path / FIXTURE.name
+    shutil.copy(FIXTURE, dest)
+    monkeypatch.chdir(tmp_path)
+    return str(dest)
+
+
+async def _until(pilot, pred, limit: int = 400) -> bool:
+    """Pump the app until *pred* holds. Must use pilot.pause(), not asyncio.sleep."""
+    for _ in range(limit):
+        if pred():
+            return True
+        await pilot.pause()
+    return pred()
+
+
+def _install_gated_build(monkeypatch, app):
+    """Each progress step parks until the test releases it.
+
+    Raises immediately if the build is still on the message-loop thread, so a
+    synchronous ``on_mount`` cannot deadlock the headless driver.
+    """
+    parked: dict[int, threading.Event] = {}
+    gates: dict[int, threading.Event] = {}
+    build_done = threading.Event()
+    real_build = parquet_cache.build_cache
+
+    def gated_build(sqlite_path, *, progress=None, env_escape=True):
+        try:
+            if progress is not None:
+                for step in (1, 2, 3):
+                    progress(f"gate-{step}.parquet", step, 3)
+                    parked.setdefault(step, threading.Event()).set()
+                    if threading.get_ident() == app._thread_id:
+                        raise AssertionError(
+                            "cache build is running on the Textual message loop — "
+                            "progress cannot be processed until it finishes"
+                        )
+                    gate = gates.setdefault(step, threading.Event())
+                    if not gate.wait(timeout=10):
+                        raise TimeoutError(f"test never released cache-build gate {step}")
+            return real_build(sqlite_path, progress=progress, env_escape=env_escape)
+        finally:
+            build_done.set()
+
+    monkeypatch.setattr(parquet_cache, "build_cache", gated_build)
+    return parked, gates, build_done
+
+
+def _release_gates(gates: dict[int, threading.Event], n: int = 8) -> None:
+    for step in range(1, n + 1):
+        gates.setdefault(step, threading.Event()).set()
+
+
+async def _assert_responsive(pilot, app, parked, gates, build_done, loaded_pred):
+    assert await _until(pilot, lambda: parked.get(1) is not None and parked[1].is_set()), (
+        "worker never reached the first gated progress step"
+    )
+    expected = format_cache_progress("gate-1.parquet", 1, 3)
+    assert await _until(pilot, lambda: app.sub_title == expected), (
+        f"UI did not show step-1 progress while the build was parked; "
+        f"sub_title={app.sub_title!r}"
+    )
+    assert not build_done.is_set(), (
+        "build finished before the UI showed progress — still synchronous on the message loop"
+    )
+    _release_gates(gates)
+    assert await _until(pilot, lambda: build_done.is_set())
+    assert await _until(pilot, loaded_pred)
+
+
+@pytest.mark.asyncio
+async def test_chat_stays_responsive_across_cache_build(profile_copy, monkeypatch):
+    from nsys_ai.tui_textual import NsysChatApp
+
+    app = NsysChatApp(profile_copy)
+    parked, gates, build_done = _install_gated_build(monkeypatch, app)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _assert_responsive(
+            pilot, app, parked, gates, build_done, lambda: bool(app._kernels)
+        )
+
+
+@pytest.mark.asyncio
+async def test_tree_stays_responsive_across_cache_build(profile_copy, monkeypatch):
+    from nsys_ai.tree.app import NsysTreeApp
+
+    app = NsysTreeApp(db_path=profile_copy, device=0, trim=FULL_TRIM)
+    parked, gates, build_done = _install_gated_build(monkeypatch, app)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _assert_responsive(
+            pilot, app, parked, gates, build_done, lambda: bool(app._json_roots)
+        )
+
+
+@pytest.mark.asyncio
+async def test_timeline_stays_responsive_across_cache_build(profile_copy, monkeypatch):
+    from nsys_ai.timeline.app import NsysTimelineApp
+
+    app = NsysTimelineApp(db_path=profile_copy, device=0, trim=FULL_TRIM)
+    parked, gates, build_done = _install_gated_build(monkeypatch, app)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _assert_responsive(
+            pilot, app, parked, gates, build_done, lambda: bool(app._kernels)
+        )
+
+
+@pytest.mark.asyncio
+async def test_tree_cache_build_writes_no_cr_to_piped_stderr(profile_copy, tmp_path):
+    from nsys_ai.tree.app import NsysTreeApp
+
+    err_path = tmp_path / "tree-stderr.bin"
+    err_fd = os.open(str(err_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    saved = os.dup(2)
+    try:
+        os.dup2(err_fd, 2)
+        os.close(err_fd)
+        app = NsysTreeApp(db_path=profile_copy, device=0, trim=FULL_TRIM)
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _until(pilot, lambda: bool(app._json_roots))
+    finally:
+        os.dup2(saved, 2)
+        os.close(saved)
+
+    data = err_path.read_bytes()
+    assert b"\r" not in data, (
+        f"carriage returns reached piped stderr during a tree TUI cache build: {data!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_timeline_cache_build_writes_no_cr_to_piped_stderr(profile_copy, tmp_path):
+    from nsys_ai.timeline.app import NsysTimelineApp
+
+    err_path = tmp_path / "timeline-stderr.bin"
+    err_fd = os.open(str(err_path), os.O_WRONLY | os.O_CREAT | os.O_TRUNC)
+    saved = os.dup(2)
+    try:
+        os.dup2(err_fd, 2)
+        os.close(err_fd)
+        app = NsysTimelineApp(db_path=profile_copy, device=0, trim=FULL_TRIM)
+        async with app.run_test(size=(120, 40)) as pilot:
+            assert await _until(pilot, lambda: bool(app._kernels))
+    finally:
+        os.dup2(saved, 2)
+        os.close(saved)
+
+    data = err_path.read_bytes()
+    assert b"\r" not in data, (
+        f"carriage returns reached piped stderr during a timeline TUI cache build: {data!r}"
+    )
+
+
+async def _quit_while_build_parked(pilot, app, parked, gates, build_done):
+    """Quit mid-load; the worker must stop without raising into the driver."""
+    assert await _until(pilot, lambda: parked.get(1) is not None and parked[1].is_set()), (
+        "worker never reached the gated progress step before quit"
+    )
+    assert not build_done.is_set(), "build finished before quit — still on the message loop"
+    app.exit()
+    _release_gates(gates)
+    # Wait on build_done alone. ``app.exit()`` returns immediately but a thread
+    # worker cannot be cancelled, so ``not app.is_running`` would let the test
+    # return while the real DuckDB build is still writing parquet under a
+    # tmp_path pytest is about to delete.
+    assert await _until(pilot, lambda: build_done.is_set())
+
+
+@pytest.mark.asyncio
+async def test_chat_quit_mid_cache_build_does_not_raise(profile_copy, monkeypatch):
+    from nsys_ai.tui_textual import NsysChatApp
+
+    app = NsysChatApp(profile_copy)
+    parked, gates, build_done = _install_gated_build(monkeypatch, app)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _quit_while_build_parked(pilot, app, parked, gates, build_done)
+
+
+@pytest.mark.asyncio
+async def test_tree_quit_mid_cache_build_does_not_raise(profile_copy, monkeypatch):
+    from nsys_ai.tree.app import NsysTreeApp
+
+    app = NsysTreeApp(db_path=profile_copy, device=0, trim=FULL_TRIM)
+    parked, gates, build_done = _install_gated_build(monkeypatch, app)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _quit_while_build_parked(pilot, app, parked, gates, build_done)
+
+
+@pytest.mark.asyncio
+async def test_timeline_quit_mid_cache_build_does_not_raise(profile_copy, monkeypatch):
+    from nsys_ai.timeline.app import NsysTimelineApp
+
+    app = NsysTimelineApp(db_path=profile_copy, device=0, trim=FULL_TRIM)
+    parked, gates, build_done = _install_gated_build(monkeypatch, app)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await _quit_while_build_parked(pilot, app, parked, gates, build_done)
+
+
+@pytest.mark.asyncio
+async def test_tree_row_highlight_after_teardown_does_not_raise(profile_copy):
+    """RowHighlighted dispatched once the app has stopped must not query the DOM.
+
+    Populating the table posts a RowHighlighted that bubbles table → … → screen
+    → app, one queue hop per pump. ``App._shutdown`` clears ``_running`` first,
+    then prunes the screen while the app's loop keeps draining, so a highlight
+    still in flight at quit reaches the handler with ``#tree-table`` gone. This
+    was observed intermittently in the responsiveness tests above; asserting it
+    on a real post-teardown app makes it deterministic.
+
+    ``dt.is_mounted`` below is the reason this is gated on the *app*: Textual
+    sets ``Widget._is_mounted`` True on mount and never back to False, so the
+    control's own flag reads True here and cannot gate anything.
+    """
+    from textual.css.query import NoMatches
+    from textual.widgets import DataTable
+
+    from nsys_ai.tree.app import NsysTreeApp
+    from nsys_ai.tree.widgets import TreeTable
+
+    app = NsysTreeApp(db_path=profile_copy, device=0, trim=FULL_TRIM)
+    async with app.run_test(size=(120, 40)) as pilot:
+        assert await _until(pilot, lambda: bool(app._json_roots))
+        dt = app.query_one("#tree-table", TreeTable).query_one(DataTable)
+
+    # Teardown is done: the app has stopped and the tree is off the DOM.
+    assert not app.is_running
+    assert dt.is_mounted, "Widget.is_mounted never returns to False — it cannot gate teardown"
+    with pytest.raises(NoMatches):
+        app.query_one("#tree-table", TreeTable)
+
+    # The handler must swallow this on the lifecycle check, not on a try/except
+    # around query_one — a live #tree-table id regression still has to raise.
+    app._on_row_highlighted(DataTable.RowHighlighted(dt, row_key=None, cursor_row=0))
+
+
+@pytest.mark.asyncio
+async def test_chat_row_highlight_after_teardown_does_not_raise(profile_copy):
+    """Same teardown race in the chat app's kernel-info bar (seen under CPU load)."""
+    from textual.css.query import NoMatches
+    from textual.widgets import DataTable, Static
+
+    from nsys_ai.tui_textual import NsysChatApp
+
+    app = NsysChatApp(profile_copy)
+    async with app.run_test(size=(120, 40)) as pilot:
+        assert await _until(pilot, lambda: bool(app._kernels))
+        dt = app.query_one(DataTable)
+
+    assert not app.is_running
+    assert dt.is_mounted, "Widget.is_mounted never returns to False — it cannot gate teardown"
+    with pytest.raises(NoMatches):
+        app.query_one("#kernel-info-bar", Static)
+
+    app.on_data_table_row_highlighted(DataTable.RowHighlighted(dt, row_key=None, cursor_row=0))

--- a/tests/test_tui_chat_app.py
+++ b/tests/test_tui_chat_app.py
@@ -392,7 +392,11 @@ async def test_cache_build_inside_textual_writes_no_cr_to_piped_stderr(profile_c
         os.close(err_fd)
         app = NsysChatApp(profile_copy)
         async with app.run_test(size=(120, 40)) as pilot:
-            await pilot.pause()
+            # Wait for the load worker to finish (kernels populated, subtitle cleared).
+            assert await _until(
+                pilot,
+                lambda: bool(app._kernels) and app.sub_title in ("", None),
+            )
     finally:
         os.dup2(saved, 2)
         os.close(saved)


### PR DESCRIPTION
Closes #332.

The cache build ran on the Textual message loop, so the app froze for the whole build and the progress
line could not update. It now runs on a worker, with the apply step marshalled back to the UI thread.

Two things this PR fixes that a previous attempt got wrong, both worth calling out because they are the
reason it took another pass:

**A guard that could never fire.** `_on_row_highlighted` carried `if not event.control.is_mounted: return`,
with a comment crediting it with closing the post-quit race. In textual 8.0.1 `Widget.is_mounted` returns
`_is_mounted`, which is assigned `False` only at `message_pump.py:129` (init) and `True` at
`message_pump.py:603`, `:659` and `app.py:3369` — never back to `False`. It is sticky-True once mounted, so
the check was dead code and the comment stated the inverse of the behaviour. The guard is gone; the
remaining one gates on `is_running`, which Textual does clear on shutdown, and its comment says which race
it covers.

**A test that passed either way.** The regression test for that race passed with the guard removed, with
the other guard removed, and with both removed. It waited on `build_done.is_set() or not table.is_mounted`,
whose second disjunct is permanently False, so it never drove the path it documented.

The replacement fails without its fix. Deleting `if not self.is_running: return` from
`_update_detail_bar` turns it red 3 runs out of 3:

```
textual/dom.py:1503: textual.css.query.NoMatches: No nodes match '#tree-table' on Screen(id='_default')
```

The same check was applied to every other new test: reverting the worker to a synchronous load turns the
responsiveness and quit tests red, and dropping the progress callback turns the piped-stderr test red with
13 real `\r` redraws captured on fd 2. None of them pass without the code they cover.

The quit tests now wait on `build_done` alone. They previously waited on `... or not app.is_running`, which
`app.exit()` satisfies on the first poll, so a test could return while an uncancellable thread worker was
still writing parquet into a `tmp_path` pytest was about to delete.

Full suite 2060 passed, 140 skipped, exit 0; ruff and bandit clean.

One latent shape found but deliberately left alone, filed as #376: `timeline/app.py::_push_canvas_state`
gates on the same sticky-True attribute. It is pre-existing, nobody has made it fire, and fixing it here
would widen a diff that is already large.
