### PR TITLE
fix(skills): refuse an MFU that exceeds peak instead of calling it healthy

### DIFF
--- a/skills/analyze/references/M3_COMPUTE.md
+++ b/skills/analyze/references/M3_COMPUTE.md
@@ -59,6 +59,7 @@ and model architecture table.
 | `tensor_core_usage[*].is_outlier` = true | Kernel has < 50% TC time (FP32 fallback) | inspect matmul shape; pad to multiple of 8/16 |
 | `region_mfu.mfu.mfu_pct < 30` | Severely underutilizing GPU | widen batch; improve memory access pattern |
 | `region_mfu.mfu.mfu_pct > 100` | FLOPs scope too broad — **always wrong** | narrow `operation` to match the actual kernel target (see MFU.md) |
+| `arithmetic_intensity` abstains with "Refusing to report MFU" | Achieved throughput came out above peak — **always wrong**, the same failure as the row above | fix the input the reason names (usually `theoretical_flops` scope, sometimes a `peak_tflops` for a precision the kernels did not use); there is no classification to report |
 | `arithmetic_intensity.classification` starts with `"Memory-bound"` | Below ridge point | fuse ops; increase tile sizes; reduce redundant loads |
 | `arithmetic_intensity.classification` starts with `"Compute-bound"` with low MFU | Above ridge but inefficient | occupancy issue; check register pressure / block size |
 | `kernel_launch_pattern.sync_stalls` > 0 on a stream | CPU dispatch bottleneck | use CUDA graphs; batch launches |

--- a/src/nsys_ai/skills/builtins/arithmetic_intensity.py
+++ b/src/nsys_ai/skills/builtins/arithmetic_intensity.py
@@ -20,7 +20,7 @@ except ImportError:
 from nsys_ai.connection import wrap_connection
 from nsys_ai.hardware import get_peak_tflops
 
-from ..base import Skill, SkillParam
+from ..base import Skill, SkillParam, abstain
 
 logger = logging.getLogger(__name__)
 
@@ -56,6 +56,17 @@ def _execute(conn, **kwargs):
     peak_tflops = kwargs.get("peak_tflops")
     hbm_bw_gbps = kwargs.get("hbm_bw_gbps")
 
+    # Where the peak came from, captured before the spec-table fallback
+    # overwrites the local. The two refusals that name a peak quote it, because
+    # "989 TFLOPS" is a different claim depending on whether the caller asserted
+    # it or this package looked it up, and the reader can only act on the one
+    # they own.
+    peak_origin = (
+        "which you provided"
+        if peak_tflops is not None
+        else "from this package's hardware spec table"
+    )
+
     if peak_tflops is None or hbm_bw_gbps is None:
         if "error" not in spec1:
             peak_tflops = peak_tflops if peak_tflops is not None else spec1.get("peak_tflops")
@@ -68,13 +79,35 @@ def _execute(conn, **kwargs):
     if hbm_bw_gbps is None and hbm_bw_raw > 0:
         hbm_bw_gbps = hbm_bw_raw / 1e9
 
-    # If peak_tflops is missing, fail explicitly.
+    # No peak, no roofline: this is the "cannot run" case, so it abstains rather
+    # than returning a row with an ``error`` key. Consumers distinguish the two —
+    # see :func:`nsys_ai.skills.base.abstain` — and an error row is data, so
+    # ``format_rows`` would hand it to ``_format`` and ``to_findings_fn`` would be
+    # entitled to mint a finding from it.
+    #
+    # This is also the whole of the "should an unknown GPU model block
+    # classification?" question, and the answer is: it already does, here, when
+    # the model is the only source of the peak. ``doctor`` refuses on this same
+    # profile with "GPU model missing from CUPTI TARGET_INFO; MFU / efficiency
+    # cannot be computed"; this branch covers that state and one more, since it
+    # also fires when the model is reported but absent from the spec table.
+    # What it must not do is refuse when the caller has supplied ``peak_tflops``
+    # themselves: the number ``doctor`` is missing is then present, from the one
+    # source that outranks a lookup table, and refusing anyway would make the
+    # documented override useless on precisely the profiles that need it — an
+    # unlisted GPU, or one whose export carries no chipName. So the header keeps
+    # saying "Unknown GPU", the arithmetic proceeds on the caller's peak, and the
+    # guards below check the *result* for consistency rather than the label.
     if peak_tflops is None:
-        return [
-            {
-                "error": f"GPU {gpu_name} ({chip_name}) not found in hardware specs. Cannot compute roofline. Please explicitly provide 'peak_tflops' and optionally 'hbm_bw_gbps'."
-            }
-        ]
+        return abstain(
+            f"This profile's GPU reports as {gpu_name}"
+            f"{f' ({chip_name})' if chip_name else ' with no chipName'}, which is not in this "
+            f"package's hardware spec table, so its peak throughput is unknown and MFU has no "
+            f"denominator. Re-run with 'peak_tflops' set to the peak for the GPU this profile "
+            f"was captured on (and optionally 'hbm_bw_gbps' for the ridge point).",
+            gpu_name=gpu_name,
+            chip_name=chip_name,
+        )
 
     if hbm_bw_gbps is None:
         # Cannot determine HBM bandwidth — skip roofline classification,
@@ -90,6 +123,20 @@ def _execute(conn, **kwargs):
 
     peak_tflops = float(peak_tflops)
     hbm_bw_gbps = float(hbm_bw_gbps)
+
+    # A non-positive peak is not a slow GPU, it is a broken denominator: every
+    # ratio below divides by it. This must stay ahead of the achieved-above-peak
+    # check, which divides by ``peak_tflops`` inside its own message and would
+    # raise ZeroDivisionError instead of explaining itself.
+    if peak_tflops <= 0:
+        return abstain(
+            f"peak_tflops is {peak_tflops:g}, {peak_origin}. MFU is a fraction of peak, so a "
+            f"peak of zero or less gives it no denominator and any classification would be an "
+            f"artefact of the input. Re-run with the peak throughput of the GPU this profile "
+            f"was captured on, in TFLOPS.",
+            gpu_name=gpu_name,
+            peak_fp16_tflops=peak_tflops,
+        )
 
     bytes_moved = kwargs.get("bytes_moved")
     if bytes_moved is not None:
@@ -153,19 +200,88 @@ def _execute(conn, **kwargs):
         kernel_count = 0
 
     if total_kernel_ns == 0 or kernel_count == 0:
-        return [
-            {
-                "error": "No kernel data found on the specified device.",
-                "gpu_name": gpu_name,
-            }
-        ]
+        # Same contract as the peak branch above: no kernel time is "cannot run",
+        # not a result. It is also the divisor two lines down, so continuing here
+        # is a ZeroDivisionError, never a number.
+        window = (
+            f" within the requested window ({trim_start}-{trim_end} ns)"
+            if trim_start is not None and trim_end is not None
+            else ""
+        )
+        return abstain(
+            f"{kernel_table} records no kernel activity on device {device}{window}, so there is "
+            f"no kernel time to divide the FLOPs by and no throughput to compare against peak. "
+            f"Check the device ID, or the trim range if one was given.",
+            gpu_name=gpu_name,
+            device=device,
+        )
+
+    # And the numerator. theoretical_flops is the caller-supplied total FLOPs of
+    # the profiled work; zero or negative is not a slow workload, it is a number
+    # that cannot describe work that ran. Left to run it reported
+    # "Severely low kernel throughput" at critical severity for 0, and a negative
+    # achieved throughput for a negative input — the same confident verdict drawn
+    # from a mistyped number as the peak guard above, one sign away.
+    if theoretical_flops <= 0:
+        return abstain(
+            f"theoretical_flops is {theoretical_flops:g}. It is read as the total FLOPs of the "
+            f"profiled work, so zero or less cannot describe work that ran, and every figure "
+            f"below it — achieved throughput, MFU, arithmetic intensity — would be an artefact "
+            f"of the input rather than a measurement. Re-run with the FLOP count for the work "
+            f"this profile captured.",
+            gpu_name=gpu_name,
+            theoretical_flops=theoretical_flops,
+        )
 
     total_kernel_s = total_kernel_ns / 1e9
     total_kernel_ms = total_kernel_ns / 1e6
 
     # --- Roofline calculations ---
     achieved_tflops = theoretical_flops / total_kernel_s / 1e12
-    mfu_pct = (achieved_tflops / peak_tflops) * 100.0 if peak_tflops > 0 else 0.0
+
+    # Achieved above peak is not a borderline reading, it is arithmetically
+    # impossible: the hardware cannot issue more FLOPs per second than its peak,
+    # so the only thing an MFU over 100% can mean is that the inputs do not
+    # support this calculation. Left to run, it took the number at face value and
+    # classified 369% as "High kernel throughput (likely compute-bound)", then
+    # sent the reader to NCU to tune a kernel on the strength of it. Both
+    # classification arms below are poisoned by it, not just the MFU heuristic:
+    # ``op_intensity`` divides the same ``theoretical_flops``, so the roofline
+    # verdict inherits whatever is wrong with it. Hence the check sits ahead of
+    # both.
+    #
+    # No tolerance band. A GPU running 1% over its own peak is as impossible as
+    # one running 300% over, and a band would only decide how much nonsense to
+    # publish.
+    if achieved_tflops > peak_tflops:
+        return abstain(
+            f"Refusing to report MFU. This calculation puts achieved throughput at "
+            f"{achieved_tflops:,.1f} TFLOPS, {achieved_tflops / peak_tflops:.1f}x the peak it is "
+            f"measured against ({peak_tflops:,.1f} TFLOPS, {peak_origin}) — an MFU of "
+            f"{(achieved_tflops / peak_tflops) * 100.0:,.1f}%. Hardware cannot exceed its own "
+            f"peak, so this is not a fast workload; one of the two inputs is not what the "
+            f"calculation assumes. theoretical_flops={theoretical_flops:.4g} is read as the "
+            f"total FLOPs of the profiled work, divided here by {total_kernel_ms:,.2f} ms of "
+            f"kernel time on device {device} ({kernel_count} kernels): passing a per-second "
+            f"rate, or a whole job's FLOPs against a profile that captured one slice of it, "
+            f"lands exactly here. Check theoretical_flops first, then peak_tflops — a peak "
+            f"quoted for a precision or a sparsity mode the kernels did not use is the other "
+            f"way in.",
+            gpu_name=gpu_name,
+            # Prefixed, deliberately. These are the repudiated numbers, kept
+            # because they are what the caller needs to see to find their input
+            # error — but a consumer reading rows[0]["mfu_pct"] must not receive
+            # the very figure this branch exists to refuse. The success row at
+            # the bottom of this function owns those key names.
+            implied_achieved_tflops=round(achieved_tflops, 1),
+            peak_fp16_tflops=round(peak_tflops, 1),
+            implied_mfu_pct=round((achieved_tflops / peak_tflops) * 100.0, 1),
+            theoretical_flops=theoretical_flops,
+            kernel_union_ms=round(total_kernel_ms, 2),
+            kernel_count=kernel_count,
+        )
+
+    mfu_pct = (achieved_tflops / peak_tflops) * 100.0
     ridge_point = (peak_tflops * 1e12) / (hbm_bw_gbps * 1e9) if hbm_bw_gbps > 0 else 0.0
 
     op_intensity = None
@@ -246,8 +362,11 @@ def _format(rows):
     if not rows:
         return "(No data for arithmetic intensity assessment)"
     r = rows[0]
-    if "error" in r:
-        return f"(Error: {r['error']})"
+    # No ``if "error" in r`` arm: every failure this function decides on now
+    # abstains, and ``Skill.format_rows`` renders an abstention with its reason
+    # before a ``format_fn`` is ever called. A missing required parameter still
+    # raises out of ``Skill.execute`` before this runs — that is issue #386, and
+    # it is the CLI's to catch, not this skill's.
 
     lines = [
         "── Arithmetic Intensity Assessment (Roofline) ──",

--- a/tests/test_skills_benchmarks.py
+++ b/tests/test_skills_benchmarks.py
@@ -112,19 +112,35 @@ def test_pipeline_bubble_metrics_no_tables_graceful(minimal_nsys_conn):
     assert rows == []
 
 
-def test_arithmetic_intensity_execute(minimal_nsys_conn):
-    """Test arithmetic_intensity produces a roofline classification."""
-    from nsys_ai.skills.registry import get_skill
+def _use_a100(conn):
+    """Point the fixture's GPU row at an A100 so the chipName lookup resolves.
 
-    # Update the fixture GPU to A100 so we can test chip lookup
-    # TARGET_INFO_GPU already has id=0 from the fixture with chipName='TestChip'
-    minimal_nsys_conn.execute(
+    TARGET_INFO_GPU already has id=0 from the fixture with chipName='TestChip',
+    which is in no spec table.
+    """
+    conn.execute(
         "UPDATE TARGET_INFO_GPU SET name='NVIDIA A100-SXM4-80GB', "
         "chipName='GA100', memoryBandwidth=2039000000000 WHERE id=0"
     )
 
+
+# The fixture's five kernels union to 4.5 ms, so achieved TFLOPS is
+# theoretical_flops / 0.0045 / 1e12 and every FLOP count below is chosen from
+# that. They used to be 1e15, which is 222,222 TFLOPS — 712x an A100's peak, and
+# the skill classified it as good throughput (#385). A test that asserts on an
+# impossible reading cannot notice when the impossible reading is the bug.
+_FIXTURE_KERNEL_S = 0.0045
+
+
+def test_arithmetic_intensity_execute(minimal_nsys_conn):
+    """Test arithmetic_intensity produces a roofline classification."""
+    from nsys_ai.skills.registry import get_skill
+
+    _use_a100(minimal_nsys_conn)
+
     skill = get_skill("arithmetic_intensity")
-    rows = skill.execute(minimal_nsys_conn, theoretical_flops=1e15)
+    # 200 TFLOPS achieved against A100's 312 TFLOPS peak -> MFU 64%.
+    rows = skill.execute(minimal_nsys_conn, theoretical_flops=200e12 * _FIXTURE_KERNEL_S)
 
     assert len(rows) == 1
     r = rows[0]
@@ -143,7 +159,7 @@ def test_arithmetic_intensity_no_gpu_table(minimal_nsys_conn):
     skill = get_skill("arithmetic_intensity")
     rows = skill.execute(
         minimal_nsys_conn,
-        theoretical_flops=1e15,
+        theoretical_flops=500e12 * _FIXTURE_KERNEL_S,
         peak_tflops=989.4,
         hbm_bw_gbps=3352,
     )
@@ -152,3 +168,272 @@ def test_arithmetic_intensity_no_gpu_table(minimal_nsys_conn):
     r = rows[0]
     assert "error" not in r
     assert r["peak_fp16_tflops"] == 989.4  # User override
+
+
+def test_arithmetic_intensity_abstains_when_achieved_exceeds_peak(minimal_nsys_conn):
+    """An MFU over 100% is impossible, so the skill must refuse, not classify.
+
+    Regression for #385: 989e12 FLOPs against a 989 TFLOPS peak came out as
+    3651 TFLOPS achieved / 369% MFU and was reported as "High kernel throughput
+    (likely compute-bound)" with a recommendation to go tune the kernel in NCU.
+    """
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("arithmetic_intensity")
+    rows = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=3651.3e12 * _FIXTURE_KERNEL_S,
+        peak_tflops=989.0,
+        hbm_bw_gbps=3350,
+    )
+
+    assert is_abstention(rows), rows
+    r = rows[0]
+    # It must not classify and must not recommend an action.
+    assert "classification" not in r
+    assert "recommendation" not in r
+    assert "severity" not in r
+
+    reason = r["reason"]
+    # The reason names the inconsistency and both inputs behind it.
+    assert "3,651.3 TFLOPS" in reason
+    assert "989.0 TFLOPS" in reason
+    assert "3.7x" in reason
+    assert "theoretical_flops" in reason
+    assert "peak_tflops" in reason
+
+    rendered = skill.format_rows(rows)
+    assert "not applicable to this profile" in rendered
+    assert "NCU" not in rendered
+    assert "compute-bound" not in rendered
+
+
+def test_arithmetic_intensity_abstains_on_a_one_percent_overshoot(minimal_nsys_conn):
+    """No tolerance band: 1% over peak is as impossible as 300% over."""
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("arithmetic_intensity")
+    rows = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=1.01 * 312e12 * _FIXTURE_KERNEL_S,
+        peak_tflops=312.0,
+        hbm_bw_gbps=2039,
+    )
+
+    assert is_abstention(rows), rows
+    assert "101.0%" in rows[0]["reason"]
+
+
+def test_arithmetic_intensity_at_exactly_peak_still_classifies(minimal_nsys_conn):
+    """100.0% MFU is the boundary and is reachable, so it must still be reported."""
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("arithmetic_intensity")
+    rows = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=312e12 * _FIXTURE_KERNEL_S,
+        peak_tflops=312.0,
+        hbm_bw_gbps=2039,
+    )
+
+    assert not is_abstention(rows)
+    assert rows[0]["mfu_pct"] == 100.0
+    assert rows[0]["classification"] == "High kernel throughput (likely compute-bound)"
+
+
+def test_arithmetic_intensity_roofline_branch_also_abstains(minimal_nsys_conn):
+    """bytes_moved reaches the other classification arm, off the same bad FLOPs.
+
+    op_intensity divides the very ``theoretical_flops`` that produced the
+    impossible throughput, so the roofline verdict is no more trustworthy than
+    the MFU one and the guard has to sit ahead of both.
+    """
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("arithmetic_intensity")
+    rows = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=3651.3e12 * _FIXTURE_KERNEL_S,
+        peak_tflops=989.0,
+        hbm_bw_gbps=3350,
+        bytes_moved=1e9,
+    )
+
+    assert is_abstention(rows), rows
+
+
+def test_arithmetic_intensity_abstains_when_peak_is_not_positive(minimal_nsys_conn):
+    """A zero peak is a broken denominator, not a severely slow GPU."""
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("arithmetic_intensity")
+    rows = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=1e12,
+        peak_tflops=0,
+        hbm_bw_gbps=3350,
+    )
+
+    assert is_abstention(rows), rows
+    assert "peak_tflops is 0" in rows[0]["reason"]
+    assert "classification" not in rows[0]
+
+
+def test_arithmetic_intensity_abstains_when_peak_unknown(minimal_nsys_conn):
+    """An unknown GPU with no caller-supplied peak abstains, not an error row.
+
+    This is the state ``doctor`` refuses on ("GPU model missing from CUPTI
+    TARGET_INFO; MFU / efficiency cannot be computed"). The skill agrees, and
+    says so through the abstention contract rather than a data row carrying an
+    ``error`` key, which consumers treat as a result.
+    """
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("arithmetic_intensity")
+    # The fixture's chipName is 'TestChip', which is in no spec table.
+    rows = skill.execute(minimal_nsys_conn, theoretical_flops=1e12)
+
+    assert is_abstention(rows), rows
+    assert "error" not in rows[0]
+    reason = rows[0]["reason"]
+    assert "TestChip" in reason
+    assert "peak_tflops" in reason
+
+
+def test_arithmetic_intensity_unknown_gpu_still_uses_a_supplied_peak(minimal_nsys_conn):
+    """The converse: an unknown model must not veto a peak the caller supplied.
+
+    Refusing on the label alone would make the documented override useless on
+    exactly the profiles that need it — an unlisted GPU, or an export with no
+    chipName.
+    """
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    # The state the issue reported: the export carries no model and no chipName,
+    # so the header reads "GPU: Unknown GPU" — the same state doctor refuses on.
+    minimal_nsys_conn.execute(
+        "UPDATE TARGET_INFO_GPU SET name=NULL, chipName=NULL, memoryBandwidth=0 WHERE id=0"
+    )
+
+    skill = get_skill("arithmetic_intensity")
+    rows = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=150e12 * _FIXTURE_KERNEL_S,
+        peak_tflops=989.0,
+        hbm_bw_gbps=3350,
+    )
+
+    assert not is_abstention(rows)
+    assert rows[0]["gpu_name"] == "Unknown GPU"
+    assert rows[0]["peak_fp16_tflops"] == 989.0
+    assert rows[0]["mfu_pct"] == 15.2
+
+
+def test_arithmetic_intensity_abstains_when_device_has_no_kernels(minimal_nsys_conn):
+    """No kernel time is "cannot run" too — and it is the divisor."""
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("arithmetic_intensity")
+    rows = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=1e12,
+        peak_tflops=989.0,
+        device=7,
+    )
+
+    assert is_abstention(rows), rows
+    assert "error" not in rows[0]
+    assert "device 7" in rows[0]["reason"]
+
+
+def test_arithmetic_intensity_legitimate_verdicts_are_unchanged(minimal_nsys_conn):
+    """A possible MFU classifies exactly as before, on both arms.
+
+    Pinned verbatim: the guard above must refuse impossible readings without
+    moving a single legitimate one.
+    """
+    from nsys_ai.skills.registry import get_skill
+
+    _use_a100(minimal_nsys_conn)
+    skill = get_skill("arithmetic_intensity")
+
+    # MFU heuristic arm (no bytes_moved): 200 / 312 = 64.1%.
+    r = skill.execute(minimal_nsys_conn, theoretical_flops=200e12 * _FIXTURE_KERNEL_S)[0]
+    assert r["achieved_tflops"] == 200.0
+    assert r["mfu_pct"] == 64.1
+    assert r["classification"] == "High kernel throughput (likely compute-bound)"
+    assert r["severity"] == "info"
+    assert r["recommendation"] == (
+        "Workload has good kernel throughput. "
+        "For further gains, consider kernel-level optimization with NCU "
+        "(occupancy, warp efficiency, instruction mix)."
+    )
+
+    # Roofline arm: AI = 9e11 / 1e10 = 90 FLOP/byte, under A100's 153 ridge.
+    r = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=200e12 * _FIXTURE_KERNEL_S,
+        bytes_moved=1e10,
+    )[0]
+    assert r["classification"] == "Memory-bound (AI=90.0 < Ridge=153.0)"
+    assert r["severity"] == "warning"
+    assert r["recommendation"] == (
+        "Workload is mathematically memory-bound (Arithmetic Intensity < Ridge Point). "
+        "Increase batch size, use operator fusion, or verify memory access patterns."
+    )
+
+
+def test_arithmetic_intensity_abstention_does_not_publish_the_refused_numbers(
+    minimal_nsys_conn,
+):
+    """The refused MFU must not come back under the healthy row's own key name.
+
+    ``skill run --format json`` dumps the rows verbatim, so a consumer reading
+    ``rows[0]["mfu_pct"]`` would otherwise receive the very figure the abstention
+    exists to refuse. The diagnostic values are kept, prefixed, because they are
+    what tells the caller which input was wrong.
+    """
+    from nsys_ai.skills.registry import get_skill
+
+    _use_a100(minimal_nsys_conn)
+    skill = get_skill("arithmetic_intensity")
+    rows = skill.execute(
+        minimal_nsys_conn,
+        theoretical_flops=1e18,  # absurd total -> achieved far above peak
+    )
+    assert rows and rows[0].get("_abstained") is True, rows
+
+    healthy_column_names = {"mfu_pct", "achieved_tflops", "classification", "recommendation"}
+    leaked = healthy_column_names & set(rows[0])
+    assert not leaked, f"abstention row republishes success columns: {sorted(leaked)}"
+    assert rows[0]["implied_mfu_pct"] > 100.0
+
+
+def test_arithmetic_intensity_abstains_on_a_non_positive_flop_count(minimal_nsys_conn):
+    """Zero or negative FLOPs cannot describe work that ran.
+
+    Left unguarded, 0 reported "Severely low kernel throughput" at critical
+    severity and a negative input reported a negative achieved throughput --
+    the same confident verdict from a mistyped number as an MFU above peak,
+    one sign away.
+    """
+    from nsys_ai.skills.registry import get_skill
+
+    skill = get_skill("arithmetic_intensity")
+    _use_a100(minimal_nsys_conn)
+    for flops in (0, -1e14):
+        rows = skill.execute(
+            minimal_nsys_conn,
+            theoretical_flops=flops,
+        )
+        assert rows and rows[0].get("_abstained") is True, (flops, rows)
+        assert "theoretical_flops" in rows[0]["reason"], rows[0]["reason"]
+        assert "classification" not in rows[0], rows[0]


### PR DESCRIPTION
Closes #385.

`arithmetic_intensity` put achieved throughput at **3,651 TFLOPS against a peak of 989** — an MFU of
369.2% — and classified it as *"High kernel throughput (likely compute-bound)"*, with a recommendation
to go tune the kernel in NCU. On `mock.sqlite` the same path reports **MFU 193,751.5%** at severity
`info`.

Achieved above peak is not a borderline reading. The hardware cannot issue more FLOPs per second than
its peak, so the only thing an MFU over 100% can mean is that the inputs do not support the
calculation. It now abstains, and the reason names both inputs and which to check first:

```console
Refusing to report MFU. This calculation puts achieved throughput at 3,651.3 TFLOPS, 3.7x the peak it
is measured against (989.0 TFLOPS, which you provided) — an MFU of 369.2%. Hardware cannot exceed its
own peak, so this is not a fast workload; one of the two inputs is not what the calculation assumes.
theoretical_flops=9.89e+14 is read as the total FLOPs of the profiled work, divided here by 270.86 ms
of kernel time on device 0 (1993 kernels): passing a per-second rate, or a whole job's FLOPs against a
profile that captured one slice of it, lands exactly here. Check theoretical_flops first, then
peak_tflops — a peak quoted for a precision or a sparsity mode the kernels did not use is the other
way in.
```

### Both ends of the division are guarded

The issue named the numerator, and a first pass guarded only the denominator. `theoretical_flops=0`
still reported "Severely low kernel throughput" at critical severity, and `-1e14` reported
`MFU: -37.3%` with a negative achieved throughput — the same confident verdict drawn from a mistyped
number, one sign away. Both now abstain.

### It abstains rather than returning an error row

The two pre-existing refusal paths returned `{"error": ...}`. Converting them to `abstain()` is what
made it honest to delete the `if "error" in r` arm from `_format` rather than leave it as a dead
branch — rendering is centralized in `Skill.format_rows`, which intercepts before a `format_fn` runs.

### The abstention does not republish what it refused

Found in review: the abstention row carried `mfu_pct: 369.2` and `achieved_tflops: 3651.3` under the
**success row's own key names**, and `skill run --format json` dumps rows verbatim — so a consumer
reading `rows[0]["mfu_pct"]` received exactly the figure the refusal exists to withhold. The
diagnostic values are kept, because they are what tells the caller which input was wrong, but prefixed
`implied_`.

Three comments that overstated what the code does were also corrected — "every refusal below quotes
it" (two of four do), "that is exactly the state this branch catches" (it is a superset), and "every
way this skill can fail now abstains" (a missing required parameter still raises, which is #386).

### Unknown GPU model

Decided explicitly rather than left implicit: an unknown model already blocks classification when it
is the only source of the peak, which is the state `doctor` refuses on. It must **not** block when the
caller supplied `peak_tflops` themselves — the number `doctor` is missing is then present, from the
one source entitled to assert it. Pinned by a test.

### Verification

Full suite 2117 passed, 140 skipped, exit 0. `ruff` and `bandit -r src/ -c pyproject.toml` clean.
This change touches `skills/`, so the path-gated smoke job applies: `bash scripts/smoke_test.sh
tests/fixtures/mock.sqlite` reports "All checks passed", and `build_fixture.py --dry-run` exits 0.

A legitimate calculation is byte-identical to main (MFU 48.5%, same classification and
recommendation). Of the eleven new tests, the ones that pin new behaviour fail against main; three
pass deliberately — they are the unchanged-behaviour pins for exactly-at-peak, unknown-GPU-with-
supplied-peak, and the legitimate verdicts.
