### PR TITLE
fix(diff): refuse to compare a capture that recorded no GPU kernels, and fail the gate on it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   VRAM and allocation/free deltas), and locate each top kernel regression to a
   specific GPU, stream, and time window.
 - `nsys-ai diff --exit-on-regression` exits non-zero on a likely-regression
-  verdict, so a diff can gate CI.
+  verdict, and on an inconclusive one, so a diff can gate CI. A comparison that
+  could not be made has not shown the absence of a regression — a capture with no
+  GPU kernel activity is the clearest case.
 - `nsys-ai diff --format json` emits a versioned envelope: a top-level
   `verdict`, a `comparability_confidence` score, step-time `category_attribution`
   (compute / communication / launch overhead / idle), and a content-derived

--- a/README.md
+++ b/README.md
@@ -173,7 +173,9 @@ nsys-ai diff before.sqlite after.sqlite --iteration 0
 nsys-ai diff before.sqlite after.sqlite --format markdown -o diff.md
 nsys-ai diff before.sqlite after.sqlite --format json
 
-# Gate CI: exit non-zero when the verdict is a likely regression
+# Gate CI: exit non-zero when the verdict is a likely regression, or when the
+# two profiles could not be compared at all (for example one side recorded no
+# GPU kernel activity because the profiling step failed)
 nsys-ai diff before.sqlite after.sqlite --exit-on-regression
 
 # Same gate with a custom regression threshold (default 5%)
@@ -195,7 +197,7 @@ across every device.
 | `--format` | `terminal` | `terminal` \| `markdown` \| `json` |
 | `--limit N` | 15 | Top regressions/improvements to show |
 | `--sort` | `delta` | `delta` \| `percent` \| `total` |
-| `--exit-on-regression` | — | Exit 1 when the verdict is `regression_likely` |
+| `--exit-on-regression` | — | Exit 1 when the verdict is `regression_likely`, or `inconclusive` because the profiles could not be compared |
 | `--gate PCT` | 5.0 | Regression threshold (%) for the verdict; implies `--exit-on-regression` |
 
 ## Baselines

--- a/docs/agent_skills/INDEX.md
+++ b/docs/agent_skills/INDEX.md
@@ -37,7 +37,7 @@ nsys-ai diff before.sqlite after.sqlite
 # Machine-readable JSON
 nsys-ai diff before.sqlite after.sqlite --format json
 
-# Fail a CI job on a likely regression verdict
+# Fail a CI job on a likely regression, or on a comparison that could not be made
 nsys-ai diff before.sqlite after.sqlite --format json --exit-on-regression
 
 # Same gate with a custom regression threshold (default 5%)

--- a/src/nsys_ai/ai/diff_narrative.py
+++ b/src/nsys_ai/ai/diff_narrative.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from nsys_ai.diff import ProfileDiffSummary
+from nsys_ai.diff import ProfileDiffSummary, empty_kernel_sides, empty_side_subject
 
 
 def _fmt_ns(ns: int) -> str:
@@ -48,6 +48,17 @@ def build_executive_summary(summary: ProfileDiffSummary) -> str:
 
     Does not call any LLM; safe to use when --no-ai or when no API key is set.
     """
+    # An empty side turns every delta below into an artefact of the absence: an
+    # empty after reads as a total win, an empty before as a total regression.
+    # Neither is a measurement. State the refusal instead of narrating arithmetic.
+    empty_sides = empty_kernel_sides(summary.before, summary.after)
+    if empty_sides:
+        return (
+            f"No comparison was made. {empty_side_subject(empty_sides)} no GPU kernel "
+            "activity. A capture that recorded nothing is not a measurement — check that "
+            "the profiled run executed and that the capture is complete."
+        )
+
     delta_ns = summary.after.total_gpu_ns - summary.before.total_gpu_ns
     direction = "faster" if delta_ns < 0 else "slower"
     total_str = f"Total GPU time went {direction} by {_fmt_delta_ns(delta_ns)}."
@@ -116,6 +127,19 @@ def generate_diff_narrative(
     warning may be set; the report still includes the deterministic summary.
     """
     executive_summary = build_executive_summary(summary)
+
+    # An empty side is refused before the model is ever asked. The prompt payload
+    # lists "Top improvements" from the same deltas, and the instruction tells the
+    # model to mention them, so an LLM handed this would narrate the vanished
+    # kernels as a win directly beneath the deterministic refusal. There is
+    # nothing here to narrate: no comparison was made.
+    if empty_kernel_sides(summary.before, summary.after):
+        return DiffNarrative(
+            executive_summary=executive_summary,
+            ai_narrative=None,
+            model=None,
+            warning=None,
+        )
 
     from nsys_ai.chat_config import _get_model_and_key
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -839,6 +839,7 @@ def _cmd_baseline_show(args, _profile):
 
 def _cmd_diff(args, _profile):
     from nsys_ai.diff import (
+        MIN_COMPARABILITY_CONFIDENCE,
         STEP_TIME_REGRESSION_PCT,
         diff_profiles,
         diff_profiles_all_gpus,
@@ -1179,6 +1180,12 @@ def _cmd_diff(args, _profile):
     relative_failed = (
         gate_enabled and gate_summary is not None and gate_summary.verdict == "regression_likely"
     )
+    # A gate exists to block regressions. A comparison that could not be made has
+    # not shown their absence, so it must not exit 0 either — that is how an empty
+    # capture from a broken profiling step green-lights a change.
+    gate_inconclusive = (
+        gate_enabled and gate_summary is not None and gate_summary.verdict == "inconclusive"
+    )
     if relative_failed:
         print(
             "Diff gate failed: "
@@ -1189,6 +1196,23 @@ def _cmd_diff(args, _profile):
             f"gate_pct={regression_pct:.2f}%.",
             file=sys.stderr,
         )
+    elif gate_inconclusive:
+        if gate_summary.warnings:
+            reason = " ".join(gate_summary.warnings)
+        elif gate_summary.step_time_delta_pct is None:
+            reason = "Step time could not be derived from these profiles."
+        else:
+            reason = "The two profiles are not comparable enough to judge."
+        print(
+            "Diff gate could not be evaluated: "
+            f"verdict={gate_summary.verdict} "
+            f"comparability_confidence={gate_summary.comparability_confidence:.3f} "
+            f"(minimum {MIN_COMPARABILITY_CONFIDENCE:.2f}). "
+            f"{reason} "
+            "Exiting non-zero: a comparison that could not be made has not shown "
+            "the absence of a regression.",
+            file=sys.stderr,
+        )
 
     if sol_failed:
         detail = ", ".join(
@@ -1197,7 +1221,7 @@ def _cmd_diff(args, _profile):
         )
         print(f"SOL gate failed: {detail}.", file=sys.stderr)
 
-    if relative_failed or sol_failed:
+    if relative_failed or gate_inconclusive or sol_failed:
         sys.exit(1)
 
 

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -854,7 +854,8 @@ def _build_parser():
     p.add_argument(
         "--exit-on-regression",
         action="store_true",
-        help="Exit with status 1 when the diff verdict is regression_likely (CI gate)",
+        help="Exit with status 1 when the diff verdict is regression_likely, or "
+        "inconclusive because the two profiles could not be compared (CI gate)",
     )
     p.add_argument(
         "--gate",

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -274,6 +274,18 @@ def build_profile_summary(
     )
 
 
+def empty_kernel_sides(before: ProfileSummary, after: ProfileSummary) -> list[str]:
+    """Return the side labels ("before"/"after") that recorded no GPU kernels."""
+    return [label for label, side in (("before", before), ("after", after)) if not side.kernel_rows]
+
+
+def empty_side_subject(empty_sides: list[str]) -> str:
+    """Sentence subject naming the empty side(s), e.g. "The after profile contains"."""
+    if len(empty_sides) > 1:
+        return "Both the before and after profiles contain"
+    return f"The {empty_sides[0]} profile contains"
+
+
 def collect_sanity_warnings(
     before: ProfileSummary, after: ProfileSummary
 ) -> tuple[list[str], float]:
@@ -281,9 +293,26 @@ def collect_sanity_warnings(
     warnings: list[str] = []
     c_schema = 1.0
     c_gpu = 1.0
+    c_empty = 1.0
     c_workload = 1.0
     c_kernel_overlap = 1.0
     c_overlap = 1.0
+
+    # A side that recorded nothing is the signature of a failed capture: the
+    # workload crashed, the trace was truncated, nsys was misconfigured, or the
+    # wrong artifact was uploaded. Every ratio below is guarded against a zero
+    # denominator and so quietly leaves confidence at 1.0, which turns "we
+    # measured nothing" into "everything got faster". Say so instead, and make
+    # it comparability zero — the same condition `nsys-ai profile` refuses to
+    # publish with "local profile contains no GPU kernel activity".
+    empty_sides = empty_kernel_sides(before, after)
+    if empty_sides:
+        warnings.append(
+            f"{empty_side_subject(empty_sides)} no GPU kernel activity; there is nothing "
+            "to compare against, so no before/after claim can be made. Check that the "
+            "profiled run actually executed and that the capture is complete."
+        )
+        c_empty = 0.0
 
     if (
         before.schema_version
@@ -336,7 +365,9 @@ def collect_sanity_warnings(
         warnings.append("Overlap analysis unavailable (missing kernels or schema).")
         c_overlap = 0.0
 
-    confidence = max(0.0, min(1.0, c_schema * c_gpu * c_workload * c_kernel_overlap * c_overlap))
+    confidence = max(
+        0.0, min(1.0, c_schema * c_gpu * c_empty * c_workload * c_kernel_overlap * c_overlap)
+    )
     # Return unrounded — compute_verdict reads this and the 0.5 gate must
     # not be crossed by rounding artifacts (e.g. 0.4996 -> 0.5).
     # Quantization happens at the serialization boundary in to_diff_json.

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -845,7 +845,9 @@ def test_diff_cli_exit_on_regression_allows_improvement(tmp_path):
     assert json.loads(result.stdout)["verdict"] == "improvement_likely"
 
 
-def test_diff_cli_exit_on_regression_allows_inconclusive(tmp_path):
+def test_diff_cli_exit_on_regression_blocks_inconclusive(tmp_path):
+    """A gate blocks regressions; a comparison that could not be made has not shown
+    their absence, so it must not exit 0 either."""
     before = tmp_path / "before.sqlite"
     after = tmp_path / "after.sqlite"
     _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
@@ -875,11 +877,113 @@ def test_diff_cli_exit_on_regression_allows_inconclusive(tmp_path):
         capture_output=True,
         text=True,
     )
-    assert result.returncode == 0, result.stderr
+    assert result.returncode == 1, result.stderr
     payload = json.loads(result.stdout)
     assert payload["verdict"] == "inconclusive"
     assert payload["comparability_confidence"] < 0.5
-    assert "Diff gate failed" not in result.stderr
+    # The reason is stated, not implied by a number.
+    assert "Diff gate could not be evaluated" in result.stderr
+    assert "verdict=inconclusive" in result.stderr
+
+
+@pytest.mark.parametrize("empty_side", ["after", "before", "both"])
+def test_diff_cli_empty_capture_is_not_an_improvement(tmp_path, empty_side):
+    """A capture that recorded nothing must not read as the best result ever seen.
+
+    This is the failure mode that silently green-lights a broken pipeline: the
+    workload crashed, the trace was truncated, nsys was misconfigured, or the
+    wrong artifact was uploaded. Every delta then points the "improvement" way.
+    """
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    kernels = [(0, 10_000_000, 0, 7, 1, 1, 2), (20_000_000, 30_000_000, 0, 7, 2, 3, 4)]
+    _make_profile(str(before), kernels=[] if empty_side in ("before", "both") else kernels)
+    _make_profile(str(after), kernels=[] if empty_side in ("after", "both") else kernels)
+
+    result = _run_diff_cli(before, after, "--no-ai", "--gate", "5")
+    # 2. The gate does not pass a comparison that could not be made.
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    # 1. No improvement claim in the executive summary.
+    assert "Total GPU time went" not in result.stdout
+    assert "Largest improvement" not in result.stdout
+    # 3. The reason is stated, in the report and on stderr, not implied by a number.
+    assert "no GPU kernel activity" in result.stdout
+    assert "Diff gate could not be evaluated" in result.stderr
+    assert "no GPU kernel activity" in result.stderr
+
+    payload = json.loads(_run_diff_cli(before, after, "--no-ai", "--format", "json").stdout)
+    assert payload["verdict"] == "inconclusive"
+    assert payload["comparability_confidence"] == 0.0
+    assert any("no GPU kernel activity" in w for w in payload["warnings"])
+
+
+def test_empty_side_is_refused_before_the_model_is_asked(tmp_path, monkeypatch):
+    """The LLM path must not narrate a comparison the deterministic path refused.
+
+    ``generate_diff_narrative`` builds a prompt listing "Top improvements" from the
+    same deltas and instructs the model to mention them, so without this an LLM
+    would narrate the vanished kernels as a win directly beneath the refusal.
+    """
+    from nsys_ai.ai import diff_narrative as narrative_module
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("the model was consulted about an empty capture")
+
+    monkeypatch.setattr(narrative_module, "_get_model_and_key", _fail, raising=False)
+    monkeypatch.setattr(
+        "nsys_ai.chat_config._get_model_and_key", _fail, raising=False
+    )
+
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.profile import Profile
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[])
+    with Profile(str(before)) as bp, Profile(str(after)) as ap:
+        summary = diff_profiles(bp, ap, gpu=0)
+
+    result = narrative_module.generate_diff_narrative(summary)
+
+    assert result.ai_narrative is None
+    assert "no GPU kernel activity" in result.executive_summary
+
+
+def test_diff_cli_all_gpu_empty_capture_is_not_an_improvement(tmp_path):
+    """The issue's own invocation: no --gpu, so every device is compared.
+
+    The parametrized test above passes --gpu 0, and on that path an empty side
+    already tripped the pre-existing "Overlap analysis unavailable" warning, so it
+    was inconclusive before this fix too. The reported defect was the all-GPU
+    default: it returned improvement_likely at confidence 1.0 and exit 0, and
+    nothing covered it end to end.
+    """
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    kernels = [(0, 10_000_000, 0, 7, 1, 1, 2), (20_000_000, 30_000_000, 0, 7, 2, 3, 4)]
+    _make_profile(str(before), kernels=kernels)
+    _make_profile(str(after), kernels=[])
+
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", str(before), str(after),
+         "--no-ai", "--gate", "5"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 1, f"stdout={result.stdout}\nstderr={result.stderr}"
+    assert "Total GPU time went" not in result.stdout
+    assert "Largest improvement" not in result.stdout
+    assert "no GPU kernel activity" in result.stdout
+
+    payload = json.loads(
+        subprocess.run(
+            [sys.executable, "-m", "nsys_ai", "diff", str(before), str(after),
+             "--no-ai", "--format", "json"],
+            capture_output=True, text=True,
+        ).stdout
+    )
+    assert payload["verdict"] == "inconclusive"
+    assert payload["comparability_confidence"] == 0.0
 
 
 def _run_diff_cli(before, after, *extra, cwd=None, env=None):
@@ -2565,6 +2669,52 @@ def test_export_schema_mismatch_still_zeros_comparability():
     )
     assert conf == 0.0
     assert any("export schema differs" in w for w in warnings)
+
+
+@pytest.mark.parametrize("empty_side", ["before", "after", "both"])
+def test_empty_kernel_side_zeros_comparability(empty_side):
+    """An empty side is comparability zero, not a 100% improvement.
+
+    Every other ratio in collect_sanity_warnings guards against a zero
+    denominator, so a side with no kernels used to leave confidence at 1.0 and
+    the verdict at improvement_likely.
+    """
+    from nsys_ai.diff import collect_sanity_warnings, compute_verdict
+
+    warnings, conf = collect_sanity_warnings(
+        _summary(kernel_rows=0 if empty_side in ("before", "both") else 100),
+        _summary(kernel_rows=0 if empty_side in ("after", "both") else 100),
+    )
+    assert conf == 0.0
+    # Same wording the `profile` command refuses this condition with.
+    assert any("no GPU kernel activity" in w for w in warnings)
+    expected_subject = (
+        "Both the before and after profiles contain"
+        if empty_side == "both"
+        else f"The {empty_side} profile contains"
+    )
+    assert any(w.startswith(expected_subject) for w in warnings), warnings
+    assert compute_verdict(-100.0, conf) == "inconclusive"
+
+
+def test_executive_summary_refuses_an_empty_capture(tmp_path):
+    """The deterministic summary states the refusal instead of narrating deltas."""
+    from nsys_ai.ai.diff_narrative import build_executive_summary
+    from nsys_ai.diff import diff_profiles
+    from nsys_ai.profile import Profile
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[])
+
+    with Profile(str(before)) as bp, Profile(str(after)) as ap:
+        summary = diff_profiles(bp, ap, gpu=0)
+
+    text = build_executive_summary(summary)
+    assert "no GPU kernel activity" in text
+    assert "Total GPU time went" not in text
+    assert "Largest improvement" not in text
 
 
 def test_build_profile_summary_reads_export_schema_not_product_version():


### PR DESCRIPTION
Closes #384.

A capture that recorded nothing was reported as the best result the project had ever produced, and the
CI gate let it through:

```console
$ nsys-ai diff before.sqlite empty.sqlite --no-ai --gate 5
EXIT=0
Total GPU time went faster by -535.20ms. Largest improvement: flash_fwd_kernel (-272.32ms).
```

`empty.sqlite` is a real profile with its kernel table emptied — the shape a CI job produces when the
workload crashed, the capture was truncated, or the wrong artifact was uploaded. Instead of failing,
the gate reported a 535 ms win.

Now:

```console
$ nsys-ai diff before.sqlite empty.sqlite --no-ai --gate 5
EXIT=1
No comparison was made. The after profile contains no GPU kernel activity. ...
Diff gate could not be evaluated: verdict=inconclusive comparability_confidence=0.000 (minimum 0.50).
... Exiting non-zero: a comparison that could not be made has not shown the absence of a regression.
```

### Both halves were broken, and each was verified separately

Reverting only `diff.py` leaves comparability at 1.0 with no warning; reverting only `handlers.py`
leaves the empty capture exiting 0. The machinery already existed — `compute_verdict` returns
`inconclusive` below `MIN_COMPARABILITY_CONFIDENCE`, and `collect_sanity_warnings` computes the
confidence — but nothing noticed a side with no kernels, and the gate fired only on
`regression_likely`.

The refusal reuses the wording `nsys-ai profile` already uses for the same condition
(`local profile contains no GPU kernel activity`), so the tool says the same thing about the same
thing. All three orientations are covered: after-empty, before-empty, and both-empty.

### A deliberate behaviour widening, called out

`--gate` / `--exit-on-regression` now exit 1 for **any** inconclusive verdict, not only an empty
capture. Measured on non-empty but incomparable pairs:

| pair | confidence | main | this branch |
|---|---|---|---|
| `mfu_2gpu_before` vs `h100_2gpu_1s` | 0.254 | exit 0 | exit 1 |
| `healthy_1pct` vs `mock` | 0.005 | exit 0 | exit 1 |

The verdict and confidence values are byte-identical between trees; only the exit code widened. This
is the general form of the same bug — a gate exists to show the absence of a regression, and a
comparison that could not be performed has not shown it — but it will newly fail CI jobs that pass
silently today on incomparable pairs. `README.md`, `CHANGELOG.md`, the `docs/agent_skills/INDEX.md`
recipe and the `--help` text all say so now.

### Found in review, after the first pass

Three things the first version got wrong, each verified before being fixed:

- **The LLM path still shipped the improvement claim.** Only `build_executive_summary` was guarded.
  `generate_diff_narrative` still handed the model `Total GPU time: before 535.20ms, after 0ns` plus a
  `Top improvements` list and an instruction to mention them, so an LLM would have narrated the
  vanished kernels as a win directly beneath the deterministic refusal. It now returns the refusal
  with `ai_narrative=None` before the model is consulted.
- **The CLI test did not reproduce the reported defect.** `_run_diff_cli` hardcodes `--gpu 0`, and on
  that path an empty side already tripped a pre-existing "Overlap analysis unavailable" warning on
  main — so its assertions were true before the fix. Mutation-proved: removing `c_empty` from the
  confidence product left that test **passing**. The issue's actual all-GPU invocation had no
  end-to-end coverage. There is now one, and it does fail when `c_empty` is removed.
- **A comment true for only half the cases it covered.** "An empty side makes every delta read as a
  total win" holds for an empty *after*; an empty *before* reads as a total regression. The comment
  and the user-facing message now say "not a measurement".

### Healthy comparisons are untouched

`mfu_2gpu_before` vs `mfu_2gpu_after` produces byte-identical output on this branch and on main, in
all three renderers (terminal, JSON, markdown), same exit 0, verdict `neutral`, comparability 0.894.
A fix that made the gate fire on healthy pairs would be worse than the bug.

### Verification

Full suite 2115 passed, 140 skipped, exit 0; ruff and bandit clean. Each of the 8 new or inverted test
cases was checked by deleting the code it covers and confirming it fails **behaviourally** — the three
reverts above produce `assert 1.0 == 0.0`, a missing refusal string, and `assert 0 == 1` respectively,
not ImportError.

Known scope gap: the terminal report's raw "Top improvements" table still lists the vanished kernels,
48 lines below the refusal. The executive summary, warnings block, JSON verdict and gate all refuse;
only that table still reads as a win to someone who scrolls past.
