### PR TITLE
fix(cli): name the loop on the front door, and stop three messages that misdirect

### DIFF
--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -60,10 +60,12 @@ def show_help():
     print("    nsys-ai profile -- <command> [args...]       Capture a local profile")
     print()
     print("  Optimization loop (diagnose -> propose -> re-profile -> diff -> decide):")
-    print("    nsys-ai evidence build <profile> --session   Findings, published to a session")
+    print("    nsys-ai optimize <profile> --repo PATH -- <command>   Whole loop, one command")
+    print("    nsys-ai diagnose <profile>               Findings, published to a session")
     print("    nsys-ai propose --session --finding-id ID --runspec runspec.json")
     print("    nsys-ai diff <before> <after>            Compare two profiles")
-    print("    nsys-ai diff <before> <after> --accept --reason TEXT   Record the outcome")
+    print("    nsys-ai diff <before> <after> --session --accept --reason TEXT   Record it")
+    print("    nsys-ai review --session ID              Where a session stands")
     print("    nsys-ai loop <before> --after <after>    Same loop, guided in the browser")
     print("    nsys-ai baseline list                    Named baselines to diff against")
     print("    See docs/user-guide.md for the whole path end to end.")
@@ -71,7 +73,7 @@ def show_help():
     print("  Skills & Agent:")
     print("    nsys-ai skill list                       List analysis skills")
     print("    nsys-ai skill run <name> <profile>       Run a specific skill")
-    print("    nsys-ai report  <profile>                Generate a performance report")
+    print("    nsys-ai report  <profile> --gpu N --trim S E   Performance report")
     print("    nsys-ai agent analyze <profile>           Full auto-analysis")
     print('    nsys-ai agent ask <profile> "question"   Ask about a profile')
     print("    nsys-ai agent-guide                      Print agent System Prompt")
@@ -82,10 +84,11 @@ def show_help():
     print("    nsys-ai root-cause submit <file.md>      Submit a new pattern")
     print()
     print("  Export:")
-    print("    nsys-ai export     <profile> -o DIR       Perfetto JSON traces")
-    print("    nsys-ai export-csv <profile> --gpu N       CSV export")
-    print("    nsys-ai viewer     <profile> --gpu N       HTML report")
-    print("    nsys-ai web        <profile> --gpu N       Browser UI")
+    print("    nsys-ai export     <profile> --trim S E -o DIR   Perfetto JSON traces")
+    print("    nsys-ai export-csv <profile> --gpu N --trim S E   CSV export")
+    print("    nsys-ai viewer     <profile> --gpu N --trim S E   HTML report")
+    print("    nsys-ai web        <profile> --gpu N --trim S E   Browser UI")
+    print("    (--trim takes seconds; `nsys-ai info <profile>` prints the window)")
     print()
     print("  Getting Started:")
     print("    1. Profile:  nsys-ai profile -- python train.py")
@@ -144,6 +147,14 @@ def _normalize_optimize_command(argv: list[str]) -> list[str]:
         # so the profile goes last and an empty workload is made explicit.
         if rest and rest[-1].startswith("-"):
             return argv
+        # ...unless the tail is plainly a workload that lost its "--". Two bare
+        # tokens in a row cannot both be option values, so rearranging here would
+        # slide a workload token onto the profile positional and the failure would
+        # surface as "could not resolve before profile", naming a file the caller
+        # never offered as one. Leave it alone; the handler reports the real cause.
+        for earlier, later in zip(rest, rest[1:]):
+            if not earlier.startswith("-") and not later.startswith("-"):
+                return argv
         return [argv[0], argv[1], *rest, profile, "--"]
     if delimiter and rest[delimiter - 1].startswith("-"):
         # The slot in front of "--" belongs to an option that is still waiting

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -92,6 +92,17 @@ def _cmd_optimize(args, _profile):
         )
         raise SystemExit(2)
 
+    # An option leading the workload means the '--' was omitted and argparse swept
+    # this command's own options into the REMAINDER. No executable is named by a
+    # flag, so this cannot be a real workload.
+    if workload[0].startswith("-"):
+        print(
+            "nsys-ai optimize: error: the workload must follow '--': "
+            "nsys-ai optimize <profile> --repo <path> -- <command> [args...]",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
     try:
         exit_code = run_optimize(
             before_path=args.profile,

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -841,7 +841,11 @@ def _build_parser():
         default="delta",
         help="Sort mode for top changes (default: delta)",
     )
-    p.add_argument("--no-ai", action="store_true", help="No-op v1 flag (reserved for AI narrative)")
+    p.add_argument(
+        "--no-ai",
+        action="store_true",
+        help="Skip the LLM narrative; report the deterministic summary only",
+    )
     p.add_argument(
         "--chat",
         action="store_true",

--- a/src/nsys_ai/timeline/app.py
+++ b/src/nsys_ai/timeline/app.py
@@ -203,7 +203,7 @@ class NsysTimelineApp(App):
         self._time_start = 0
         self._time_end = 0
         self._time_span = 1
-        self._is_mounted = False
+        self._dom_ready = False
 
         # Bookmarks and navigation state
         self._bookmarks: list[dict] = []
@@ -354,7 +354,7 @@ class NsysTimelineApp(App):
         # initial zoom: fit full trace in ~100 columns
         self.ns_per_col = max(1, self._time_span // 100)
         self.cursor_ns = self._time_start
-        if self._is_mounted:
+        if self._dom_ready:
             self.query_one("#bottom-panel", BottomPanel).set_nvtx_spans(
                 getattr(self, "_nvtx_spans", [])
             )
@@ -385,7 +385,7 @@ class NsysTimelineApp(App):
     # Mount
     # -------------------------------------------------------------------------
     def on_mount(self) -> None:
-        self._is_mounted = True
+        self._dom_ready = True
         if not self._kernels and self._db_path:
             self._run_load_worker()
         else:
@@ -422,8 +422,13 @@ class NsysTimelineApp(App):
         self.call_from_thread(self._apply_gpu_data, payload, error)
 
     def _push_canvas_state(self) -> None:
-        if not self._is_mounted:
-            return  # DOM not ready yet — called from __init__ via reactive setter
+        # Two different "not now"s. ``_dom_ready`` is startup: reactive setters run
+        # from __init__ before compose(). ``is_running`` is teardown: quit clears it
+        # and then prunes the screen, so a watcher firing in between would query a
+        # widget that is gone. Textual never sets a widget's own ``is_mounted`` back
+        # to False, so it cannot stand in for the second one.
+        if not self._dom_ready or not self.is_running:
+            return
         canvas = self.query_one("#canvas", TimelineCanvas)
         viewport_start = center_viewport(
             self.cursor_ns, self.ns_per_col, max(canvas.size.width - canvas.label_w, 1)
@@ -498,7 +503,7 @@ class NsysTimelineApp(App):
 
     def watch_selected_stream_idx(self) -> None:
         self._push_canvas_state()
-        if self._is_mounted:
+        if self._dom_ready:
             self._update_title()
 
     def watch_ns_per_col(self) -> None:
@@ -506,12 +511,12 @@ class NsysTimelineApp(App):
 
     def watch_filter_text(self) -> None:
         self._push_canvas_state()
-        if self._is_mounted:
+        if self._dom_ready:
             self._update_title()
 
     def watch_min_dur_us(self) -> None:
         self._push_canvas_state()
-        if self._is_mounted:
+        if self._dom_ready:
             self._update_title()
 
     # -------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -922,3 +922,189 @@ def test_warm_succeeds_when_there_is_nothing_for_the_sweep_to_read(tmp_path):
     assert "nothing for the sweep to read" in result.stdout
     assert "runtime.parquet" in result.stdout
     assert (tmp_path / "min.nsys-cache").is_dir()
+
+
+def _help_screen() -> str:
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "help"], capture_output=True, text=True
+    )
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+def _declared_subcommands() -> set[str]:
+    """Every command `main()` can dispatch, across both parsers.
+
+    `main()` picks `_build_legacy_parser` by name for the legacy commands
+    (summary, tui, viewer, export-csv, ...) and `_build_parser` otherwise, so
+    neither one alone is the full surface.
+    """
+    from nsys_ai.cli.parsers import _build_legacy_parser, _build_parser
+
+    names: set[str] = set()
+    for parser in (_build_parser(), _build_legacy_parser()):
+        for action in parser._subparsers._group_actions:  # noqa: SLF001 - argparse has no public API
+            names.update(action.choices)
+    return names
+
+
+def test_getting_started_screen_names_the_loop_verbs():
+    """`nsys-ai help` is the front door; the loop is the headline feature.
+
+    It previously named none of `loop`, `diff`, `doctor`, `baseline`, so the whole
+    diagnose -> propose -> re-profile -> diff -> decide path was undiscoverable
+    from the tool's own introduction.
+    """
+    screen = _help_screen()
+    for verb in ("optimize", "diagnose", "propose", "diff", "review", "loop", "doctor", "baseline"):
+        assert f"nsys-ai {verb}" in screen, f"help screen does not name `{verb}`"
+
+
+def test_getting_started_screen_only_advertises_commands_that_exist():
+    """Every `nsys-ai <verb>` the screen shows must be a real subcommand.
+
+    A getting-started screen that names a command the parser rejects is worse than
+    one that omits it: the reader runs it and gets `invalid choice`.
+    """
+    import re
+
+    declared = _declared_subcommands()
+    advertised = {
+        m.group(1)
+        for m in re.finditer(r"nsys-ai ([a-z][a-z0-9-]*)", _help_screen())
+        if m.group(1) not in {"help"}
+    }
+    missing = sorted(advertised - declared)
+    assert not missing, f"help screen advertises non-existent subcommands: {missing}"
+
+
+def test_optimize_without_the_delimiter_does_not_blame_the_workload():
+    """Omitting '--' must not report the workload as an unreadable profile.
+
+    The argv normaliser used to slide the profile token past a workload that had
+    lost its '--', so `optimize before.sqlite --repo /tmp ./axpy 40` failed with
+    "could not resolve before profile: .../axpy" -- naming a file the caller never
+    offered as a profile.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "optimize", "before.sqlite",
+         "--repo", "/tmp", "./axpy", "40"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "could not resolve before profile" not in combined, combined
+    assert "axpy" not in combined, combined
+
+
+def test_optimize_reports_a_flag_led_workload_as_a_missing_delimiter():
+    """No executable is named by a flag, so this can only be a dropped '--'."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "optimize", "--repo", "/tmp",
+         "before.sqlite", "--verbose", "40"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 2
+    assert "the workload must follow '--'" in result.stdout + result.stderr
+
+
+def test_optimize_argv_normaliser_leaves_a_delimiterless_workload_alone():
+    from nsys_ai.cli.app import _normalize_optimize_command
+
+    # Two bare tokens in a row cannot both be option values -> a lost '--'.
+    argv = ["x", "optimize", "b.sqlite", "--repo", "/r", "./axpy", "40"]
+    assert _normalize_optimize_command(argv) == argv
+
+    # The documented spellings still normalise to the options-first form.
+    assert _normalize_optimize_command(
+        ["x", "optimize", "b.sqlite", "--repo", "/r", "--", "./axpy", "40"]
+    ) == ["x", "optimize", "--repo", "/r", "b.sqlite", "--", "./axpy", "40"]
+    assert _normalize_optimize_command(["x", "optimize", "b.sqlite", "--repo", "/r"]) == [
+        "x", "optimize", "--repo", "/r", "b.sqlite", "--",
+    ]
+
+
+def test_no_ai_help_does_not_call_itself_a_no_op():
+    """--no-ai selects the deterministic narrative; it is not decorative."""
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", "--help"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    assert "No-op" not in result.stdout
+
+
+def _advertised_invocations() -> list[tuple[str, list[str]]]:
+    """Turn each `nsys-ai <verb> ...` line on the help screen into a real argv.
+
+    The screen is column-aligned, so the description cannot be found by splitting
+    on runs of spaces. Instead the command ends at the first token that reads as
+    prose: capitalised and not the value of a preceding flag.
+    """
+    import shlex
+
+    values = {
+        "<profile>": "p.sqlite", "<profile.sqlite>": "p.sqlite",
+        "<before>": "b.sqlite", "<after>": "a.sqlite", "<command>": "true",
+        "<name>": "top_kernels", "<file.md>": "f.md", "<id>": "x",
+        "DIR": "out", "TEXT": "why", "ID": "x", "PATH": "p", "N": "0",
+        "S": "0", "E": "1", "runspec.json": "r.json", "findings.json": "f.json",
+    }
+    out: list[tuple[str, list[str]]] = []
+    for line in _help_screen().splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("nsys-ai "):
+            continue
+        tokens = shlex.split(stripped)[1:]  # drop "nsys-ai"
+        if not tokens or tokens[0].startswith(("<", "(")):
+            continue  # the bare-profile shortcut, or a prose line
+        argv: list[str] = []
+        shown = ["nsys-ai"]
+        for token in tokens:
+            if token.startswith("["):
+                break  # optional group; everything after is optional or prose
+            # Every flag value on this screen is a placeholder (N, S, E, DIR,
+            # TEXT, ID, PATH), so a capitalised token that is not one is where
+            # the right-hand description begins.
+            if token[:1].isupper() and token not in values and not token.startswith("-"):
+                break
+            shown.append(token)
+            argv.append(values.get(token, token))
+        if argv:
+            out.append((" ".join(shown), argv))
+    return out
+
+
+def test_every_advertised_invocation_parses():
+    """The screen must show forms that run, not forms that error on required flags.
+
+    `nsys-ai viewer <profile> --gpu N` was advertised for five commands that also
+    require --trim, so a newcomer typing what the front door showed got
+    "error: the following arguments are required: --trim" five times in a row.
+    """
+    import contextlib
+    import io
+
+    from nsys_ai.cli.parsers import _build_legacy_parser, _build_parser
+
+    failures = []
+    for shown, argv in _advertised_invocations():
+        if not argv:
+            continue
+        if argv[0] == "optimize":
+            from nsys_ai.cli.app import _normalize_optimize_command
+
+            argv = _normalize_optimize_command(["nsys-ai", *argv])[1:]
+        legacy = argv[0] in {
+            "summary", "tui", "timeline", "viewer", "export-csv", "analyze",
+            "overlap", "nccl", "iters", "tree", "markdown", "search",
+            "export-json", "timeline-html", "perfetto",
+        }
+        parser = _build_legacy_parser() if legacy else _build_parser()
+        stderr = io.StringIO()
+        try:
+            with contextlib.redirect_stderr(stderr):
+                parser.parse_args(argv)
+        except SystemExit:
+            message = stderr.getvalue().strip().splitlines()
+            failures.append(f"{shown!r} -> {message[-1] if message else 'SystemExit'}")
+    assert not failures, "help screen shows invocations that do not parse:\n  " + "\n  ".join(failures)


### PR DESCRIPTION
Closes #376.

Four defects found by using the tool as a new user would, all in messages the reader is meant to trust.

### The front door advertised five commands in forms that fail

Found by an end-to-end pass as a first-time user: read the screen, type what it says.

```console
$ nsys-ai viewer p.sqlite --gpu 0        # exactly as advertised
nsys-ai viewer: error: the following arguments are required: --trim
```

The same for `export`, `export-csv`, `web` and `report` — five errors in a row, following the
tool's own instructions. The shown forms now carry every required flag.

A test now parses each advertised invocation against the parser, so a form that cannot run cannot be
advertised. It immediately caught the `optimize` line added in this same commit omitting `--repo`.

### The front door did not name the loop

`nsys-ai help` is where `nsys-ai` with no arguments sends you, and it named none of `optimize`,
`diagnose`, `review`, `loop`, `diff`, `doctor` or `baseline` — the whole headline workflow was
undiscoverable from the tool's own introduction. It now lists the loop as a sequence.

Two tests guard it: one fails if a loop verb goes missing, the other fails if the screen advertises a
command the parser will reject. The second one caught something worth recording — it first flagged
`summary`, `tui`, `viewer`, `export-csv` and `timeline` as non-existent, but all five work. This
codebase has **two** parsers, and `main()` chooses between `_build_parser` and `_build_legacy_parser`
by command name, so neither alone is the command surface. That is now written down in the helper.

### Dropping `--` blamed the wrong file

```console
$ nsys-ai optimize before.sqlite --repo /tmp ./axpy 40
Error: could not resolve before profile: profile not found: .../axpy
```

`./axpy` was never offered as a profile. The argv normaliser rearranges `optimize <profile> [options]
-- <workload>` into the options-first spelling argparse parses natively, and its no-delimiter branch
did that rearranging even when the tail was plainly a workload, sliding a workload token onto the
profile positional.

It now leaves argv alone when two bare tokens appear in a row — they cannot both be option values — so
the failure is argparse's own accurate `required: --repo`. And a workload whose first token is a flag
is reported as the dropped delimiter it is, since no executable is named by a flag.

### `--no-ai` called itself a no-op

Its help read "No-op v1 flag (reserved for AI narrative)" while the flag actually selects
`offline_diff_narrative` over the LLM path. A reader would conclude `diff` is already LLM-free.

### The timeline app overwrote a Textual attribute

`TimelineApp` kept its DOM-ready flag in `self._is_mounted`, which is `MessagePump`'s own private
attribute. It happened to work because the values coincide, but it is a framework internal borrowed for
a different question. Renamed to `_dom_ready`, and `_push_canvas_state` gained the `is_running` check it
was missing: startup ("compose has not run") and teardown ("the screen is being pruned") are different
questions, and a widget's `is_mounted` never returns to `False`, so it cannot answer the second. Its
watchers could otherwise reach `query_one("#canvas")` on a pruned screen.

### Verification

Full suite 2098 passed, 140 skipped, exit 0; ruff and bandit clean. Each new test was checked by
reverting the source it covers and confirming it goes red.
