### PR TITLE
feat(cli): add an optimize command that carries one profile to a decision

### DIFF
--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -116,10 +116,47 @@ def _normalize_default_profile_command(argv: list[str]) -> list[str]:
     return argv
 
 
+def _normalize_optimize_command(argv: list[str]) -> list[str]:
+    """Accept ``optimize <profile> [options] -- <command>`` as documented.
+
+    ``optimize`` takes a leading positional and then a workload that must reach
+    the child process verbatim, so the workload is an ``argparse.REMAINDER``.
+    REMAINDER starts at the token after the profile, which means the documented
+    order leaves ``--repo`` and the rest inside the workload. Moving the profile
+    token to sit directly in front of the ``--`` delimiter (or, with no
+    delimiter, to the end followed by an explicit ``--``) produces the
+    options-first spelling argparse parses natively. Nothing after ``--`` is
+    touched, so a workload keeps its own flags and its own ``--``, and both
+    spellings reach the same Namespace.
+
+    Anything else is returned unchanged so argparse still owns the error.
+    """
+    if len(argv) < 3 or argv[1] != "optimize":
+        return argv
+    profile = argv[2]
+    if profile.startswith("-"):
+        return argv  # already options-first, or -h/--help
+    rest = argv[3:]
+    try:
+        delimiter = rest.index("--")
+    except ValueError:
+        # No workload at all. Everything after the profile is an nsys-ai option,
+        # so the profile goes last and an empty workload is made explicit.
+        if rest and rest[-1].startswith("-"):
+            return argv
+        return [argv[0], argv[1], *rest, profile, "--"]
+    if delimiter and rest[delimiter - 1].startswith("-"):
+        # The slot in front of "--" belongs to an option that is still waiting
+        # for its value, so putting the profile there would hand it over.
+        return argv
+    return [argv[0], argv[1], *rest[:delimiter], profile, *rest[delimiter:]]
+
+
 def main():
     from .parsers import _build_legacy_parser, _build_parser
 
     sys.argv = _normalize_default_profile_command(sys.argv)
+    sys.argv = _normalize_optimize_command(sys.argv)
 
     legacy_commands = {
         "analyze",

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -79,6 +79,39 @@ def _cmd_review(args, _profile):
         raise SystemExit(exit_code)
 
 
+def _cmd_optimize(args, _profile):
+    """Front door over the loop: diagnose -> propose -> capture -> diff -> decision."""
+    from nsys_ai.optimize_command import OptimizeCommandError, run_optimize
+
+    workload = list(getattr(args, "workload", None) or [])
+    if not workload:
+        print(
+            "nsys-ai optimize: error: a verification workload is required, "
+            "after '--': nsys-ai optimize <profile> --repo <path> -- <command>",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    try:
+        exit_code = run_optimize(
+            before_path=args.profile,
+            repo=args.repo,
+            workload=workload,
+            session_id=getattr(args, "session", None),
+            nsys=getattr(args, "nsys", "nsys"),
+            gpu=getattr(args, "gpu", 0) or 0,
+            trim=_parse_trim(args),
+        )
+    except KeyboardInterrupt:
+        print("Verification capture cancelled.", file=sys.stderr)
+        raise SystemExit(130) from None
+    except OptimizeCommandError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+    if exit_code:
+        raise SystemExit(exit_code)
+
+
 # ---------------------------------------------------------------------------
 # cutracer subcommand
 # ---------------------------------------------------------------------------

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -36,6 +36,7 @@ from .handlers import (
     _cmd_markdown,
     _cmd_nccl,
     _cmd_open,
+    _cmd_optimize,
     _cmd_overlap,
     _cmd_perfetto,
     _cmd_profile,
@@ -154,6 +155,71 @@ def _register_profile_parser(sub):
         help="Workload command and arguments; wrapper options must precede it",
     )
     p.set_defaults(handler=_cmd_profile)
+    return p
+
+
+def _register_optimize_parser(sub):
+    """Register the ``optimize`` front door on *sub*."""
+    p = sub.add_parser(
+        "optimize",
+        help="Run the whole loop on one profile: diagnose, propose, re-capture, diff, decide",
+        description=(
+            "Take a baseline profile to a recorded verdict without a "
+            "hand-supplied after-profile. optimize runs the default skill pack "
+            "(diagnose), turns the top actionable finding into a deterministic "
+            "proposal, executes that proposal's verification RunSpec with the "
+            "local nsys runner to capture the after-profile, runs the canonical "
+            "all-GPU diff, and records accept/reject with a reason in diff.json. "
+            "It writes no analysis of its own. Every step is published to the "
+            "session first, so re-running the same command resumes from the last "
+            "artifact instead of redoing it. If the proposal abstains -- no "
+            "verification RunSpec, or a finding with no suggested action -- "
+            "optimize stops before re-profiling and names the precondition that "
+            "failed. Exit status: 0 only when a decision was recorded, 1 when a "
+            "step failed, 2 when the loop stopped before a decision, 130 when "
+            "the capture was cancelled."
+        ),
+    )
+    p.add_argument("profile", help="Before profile (.sqlite or .nsys-rep)")
+    p.add_argument(
+        "--repo",
+        required=True,
+        metavar="PATH",
+        help="Directory the verification run executes in, recorded on the RunSpec",
+    )
+    p.add_argument(
+        "--session",
+        default=None,
+        metavar="ID",
+        help=(
+            "Session to create or resume (default: derived from the before "
+            "profile content id, so re-running resumes the same session)"
+        ),
+    )
+    p.add_argument("--nsys", default="nsys", help="Nsight Systems executable")
+    p.add_argument(
+        "--gpu",
+        type=int,
+        default=0,
+        help="GPU device id for diagnose (default: 0, as evidence build); the diff stays all-GPU",
+    )
+    p.add_argument(
+        "--trim",
+        nargs=2,
+        type=float,
+        metavar=("START_S", "END_S"),
+        default=None,
+        help="Time window in seconds, applied to diagnose and to the diff",
+    )
+    p.add_argument(
+        # REMAINDER, not "*", so a workload keeps its own flags and its own
+        # "--" verbatim instead of having them parsed or dropped by nsys-ai.
+        "workload",
+        nargs=argparse.REMAINDER,
+        metavar="COMMAND",
+        help="Verification workload after '--', e.g. -- ./axpy 20",
+    )
+    p.set_defaults(handler=_cmd_optimize)
     return p
 
 
@@ -420,12 +486,13 @@ def _build_parser():
         dest="command",
         metavar=(
             "{open,web,timeline-web,loop,chat,ask,agent,agent-guide,"
-            "profile,propose,diagnose,review,info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
+            "profile,propose,diagnose,review,optimize,info,doctor,warm,skill,evidence,report,diff,diff-web,baseline,export,cutracer,"
             "root-cause,help}"
         ),
     )
 
     _register_profile_parser(sub)
+    _register_optimize_parser(sub)
 
     p = sub.add_parser(
         "propose",

--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -1,0 +1,626 @@
+"""Headless ``nsys-ai optimize`` — one front door over the verified loop.
+
+``optimize`` owns no analysis. It composes the existing contracts in order —
+:func:`nsys_ai.diagnose_command.run_diagnose`,
+:func:`nsys_ai.propose_command.run_propose`,
+:class:`nsys_ai.profile_runner.LocalProfileRunner`,
+:func:`nsys_ai.diff.diff_profiles` and
+:meth:`nsys_ai.session_store.SessionWriter.publish_decision` — and persists
+every step through :class:`~nsys_ai.session_store.SessionStore`, so an
+interrupted run resumes from the last published artifact instead of redoing it.
+
+Two behaviours are load-bearing:
+
+* It stops before re-profiling whenever the loop cannot honestly continue. The
+  common case is an abstaining proposal (no verification RunSpec, or a finding
+  with no suggested action); ``optimize`` reports which precondition failed and
+  never fabricates a proposal or presents a partial run as a completed loop.
+* Only a recorded decision exits 0. Every other outcome exits non-zero so a
+  wrapping script can tell a completed loop from a stopped one.
+
+Exit codes
+----------
+``0``
+    The loop reached a recorded accept/reject decision (this run or an earlier
+    one).
+``1``
+    A step ran and failed: the verification capture, or the diff.
+``2``
+    The loop stopped before a decision because a precondition was not met —
+    an abstaining proposal, a finding with no id, a rejected publication.
+``130``
+    The verification capture was cancelled.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import TextIO
+
+from .annotation import EvidenceReport
+from .diagnose_command import DiagnoseCommandError, run_diagnose
+from .exceptions import NsysAiError, ProfileError
+from .profile_command import (
+    ProfileCommandError,
+    default_output_leaf,
+    detect_supported_trace_domains,
+    discover_git_provenance,
+    normalize_workload,
+    resolve_nsys_executable,
+    select_trace_domains,
+)
+from .profile_reference import LocalProfileReference
+from .profile_runner import (
+    LocalProfileRunner,
+    RunProgress,
+    RunStatus,
+    build_local_profile_reference,
+)
+from .proposal import Proposal
+from .propose_command import ProposeCommandError, run_propose
+from .runspec import EnvironmentSpec, NsysTraceOptions, RunSpec, RunSpecError
+from .session_cli import (
+    project_loop_state,
+    publish_session_diff,
+    resolve_session_id,
+    session_dir,
+)
+from .session_store import SessionNotFoundError, SessionSnapshot, SessionStore
+
+#: Exit code for "the loop stopped before a decision, and said why".
+STOPPED_EXIT_CODE = 2
+#: Exit code for "a step ran and failed".
+FAILED_EXIT_CODE = 1
+#: Exit code for "the verification capture was cancelled".
+CANCELLED_EXIT_CODE = 130
+
+# Measured on merged main against a 3.5 GB capture (issue #28 cost note): the
+# default pack is ~49 s with a warm Parquet cache and ~157 s cold, nearly all of
+# it inside profile_health_manifest. Without this line the first minute of a
+# large profile reads as a hang.
+_DIAGNOSE_COST_NOTE = (
+    "Step 1/5 diagnose: running the default skill pack. On a multi-GB capture "
+    "this is ~50s with a warm cache and ~2-3min cold, before anything else in "
+    "the loop starts."
+)
+
+
+class OptimizeCommandError(NsysAiError):
+    """``optimize`` could not start: its own inputs are unusable."""
+
+    error_code = "OPTIMIZE_COMMAND_FAILED"
+
+
+def _resume_command(
+    *, before_path: str, repo: str, session_id: str, workload: Sequence[str]
+) -> str:
+    """The single command that picks the loop up where it stopped."""
+    return (
+        f"nsys-ai optimize {before_path} --repo {repo} "
+        f"--session {session_id} -- {' '.join(workload)}"
+    )
+
+
+def _select_finding_id(report: EvidenceReport) -> str | None:
+    """Pick the finding to propose from: ranked order, actionable first.
+
+    ``findings`` arrives already ranked by :func:`rank_findings`, so the first
+    entry carrying both an id and a suggested action is the highest-upside
+    finding that can produce a non-abstaining proposal. Falling back to the
+    first identified finding keeps the abstention honest and specific ("no
+    suggested action") rather than turning it into "no finding id".
+    """
+    for finding in report.findings:
+        if finding.id and finding.suggested_actions:
+            return finding.id
+    for finding in report.findings:
+        if finding.id:
+            return finding.id
+    return None
+
+
+def _decision_for_verdict(verdict: str, step_time_delta_pct: float | None) -> tuple[str, str]:
+    """Map a canonical diff verdict onto accept/reject plus a mandatory reason.
+
+    The store accepts only ``accept`` or ``reject``, so a verdict that is not an
+    improvement is recorded as a reject whose reason names the verdict verbatim.
+    A reader must not be able to mistake "not measurably better" for "worse".
+    """
+    normalized = (verdict or "neutral").strip().lower()
+    if step_time_delta_pct is None:
+        measured = "step time was not comparable"
+    else:
+        measured = f"step time moved {step_time_delta_pct:+.2f}%"
+    if normalized == "improvement_likely":
+        return "accept", f"diff verdict {normalized}: {measured}"
+    return "reject", f"diff verdict {normalized}: {measured}"
+
+
+def _step_time_delta_pct(diff: Mapping[str, object]) -> float | None:
+    step_time = diff.get("step_time")
+    if not isinstance(step_time, Mapping):
+        return None
+    value = step_time.get("delta_pct")
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _print_recorded_decision(
+    session_id: str,
+    snapshot: SessionSnapshot,
+    session_root: str | os.PathLike[str],
+    *,
+    stdout: TextIO,
+) -> None:
+    directory = session_dir(session_id, root=session_root)
+    projected = project_loop_state(snapshot, session_dir_path=directory)
+    print(f"Session: {session_id}", file=stdout)
+    print(f"Phase: {snapshot.state.phase}", file=stdout)
+    print(f"Verdict: {projected.get('verdict')}", file=stdout)
+    print(f"Decision: {projected.get('decision')}", file=stdout)
+    reason = projected.get("decision_reason") or ""
+    if reason:
+        print(f"Reason: {reason}", file=stdout)
+    print(f"Diff artifact: {directory / 'diff.json'}", file=stdout)
+
+
+def _print_verification_plan(
+    proposal: Proposal, runspec: RunSpec, *, stdout: TextIO
+) -> None:
+    """Show the proposal and the exact RunSpec before anything is executed."""
+    print("-- Proposal --", file=stdout)
+    print(f"Summary: {proposal.summary}", file=stdout)
+    for action in proposal.suggested_actions:
+        print(f"  action: {action}", file=stdout)
+    if proposal.expected_impact is not None:
+        print(
+            f"Expected impact: {proposal.expected_impact.headroom_ms} ms "
+            f"({proposal.expected_impact.headroom_basis})",
+            file=stdout,
+        )
+    print(f"Confidence: {proposal.confidence}", file=stdout)
+    print("-- Verification RunSpec (about to execute) --", file=stdout)
+    print(
+        json.dumps(runspec.to_dict(), indent=2, sort_keys=True, allow_nan=False),
+        file=stdout,
+    )
+
+
+def _build_runspec(
+    *, repo: Path, workload: Sequence[str], nsys_executable: str, stderr: TextIO
+) -> RunSpec:
+    """Build the verification RunSpec from ``--repo`` and the workload argv."""
+    repository, commit, runspec_cwd = discover_git_provenance(repo)
+    if repository is None:
+        # Not a Git checkout: still bind the run to the directory the user
+        # named, so the recorded RunSpec is reproducible without a commit.
+        repository, runspec_cwd = str(repo), "."
+    supported = detect_supported_trace_domains(nsys_executable)
+    trace = select_trace_domains(
+        "auto", supported, warning=lambda message: print(f"Warning: {message}", file=stderr)
+    )
+    return RunSpec(
+        argv=tuple(workload),
+        cwd=runspec_cwd,
+        repository=repository,
+        commit=commit,
+        environment=EnvironmentSpec(policy="inherit"),
+        trace_options=NsysTraceOptions(trace=trace),
+    )
+
+
+def _resolve_repo(repo: str | os.PathLike[str], working_directory: Path) -> Path:
+    path = Path(repo).expanduser()
+    if not path.is_absolute():
+        path = working_directory / path
+    path = path.resolve()
+    if not path.is_dir():
+        raise OptimizeCommandError(f"--repo is not a directory: {path}")
+    return path
+
+
+def _load_snapshot(store: SessionStore, session_id: str) -> SessionSnapshot | None:
+    try:
+        return store.load(session_id)
+    except SessionNotFoundError:
+        return None
+
+
+def _decision_recorded(snapshot: SessionSnapshot) -> bool:
+    return isinstance(snapshot.diff, Mapping) and isinstance(
+        snapshot.diff.get("decision"), Mapping
+    )
+
+
+def run_optimize(
+    *,
+    before_path: str | os.PathLike[str],
+    repo: str | os.PathLike[str],
+    workload: Sequence[str],
+    session_id: str | None = None,
+    nsys: str = "nsys",
+    gpu: int = 0,
+    trim: tuple[int, int] | None = None,
+    session_root: str | os.PathLike[str] = ".nsys-ai/sessions",
+    cwd: str | os.PathLike[str] | None = None,
+    runner_factory: Callable[[Path, str], LocalProfileRunner] = LocalProfileRunner,
+    stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
+    environment: Mapping[str, str] = os.environ,
+) -> int:
+    """Drive diagnose -> propose -> capture -> diff -> decision over one session.
+
+    Each step is skipped when the session already holds its artifact, so an
+    interrupted run resumes rather than repeats. Returns one of the documented
+    module-level exit codes; only a recorded decision returns ``0``.
+    """
+    working_directory = Path(cwd or Path.cwd()).resolve()
+    repo_path = _resolve_repo(repo, working_directory)
+
+    raw_before = os.path.abspath(os.path.expanduser(os.fspath(before_path)))
+    try:
+        from .profile import resolve_profile_path
+
+        before_sqlite = resolve_profile_path(raw_before)
+        before_ref = build_local_profile_reference(before_sqlite)
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        raise OptimizeCommandError(f"could not resolve before profile: {exc}") from exc
+
+    try:
+        normalized = normalize_workload(workload)
+    except ProfileCommandError as exc:
+        raise OptimizeCommandError(str(exc)) from exc
+
+    resolved_id = resolve_session_id(session_id or None, before=before_ref)
+    resume = _resume_command(
+        before_path=raw_before,
+        repo=str(repo_path),
+        session_id=resolved_id,
+        workload=normalized,
+    )
+    store = SessionStore(session_root)
+
+    def stopped(message: str, *, code: int = STOPPED_EXIT_CODE) -> int:
+        print(f"Stopped: {message}", file=stderr)
+        print(f"Resume: {resume}", file=stderr)
+        return code
+
+    snapshot = _load_snapshot(store, resolved_id)
+    if snapshot is not None:
+        if _decision_recorded(snapshot):
+            print(
+                "Loop already complete; reporting the recorded decision.", file=stdout
+            )
+            _print_recorded_decision(resolved_id, snapshot, session_root, stdout=stdout)
+            return 0
+        recorded_before = snapshot.state.before_profile
+        if recorded_before is not None and recorded_before != before_ref:
+            raise OptimizeCommandError(
+                f"session {resolved_id} was opened on a different before profile "
+                f"({recorded_before.path}); pass --session with a new id"
+            )
+
+    # Step 1 — diagnose.
+    if snapshot is None or snapshot.findings is None:
+        print(_DIAGNOSE_COST_NOTE, file=stderr, flush=True)
+        try:
+            code = run_diagnose(
+                profile_path=before_sqlite,
+                session_id=resolved_id,
+                gpu=gpu,
+                trim=trim,
+                web=False,
+                session_root=session_root,
+                stdout=stdout,
+                stderr=stderr,
+            )
+        except DiagnoseCommandError as exc:
+            return stopped(f"diagnose failed: {exc}")
+        if code:
+            return stopped(f"diagnose exited {code}", code=code)
+        snapshot = _load_snapshot(store, resolved_id)
+    else:
+        print(
+            f"Step 1/5 diagnose: reusing {len(snapshot.findings.findings)} "
+            "findings already published to this session.",
+            file=stderr,
+        )
+
+    if snapshot is None or snapshot.findings is None:
+        return stopped("diagnose published no findings.json")
+
+    # Step 2 — propose, or reuse the proposal this session already carries.
+    if snapshot.proposal is None:
+        finding_id = _select_finding_id(snapshot.findings)
+        if finding_id is None:
+            return stopped(
+                "no finding carries a stable id, so there is nothing to propose "
+                "from; re-run diagnose or open the session with "
+                f"nsys-ai diagnose --session {resolved_id} --web"
+            )
+        try:
+            runspec = _build_runspec(
+                repo=repo_path,
+                workload=normalized,
+                nsys_executable=resolve_nsys_executable(nsys),
+                stderr=stderr,
+            )
+        except (ProfileCommandError, RunSpecError) as exc:
+            return stopped(f"could not build the verification RunSpec: {exc}")
+
+        print(
+            f"Step 2/5 propose: deriving a proposal from finding {finding_id}.",
+            file=stderr,
+            flush=True,
+        )
+        code = _publish_proposal(
+            session_id=resolved_id,
+            finding_id=finding_id,
+            runspec=runspec,
+            session_root=session_root,
+            stdout=stdout,
+            stderr=stderr,
+            environment=environment,
+            resume=resume,
+        )
+        if code:
+            return code
+        snapshot = _load_snapshot(store, resolved_id)
+        if snapshot is None:
+            return stopped("session disappeared while publishing the proposal")
+
+    proposal = snapshot.proposal
+    if proposal is None:
+        return stopped("propose published no proposal.json")
+
+    if proposal.abstained:
+        reason = proposal.abstention_reason or "no reason recorded"
+        print(f"Abstained before re-profiling: {reason}", file=stdout)
+        return stopped(
+            "the proposal abstained, so nothing was re-profiled and no verdict "
+            f"was reached. Precondition that failed: {reason}"
+        )
+
+    runspec = snapshot.runspec
+    if runspec is None:
+        # publish_proposal already rejects this combination; treat a store that
+        # somehow holds one as a stop, never as a licence to invent a RunSpec.
+        return stopped(
+            "the session holds a non-abstaining proposal with no verification "
+            "RunSpec, so there is nothing to execute"
+        )
+
+    # Step 3 — execute the recorded RunSpec, and Step 4 register the capture.
+    if snapshot.state.after_profile is None:
+        _print_verification_plan(proposal, runspec, stdout=stdout)
+        outcome = _capture_after_profile(
+            runspec=runspec,
+            nsys=nsys,
+            working_directory=working_directory,
+            runner_factory=runner_factory,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        if isinstance(outcome, int):
+            if outcome == CANCELLED_EXIT_CODE:
+                print(f"Resume: {resume}", file=stderr)
+                return outcome
+            return stopped("the verification capture did not produce a profile", code=outcome)
+        try:
+            with store.writer(resolved_id) as writer:
+                writer.publish_after_profile(outcome)
+        except (OSError, ProfileError, TypeError, ValueError) as exc:
+            return stopped(f"could not register the after profile: {exc}")
+        snapshot = _load_snapshot(store, resolved_id)
+        if snapshot is None:
+            return stopped("session disappeared while registering the after profile")
+    else:
+        print(
+            "Step 3/5 capture: reusing the after profile already registered "
+            f"({snapshot.state.after_profile.path}).",
+            file=stderr,
+        )
+
+    after_ref = snapshot.state.after_profile
+    if after_ref is None:
+        return stopped("the session has no after profile to diff against")
+
+    # Step 5 — canonical diff, then the decision it implies.
+    if snapshot.diff is None:
+        code = _publish_diff(
+            session_id=resolved_id,
+            before_ref=snapshot.state.before_profile or before_ref,
+            after_ref=after_ref,
+            trim=trim,
+            session_root=session_root,
+            stdout=stdout,
+            stderr=stderr,
+            resume=resume,
+        )
+        if code:
+            return code
+        snapshot = _load_snapshot(store, resolved_id)
+        if snapshot is None:
+            return stopped("session disappeared while publishing the diff")
+    else:
+        print(
+            "Step 4/5 diff: reusing the diff already published "
+            f"(verdict={snapshot.diff.get('verdict', 'unknown')}).",
+            file=stderr,
+        )
+
+    if snapshot.diff is None:
+        return stopped("diff published no diff.json")
+    if _decision_recorded(snapshot):
+        _print_recorded_decision(resolved_id, snapshot, session_root, stdout=stdout)
+        return 0
+
+    verdict = str(snapshot.diff.get("verdict") or "neutral")
+    decision, reason = _decision_for_verdict(verdict, _step_time_delta_pct(snapshot.diff))
+    print(f"Step 5/5 decide: recording {decision} for verdict {verdict}.", file=stderr)
+    try:
+        with store.writer(resolved_id) as writer:
+            _state, _payload, warnings = writer.publish_decision(decision, reason)
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        return stopped(f"could not record the decision: {exc}")
+    for warning in warnings:
+        print(f"Warning: {warning}", file=stderr)
+
+    snapshot = _load_snapshot(store, resolved_id)
+    if snapshot is None or not _decision_recorded(snapshot):
+        return stopped("the decision was not persisted to diff.json")
+    _print_recorded_decision(resolved_id, snapshot, session_root, stdout=stdout)
+    return 0
+
+
+def _publish_proposal(
+    *,
+    session_id: str,
+    finding_id: str,
+    runspec: RunSpec,
+    session_root: str | os.PathLike[str],
+    stdout: TextIO,
+    stderr: TextIO,
+    environment: Mapping[str, str],
+    resume: str,
+) -> int:
+    """Run ``propose`` against the session, handing it the built RunSpec."""
+    handle_path: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", suffix=".json", prefix="nsys-ai-optimize-runspec-", delete=False
+        ) as handle:
+            handle.write(runspec.canonical_json_bytes())
+            handle_path = handle.name
+        try:
+            code = run_propose(
+                finding_id=finding_id,
+                session_id=session_id,
+                runspec_path=handle_path,
+                session_root=session_root,
+                stdout=stdout,
+                environment=environment,
+            )
+        except (ProposeCommandError, RunSpecError, ProfileError, ValueError) as exc:
+            print(f"Stopped: propose failed: {exc}", file=stderr)
+            print(f"Resume: {resume}", file=stderr)
+            return STOPPED_EXIT_CODE
+        if code:
+            print(f"Stopped: propose exited {code}", file=stderr)
+            print(f"Resume: {resume}", file=stderr)
+            return code or STOPPED_EXIT_CODE
+    finally:
+        if handle_path is not None:
+            try:
+                os.unlink(handle_path)
+            except OSError:
+                pass
+    return 0
+
+
+def _capture_after_profile(
+    *,
+    runspec: RunSpec,
+    nsys: str,
+    working_directory: Path,
+    runner_factory: Callable[[Path, str], LocalProfileRunner],
+    stdout: TextIO,
+    stderr: TextIO,
+) -> LocalProfileReference | int:
+    """Execute the recorded RunSpec; return the capture or a failing exit code."""
+    print("Step 3/5 capture: executing the recorded RunSpec.", file=stderr, flush=True)
+    try:
+        nsys_executable = resolve_nsys_executable(nsys)
+    except ProfileCommandError as exc:
+        print(f"Stopped: {exc}", file=stderr)
+        return STOPPED_EXIT_CODE
+
+    def progress(update: RunProgress) -> None:
+        print(f"[{update.stage.value}] {update.elapsed_seconds:.1f}s", file=stderr, flush=True)
+
+    runner = runner_factory(default_output_leaf(working_directory), nsys_executable)
+    try:
+        result = runner.run(runspec, progress_callback=progress)
+    except KeyboardInterrupt:
+        print("Verification capture cancelled.", file=stderr)
+        return CANCELLED_EXIT_CODE
+    except (OSError, ProfileError, RunSpecError) as exc:
+        print(f"Verification capture failed: {exc}", file=stderr)
+        return FAILED_EXIT_CODE
+
+    if result.status is RunStatus.CANCELLED:
+        print("Verification capture cancelled.", file=stderr)
+        return CANCELLED_EXIT_CODE
+    if result.status is not RunStatus.SUCCEEDED or result.profile is None:
+        print(f"Verification capture failed: {result.detail or result.status.value}", file=stderr)
+        for label, path in (("stdout", result.stdout_path), ("stderr", result.stderr_path)):
+            if path:
+                print(f"  {label}: {path}", file=stderr)
+        return FAILED_EXIT_CODE
+
+    print(f"After SQLite: {result.sqlite_path}", file=stdout)
+    return result.profile
+
+
+def _publish_diff(
+    *,
+    session_id: str,
+    before_ref: LocalProfileReference,
+    after_ref: LocalProfileReference,
+    trim: tuple[int, int] | None,
+    session_root: str | os.PathLike[str],
+    stdout: TextIO,
+    stderr: TextIO,
+    resume: str,
+) -> int:
+    """Compute and publish the canonical all-GPU diff for this session."""
+    from .diff import STEP_TIME_REGRESSION_PCT, diff_profiles
+    from .diff_render import format_diff_terminal, to_diff_dict
+    from .profile import Profile
+
+    print("Step 4/5 diff: comparing the before and after captures.", file=stderr, flush=True)
+    try:
+        with Profile(before_ref.path) as before, Profile(after_ref.path) as after:
+            # gpu=None is the global summary diff --session publishes; limit and
+            # sort match the diff defaults so the artifact is the same shape.
+            summary = diff_profiles(
+                before,
+                after,
+                gpu=None,
+                trim=trim,
+                limit=15,
+                sort="delta",
+                regression_pct=STEP_TIME_REGRESSION_PCT,
+            )
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        print(f"Stopped: diff failed: {exc}", file=stderr)
+        print(f"Resume: {resume}", file=stderr)
+        return FAILED_EXIT_CODE
+
+    payload = to_diff_dict(summary)
+    # to_diff_dict carries Profile.path, which keeps the caller's spelling; the
+    # store compares absolute paths against its own references.
+    for side, reference in (("before", before_ref), ("after", after_ref)):
+        entry = payload.get(side)
+        if isinstance(entry, dict):
+            entry["path"] = reference.path
+    try:
+        publish_session_diff(
+            session_id=session_id,
+            diff=payload,
+            after_profile=after_ref,
+            root=session_root,
+        )
+    except (OSError, ProfileError, TypeError, ValueError) as exc:
+        print(f"Stopped: could not publish the diff: {exc}", file=stderr)
+        print(f"Resume: {resume}", file=stderr)
+        return STOPPED_EXIT_CODE
+
+    print(format_diff_terminal(summary), end="", file=stdout)
+    return 0

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -48,15 +48,18 @@ def run_review(
     """Resume a session decision path, or compare a before/after pair without a session.
 
     Pass either ``before_path`` + ``after_path`` (no session ownership), or
-    ``session_id`` to resume. The pair form does not invent a session, and
-    passing a session id alongside a pair is an error rather than ignored.
+    ``session_id`` to resume. The pair form neither invents nor binds a session,
+    and combining it with ``session_id`` is an error, not a silent ignore:
+    ``ReviewCommandError`` is raised and the CLI exits 2.
 
     Parameters forwarded from ``diff`` keep the same defaults: ``gpu`` is
     ``None`` (all GPUs), ``trim`` optional. Not forwarded: ``--against``,
     ``--iteration``, ``--marker``, ``--format``, ``--output``, ``--limit``,
-    ``--sort``, ``--no-ai``, ``--chat``, gates, or ``--accept``/``--reject``
-    (decisions are recorded by ``nsys-ai diff --session --accept/--reject`` or
-    in the browser; this verb presents the decision path rather than owning it).
+    ``--sort``, ``--no-ai``, ``--chat``, gates, or ``--accept``/``--reject``.
+    ``review`` never records a decision itself; it reports the decision path and
+    leaves the writing to ``SessionWriter.publish_decision``, reached from
+    ``nsys-ai diff --session --accept/--reject``, the browser overlay, and
+    ``nsys-ai optimize``.
     Internal diff uses the same limit=15 and sort=delta defaults as ``diff``.
 
     The pair form prints the terminal report ``diff`` prints, with no LLM call:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,7 @@ def test_subcommands():
         "propose",
         "diagnose",
         "review",
+        "optimize",
         "info",
         "warm",
         "skill",
@@ -232,6 +233,115 @@ def test_review_subcommand_help():
     assert "before" in result.stdout
     # gpu must default like diff (all GPUs), not silently to device 0
     assert "default: all GPUs" in result.stdout
+
+
+def test_optimize_subcommand_help():
+    """optimize should document the whole loop, its inputs and its exit codes."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "optimize", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "--repo" in result.stdout
+    assert "--session" in result.stdout
+    assert "profile" in result.stdout
+    # argparse re-wraps the description, so compare against unwrapped text.
+    unwrapped = " ".join(result.stdout.split())
+    # A wrapping script needs to know that only a decision exits 0.
+    assert "0 only when a decision was recorded" in unwrapped
+    # The abstention promise is part of the contract, not an implementation note.
+    assert "stops before re-profiling" in unwrapped
+
+
+def test_optimize_documented_argument_order_parses():
+    """``optimize <profile> --repo R -- <cmd>`` is the spelling the help shows."""
+    from nsys_ai.cli.app import _normalize_optimize_command
+    from nsys_ai.cli.parsers import _build_parser
+
+    documented = [
+        "nsys-ai",
+        "optimize",
+        "before.sqlite",
+        "--repo",
+        "/repo",
+        "--session",
+        "sid",
+        "--",
+        "./axpy",
+        "--launches",
+        "20",
+    ]
+    args = _build_parser().parse_args(_normalize_optimize_command(documented)[1:])
+    assert args.command == "optimize"
+    assert args.profile == "before.sqlite"
+    assert args.repo == "/repo"
+    assert args.session == "sid"
+    # Options belonging to the workload must survive, not be parsed by nsys-ai.
+    assert args.workload == ["./axpy", "--launches", "20"]
+
+    # The options-first spelling argparse handles natively must agree.
+    options_first = [
+        "nsys-ai",
+        "optimize",
+        "--repo",
+        "/repo",
+        "--session",
+        "sid",
+        "before.sqlite",
+        "--",
+        "./axpy",
+        "--launches",
+        "20",
+    ]
+    assert _normalize_optimize_command(options_first) == options_first
+    same = _build_parser().parse_args(options_first[1:])
+    assert (same.profile, same.repo, same.session, same.workload) == (
+        args.profile,
+        args.repo,
+        args.session,
+        args.workload,
+    )
+
+    # A workload may contain its own '--'; nsys-ai must hand it over untouched.
+    nested = ["nsys-ai", "optimize", "b.sqlite", "--repo", "/r", "--", "./a", "--", "-v"]
+    assert _build_parser().parse_args(
+        _normalize_optimize_command(nested)[1:]
+    ).workload == ["./a", "--", "-v"]
+
+
+def test_optimize_does_not_rewrite_an_option_into_the_profile_slot():
+    """Rewriting must never feed the profile to an option waiting for a value."""
+    import pytest
+
+    from nsys_ai.cli.app import _normalize_optimize_command
+    from nsys_ai.cli.parsers import _build_parser
+
+    malformed = ["nsys-ai", "optimize", "b.sqlite", "--repo", "/r", "--session", "--", "./a"]
+    assert _normalize_optimize_command(malformed) == malformed
+    with pytest.raises(SystemExit) as excinfo:
+        _build_parser().parse_args(_normalize_optimize_command(malformed)[1:])
+    assert excinfo.value.code == 2
+
+
+def test_optimize_without_a_workload_exits_2(tmp_path):
+    """No verification workload means no loop; say so instead of profiling."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "optimize",
+            str(tmp_path / "before.sqlite"),
+            "--repo",
+            str(tmp_path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 2
+    assert "a verification workload is required" in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def test_loop_missing_profile_has_friendly_error(tmp_path):

--- a/tests/test_optimize_command.py
+++ b/tests/test_optimize_command.py
@@ -1,0 +1,331 @@
+"""Behaviour of the ``nsys-ai optimize`` front door.
+
+These tests drive the real session store, the real proposal generator and the
+real diff against committed fixture profiles. Only the two things that need a
+GPU are substituted: the nsys capability probe and the local runner. Nothing
+here asserts on analysis numbers — that is covered where the analysis lives.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.annotation import EvidenceReport, Finding, TraceSelection
+from nsys_ai.optimize_command import (
+    OptimizeCommandError,
+    _decision_for_verdict,
+    run_optimize,
+)
+from nsys_ai.profile_runner import (
+    RunResult,
+    RunStatus,
+    RunTimings,
+    build_local_profile_reference,
+)
+from nsys_ai.session_cli import publish_session_findings
+from nsys_ai.session_store import SessionStore
+
+ROOT = Path(__file__).resolve().parents[1]
+BEFORE = ROOT / "tests" / "fixtures" / "mfu_2gpu_before.sqlite"
+AFTER = ROOT / "tests" / "fixtures" / "mfu_2gpu_after.sqlite"
+
+SESSION_ID = "optimize-test"
+
+
+def _session_root(tmp_path: Path) -> Path:
+    return tmp_path / ".nsys-ai" / "sessions"
+
+
+def _timings() -> RunTimings:
+    return RunTimings(
+        started_at_utc="2026-01-01T00:00:00+00:00",
+        capture_seconds=0.0,
+        export_seconds=0.0,
+        validation_seconds=0.0,
+        total_seconds=0.0,
+    )
+
+
+class _StubRunner:
+    """Stands in for LocalProfileRunner: records the spec, returns a result."""
+
+    def __init__(self, result_factory):
+        self._result_factory = result_factory
+        self.specs = []
+
+    def __call__(self, artifact_dir, nsys_executable):
+        self.artifact_dir = artifact_dir
+        self.nsys_executable = nsys_executable
+        return self
+
+    def run(self, spec, progress_callback=None, cancellation=None):
+        self.specs.append(spec)
+        return self._result_factory()
+
+
+def _succeeding_runner(after_reference):
+    return _StubRunner(
+        lambda: RunResult(
+            status=RunStatus.SUCCEEDED,
+            nsys_return_code=0,
+            application_return_code=None,
+            timings=_timings(),
+            runspec_path=None,
+            stdout_path=None,
+            stderr_path=None,
+            report_path=None,
+            sqlite_path=after_reference.path,
+            profile=after_reference,
+        )
+    )
+
+
+def _failing_runner():
+    return _StubRunner(
+        lambda: RunResult(
+            status=RunStatus.APPLICATION_FAILED,
+            nsys_return_code=1,
+            application_return_code=None,
+            timings=_timings(),
+            runspec_path=None,
+            stdout_path=None,
+            stderr_path=None,
+            report_path=None,
+            sqlite_path=None,
+            profile=None,
+            detail="workload exited 1",
+        )
+    )
+
+
+def _exploding_runner():
+    def _boom(artifact_dir, nsys_executable):
+        raise AssertionError("optimize re-profiled after it should have stopped")
+
+    return _boom
+
+
+def _seed_findings(tmp_path: Path, *, actionable: bool = True, with_id: bool = True):
+    """Publish one hand-built finding so the tests control the propose outcome."""
+    reference = build_local_profile_reference(BEFORE)
+    selection = TraceSelection(
+        id="optimize-test-selection",
+        profile_id=reference.profile_id,
+        source="skill:top_kernels",
+        start_ns=0,
+        end_ns=1_000_000,
+    )
+    finding = Finding(
+        type="highlight",
+        label="Hotspot: fixture kernel",
+        start_ns=0,
+        end_ns=1_000_000,
+        severity="warning",
+        id="optimize-test-finding" if with_id else None,
+        selection=selection,
+        explanation="One fixture kernel dominates the selected window.",
+        suggested_actions=["Fuse the kernel with its neighbour"] if actionable else None,
+    )
+    report = EvidenceReport(
+        "optimize fixture",
+        str(reference.path),
+        [finding],
+        profile_id=reference.profile_id,
+    )
+    publish_session_findings(
+        session_id=SESSION_ID,
+        report=report,
+        before_profile=reference,
+        root=_session_root(tmp_path),
+    )
+    return reference
+
+
+@pytest.fixture(autouse=True)
+def _stub_nsys_probe(monkeypatch):
+    """Only the GPU-bound parts are stubbed; the RunSpec is built for real."""
+    monkeypatch.setattr(
+        "nsys_ai.optimize_command.resolve_nsys_executable", lambda selected: "/usr/bin/nsys"
+    )
+    monkeypatch.setattr(
+        "nsys_ai.optimize_command.detect_supported_trace_domains",
+        lambda executable: ("cuda", "nvtx", "nccl"),
+    )
+
+
+def _run(tmp_path, runner_factory, **overrides):
+    stdout, stderr = io.StringIO(), io.StringIO()
+    code = run_optimize(
+        before_path=BEFORE,
+        repo=tmp_path,
+        workload=["./axpy", "20"],
+        session_id=SESSION_ID,
+        trim=None,
+        session_root=_session_root(tmp_path),
+        cwd=tmp_path,
+        runner_factory=runner_factory,
+        stdout=stdout,
+        stderr=stderr,
+        **overrides,
+    )
+    return code, stdout.getvalue(), stderr.getvalue()
+
+
+def _snapshot(tmp_path: Path):
+    return SessionStore(_session_root(tmp_path)).load(SESSION_ID)
+
+
+def test_optimize_reaches_a_recorded_decision_without_a_supplied_after_profile(tmp_path):
+    """The whole loop runs from a baseline profile and ends at a decision."""
+    _seed_findings(tmp_path)
+    after_reference = build_local_profile_reference(AFTER)
+    runner = _succeeding_runner(after_reference)
+
+    code, out, err = _run(tmp_path, runner)
+
+    assert code == 0, err
+    assert len(runner.specs) == 1
+    # The executed RunSpec is the recorded one, not a fresh guess.
+    assert runner.specs[0] == _snapshot(tmp_path).runspec
+    # The plan is visible before the capture, and the verdict after it.
+    assert "-- Verification RunSpec (about to execute) --" in out
+    assert out.index("-- Proposal --") < out.index("Profile Diff")
+
+    snapshot = _snapshot(tmp_path)
+    assert snapshot.state.phase == "accept"
+    assert snapshot.state.after_profile == after_reference
+    decision = snapshot.diff["decision"]
+    assert decision["status"] in {"accepted", "rejected"}
+    assert decision["reason"].startswith("diff verdict ")
+    payload = json.loads(
+        (_session_root(tmp_path) / SESSION_ID / "diff.json").read_text(encoding="utf-8")
+    )
+    assert payload["decision"]["reason"] == decision["reason"]
+
+
+def test_optimize_reports_an_already_decided_session_without_re_profiling(tmp_path):
+    """Re-running a finished loop must report, not re-capture."""
+    _seed_findings(tmp_path)
+    after_reference = build_local_profile_reference(AFTER)
+    first, _out, err = _run(tmp_path, _succeeding_runner(after_reference))
+    assert first == 0, err
+
+    code, out, _err = _run(tmp_path, _exploding_runner())
+
+    assert code == 0
+    assert "Loop already complete" in out
+    assert "Decision: " in out
+
+
+def test_optimize_stops_before_reprofile_when_the_proposal_abstains(tmp_path):
+    """A finding with no suggested action cannot produce a proposal to verify."""
+    _seed_findings(tmp_path, actionable=False)
+
+    code, out, err = _run(tmp_path, _exploding_runner())
+
+    assert code == 2
+    assert "Abstained before re-profiling: source finding has no suggested action" in out
+    assert "nothing was re-profiled and no verdict was reached" in err
+    assert "Resume: nsys-ai optimize " in err
+
+    snapshot = _snapshot(tmp_path)
+    assert snapshot.proposal is not None
+    assert snapshot.proposal.abstained is True
+    assert snapshot.state.after_profile is None
+    assert snapshot.diff is None
+    # Nothing was captured, so no capture artifacts were created either.
+    assert not (tmp_path / ".nsys-ai" / "profiles").exists()
+
+
+def test_optimize_stops_when_no_finding_carries_an_id(tmp_path):
+    """Without a finding id there is no input for a proposal at all."""
+    _seed_findings(tmp_path, with_id=False)
+
+    code, _out, err = _run(tmp_path, _exploding_runner())
+
+    assert code == 2
+    assert "no finding carries a stable id" in err
+    assert _snapshot(tmp_path).proposal is None
+
+
+def test_optimize_resumes_from_the_session_after_a_failed_capture(tmp_path):
+    """A failed capture keeps diagnose and propose; the retry only re-captures."""
+    _seed_findings(tmp_path)
+
+    failed_code, _out, err = _run(tmp_path, _failing_runner())
+    assert failed_code == 1
+    assert "Verification capture failed: workload exited 1" in err
+    interrupted = _snapshot(tmp_path)
+    assert interrupted.proposal is not None
+    assert interrupted.state.after_profile is None
+
+    after_reference = build_local_profile_reference(AFTER)
+    runner = _succeeding_runner(after_reference)
+    code, _out2, err2 = _run(tmp_path, runner)
+
+    assert code == 0, err2
+    assert "Step 1/5 diagnose: reusing 1 findings" in err2
+    assert "Step 2/5 propose" not in err2
+    assert len(runner.specs) == 1
+    assert runner.specs[0] == interrupted.runspec
+    assert _snapshot(tmp_path).state.phase == "accept"
+
+
+def test_optimize_refuses_a_session_opened_on_another_profile(tmp_path):
+    """The session id is the loop's identity; silently rebinding it would lie."""
+    _seed_findings(tmp_path)
+    with pytest.raises(OptimizeCommandError, match="different before profile"):
+        run_optimize(
+            before_path=AFTER,
+            repo=tmp_path,
+            workload=["./axpy"],
+            session_id=SESSION_ID,
+            session_root=_session_root(tmp_path),
+            cwd=tmp_path,
+            runner_factory=_exploding_runner(),
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+
+
+def test_optimize_rejects_a_repo_that_is_not_a_directory(tmp_path):
+    """--repo names the directory the verification run executes in."""
+    missing = tmp_path / "not-a-repo"
+    with pytest.raises(OptimizeCommandError, match="--repo is not a directory"):
+        run_optimize(
+            before_path=BEFORE,
+            repo=missing,
+            workload=["./axpy"],
+            session_id=SESSION_ID,
+            session_root=_session_root(tmp_path),
+            cwd=tmp_path,
+            runner_factory=_exploding_runner(),
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected"),
+    [
+        ("improvement_likely", "accept"),
+        ("regression_likely", "reject"),
+        ("neutral", "reject"),
+        ("inconclusive", "reject"),
+    ],
+)
+def test_decision_reason_names_the_verdict_it_came_from(verdict, expected):
+    """Only a measured improvement is accepted, and the reason says why."""
+    decision, reason = _decision_for_verdict(verdict, -3.5)
+    assert decision == expected
+    assert verdict in reason
+    assert "-3.50%" in reason
+
+
+def test_decision_reason_is_explicit_when_step_time_is_not_comparable():
+    _decision, reason = _decision_for_verdict("inconclusive", None)
+    assert "step time was not comparable" in reason


### PR DESCRIPTION
Closes #28.

One command carries a baseline profile to a recorded decision: diagnose, propose, capture the
verification run from the proposal's own RunSpec, diff, decide. It writes no new analysis — every step
already existed and this composes them.

On a real capture, local RTX 3080:

```console
$ nsys-ai profile -o before -- ./axpy 20
$ nsys-ai optimize before/profile.sqlite --repo . -- ./axpy 40
...
Step 5/5 decide: recording reject for verdict regression_likely.
Phase: accept
Verdict: regression_likely
Decision: reject
Reason: diff verdict regression_likely: step time moved +93.33%
```

2.9s, and the session directory holds findings, proposal, runspec, diff and the decision.

### Stopping honestly is the point

- **Abstention stops the loop before re-profiling.** Driven on real hardware with a finding carrying no
  suggested action: exit 2, `Abstained before re-profiling: source finding has no suggested action`,
  and the runner is never constructed — no capture is attempted.
- **A failed capture exits non-zero and says which step failed**, with the stdout/stderr log paths and
  a `Resume:` line.
- **Resume is backed by the session store, not memory.** Re-running after a failed capture prints
  `Step 1/5 diagnose: reusing 7 findings already published to this session.` and retries only the
  capture. Re-running a finished loop prints `Loop already complete; reporting the recorded decision.`
  and does not capture again.

### Verification

Reviewed by applying eight separate mutations to the shipped source — deleting the abstention guard,
the already-decided short circuit, the argv normaliser, the workload guard, the diagnose-reuse branch,
the `publish_decision` call, four validation guards at once, and the parser registration — and
confirming each turned the covering test red and green again on restore. No test passes without the
code it covers.

Full suite 2076 passed, 140 skipped, exit 0; ruff and bandit clean. `scripts/` is untouched
(`git diff upstream/main -- scripts/` is empty).

One docstring in `review_command.py` is updated where this branch and the decision-recording change met:
`review` still never records a decision itself, and the writers are now `diff --session
--accept/--reject`, the browser overlay, and `optimize`.

Known rough edge, filed rather than fixed here: omitting the `--` separator mis-parses argv and reports
`could not resolve before profile` instead of naming the missing workload. No capture runs and nothing
is corrupted — it is a message-quality issue on a malformed invocation.
