### PR TITLE
perf(web): compress served responses, cutting a cold timeline load 8x

### DIFF
--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -10,6 +10,7 @@ Usage:
     nsys-ai perfetto profile.sqlite --gpu 0 --trim 39 42
 """
 
+import gzip
 import json
 import logging
 import os
@@ -49,6 +50,53 @@ def _template_asset_version() -> str:
 
 def _versioned_asset_url(path: str) -> str:
     return f"{path}?v={_template_asset_version()}"
+
+
+#: Below this, the gzip header costs more than the compression saves.
+_MIN_COMPRESS_BYTES = 1024
+
+#: Level 1, not the default 9. Measured on a 932 KB kernel window: level 1 gives
+#: 11.2% of the original in 2.9 ms, level 6 gives 7.9% in 6.3 ms, level 9 gives
+#: 7.2% in 27.2 ms. The whole request currently takes ~7 ms, and the common case
+#: is a browser on the same machine, so the 30 KB that level 6 saves does not pay
+#: for the CPU it costs. Compression runs on the request thread.
+_COMPRESS_LEVEL = 1
+
+
+def _send_body(
+    handler,
+    body: bytes,
+    content_type: str,
+    status: int = 200,
+    extra_headers: dict[str, str] | None = None,
+) -> None:
+    """Write a response body, compressed when the client said it can read it.
+
+    Timeline payloads are highly repetitive JSON — a window of kernels compresses
+    to roughly 7% of its size — and the server prints an SSH port-forward hint on
+    startup, so it is expected to be read over a link where those bytes are the
+    whole cost. Compression is negotiated, never assumed: a client that does not
+    advertise gzip gets the plain body.
+    """
+    encoding = None
+    accepted = handler.headers.get("Accept-Encoding", "") if handler.headers else ""
+    if len(body) >= _MIN_COMPRESS_BYTES and "gzip" in accepted.lower():
+        compressed = gzip.compress(body, compresslevel=_COMPRESS_LEVEL)
+        # Refuse a "compression" that made it bigger (already-compressed content).
+        if len(compressed) < len(body):
+            body = compressed
+            encoding = "gzip"
+    handler.send_response(status)
+    handler.send_header("Content-Type", content_type)
+    for name, value in (extra_headers or {}).items():
+        handler.send_header(name, value)
+    if encoding:
+        handler.send_header("Content-Encoding", encoding)
+    # Caches must not serve a gzipped body to a client that cannot read it.
+    handler.send_header("Vary", "Accept-Encoding")
+    handler.send_header("Content-Length", str(len(body)))
+    handler.end_headers()
+    handler.wfile.write(body)
 
 
 class _ThreadPoolMixIn(socketserver.ThreadingMixIn):
@@ -230,12 +278,12 @@ class _ViewerHandler(BaseHTTPRequestHandler):
         if path == "/api/loop/state":
             self._handle_loop_get()
             return
-        self.send_response(200)
-        self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.send_header("Cache-Control", "no-cache, must-revalidate")
-        self.send_header("Content-Length", str(len(self.html_bytes)))
-        self.end_headers()
-        self.wfile.write(self.html_bytes)
+        _send_body(
+            self,
+            self.html_bytes,
+            "text/html; charset=utf-8",
+            extra_headers={"Cache-Control": "no-cache, must-revalidate"},
+        )
 
     def _serve_asset(self, filename: str, content_type: str):
         """Serve static timeline assets; reload when template files change on disk."""
@@ -253,12 +301,15 @@ class _ViewerHandler(BaseHTTPRequestHandler):
             cache[filename] = (mtime, body)
         else:
             body = cached[1]
-        self.send_response(200)
-        self.send_header("Content-Type", content_type)
-        self.send_header("Cache-Control", "no-cache, must-revalidate")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+        # timeline.js is ~150 KB and timeline.css ~40 KB of text; both are paid on
+        # every cold load and compress to a fraction of that. Cache-Control stays
+        # as it was: the ?v= token busts the cache, so the browser must revalidate.
+        _send_body(
+            self,
+            body,
+            content_type,
+            extra_headers={"Cache-Control": "no-cache, must-revalidate"},
+        )
 
     def _handle_meta(self):
         """Return profile metadata: time range, GPU list, device count."""
@@ -377,11 +428,7 @@ class _ViewerHandler(BaseHTTPRequestHandler):
                 f"[tile] {start_s:.1f}s–{end_s:.1f}s  done in {elapsed:.3f}s  ({len(body) // 1024}KB)",
                 flush=True,
             )
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json; charset=utf-8")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+            _send_body(self, body, "application/json; charset=utf-8")
         except (BrokenPipeError, ConnectionResetError, OSError):
             pass
         except Exception as e:
@@ -391,12 +438,9 @@ class _ViewerHandler(BaseHTTPRequestHandler):
             self._json_response({"error": str(e)}, 500)
 
     def _json_response(self, obj, status=200):
-        body = json.dumps(obj).encode("utf-8")
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+        _send_body(
+            self, json.dumps(obj).encode("utf-8"), "application/json; charset=utf-8", status
+        )
 
     def _handle_analyze(self):
         """POST /api/analyze — run EvidenceBuilder, replace all findings."""
@@ -1020,11 +1064,7 @@ class _EvidenceHandler(BaseHTTPRequestHandler):
             self._handle_data()
             return
         # Default: serve evidence HTML
-        self.send_response(200)
-        self.send_header("Content-Type", "text/html; charset=utf-8")
-        self.send_header("Content-Length", str(len(self.html_bytes)))
-        self.end_headers()
-        self.wfile.write(self.html_bytes)
+        _send_body(self, self.html_bytes, "text/html; charset=utf-8")
 
     def _serve_asset(self, filename: str, content_type: str):
         path = os.path.join(_TEMPLATE_DIR, filename)
@@ -1041,20 +1081,20 @@ class _EvidenceHandler(BaseHTTPRequestHandler):
             cache[filename] = (mtime, body)
         else:
             body = cached[1]
-        self.send_response(200)
-        self.send_header("Content-Type", content_type)
-        self.send_header("Cache-Control", "no-cache, must-revalidate")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+        # timeline.js is ~150 KB and timeline.css ~40 KB of text; both are paid on
+        # every cold load and compress to a fraction of that. Cache-Control stays
+        # as it was: the ?v= token busts the cache, so the browser must revalidate.
+        _send_body(
+            self,
+            body,
+            content_type,
+            extra_headers={"Cache-Control": "no-cache, must-revalidate"},
+        )
 
     def _json_response(self, obj, status=200):
-        body = json.dumps(obj).encode("utf-8")
-        self.send_response(status)
-        self.send_header("Content-Type", "application/json; charset=utf-8")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
+        _send_body(
+            self, json.dumps(obj).encode("utf-8"), "application/json; charset=utf-8", status
+        )
 
     def _handle_data(self):
         """Return kernel data for a time window from this handler's prebuilt cache."""
@@ -1080,11 +1120,7 @@ class _EvidenceHandler(BaseHTTPRequestHandler):
                     gpu_entries.append(filtered)
             data_json = json.dumps({"gpus": gpu_entries})
             body = data_json.encode("utf-8")
-            self.send_response(200)
-            self.send_header("Content-Type", "application/json; charset=utf-8")
-            self.send_header("Content-Length", str(len(body)))
-            self.end_headers()
-            self.wfile.write(body)
+            _send_body(self, body, "application/json; charset=utf-8")
         except (BrokenPipeError, ConnectionResetError, OSError):
             pass
         except Exception as e:
@@ -1158,12 +1194,19 @@ class _PerfettoHandler(BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self):
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(self.trace_bytes)))
-        self._cors_headers()
-        self.end_headers()
-        self.wfile.write(self.trace_bytes)
+        # The Perfetto trace is the largest thing this server hands out, and it
+        # crosses the network to ui.perfetto.dev's fetch. CORS headers are set
+        # first so they survive on the compressed response too.
+        _send_body(
+            self,
+            self.trace_bytes,
+            "application/json",
+            extra_headers={
+                "Access-Control-Allow-Origin": "*",
+                "Access-Control-Allow-Methods": "GET, OPTIONS",
+                "Access-Control-Allow-Headers": "*",
+            },
+        )
 
     def _cors_headers(self):
         self.send_header("Access-Control-Allow-Origin", "*")

--- a/tests/test_web_compression.py
+++ b/tests/test_web_compression.py
@@ -1,0 +1,141 @@
+"""HTTP responses are compressed when the client says it can read them (#UX).
+
+A timeline window is ~1 MB of highly repetitive JSON and timeline.js is ~150 KB
+of text, all of it paid on every cold load. The server prints an SSH
+port-forward hint on startup, so it expects to be read over a link where those
+bytes are the whole cost.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+
+from nsys_ai.web import _MIN_COMPRESS_BYTES, _send_body
+
+
+class _FakeHandler:
+    """Minimal stand-in for BaseHTTPRequestHandler's response surface."""
+
+    def __init__(self, accept_encoding: str | None):
+        self.headers = {} if accept_encoding is None else {"Accept-Encoding": accept_encoding}
+        self.status: int | None = None
+        self.sent: dict[str, str] = {}
+        self.body = b""
+
+    def send_response(self, status):
+        self.status = status
+
+    def send_header(self, name, value):
+        self.sent[name] = value
+
+    def end_headers(self):
+        pass
+
+    @property
+    def wfile(self):
+        return self
+
+    def write(self, data):
+        self.body += data
+
+
+def _big_payload() -> bytes:
+    rows = [{"name": "elementwise_kernel", "start_ns": 60111541307 + i, "stream": 7} for i in range(400)]
+    body = json.dumps({"gpus": [{"id": 0, "kernels": rows}]}).encode()
+    assert len(body) > _MIN_COMPRESS_BYTES
+    return body
+
+
+def test_gzip_is_used_when_offered_and_round_trips_exactly():
+    body = _big_payload()
+    handler = _FakeHandler("gzip, deflate, br")
+    _send_body(handler, body, "application/json; charset=utf-8")
+
+    assert handler.sent.get("Content-Encoding") == "gzip"
+    assert len(handler.body) < len(body), "compression did not shrink the body"
+    assert gzip.decompress(handler.body) == body, "decompressed body is not the original"
+    assert handler.sent["Content-Length"] == str(len(handler.body))
+
+
+def test_a_client_that_cannot_gzip_gets_the_plain_body():
+    body = _big_payload()
+    handler = _FakeHandler(None)
+    _send_body(handler, body, "application/json; charset=utf-8")
+
+    assert "Content-Encoding" not in handler.sent
+    assert handler.body == body
+    assert handler.sent["Content-Length"] == str(len(body))
+
+
+def test_vary_is_always_set_so_caches_do_not_cross_serve():
+    """Without Vary a cache can hand a gzipped body to a client that cannot read it."""
+    for accept in ("gzip", None):
+        handler = _FakeHandler(accept)
+        _send_body(handler, _big_payload(), "application/json; charset=utf-8")
+        assert handler.sent.get("Vary") == "Accept-Encoding"
+
+
+def test_small_bodies_are_not_compressed():
+    """Below the threshold the gzip header costs more than it saves."""
+    body = b'{"ok":1}'
+    handler = _FakeHandler("gzip")
+    _send_body(handler, body, "application/json; charset=utf-8")
+
+    assert "Content-Encoding" not in handler.sent
+    assert handler.body == body
+
+
+def test_extra_headers_survive_compression():
+    """Assets carry Cache-Control; compressing them must not drop it."""
+    handler = _FakeHandler("gzip")
+    _send_body(
+        handler,
+        _big_payload(),
+        "application/javascript; charset=utf-8",
+        extra_headers={"Cache-Control": "no-cache, must-revalidate"},
+    )
+    assert handler.sent["Cache-Control"] == "no-cache, must-revalidate"
+    assert handler.sent.get("Content-Encoding") == "gzip"
+
+
+def test_incompressible_body_is_sent_as_is():
+    """Refuse a "compression" that grew the payload."""
+    body = gzip.compress(b"x" * 4096)  # already compressed, gzipping again grows it
+    handler = _FakeHandler("gzip")
+    _send_body(handler, body, "application/octet-stream")
+
+    assert "Content-Encoding" not in handler.sent
+    assert handler.body == body
+
+
+def test_every_buffered_response_goes_through_the_shared_writer():
+    """Pins the wiring, not just the helper.
+
+    A new endpoint that writes its own body would silently opt out of
+    compression, which is exactly how the timeline ended up shipping 2 MB per
+    cold load. Streaming responses are the deliberate exception: SSE must not be
+    buffered to be compressed.
+    """
+    import re
+    from pathlib import Path
+
+    import nsys_ai.web as web_module
+
+    source = Path(web_module.__file__).read_text(encoding="utf-8")
+    lines = source.splitlines()
+    offenders = []
+    for number, line in enumerate(lines, start=1):
+        if not re.search(r"\bwfile\.write\(", line):
+            continue
+        # The writer itself, and the streaming chat path.
+        context = "\n".join(lines[max(0, number - 40) : number])
+        if "def _send_body" in context and "class " not in context.split("def _send_body")[-1]:
+            continue
+        if "stream" in context or "LLM not configured" in line or "text/event-stream" in context:
+            continue
+        offenders.append(f"{number}: {line.strip()}")
+    assert not offenders, (
+        "these response paths bypass _send_body and so are never compressed:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
A cold `timeline-web` load moved **2,184,087 bytes** — 210 KB of HTML/JS/CSS and 1.9 MB of window
JSON, none of it compressed. The startup banner prints an SSH port-forward hint, so the server already
expects to be read over a link where those bytes are the whole cost.

Measured on the 2-GPU fixture:

| | before | after | |
|---|---|---|---|
| HTML | 18,811 | 4,836 | |
| `timeline.js` | 150,778 | 44,299 | 3.4x |
| `timeline.css` | 40,862 | 8,084 | 5.1x |
| `/api/data` x2 | 1,973,636 | 215,282 | 9.2x |
| **cold load** | **2,184,087** | **272,501** | **8.0x** |
| Perfetto trace | 1,022,424 | 100,320 | 10.2x |

### One writer, not four

Compression was not simply "missing" — there were three independent copies of the send-a-body code
(two `_json_response` methods, the tile path) plus the asset and page writers, so there was no single
place to add it. They now share one negotiated writer.

It is negotiated, never assumed: a client that does not advertise gzip gets the plain body byte for
byte, `Vary: Accept-Encoding` is always set so a cache cannot hand a gzipped body to a client that
cannot read it, and a body that grew under compression is sent as-is. `Cache-Control` on assets and
the CORS headers on the Perfetto trace are preserved. Streaming chat is deliberately excluded — SSE
cannot be buffered.

### Level 1, not the default

On a 932 KB window: level 1 costs 2.9 ms for 11.2% of the original, level 6 costs 6.3 ms for 7.9%,
level 9 costs 27.2 ms for 7.2%. The whole request takes about 7 ms today and the usual client is a
browser on the same machine, so the higher levels do not pay for the CPU they spend on the request
thread. The reasoning is in the constant.

### What this does not fix

Compression addresses transfer, not computation, and the remaining two are worth stating:

- An NVTX tile still costs **110–336 ms** per new window against **2–18 ms** for kernels. That is what
  makes panning and zooming feel heavy, and it is unchanged here. The result is cached per exact
  window, so only a repeat of the identical request is fast.
- There is still no level of detail: every event in the window is returned, ~175 bytes each raw and
  ~20 compressed. A profile with millions of kernels still will not fit; the wall has moved 8x, not
  gone.

### Verification

Full suite 2099 passed, 140 skipped, exit 0; ruff and bandit clean. Seven new tests cover the round
trip, the plain-client path, `Vary`, the small-body threshold, header preservation and the
incompressible case.

One of them walks `web.py` and fails on any response path that writes its own body, because three
independent copies of that code are exactly how this shipped uncompressed in the first place.
