### PR TITLE
fix(timeline): make progressive overview and navigation profile-aware

### DIFF
--- a/src/nsys_ai/templates/timeline.css
+++ b/src/nsys_ai/templates/timeline.css
@@ -98,6 +98,38 @@
             font-size: 11px;
         }
 
+        .viewport-readout {
+            display: flex;
+            align-items: center;
+            gap: 7px;
+            min-width: 150px;
+            padding: 5px 9px;
+            border: 1px solid var(--border-subtle);
+            border-radius: 7px;
+            background: var(--bg);
+            font-family: var(--font-ui);
+            font-size: 11px;
+            font-variant-numeric: tabular-nums;
+            white-space: nowrap;
+        }
+
+        .viewport-readout-label {
+            color: var(--text-muted);
+            font-size: 9px;
+            font-weight: 700;
+            letter-spacing: .08em;
+        }
+
+        .viewport-readout strong {
+            color: var(--text);
+            font-weight: 600;
+        }
+
+        .viewport-zoom {
+            color: var(--accent);
+            margin-left: auto;
+        }
+
         .stat-chip {
             display: inline-flex;
             align-items: center;
@@ -274,6 +306,14 @@
             text-align: center;
         }
 
+        .tool-btn-icon {
+            min-width: 28px;
+            padding-left: 6px;
+            padding-right: 6px;
+            font-size: 16px;
+            line-height: 1;
+        }
+
         .tool-select {
             font-family: var(--font-ui);
             font-size: 11px;
@@ -289,6 +329,12 @@
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='10' height='6' fill='none'%3E%3Cpath stroke='%238b949e' stroke-width='1.2' d='M1 1l4 4 4-4'/%3E%3C/svg%3E");
             background-repeat: no-repeat;
             background-position: right 8px center;
+        }
+
+        .gpu-select {
+            display: none;
+            min-width: 92px;
+            max-width: 110px;
         }
 
         .tool-select:hover {
@@ -356,6 +402,94 @@
         @keyframes nvtxPulse {
             0%, 100% { opacity: 0.4; }
             50% { opacity: 1; }
+        }
+
+        #overviewBar {
+            display: flex;
+            align-items: center;
+            gap: 10px;
+            min-height: 46px;
+            flex-shrink: 0;
+            padding: 5px 12px 6px;
+            background: #0b1017;
+            border-bottom: 1px solid var(--border);
+            color: var(--text-muted);
+            font-family: var(--font-ui);
+        }
+
+        .overview-label {
+            width: 64px;
+            flex-shrink: 0;
+            font-size: 9px;
+            font-weight: 700;
+            letter-spacing: .08em;
+            text-align: right;
+        }
+
+        #overviewCanvas {
+            display: block;
+            width: 100%;
+            height: 34px;
+            min-width: 80px;
+            border: 1px solid var(--border-subtle);
+            border-radius: 5px;
+            background: #0d1117;
+            cursor: grab;
+        }
+
+        #overviewCanvas:active {
+            cursor: grabbing;
+        }
+
+        .overview-hint {
+            width: 150px;
+            flex-shrink: 0;
+            color: var(--text-muted);
+            font-size: 10px;
+            white-space: nowrap;
+        }
+
+        .render-summary {
+            min-width: 0;
+            overflow: hidden;
+            color: var(--text-muted);
+            font-size: 10px;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .focus-mode .app-chrome,
+        .focus-mode #overviewBar {
+            display: none;
+        }
+
+        .focus-mode #canvasWrap {
+            cursor: grab;
+        }
+
+        @media (max-width: 900px) {
+            .chrome-bar {
+                gap: 8px;
+                padding-left: 10px;
+                padding-right: 10px;
+            }
+
+            .chrome-stats {
+                display: none;
+            }
+
+            .viewport-readout {
+                margin-left: auto;
+                min-width: 0;
+            }
+
+            .overview-hint {
+                display: none;
+            }
+
+            .render-summary {
+                max-width: 220px;
+            }
         }
 
         #canvasWrap {

--- a/src/nsys_ai/templates/timeline.css
+++ b/src/nsys_ai/templates/timeline.css
@@ -1010,7 +1010,7 @@
 
         /* ── Findings sidebar ── */
         #findingsSidebar {
-            width: 300px;
+            width: 360px;
             flex-shrink: 0;
             display: none;
             flex-direction: column;
@@ -1632,8 +1632,34 @@
             padding: 4px 0;
         }
 
+        .evidence-filters {
+            display: flex;
+            gap: 4px;
+            flex-wrap: wrap;
+            padding: 7px 10px 6px;
+            border-bottom: 1px solid var(--border);
+            background: rgba(13, 17, 23, 0.28);
+        }
+
+        .evidence-filter {
+            border: 1px solid var(--border);
+            border-radius: 10px;
+            padding: 3px 7px;
+            color: var(--text-dim);
+            background: transparent;
+            font-size: 10px;
+            cursor: pointer;
+        }
+
+        .evidence-filter:hover,
+        .evidence-filter.active {
+            color: var(--text);
+            border-color: var(--accent-dim);
+            background: rgba(88,166,255,0.12);
+        }
+
         .finding-card {
-            padding: 10px 12px;
+            padding: 9px 12px;
             border-bottom: 1px solid var(--border);
             cursor: pointer;
             border-left: 4px solid transparent;
@@ -1704,6 +1730,12 @@
             -webkit-line-clamp: 2;
             -webkit-box-orient: vertical;
             overflow: hidden;
+        }
+
+        /* The canvas carries location only; the sidebar carries explanation. */
+        .finding-card.active .fc-note {
+            -webkit-line-clamp: 5;
+            color: var(--text);
         }
 
         /* Chat finding links — [Finding N] clickable references */

--- a/src/nsys_ai/templates/timeline.html
+++ b/src/nsys_ai/templates/timeline.html
@@ -121,6 +121,12 @@
                 <span class="findings-badge" id="findingsCount"></span>
                 <button onclick="toggleFindings()" title="Close">✕</button>
             </div>
+            <div id="findingsFilters" class="evidence-filters" aria-label="Filter evidence by severity">
+                <button type="button" class="evidence-filter active" data-severity="all">All</button>
+                <button type="button" class="evidence-filter" data-severity="critical">● Critical</button>
+                <button type="button" class="evidence-filter" data-severity="warning">▲ Warning</button>
+                <button type="button" class="evidence-filter" data-severity="info">● Info</button>
+            </div>
             <div id="findingsList"></div>
         </div>
         <div id="loopSidebar" data-loop-ui="2">
@@ -371,6 +377,7 @@
             TILE_WINDOW_S: 5,
             FINDINGS: $FINDINGS_JSON,
             PROFILE_PATH: $PROFILE_PATH,
+            PROFILE_ID: $PROFILE_ID,
             LOOP_TRIM_NS: $LOOP_TRIM_NS,
             LOOP_MODE: '$LOOP_MODE' === '1',
         };

--- a/src/nsys_ai/templates/timeline.html
+++ b/src/nsys_ai/templates/timeline.html
@@ -16,6 +16,11 @@
                 <span class="chrome-meta">$GPU_LABEL$TRIM_META</span>
             </div>
             <div class="chrome-stats" id="stats"></div>
+            <div class="viewport-readout" id="viewportReadout" aria-live="polite">
+                <span class="viewport-readout-label">VIEW</span>
+                <strong id="viewportRange">—</strong>
+                <span class="viewport-zoom" id="viewportZoom">—</span>
+            </div>
         </div>
         <div id="gpuInfoPanel" class="gpu-info-panel">
             <div id="gpuInfoContent"></div>
@@ -24,15 +29,19 @@
             <div class="tool-group">
                 <span class="tool-group-label">View</span>
                 <div class="tool-group-body">
+                    <button type="button" class="tool-btn tool-btn-icon" onclick="goBackView()" id="viewBackBtn" title="Previous viewport (Alt+←)" aria-label="Previous viewport">↶</button>
+                    <button type="button" class="tool-btn tool-btn-icon" onclick="goForwardView()" id="viewForwardBtn" title="Next viewport (Alt+→)" aria-label="Next viewport">↷</button>
                     <button type="button" class="tool-btn" onclick="zoomIn()" title="Zoom in (+)">Zoom in</button>
                     <button type="button" class="tool-btn" onclick="zoomOut()" title="Zoom out (−)">Zoom out</button>
                     <button type="button" class="tool-btn" onclick="fitAll()" title="Fit full range">Fit</button>
+                    <button type="button" class="tool-btn" onclick="gotoTimePrompt()" title="Go to time (G)">Go to</button>
                 </div>
             </div>
             <div class="tool-group tool-group-nvtx">
                 <span class="tool-group-label">NVTX</span>
                 <div class="tool-group-body">
                     <button type="button" class="tool-btn tool-btn-toggle active" onclick="toggleNVTX()" id="nvtxBtn" title="Show NVTX lanes (N)">Lanes</button>
+                    <select id="gpuSel" class="tool-select gpu-select" onchange="onGpuChange()" title="NVTX GPU"></select>
                     <select id="nvtxThreadSel" class="tool-select" onchange="onNvtxThreadChange()" title="NVTX thread">
                         <option value="auto">Auto thread</option>
                     </select>
@@ -60,17 +69,23 @@
                     <button type="button" class="tool-btn tool-btn-accent" onclick="toggleLoop()" id="loopBtn" title="Guided workflow (W)">Loop</button>
                     <button type="button" class="tool-btn" onclick="toggleChat()" id="chatBtn">Chat</button>
                     <button type="button" class="tool-btn" onclick="toggleFindings()" id="findingsBtn" style="display:none">Evidence</button>
+                    <button type="button" class="tool-btn" onclick="toggleFocus()" id="focusBtn" title="Focus mode (F)">Focus</button>
                     <button type="button" class="tool-btn tool-btn-ghost" onclick="toggleHelp()" title="Keyboard shortcuts">?</button>
                 </div>
             </div>
         </nav>
     </div>
+    <div id="overviewBar" aria-label="Timeline overview and viewport navigation">
+        <span class="overview-label">OVERVIEW</span>
+        <canvas id="overviewCanvas" height="34"></canvas>
+        <span class="render-summary" id="renderSummary" aria-live="polite"></span>
+        <span class="overview-hint">drag to pan · Shift+drag to zoom</span>
+    </div>
     <div id="appLayout">
         <div id="mainCol">
             <div id="canvasWrap"><canvas id="c"></canvas></div>
             <div id="detailResizeHandle" title="Drag to resize details"></div>
-            <div id="detail" class="empty">Click a kernel to see details. Press A for AI chat. Keyboard: ←/→ pan, +/-
-                zoom, ↑/↓ stream, / search, ? help</div>
+            <div id="detail" class="empty">Click a kernel to see details. Drag to pan; Shift+drag to zoom a range. Press A for AI chat, / to search, ? for help.</div>
         </div>
         <div id="chatSidebar">
             <div id="chatHeader">
@@ -262,6 +277,10 @@
                 <td>Pan viewport</td>
             </tr>
             <tr>
+                <td><span class="key">Alt+← →</span></td>
+                <td>Previous / next viewport</td>
+            </tr>
+            <tr>
                 <td><span class="key">+ −</span></td>
                 <td>Zoom in/out</td>
             </tr>
@@ -330,7 +349,7 @@
                 <td>Toggle help</td>
             </tr>
         </table>
-        <div style="margin-top:8px;color:var(--text-dim);font-size:11px">Mouse: scroll=zoom, drag=pan, click=select, double-click=fit/toggle
+        <div style="margin-top:8px;color:var(--text-dim);font-size:11px">Mouse: drag=pan, Shift+drag=zoom range, Shift+wheel=zoom, click=select, double-click=fit/toggle
         </div>
     </div>
     <div class="command-palette" id="commandPalette" style="display:none">

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -8,6 +8,8 @@ const FINDINGS = Array.isArray(BOOT.FINDINGS) ? BOOT.FINDINGS : [];
 const canvas = document.getElementById('c');
 const ctx = canvas.getContext('2d');
 const wrap = document.getElementById('canvasWrap');
+const overviewCanvas = document.getElementById('overviewCanvas');
+const overviewCtx = overviewCanvas ? overviewCanvas.getContext('2d') : null;
 
 // ── Tile Cache ──
 class TileCache {
@@ -33,9 +35,31 @@ class TileCache {
     put(startS, endS, data) {
         const k = this.key(startS, endS);
         const sizeEst = JSON.stringify(data).length * 2;  // rough byte estimate
-        // No eviction — tiles are small with pre-built server cache
+        const previous = this.tiles.get(k);
+        if (previous) this.currentBytes -= previous.sizeEst;
         this.tiles.set(k, { data, ts: Date.now(), sizeEst });
         this.currentBytes += sizeEst;
+        // Keep the browser bounded on long profiles.  The active viewport is
+        // always re-fetched before it is drawn, so evicted history remains
+        // transparent to the user.
+        while (this.currentBytes > this.maxBytes && this.tiles.size > 1) {
+            let oldestKey = null;
+            let oldestTs = Infinity;
+            for (const [key, entry] of this.tiles) {
+                if (key === k) continue;
+                if (entry.ts < oldestTs) {
+                    oldestKey = key;
+                    oldestTs = entry.ts;
+                }
+            }
+            if (oldestKey === null) break;
+            const evicted = this.tiles.get(oldestKey);
+            this.tiles.delete(oldestKey);
+            this.currentBytes -= evicted ? evicted.sizeEst : 0;
+            for (const readyKey of this.nvtxReady) {
+                if (readyKey.startsWith(oldestKey + '|')) this.nvtxReady.delete(readyKey);
+            }
+        }
         this._dirty = true;
     }
     mergeNvtx(startS, endS, nvtxData, gpuId) {
@@ -118,6 +142,7 @@ class TileCache {
 }
 const tileCache = new TileCache();
 const nvtxInflight = new Set();
+const tileInflight = new Map();
 let profileMeta = null;  // {time_range_ns, gpus, device_ids}
 let isLoading = false;
 
@@ -142,16 +167,30 @@ function hideLoading() {
 // ── Fetch data for a time window ──
 async function fetchTile(startS, endS, { requestNvtx = false } = {}) {
     if (tileCache.has(startS, endS)) return tileCache.get(startS, endS);
+    const tileKey = tileCache.key(startS, endS);
+    if (tileInflight.has(tileKey)) return tileInflight.get(tileKey);
     const pfx = BOOT.API_PREFIX || '';
-    const resp = await fetch(`${pfx}/api/data?start_s=${startS}&end_s=${endS}&kernels=1&nvtx=0`);
-    const data = await resp.json();
-    if (data.error) { console.error('fetchTile error:', data.error); return null; }
-    tileCache.put(startS, endS, data);
-    if (requestNvtx && showNVTX) void fetchTileNvtx(startS, endS, currentActiveGpuId());
-    return data;
+    const request = fetch(`${pfx}/api/data?start_s=${startS}&end_s=${endS}&kernels=1&nvtx=0`)
+        .then(async resp => {
+            if (!resp.ok) throw new Error(`tile request failed (${resp.status})`);
+            const data = await resp.json();
+            if (data.error) throw new Error(data.error);
+            tileCache.put(startS, endS, data);
+            if (requestNvtx && showNVTX) void fetchTileNvtx(startS, endS, currentActiveGpuId());
+            return data;
+        })
+        .catch(err => {
+            console.error('fetchTile error:', err);
+            showToast(`Unable to load ${startS.toFixed(1)}–${endS.toFixed(1)}s`);
+            return null;
+        })
+        .finally(() => tileInflight.delete(tileKey));
+    tileInflight.set(tileKey, request);
+    return request;
 }
 
 function currentActiveGpuId() {
+    if (selectedGpuId !== null && gpuIds.includes(selectedGpuId)) return selectedGpuId;
     if (isMultiGPU && streamIds[selectedStreamIdx]) {
         const parts = String(streamIds[selectedStreamIdx]).split(':');
         const maybeGpu = parseInt(parts[0], 10);
@@ -172,11 +211,15 @@ async function fetchTileNvtx(startS, endS, gpuId) {
     try {
         const pfx = BOOT.API_PREFIX || '';
         const resp = await fetch(`${pfx}/api/data?start_s=${startS}&end_s=${endS}&kernels=0&nvtx=1&gpu=${gpuId}`);
+        if (!resp.ok) throw new Error(`NVTX request failed (${resp.status})`);
         const data = await resp.json();
-        if (data.error) { console.error('fetchTileNvtx error:', data.error); return; }
+        if (data.error) throw new Error(data.error);
         tileCache.mergeNvtx(startS, endS, data, gpuId);
         rebuildDataFromCache();
         draw();
+    } catch (err) {
+        console.error('fetchTileNvtx error:', err);
+        showToast('NVTX is not available for this view');
     } finally {
         nvtxInflight.delete(key);
         updateNvtxLoadingIndicator();
@@ -201,12 +244,20 @@ function tileBounds(ns) {
     return [startS, startS + TILE_WINDOW_S];
 }
 
+function tileRangeForView(vStart, vEnd) {
+    const startS = tileBounds(vStart)[0];
+    const endS = Math.max(
+        startS + TILE_WINDOW_S,
+        Math.ceil((vEnd / 1e9) / TILE_WINDOW_S) * TILE_WINDOW_S,
+    );
+    return [startS, endS];
+}
+
 // ── Load tiles covering the current viewport ──
 async function ensureTilesForView(vStart, vEnd) {
-    const startTile = tileBounds(vStart);
-    const endTile = tileBounds(vEnd);
+    const [startS, endS] = tileRangeForView(vStart, vEnd);
     const promises = [];
-    for (let s = startTile[0]; s < endTile[1]; s += TILE_WINDOW_S) {
+    for (let s = startS; s < endS; s += TILE_WINDOW_S) {
         if (!renderLockIntersects(s, s + TILE_WINDOW_S)) continue;
         if (!tileCache.has(s, s + TILE_WINDOW_S)) {
             promises.push(fetchTile(s, s + TILE_WINDOW_S));
@@ -227,11 +278,10 @@ async function ensureTilesForView(vStart, vEnd) {
 
 function maybeFetchNvtxForCurrentView() {
     if (!PROGRESSIVE || !showNVTX) return;
-    const startTile = tileBounds(viewStart);
-    const endTile = tileBounds(viewEnd);
+    const [startS, endS] = tileRangeForView(viewStart, viewEnd);
     const activeGpu = currentActiveGpuId();
     if (activeGpu === null || activeGpu === undefined) return;
-    for (let s = startTile[0]; s < endTile[1]; s += TILE_WINDOW_S) {
+    for (let s = startS; s < endS; s += TILE_WINDOW_S) {
         if (!renderLockIntersects(s, s + TILE_WINDOW_S)) continue;
         if (tileCache.has(s, s + TILE_WINDOW_S)) {
             void fetchTileNvtx(s, s + TILE_WINDOW_S, activeGpu);
@@ -243,11 +293,10 @@ function maybeFetchNvtxForCurrentView() {
 function prefetchAdjacent() {
     if (!PROGRESSIVE || typeof requestIdleCallback === 'undefined') return;
     requestIdleCallback(() => {
-        const startTile = tileBounds(viewStart);
-        const endTile = tileBounds(viewEnd);
+        const [startS, endS] = tileRangeForView(viewStart, viewEnd);
         // Prefetch one tile before and after
-        const before = [startTile[0] - TILE_WINDOW_S, startTile[0]];
-        const after = [endTile[1], endTile[1] + TILE_WINDOW_S];
+        const before = [startS - TILE_WINDOW_S, startS];
+        const after = [endS, endS + TILE_WINDOW_S];
         if (profileMeta) {
             const pStartS = profileMeta.time_range_ns[0] / 1e9;
             const pEndS = profileMeta.time_range_ns[1] / 1e9;
@@ -327,6 +376,8 @@ function rebuildDataFromCache() {
     // Clear and rebuild from all cached tiles (progressive) or from baked data
     allNodes = []; kernels = []; nvtxSpans = [];
     gpuIds = []; isMultiGPU = false;
+    renderStateCacheKey = '';
+    renderStateCache = null;
 
     if (PROGRESSIVE) {
         loadFromData(tileCache.allData());
@@ -413,7 +464,92 @@ function rebuildDataFromCache() {
     chips.push(`<span class="stat-chip">GPU <strong>${totalMs.toFixed(1)}</strong><span class="stat-unit">ms</span></span>`);
     document.getElementById('stats').innerHTML = chips.join('');
     ensureRenderLockDefaults();
+    updateGpuOptions();
     updateNvtxThreadOptions();
+    overviewDirty = true;
+    rebuildOverviewHistogram();
+    updateViewportReadout();
+}
+
+function overviewRangeNs() {
+    if (profileMeta && Array.isArray(profileMeta.time_range_ns)) {
+        return profileMeta.time_range_ns;
+    }
+    return [timeStart, timeEnd];
+}
+
+function rebuildOverviewHistogram() {
+    if (profileMeta && Array.isArray(profileMeta.overview_bins) && profileMeta.overview_bins.length) {
+        const max = Math.max(...profileMeta.overview_bins, 1);
+        overviewBins = profileMeta.overview_bins.map(value => value / max);
+        overviewDirty = false;
+        return;
+    }
+    const [lo, hi] = overviewRangeNs();
+    const span = Math.max(hi - lo, 1);
+    const count = 240;
+    const bins = new Array(count).fill(0);
+    for (const k of kernels) {
+        const start = Math.max(0, Math.floor((k.start_ns - lo) / span * count));
+        const end = Math.min(count - 1, Math.floor((k.end_ns - lo) / span * count));
+        for (let i = start; i <= end; i++) bins[i] += Math.max(1, Math.min(8, k.duration_ms || 1));
+    }
+    let max = 1;
+    for (const v of bins) if (v > max) max = v;
+    overviewBins = bins.map(v => v / max);
+    overviewDirty = false;
+}
+
+function updateViewportReadout() {
+    const range = document.getElementById('viewportRange');
+    const zoom = document.getElementById('viewportZoom');
+    if (!range || !zoom || !Number.isFinite(viewStart) || !Number.isFinite(viewEnd)) return;
+    const span = Math.max(viewEnd - viewStart, 1);
+    range.textContent = `${fmtTimeS(viewStart)} → ${fmtTimeS(viewEnd)}`;
+    const [lo, hi] = overviewRangeNs();
+    const fullSpan = Math.max(hi - lo, 1);
+    zoom.textContent = `${Math.max(0.01, fullSpan / span).toFixed(1)}×`;
+    const back = document.getElementById('viewBackBtn');
+    const forward = document.getElementById('viewForwardBtn');
+    if (back) back.disabled = viewHistoryIndex <= 0;
+    if (forward) forward.disabled = viewHistoryIndex < 0 || viewHistoryIndex >= viewHistory.length - 1;
+}
+
+function resizeOverview() {
+    if (!overviewCanvas || !overviewCtx) return;
+    const width = Math.max(80, overviewCanvas.clientWidth || wrap.clientWidth || 80);
+    const dpr = window.devicePixelRatio || 1;
+    overviewCanvas.width = Math.round(width * dpr);
+    overviewCanvas.height = Math.round(34 * dpr);
+    overviewCtx.setTransform(dpr, 0, 0, dpr, 0, 0);
+}
+
+function drawOverview() {
+    if (!overviewCanvas || !overviewCtx) return;
+    if (overviewDirty) rebuildOverviewHistogram();
+    const width = overviewCanvas.width / (window.devicePixelRatio || 1);
+    const height = 34;
+    const [lo, hi] = overviewRangeNs();
+    const fullSpan = Math.max(hi - lo, 1);
+    overviewCtx.clearRect(0, 0, width, height);
+    overviewCtx.fillStyle = '#0d1117';
+    overviewCtx.fillRect(0, 0, width, height);
+    const barWidth = Math.max(1, width / Math.max(overviewBins.length, 1));
+    for (let i = 0; i < overviewBins.length; i++) {
+        const h = Math.max(1, overviewBins[i] * 21);
+        overviewCtx.fillStyle = `rgba(88, 166, 255, ${0.16 + overviewBins[i] * 0.58})`;
+        overviewCtx.fillRect(i * barWidth, height - h - 4, Math.ceil(barWidth), h);
+    }
+    const x1 = Math.max(0, (viewStart - lo) / fullSpan * width);
+    const x2 = Math.min(width, (viewEnd - lo) / fullSpan * width);
+    overviewCtx.fillStyle = 'rgba(88, 166, 255, 0.12)';
+    overviewCtx.fillRect(x1, 0, Math.max(2, x2 - x1), height);
+    overviewCtx.strokeStyle = '#79b8ff';
+    overviewCtx.lineWidth = 1;
+    overviewCtx.strokeRect(x1 + 0.5, 1.5, Math.max(1, x2 - x1 - 1), height - 3);
+    overviewCtx.fillStyle = '#79b8ff';
+    overviewCtx.fillRect(Math.max(0, x1 - 1), 0, 3, height);
+    overviewCtx.fillRect(Math.min(width - 2, x2 - 1), 0, 3, height);
 }
 
 // ── Initialization ──
@@ -421,8 +557,10 @@ async function initData() {
     if (INITIAL_DATA !== null) {
         // Baked-in data mode (--trim was specified)
         rebuildDataFromCache();
+        resetViewHistory();
         viewStart = timeStart - timeSpan * 0.02;
         viewEnd = timeEnd + timeSpan * 0.02;
+        resetViewHistory();
         resize();
         return;
     }
@@ -442,6 +580,7 @@ async function initData() {
                 viewEnd = saved.e;
                 await ensureTilesForView(viewStart, viewEnd);
                 rebuildDataFromCache();
+                resetViewHistory();
                 restored = true;
             }
         } catch (e) { }
@@ -452,6 +591,7 @@ async function initData() {
             viewEnd = firstEnd * 1e9;
             await ensureTilesForView(viewStart, viewEnd);
             rebuildDataFromCache();
+            resetViewHistory();
         }
         hideLoading();
         resize();
@@ -470,6 +610,7 @@ let viewEnd = 1;
 let selectedKernel = null;
 let selectedNvtx = null;
 let selectedStreamIdx = 0;
+let selectedGpuId = null;  // null follows the selected stream; a number pins NVTX
 let showNVTX = true;
 let selectedNvtxThread = 'auto';
 let searchQuery = '';
@@ -480,6 +621,15 @@ let isSelecting = false, selectStartX = 0, selectStartNs = 0, selectEndNs = 0;
 let isResizingDetail = false, detailResizeStartY = 0, detailResizeStartH = 0;
 let bookmarks = [];
 let hiddenStreams = new Set();  // stream keys to hide
+let viewHistory = [];
+let viewHistoryIndex = -1;
+let overviewBins = [];
+let overviewDirty = true;
+let overviewDragging = false;
+let overviewDragOffset = 0;
+let overviewDragSpan = 0;
+let renderStateCacheKey = '';
+let renderStateCache = null;
 const RENDER_SETTINGS_KEY = 'timeline-render-settings-v1';
 const RENDER_LOCK_KEY = 'timeline-render-lock-v1';
 const DEFAULT_RENDER_SETTINGS = Object.freeze({
@@ -905,6 +1055,43 @@ function updateNvtxThreadOptions() {
     sel.value = selectedNvtxThread;
 }
 
+function updateGpuOptions() {
+    const sel = document.getElementById('gpuSel');
+    if (!sel) return;
+    sel.innerHTML = '';
+    if (!isMultiGPU) {
+        sel.style.display = 'none';
+        selectedGpuId = null;
+        return;
+    }
+    sel.style.display = 'inline-block';
+    const auto = document.createElement('option');
+    auto.value = 'auto';
+    auto.textContent = 'GPU follows stream';
+    sel.appendChild(auto);
+    for (const id of gpuIds) {
+        const opt = document.createElement('option');
+        opt.value = String(id);
+        opt.textContent = `GPU ${id}`;
+        sel.appendChild(opt);
+    }
+    sel.value = selectedGpuId === null ? 'auto' : String(selectedGpuId);
+}
+
+function onGpuChange() {
+    const sel = document.getElementById('gpuSel');
+    if (!sel) return;
+    selectedGpuId = sel.value === 'auto' ? null : Number(sel.value);
+    if (selectedGpuId !== null) {
+        const first = streamIds.findIndex(sid => String(sid).startsWith(selectedGpuId + ':'));
+        if (first >= 0) selectedStreamIdx = first;
+    }
+    selectedNvtx = null;
+    updateNvtxThreadOptions();
+    maybeFetchNvtxForCurrentView();
+    draw();
+}
+
 function onNvtxThreadChange() {
     const sel = document.getElementById('nvtxThreadSel');
     selectedNvtxThread = sel ? sel.value : 'auto';
@@ -925,6 +1112,7 @@ function resize() {
     canvas.style.width = r.width + 'px';
     canvas.style.height = needH + 'px';
     ctx.setTransform(DPR, 0, 0, DPR, 0, 0);
+    resizeOverview();
     draw();
 }
 window.addEventListener('resize', resize);
@@ -960,13 +1148,97 @@ function streamY(idx) {
 function draw() {
     const W = canvas.width / DPR;
     const H = canvas.height / DPR;
+    const renderState = timelineRenderState(W);
     ctx.clearRect(0, 0, W, H);
     ctx.font = '11px SF Mono, Cascadia Code, Fira Code, monospace';
 
     drawRuler(W);
     if (showNVTX) drawNVTX(W);
-    drawStreams(W, H);
+    drawStreams(W, H, renderState);
     if (FINDINGS.length) drawFindings(W, H);
+    updateRenderSummary(renderState);
+    drawOverview();
+    updateViewportReadout();
+}
+
+function kernelOverlapsView(k) {
+    return k.end_ns >= viewStart && k.start_ns <= viewEnd;
+}
+
+function isKernelEmphasized(k) {
+    return k === selectedKernel || (searchQuery && searchKernelMatches.has(k));
+}
+
+function timelineRenderState(W) {
+    const plotW = Math.max(1, W - LABEL_W);
+    const hiddenKey = Array.from(hiddenStreams).sort().join(',');
+    const key = `${Math.round(viewStart)}:${Math.round(viewEnd)}:${Math.round(plotW)}:${kernels.length}:${hiddenKey}:${searchQuery}`;
+    if (renderStateCacheKey === key && renderStateCache) return renderStateCache;
+
+    let visibleKernels = 0;
+    let repeatedItems = 0;
+    let repeatedGroups = 0;
+    const names = new Map();
+    for (const sid of streamIds) {
+        if (hiddenStreams.has(sid)) continue;
+        for (const k of (streamMap[sid] || [])) {
+            if (!kernelOverlapsView(k)) continue;
+            visibleKernels++;
+            const name = String(k.name || '(unnamed)');
+            names.set(name, (names.get(name) || 0) + 1);
+        }
+    }
+    for (const count of names.values()) {
+        if (count > 1) {
+            repeatedGroups++;
+            repeatedItems += count - 1;
+        }
+    }
+
+    const averagePixels = plotW / Math.max(visibleKernels, 1);
+    let mode = 'detail';
+    if (visibleKernels > Math.max(2200, plotW * 2.2) || averagePixels < 1.2) {
+        mode = 'density';
+    } else if (visibleKernels > Math.max(700, plotW * 0.7) || averagePixels < 3.5) {
+        mode = 'compact';
+    }
+    const state = {
+        mode,
+        visibleKernels,
+        repeatedGroups,
+        repeatedItems,
+        condensedNvtx: 0,
+    };
+    renderStateCacheKey = key;
+    renderStateCache = state;
+
+    return state;
+}
+
+function updateRenderSummary(state) {
+    const summary = document.getElementById('renderSummary');
+    if (!summary) return;
+    const count = new Intl.NumberFormat().format(state.visibleKernels);
+    const fullCount = profileMeta && Number.isFinite(profileMeta.overview_kernel_count)
+        ? profileMeta.overview_kernel_count : 0;
+    const loadedCount = kernels.length;
+    const coverage = fullCount > loadedCount
+        ? ` · ${new Intl.NumberFormat().format(loadedCount)}/${new Intl.NumberFormat().format(fullCount)} loaded` : '';
+    let text;
+    if (state.mode === 'density') {
+        text = `${count} kernels · condensed view · zoom in for names${coverage}`;
+    } else if (state.mode === 'compact') {
+        const repeats = state.repeatedGroups ? ` · ${state.repeatedGroups} repeated groups collapsed` : '';
+        text = `${count} kernels · compact labels${repeats}${coverage}`;
+    } else {
+        text = `${count} kernels · detailed view${coverage}`;
+    }
+    if (state.condensedNvtx) text += ` · ${state.condensedNvtx} NVTX ranges condensed`;
+    if (state.hiddenInfoFindings) text += ` · ${state.hiddenInfoFindings} info findings hidden`;
+    summary.textContent = text;
+    summary.title = state.repeatedItems
+        ? `${count} kernels in view; ${state.repeatedItems} repeated occurrences share a name`
+        : `${count} kernels in view`;
 }
 
 function drawRuler(W) {
@@ -1043,13 +1315,29 @@ function formatTickValue(ns, div, decimals) {
     return fmt.format(v);
 }
 
+function nvtxSpansForRender(spans, renderState) {
+    if (renderState.mode !== 'density' || spans.length <= 180) return spans;
+    const keep = new Set();
+    const ranked = spans.slice().sort((a, b) =>
+        ((b.end - b.start) - (a.end - a.start)) || ((a.depth || 0) - (b.depth || 0))
+    );
+    for (let i = 0; i < ranked.length && keep.size < 180; i++) keep.add(ranked[i]._key);
+    if (selectedNvtx) keep.add(selectedNvtx.key);
+    renderState.condensedNvtx = Math.max(0, spans.length - keep.size);
+    return spans.filter(s => keep.has(s._key));
+}
+
 function drawNVTX(W) {
+    const renderState = timelineRenderState(W);
     const baseY = RULER_H + findingsLaneH();
     ctx.fillStyle = 'rgba(22, 27, 34, 0.85)';
     ctx.fillRect(0, baseY, W, nvtxAreaH());
 
-    const { activeGpu, thread, spans: visibleSpans, clipped } = activeNvtxLayout();
+    const { activeGpu, thread, spans: allVisibleSpans, clipped } = activeNvtxLayout();
+    const visibleSpans = nvtxSpansForRender(allVisibleSpans, renderState);
+    let clippedCount = clipped + Math.max(0, allVisibleSpans.length - visibleSpans.length);
     const depthMax = activeNvtxMaxDepth();
+    const seenLabels = new Set();
 
     for (const span of visibleSpans) {
         const x1 = Math.max(LABEL_W, nsToX(span.start));
@@ -1074,8 +1362,14 @@ function drawNVTX(W) {
         ctx.strokeRect(x1 + 0.5, y + 0.5, w - 1, h - 1);
         ctx.globalAlpha = 1;
 
-        // Label if wide enough
-        if (w > 40) {
+        // Repeated nested ranges are useful at detail scale, but become noise
+        // when zoomed out. Keep one label per lane/name until the user zooms.
+        const labelKey = `${span._lane}|${span.name}`;
+        const canLabel = renderState.mode === 'detail'
+            ? w > 40
+            : w > 60 && !seenLabels.has(labelKey);
+        if (canLabel || isSel || (searchQuery && isSearchMatch)) {
+            seenLabels.add(labelKey);
             ctx.fillStyle = isSel ? '#ffffff' : (searchQuery && !isSearchMatch ? '#6b7280' : '#e6edf3');
             ctx.textAlign = 'left';
             ctx.textBaseline = 'middle';
@@ -1119,10 +1413,10 @@ function drawNVTX(W) {
         ctx.textBaseline = 'top';
         const threadLabel = thread ? ` • ${thread}` : '';
         ctx.fillText(`NVTX: GPU ${activeGpu}${threadLabel}`, LABEL_W + 4, baseY + 2);
-        if (clipped > 0) {
+        if (clippedCount > 0) {
             ctx.fillStyle = '#8b949e';
             ctx.textAlign = 'right';
-            ctx.fillText(`+${clipped} clipped`, W - 8, baseY + 2);
+            ctx.fillText(`+${clippedCount} condensed`, W - 8, baseY + 2);
         }
     }
     ctx.font = '11px SF Mono, Cascadia Code, Fira Code, monospace';
@@ -1133,7 +1427,108 @@ function drawNVTX(W) {
     ctx.beginPath(); ctx.moveTo(0, sepY); ctx.lineTo(W, sepY); ctx.stroke();
 }
 
-function drawStreams(W, H) {
+function drawKernelBlock(k, y, W, options = {}) {
+    let x1 = nsToX(k.start_ns);
+    let x2 = nsToX(k.end_ns);
+    if (x2 < LABEL_W || x1 > W) return;
+    x1 = Math.max(LABEL_W, x1);
+    x2 = Math.min(W, x2);
+    const w = Math.max(MIN_BLOCK_W, x2 - x1);
+    const bY = y + 2;
+    const bH = STREAM_H - 4;
+    const isMatch = !searchQuery || searchKernelMatches.has(k);
+    const isSel = k === selectedKernel;
+    const isNcclK = String(k.name || '').toLowerCase().includes('nccl');
+
+    // Per-kernel color from name hash (NCCL keeps special purple).
+    if (!k._nsysColor) {
+        k._nsysColor = isNcclK
+            ? { color: '#d2a8ff', lightness: 72 }
+            : kernelColorFromName(k.name);
+    }
+    const kColor = k._nsysColor;
+    let fillColor = kColor.color;
+    const kLightness = kColor.lightness;
+    let alpha = 0.78 + 0.22 * (k.heat || 0);
+    if (searchQuery && !isMatch) {
+        alpha = renderSettings.kernelSearchNonMatchAlpha;
+    } else if (selectedNvtx && !isSel) {
+        alpha = renderSettings.kernelWhenNvtxSelectedAlpha;
+    } else if (w < 6) {
+        alpha *= Math.max(0.25, w / 6);
+    }
+    if (isSel) fillColor = '#79b8ff', alpha = 1;
+
+    ctx.globalAlpha = alpha;
+    ctx.fillStyle = fillColor;
+    ctx.fillRect(x1, bY, w, bH);
+    ctx.globalAlpha = 1;
+    if (!isSel) {
+        ctx.strokeStyle = fillColor;
+        ctx.globalAlpha = 0.5;
+        ctx.strokeRect(x1 + 0.5, bY + 0.5, w - 1, bH - 1);
+        ctx.globalAlpha = 1;
+    }
+    if (isSel) {
+        ctx.strokeStyle = '#79b8ff';
+        ctx.lineWidth = 2;
+        ctx.strokeRect(x1, bY, w, bH);
+        ctx.lineWidth = 1;
+    }
+
+    if (options.label && w > 20) {
+        ctx.fillStyle = isSel
+            ? '#fff'
+            : (searchQuery && !isMatch ? '#555' : (kLightness > 55 ? '#1c1c1c' : '#e6edf3'));
+        ctx.textAlign = 'left';
+        ctx.textBaseline = 'middle';
+        ctx.save();
+        ctx.beginPath(); ctx.rect(x1 + 1, bY, w - 2, bH); ctx.clip();
+        const short = String(k.name || '(unnamed)').length > 40
+            ? String(k.name || '(unnamed)').slice(0, 38) + '…'
+            : String(k.name || '(unnamed)');
+        const label = w > 100 ? short + ' ' + fmtDur(k.duration_ms) : short;
+        ctx.fillText(label, x1 + 3, bY + bH / 2);
+        ctx.restore();
+    }
+}
+
+function drawDenseStream(ks, y, W) {
+    const plotW = Math.max(1, W - LABEL_W);
+    const bucketCount = Math.max(48, Math.min(320, Math.floor(plotW / 3)));
+    const counts = new Array(bucketCount).fill(0);
+    const heat = new Array(bucketCount).fill(0);
+    const span = Math.max(viewEnd - viewStart, 1);
+    for (const k of ks) {
+        if (!kernelOverlapsView(k)) continue;
+        const b1 = Math.max(0, Math.floor((Math.max(k.start_ns, viewStart) - viewStart) / span * bucketCount));
+        const b2 = Math.min(bucketCount - 1, Math.floor((Math.min(k.end_ns, viewEnd) - viewStart) / span * bucketCount));
+        for (let b = b1; b <= b2; b++) {
+            counts[b]++;
+            heat[b] = Math.max(heat[b], k.heat || 0);
+        }
+    }
+    const bucketW = plotW / bucketCount;
+    for (let b = 0; b < bucketCount; b++) {
+        if (!counts[b]) continue;
+        const x = LABEL_W + b * bucketW;
+        const alpha = Math.min(0.82, 0.18 + Math.log2(counts[b] + 1) * 0.12 + heat[b] * 0.18);
+        ctx.fillStyle = '#58a6ff';
+        ctx.globalAlpha = alpha;
+        ctx.fillRect(x, y + 3, Math.max(1, bucketW + 0.5), STREAM_H - 6);
+        ctx.globalAlpha = 1;
+    }
+
+    // Keep search and selection actionable even when the background is condensed.
+    let emphasized = 0;
+    for (const k of ks) {
+        if (!kernelOverlapsView(k) || !isKernelEmphasized(k)) continue;
+        if (k !== selectedKernel && emphasized++ > 500) continue;
+        drawKernelBlock(k, y, W, { label: k === selectedKernel });
+    }
+}
+
+function drawStreams(W, H, renderState) {
     // Draw GPU separator rows first (if multi-GPU)
     if (isMultiGPU) {
         for (let gi = 0; gi < gpuBands.length; gi++) {
@@ -1211,81 +1606,23 @@ function drawStreams(W, H) {
         }
         ctx.fillText(streamLabel, LABEL_W - 6, y + STREAM_H / 2);
 
-        // Kernel blocks
-        for (const k of ks) {
-            let x1 = nsToX(k.start_ns);
-            let x2 = nsToX(k.end_ns);
-            if (x2 < LABEL_W || x1 > W) continue;
-            x1 = Math.max(LABEL_W, x1);
-            x2 = Math.min(W, x2);
-            const w = Math.max(MIN_BLOCK_W, x2 - x1);
-            const bY = y + 2;
-            const bH = STREAM_H - 4;
-
-            const isMatch = !searchQuery || searchKernelMatches.has(k);
-            const isSel = k === selectedKernel;
-            const isNcclK = k.name.toLowerCase().includes('nccl');
-
-            // Per-kernel color from name hash (NCCL keeps special purple).
-            // Cache the resolved {color, lightness} on the kernel object so we
-            // don't recompute it on every redraw inside the hot render loop.
-            if (!k._nsysColor) {
-                if (isNcclK) {
-                    // #d2a8ff ≈ L72
-                    k._nsysColor = { color: '#d2a8ff', lightness: 72 };
-                } else {
-                    k._nsysColor = kernelColorFromName(k.name);
+        // At wide scales, render a quiet density map.  Selecting or searching
+        // still paints the matching raw blocks above it.
+        if (renderState.mode === 'density') {
+            drawDenseStream(ks, y, W);
+        } else {
+            const seenLabels = new Set();
+            for (const k of ks) {
+                if (!kernelOverlapsView(k)) continue;
+                const width = Math.max(MIN_BLOCK_W, nsToX(k.end_ns) - nsToX(k.start_ns));
+                const emphasized = isKernelEmphasized(k);
+                let label = width > 20;
+                if (renderState.mode === 'compact' && !emphasized) {
+                    const name = String(k.name || '(unnamed)');
+                    label = width > 40 && !seenLabels.has(name);
+                    if (label) seenLabels.add(name);
                 }
-            }
-
-            const kColor = k._nsysColor;
-            let fillColor = kColor.color;
-            let kLightness = kColor.lightness;
-            let alpha = 0.78 + 0.22 * (k.heat || 0);
-            // Apply dim overrides (search/NVTX) OR density reduction, not both
-            if (searchQuery && !isMatch) {
-                alpha = renderSettings.kernelSearchNonMatchAlpha;
-            } else if (selectedNvtx && !isSel) {
-                alpha = renderSettings.kernelWhenNvtxSelectedAlpha;
-            } else if (w < 6) {
-                // Density-aware: 1px → 0.25α, 3px → 0.5α, 6px+ → full
-                alpha *= Math.max(0.25, w / 6);
-            }
-            if (isSel) { fillColor = '#79b8ff'; kLightness = 60; alpha = 1; }
-
-            ctx.globalAlpha = alpha;
-            ctx.fillStyle = fillColor;
-            ctx.fillRect(x1, bY, w, bH);
-            ctx.globalAlpha = 1;
-            // Subtle border so blocks don't blend into background
-            if (!isSel) {
-                ctx.strokeStyle = fillColor;
-                ctx.globalAlpha = 0.5;
-                ctx.strokeRect(x1 + 0.5, bY + 0.5, w - 1, bH - 1);
-                ctx.globalAlpha = 1;
-            }
-
-            if (isSel) {
-                ctx.strokeStyle = '#79b8ff';
-                ctx.lineWidth = 2;
-                ctx.strokeRect(x1, bY, w, bH);
-                ctx.lineWidth = 1;
-            }
-
-            // Kernel name label (dynamic contrast: dark text on light bars, white on dark)
-            if (w > 20) {
-                ctx.fillStyle = isSel
-                    ? '#fff'
-                    : (searchQuery && !isMatch ? '#555' : (kLightness > 55 ? '#1c1c1c' : '#e6edf3'));
-                ctx.textAlign = 'left';
-                ctx.textBaseline = 'middle';
-                ctx.save();
-                ctx.beginPath(); ctx.rect(x1 + 1, bY, w - 2, bH); ctx.clip();
-                const short = k.name.length > 40 ? k.name.slice(0, 38) + '…' : k.name;
-                // Name first, duration only if space
-                const label = w > 100 ? short + ' ' + fmtDur(k.duration_ms) : short;
-                if (label) ctx.fillText(label, x1 + 3, bY + bH / 2);
-                ctx.restore();
+                drawKernelBlock(k, y, W, { label });
             }
         }
 
@@ -1365,7 +1702,7 @@ function kernelPathForDisplay(k) {
 function showDetail(item) {
     if (!item) {
         document.getElementById('detail').className = 'empty';
-        document.getElementById('detail').innerHTML = 'Click a kernel or NVTX to see details. Press A for AI chat. Keyboard: ←/→ pan, +/- zoom, ↑/↓ stream, / search, ? help';
+        document.getElementById('detail').innerHTML = 'Click a kernel or NVTX to see details. Drag to pan; Shift+drag to zoom a range. Press A for AI chat, / to search, ? for help.';
         return;
     }
     if (item._kind === 'nvtx') {
@@ -1421,13 +1758,61 @@ function renderPathHtml(path) {
 // ── Navigation ──
 // ── Progressive tile loading on viewport change ──
 let _viewChangeTimer = null;
+let _tileLoadTimer = null;
 const _viewLabel = (typeof BOOT.GPU_LABEL === 'string' && BOOT.GPU_LABEL) ? BOOT.GPU_LABEL : 'timeline';
 const _viewKey = 'timeline-view-' + _viewLabel.replace(/[^a-zA-Z0-9]/g, '_');
-function afterViewChange() {
+function resetViewHistory() {
+    viewHistory = [{ start: viewStart, end: viewEnd }];
+    viewHistoryIndex = 0;
+    updateViewportReadout();
+}
+
+function recordViewHistory() {
+    const current = { start: viewStart, end: viewEnd };
+    const previous = viewHistory[viewHistoryIndex];
+    if (previous && Math.abs(previous.start - current.start) < 1 && Math.abs(previous.end - current.end) < 1) {
+        return;
+    }
+    if (viewHistoryIndex < viewHistory.length - 1) {
+        viewHistory = viewHistory.slice(0, viewHistoryIndex + 1);
+    }
+    viewHistory.push(current);
+    if (viewHistory.length > 80) viewHistory.shift();
+    viewHistoryIndex = viewHistory.length - 1;
+}
+
+function restoreViewSnapshot(snapshot) {
+    if (!snapshot) return;
+    viewStart = snapshot.start;
+    viewEnd = snapshot.end;
+    clampView();
+    draw();
+    afterViewChange({ record: false });
+}
+
+function goBackView() {
+    if (viewHistoryIndex <= 0) return;
+    viewHistoryIndex -= 1;
+    restoreViewSnapshot(viewHistory[viewHistoryIndex]);
+}
+
+function goForwardView() {
+    if (viewHistoryIndex >= viewHistory.length - 1) return;
+    viewHistoryIndex += 1;
+    restoreViewSnapshot(viewHistory[viewHistoryIndex]);
+}
+
+function afterViewChange({ record = true, deferLoad = false } = {}) {
+    if (record) recordViewHistory();
     // Persist viewport to localStorage
     try { localStorage.setItem(_viewKey, JSON.stringify({ s: viewStart, e: viewEnd, t: Date.now() })); } catch (e) { }
     if (PROGRESSIVE) {
-        ensureTilesForView(viewStart, viewEnd).catch(console.error);
+        clearTimeout(_tileLoadTimer);
+        if (deferLoad) {
+            _tileLoadTimer = setTimeout(() => ensureTilesForView(viewStart, viewEnd).catch(console.error), 120);
+        } else {
+            ensureTilesForView(viewStart, viewEnd).catch(console.error);
+        }
         prefetchAdjacent();
     }
     if (window.parent && window.parent !== window) {
@@ -1848,6 +2233,17 @@ function showToast(msg) {
     setTimeout(() => { toast.style.opacity = '0'; }, 2000);
 }
 
+function toggleFocus() {
+    const active = document.body.classList.toggle('focus-mode');
+    const btn = document.getElementById('focusBtn');
+    if (btn) {
+        btn.classList.toggle('active', active);
+        btn.textContent = active ? 'Exit focus' : 'Focus';
+    }
+    setTimeout(resize, 0);
+    showToast(active ? 'Focus mode — press F or Esc to restore controls' : 'Controls restored');
+}
+
 function toggleNVTX() {
     showNVTX = !showNVTX;
     document.getElementById('nvtxBtn').classList.toggle('active', showNVTX);
@@ -2051,8 +2447,9 @@ canvas.addEventListener('mousedown', e => {
         if (hit.kernel) { selectKernel(hit.kernel); return; }
     }
 
-    // Shift+drag = pan (old behavior), plain drag = select time range
-    if (e.shiftKey) {
+    // Plain drag pans (the discoverable default); Shift+drag selects a time
+    // range and zooms to it on release.
+    if (!e.shiftKey) {
         isDragging = true;
         dragStartX = e.clientX;
         dragViewStart = viewStart;
@@ -2100,7 +2497,7 @@ canvas.addEventListener('mousemove', e => {
         viewStart = dragViewStart - dx * nsPerPx;
         viewEnd = dragViewEnd - dx * nsPerPx;
         clampView();
-        afterViewChange();
+        afterViewChange({ record: false, deferLoad: true });
         draw();
         return;
     }
@@ -2181,7 +2578,7 @@ canvas.addEventListener('mouseup', () => {
     if (isSelecting) {
         isSelecting = false;
         canvas.style.cursor = 'crosshair';
-        // Zoom to selection if it's wide enough
+        // Zoom to selection if it's wide enough.
         const sNs = Math.min(selectStartNs, selectEndNs);
         const eNs = Math.max(selectStartNs, selectEndNs);
         if (eNs - sNs > 1000) {
@@ -2194,9 +2591,15 @@ canvas.addEventListener('mouseup', () => {
         }
         return;
     }
-    isDragging = false; canvas.style.cursor = 'crosshair';
+    if (isDragging) {
+        isDragging = false;
+        afterViewChange();
+        draw();
+    }
+    canvas.style.cursor = 'crosshair';
 });
 canvas.addEventListener('mouseleave', () => {
+    if (isDragging) afterViewChange();
     isDragging = false; isSelecting = false; canvas.style.cursor = 'crosshair';
     document.getElementById('tooltip').style.display = 'none';
 });
@@ -2222,6 +2625,53 @@ canvas.addEventListener('wheel', e => {
         afterViewChange();
     }
 }, { passive: false });
+
+// ── Overview navigator ──
+function updateFromOverview(clientX) {
+    if (!overviewCanvas) return;
+    const rect = overviewCanvas.getBoundingClientRect();
+    const [lo, hi] = overviewRangeNs();
+    const fullSpan = Math.max(hi - lo, 1);
+    const px = Math.max(0, Math.min(rect.width, clientX - rect.left));
+    const nextStart = lo + ((px - overviewDragOffset) / Math.max(rect.width, 1)) * fullSpan;
+    viewStart = nextStart;
+    viewEnd = nextStart + overviewDragSpan;
+    clampView();
+    afterViewChange({ record: false, deferLoad: true });
+    draw();
+}
+
+if (overviewCanvas) {
+    overviewCanvas.addEventListener('mousedown', e => {
+        if (e.button !== 0) return;
+        e.preventDefault();
+        const rect = overviewCanvas.getBoundingClientRect();
+        const [lo, hi] = overviewRangeNs();
+        const fullSpan = Math.max(hi - lo, 1);
+        const x = e.clientX - rect.left;
+        const currentStartX = (viewStart - lo) / fullSpan * rect.width;
+        const currentEndX = (viewEnd - lo) / fullSpan * rect.width;
+        overviewDragSpan = viewEnd - viewStart;
+        overviewDragOffset = x >= currentStartX && x <= currentEndX
+            ? x - currentStartX
+            : (currentEndX - currentStartX) / 2;
+        overviewDragging = true;
+        updateFromOverview(e.clientX);
+    });
+    overviewCanvas.addEventListener('mousemove', e => {
+        if (overviewDragging) updateFromOverview(e.clientX);
+    });
+    overviewCanvas.addEventListener('mouseup', () => {
+        if (!overviewDragging) return;
+        overviewDragging = false;
+        afterViewChange();
+    });
+    overviewCanvas.addEventListener('mouseleave', () => {
+        if (!overviewDragging) return;
+        overviewDragging = false;
+        afterViewChange();
+    });
+}
 
 const detailEl = document.getElementById('detail');
 const detailResizeHandle = document.getElementById('detailResizeHandle');
@@ -2329,6 +2779,17 @@ document.addEventListener('keydown', e => {
     const helpEl = document.getElementById('helpOverlay');
     if (helpEl.style.display === 'block' && e.key !== '?') { helpEl.style.display = 'none'; return; }
 
+    if (e.altKey && e.key === 'ArrowLeft') {
+        e.preventDefault();
+        goBackView();
+        return;
+    }
+    if (e.altKey && e.key === 'ArrowRight') {
+        e.preventDefault();
+        goForwardView();
+        return;
+    }
+
     switch (e.key) {
         case 'ArrowLeft': case 'h': e.preventDefault(); panBy(-0.15); break;
         case 'ArrowRight': case 'l': e.preventDefault(); panBy(0.15); break;
@@ -2363,6 +2824,7 @@ document.addEventListener('keydown', e => {
         case 'v': case 'V': e.preventDefault(); gotoNvtxPrompt(); break;
         case '/': e.preventDefault(); document.getElementById('searchInput').focus(); break;
         case 'Escape':
+            if (document.body.classList.contains('focus-mode')) toggleFocus();
             selectedKernel = null; selectedNvtx = null; selectedFindingIdx = -1;
             document.querySelectorAll('.finding-card').forEach(el => el.classList.remove('active'));
             showDetail(null);
@@ -2375,7 +2837,7 @@ document.addEventListener('keydown', e => {
         case 'a': case 'A': toggleChat(); break;
         case 'e': case 'E': if (FINDINGS.length) toggleFindings(); break;
         case 'w': case 'W': toggleLoop(); break;
-        case 'f': case 'F': fitAll(); break;
+        case 'f': case 'F': toggleFocus(); break;
         case 'b': saveBookmark(); break;
         case 'B': toggleBookmarkList(); break;
         case 's': case 'S': toggleStreamFilter(); break;
@@ -2779,9 +3241,30 @@ function _findingStreamRange(f) {
     return { y: topY, h: totalH };
 }
 
+function findingIndicesForRender(renderState) {
+    const visible = [];
+    let hiddenInfo = 0;
+    for (let i = 0; i < FINDINGS.length; i++) {
+        const f = FINDINGS[i];
+        const endNs = f.end_ns ?? f.start_ns;
+        if (endNs < viewStart || f.start_ns > viewEnd) continue;
+        // Info annotations remain available in the evidence sidebar, but do
+        // not compete with critical/warning markers at the overview scale.
+        if (renderState.mode === 'density' && f.severity === 'info' && i !== selectedFindingIdx) {
+            hiddenInfo++;
+            continue;
+        }
+        visible.push(i);
+    }
+    renderState.hiddenInfoFindings = hiddenInfo;
+    return visible;
+}
+
 function drawFindings(W, H) {
     const font = ctx.font;
     ctx.save();
+    const renderState = timelineRenderState(W);
+    const findingIndices = findingIndicesForRender(renderState);
 
     const hasActive = selectedFindingIdx >= 0 && selectedFindingIdx < FINDINGS.length;
     const laneY = RULER_H;  // annotation lane starts right below the ruler
@@ -2834,7 +3317,7 @@ function drawFindings(W, H) {
     }
 
     // ── Pass 2: Draw region/highlight/marker overlays on streams ──
-    for (let i = 0; i < FINDINGS.length; i++) {
+    for (const i of findingIndices) {
         const f = FINDINGS[i];
         const startNs = f.start_ns;
         const endNs = f.end_ns ?? startNs;
@@ -2846,7 +3329,8 @@ function drawFindings(W, H) {
         const isActive = i === selectedFindingIdx;
         const sevCol = _findingSevColor(f.severity);
         const { y: targetY, h: targetH } = _findingStreamRange(f);
-        const baseAlpha = hasActive && !isActive ? 0.1 : 1;
+        const severityAlpha = renderState.mode === 'compact' && f.severity === 'info' ? 0.45 : 1;
+        const baseAlpha = (hasActive && !isActive ? 0.1 : 1) * severityAlpha;
 
         if (f.type === 'region' || f.type === 'highlight') {
             ctx.globalAlpha = baseAlpha;
@@ -2900,7 +3384,7 @@ function drawFindings(W, H) {
 
     // ── Pass 3: Draw annotation lane pills + connecting lines ──
     if (laneH > 0) {
-        for (let i = 0; i < FINDINGS.length; i++) {
+        for (const i of findingIndices) {
             const f = FINDINGS[i];
             const startNs = f.start_ns;
             const endNs = f.end_ns ?? startNs;
@@ -2911,7 +3395,8 @@ function drawFindings(W, H) {
             const midX = (x1 + x2) / 2;
             const isActive = i === selectedFindingIdx;
             const sevCol = _findingSevColor(f.severity);
-            const baseAlpha = hasActive && !isActive ? 0.2 : 1;
+            const severityAlpha = renderState.mode === 'compact' && f.severity === 'info' ? 0.45 : 1;
+            const baseAlpha = (hasActive && !isActive ? 0.2 : 1) * severityAlpha;
             const { y: targetY, h: targetH } = _findingStreamRange(f);
 
             // ── Connecting dotted line from pill to target region ──
@@ -3164,7 +3649,7 @@ function selectFinding(idx) {
     viewEnd = endNs + pad;
     clampView();
     draw();
-    if (PROGRESSIVE) ensureTilesForView(viewStart, viewEnd);
+    afterViewChange();
 }
 
 function toggleFindings() {

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -478,6 +478,13 @@ function overviewRangeNs() {
     return [timeStart, timeEnd];
 }
 
+function profileRangeNs() {
+    const range = overviewRangeNs();
+    const lo = Number.isFinite(range[0]) ? range[0] : 0;
+    const hi = Number.isFinite(range[1]) && range[1] > lo ? range[1] : lo + 1;
+    return [lo, hi];
+}
+
 function rebuildOverviewHistogram() {
     if (profileMeta && Array.isArray(profileMeta.overview_bins) && profileMeta.overview_bins.length) {
         const max = Math.max(...profileMeta.overview_bins, 1);
@@ -550,6 +557,14 @@ function drawOverview() {
     overviewCtx.fillStyle = '#79b8ff';
     overviewCtx.fillRect(Math.max(0, x1 - 1), 0, 3, height);
     overviewCtx.fillRect(Math.min(width - 2, x2 - 1), 0, 3, height);
+    if (overviewSelecting) {
+        const sx = Math.max(0, Math.min(width, (overviewSelectStartNs - lo) / fullSpan * width));
+        const ex = Math.max(0, Math.min(width, (overviewSelectEndNs - lo) / fullSpan * width));
+        overviewCtx.fillStyle = 'rgba(210, 168, 255, 0.24)';
+        overviewCtx.fillRect(Math.min(sx, ex), 0, Math.max(2, Math.abs(ex - sx)), height);
+        overviewCtx.strokeStyle = '#d2a8ff';
+        overviewCtx.strokeRect(Math.min(sx, ex) + 0.5, 1.5, Math.max(1, Math.abs(ex - sx) - 1), height - 3);
+    }
 }
 
 // ── Initialization ──
@@ -573,7 +588,7 @@ async function initData() {
         // Check for saved viewport
         let restored = false;
         try {
-            const saved = JSON.parse(localStorage.getItem(_viewKey));
+            const saved = JSON.parse(localStorage.getItem(viewStorageKey()));
             if (saved && saved.s !== undefined && saved.e !== undefined) {
                 // Set view first so NVTX fetch targets the correct viewport/GPU.
                 viewStart = saved.s;
@@ -585,10 +600,11 @@ async function initData() {
             }
         } catch (e) { }
         if (!restored) {
-            // Default view: first 5 seconds
-            const firstEnd = TILE_WINDOW_S;
-            viewStart = 0;
-            viewEnd = firstEnd * 1e9;
+            // Default view starts at the profile's actual first event. Profiles
+            // exported from Nsight commonly have a non-zero epoch-relative start.
+            const [profileStart, profileEnd] = profileRangeNs();
+            viewStart = profileStart;
+            viewEnd = Math.min(profileEnd, profileStart + TILE_WINDOW_S * 1e9);
             await ensureTilesForView(viewStart, viewEnd);
             rebuildDataFromCache();
             resetViewHistory();
@@ -616,6 +632,10 @@ let selectedNvtxThread = 'auto';
 let searchQuery = '';
 let searchKernelMatches = new Set();
 let searchNvtxMatches = new Set();
+let searchResults = [];
+let searchGlobalCount = 0;
+let searchTimer = null;
+let searchRequestSerial = 0;
 let isDragging = false, dragStartX = 0, dragViewStart = 0, dragViewEnd = 0;
 let isSelecting = false, selectStartX = 0, selectStartNs = 0, selectEndNs = 0;
 let isResizingDetail = false, detailResizeStartY = 0, detailResizeStartH = 0;
@@ -628,6 +648,9 @@ let overviewDirty = true;
 let overviewDragging = false;
 let overviewDragOffset = 0;
 let overviewDragSpan = 0;
+let overviewSelecting = false;
+let overviewSelectStartNs = 0;
+let overviewSelectEndNs = 0;
 let renderStateCacheKey = '';
 let renderStateCache = null;
 const RENDER_SETTINGS_KEY = 'timeline-render-settings-v1';
@@ -653,7 +676,8 @@ let fitZoomState = null;
 // ── Layout constants ──
 const LABEL_W = isMultiGPU ? 110 : 90;
 const RULER_H = 24;
-const FINDINGS_LANE_H = 28;  // dedicated annotation lane for AI findings
+const FINDINGS_LANE_H = 58;  // three compact rows keep overlapping findings readable
+const FINDING_ROW_H = 18;
 const NVTX_ROW_H = 20;
 const NVTX_PIN_ROWS = 5;
 const STREAM_H = 32;
@@ -1179,10 +1203,25 @@ function timelineRenderState(W) {
     let repeatedItems = 0;
     let repeatedGroups = 0;
     const names = new Map();
+    const visibleByStream = new Map();
+    const lowerBound = (items, value, field) => {
+        let lo = 0, hi = items.length;
+        while (lo < hi) {
+            const mid = (lo + hi) >> 1;
+            if (items[mid][field] < value) lo = mid + 1;
+            else hi = mid;
+        }
+        return lo;
+    };
     for (const sid of streamIds) {
         if (hiddenStreams.has(sid)) continue;
-        for (const k of (streamMap[sid] || [])) {
-            if (!kernelOverlapsView(k)) continue;
+        const all = streamMap[sid] || [];
+        let first = lowerBound(all, viewStart, 'start_ns');
+        while (first > 0 && all[first - 1].end_ns >= viewStart) first--;
+        const last = lowerBound(all, viewEnd, 'start_ns');
+        const visible = all.slice(first, Math.min(all.length, last + 1)).filter(kernelOverlapsView);
+        visibleByStream.set(sid, visible);
+        for (const k of visible) {
             visibleKernels++;
             const name = String(k.name || '(unnamed)');
             names.set(name, (names.get(name) || 0) + 1);
@@ -1207,6 +1246,7 @@ function timelineRenderState(W) {
         visibleKernels,
         repeatedGroups,
         repeatedItems,
+        visibleByStream,
         condensedNvtx: 0,
     };
     renderStateCacheKey = key;
@@ -1580,7 +1620,7 @@ function drawStreams(W, H, renderState) {
     for (let si = 0; si < streamIds.length; si++) {
         const sid = streamIds[si];
         if (hiddenStreams.has(sid)) continue;  // skip hidden streams
-        const ks = streamMap[sid];
+        const ks = renderState.visibleByStream.get(sid) || [];
         const y = streamY(si) + (isMultiGPU && gpuBands[0].startIdx === 0 ? GPU_SEP_H : 0);
         const isSelected = si === selectedStreamIdx;
         const color = streamColor(si);
@@ -1613,7 +1653,6 @@ function drawStreams(W, H, renderState) {
         } else {
             const seenLabels = new Set();
             for (const k of ks) {
-                if (!kernelOverlapsView(k)) continue;
                 const width = Math.max(MIN_BLOCK_W, nsToX(k.end_ns) - nsToX(k.start_ns));
                 const emphasized = isKernelEmphasized(k);
                 let label = width > 20;
@@ -1659,8 +1698,12 @@ function hitTest(mx, my) {
     for (let si = 0; si < streamIds.length; si++) {
         const y = streamY(si) + (isMultiGPU && gpuBands[0].startIdx === 0 ? GPU_SEP_H : 0);
         if (my < y || my > y + STREAM_H) continue;
-        const ks = streamMap[streamIds[si]];
-        for (const k of ks) {
+        const state = timelineRenderState(canvas.width / DPR);
+        const ks = state.visibleByStream.get(streamIds[si]) || [];
+        // Iterate backwards: later/shorter blocks are painted on top and are
+        // the ones a user can actually see and click.
+        for (let ki = ks.length - 1; ki >= 0; ki--) {
+            const k = ks[ki];
             const x1 = Math.max(LABEL_W, nsToX(k.start_ns));
             const x2 = Math.min(canvas.width / DPR, nsToX(k.end_ns));
             if (mx >= x1 && mx <= Math.max(x1 + MIN_BLOCK_W, x2)) {
@@ -1760,7 +1803,10 @@ function renderPathHtml(path) {
 let _viewChangeTimer = null;
 let _tileLoadTimer = null;
 const _viewLabel = (typeof BOOT.GPU_LABEL === 'string' && BOOT.GPU_LABEL) ? BOOT.GPU_LABEL : 'timeline';
-const _viewKey = 'timeline-view-' + _viewLabel.replace(/[^a-zA-Z0-9]/g, '_');
+function viewStorageKey() {
+    const identity = (profileMeta && profileMeta.profile_id) || BOOT.PROFILE_ID || _viewLabel;
+    return 'timeline-view-' + String(identity).replace(/[^a-zA-Z0-9_-]/g, '_');
+}
 function resetViewHistory() {
     viewHistory = [{ start: viewStart, end: viewEnd }];
     viewHistoryIndex = 0;
@@ -1805,7 +1851,7 @@ function goForwardView() {
 function afterViewChange({ record = true, deferLoad = false } = {}) {
     if (record) recordViewHistory();
     // Persist viewport to localStorage
-    try { localStorage.setItem(_viewKey, JSON.stringify({ s: viewStart, e: viewEnd, t: Date.now() })); } catch (e) { }
+    try { localStorage.setItem(viewStorageKey(), JSON.stringify({ s: viewStart, e: viewEnd, t: Date.now() })); } catch (e) { }
     if (PROGRESSIVE) {
         clearTimeout(_tileLoadTimer);
         if (deferLoad) {
@@ -1825,9 +1871,13 @@ function afterViewChange({ record = true, deferLoad = false } = {}) {
 }
 
 function clampView() {
-    const minNs = 0;  // time is never negative
-    const maxNs = profileMeta ? profileMeta.time_range_ns[1] : timeEnd;
-    const span = viewEnd - viewStart;
+    const [minNs, maxNs] = profileRangeNs();
+    const span = Math.max(1, viewEnd - viewStart);
+    if (span >= maxNs - minNs) {
+        viewStart = minNs;
+        viewEnd = maxNs;
+        return;
+    }
     if (viewStart < minNs) { viewStart = minNs; viewEnd = minNs + span; }
     if (viewEnd > maxNs) { viewEnd = maxNs; viewStart = maxNs - span; }
     // Final clamp in case span > total range
@@ -1858,8 +1908,8 @@ function zoomAt(factor, centerNs) {
 function zoomIn() { zoomAt(0.5); }
 function zoomOut() { zoomAt(2); }
 function fitAll() {
-    const maxNs = profileMeta ? profileMeta.time_range_ns[1] : timeEnd;
-    viewStart = 0;
+    const [minNs, maxNs] = profileRangeNs();
+    viewStart = minNs;
     viewEnd = maxNs;
     clampView();
     draw();
@@ -2395,14 +2445,36 @@ function onSearch() {
         });
         const modeLabel = isRegex ? ' (regex)' : '';
         document.getElementById('searchHint').textContent =
-            `${searchKernelMatches.size} kernels, ${searchNvtxMatches.size} NVTX${modeLabel}`;
+            `${searchKernelMatches.size} loaded kernels, ${searchNvtxMatches.size} loaded NVTX${modeLabel}`;
     } else {
         document.getElementById('searchHint').textContent = '';
+    }
+    clearTimeout(searchTimer);
+    searchResults = [];
+    searchGlobalCount = 0;
+    if (raw && PROGRESSIVE) {
+        const serial = ++searchRequestSerial;
+        searchTimer = setTimeout(async () => {
+            try {
+                const pfx = BOOT.API_PREFIX || '';
+                const resp = await fetch(`${pfx}/api/search?q=${encodeURIComponent(raw)}&limit=200`);
+                const data = await resp.json();
+                if (serial !== searchRequestSerial || data.error) return;
+                searchResults = Array.isArray(data.matches) ? data.matches : [];
+                searchGlobalCount = Number(data.count || searchResults.length);
+                const suffix = data.truncated ? '+' : '';
+                document.getElementById('searchHint').textContent =
+                    `${searchGlobalCount}${suffix} profile matches · ${searchKernelMatches.size} loaded here`;
+                draw();
+            } catch (e) {
+                // Local matches remain useful if the server search is unavailable.
+            }
+        }, 220);
     }
     draw();
 }
 
-function gotoFirstSearchMatch() {
+async function gotoFirstSearchMatch() {
     if (!searchQuery) return;
     const kernel = kernels.find(k => searchKernelMatches.has(k));
     if (kernel) {
@@ -2410,6 +2482,25 @@ function gotoFirstSearchMatch() {
         if (si >= 0) selectedStreamIdx = si;
         selectKernel(kernel);
         ensureVisible(kernel);
+        return;
+    }
+    const global = searchResults[0];
+    if (global && global.kind === 'kernel') {
+        const pad = Math.max(1e6, (global.end_ns - global.start_ns) * 2);
+        viewStart = global.start_ns - pad;
+        viewEnd = global.end_ns + pad;
+        clampView();
+        if (PROGRESSIVE) await ensureTilesForView(viewStart, viewEnd);
+        rebuildDataFromCache();
+        const loaded = kernels.find(k => k._gpu === global.gpu &&
+            k.start_ns === global.start_ns && k.end_ns === global.end_ns &&
+            String(k.name) === String(global.name));
+        if (loaded) {
+            selectKernel(loaded);
+            ensureVisible(loaded);
+        } else {
+            draw();
+        }
         return;
     }
     const { spans } = activeGpuNvtxSpans();
@@ -2641,10 +2732,24 @@ function updateFromOverview(clientX) {
     draw();
 }
 
+function overviewNsAt(clientX) {
+    const rect = overviewCanvas.getBoundingClientRect();
+    const [lo, hi] = overviewRangeNs();
+    const px = Math.max(0, Math.min(rect.width, clientX - rect.left));
+    return lo + px / Math.max(rect.width, 1) * Math.max(hi - lo, 1);
+}
+
 if (overviewCanvas) {
     overviewCanvas.addEventListener('mousedown', e => {
         if (e.button !== 0) return;
         e.preventDefault();
+        if (e.shiftKey) {
+            overviewSelecting = true;
+            overviewSelectStartNs = overviewNsAt(e.clientX);
+            overviewSelectEndNs = overviewSelectStartNs;
+            drawOverview();
+            return;
+        }
         const rect = overviewCanvas.getBoundingClientRect();
         const [lo, hi] = overviewRangeNs();
         const fullSpan = Math.max(hi - lo, 1);
@@ -2659,14 +2764,36 @@ if (overviewCanvas) {
         updateFromOverview(e.clientX);
     });
     overviewCanvas.addEventListener('mousemove', e => {
-        if (overviewDragging) updateFromOverview(e.clientX);
+        if (overviewSelecting) {
+            overviewSelectEndNs = overviewNsAt(e.clientX);
+            drawOverview();
+        } else if (overviewDragging) updateFromOverview(e.clientX);
     });
     overviewCanvas.addEventListener('mouseup', () => {
+        if (overviewSelecting) {
+            overviewSelecting = false;
+            const start = Math.min(overviewSelectStartNs, overviewSelectEndNs);
+            const end = Math.max(overviewSelectStartNs, overviewSelectEndNs);
+            if (end - start >= 100) {
+                viewStart = start;
+                viewEnd = end;
+                clampView();
+                afterViewChange();
+                draw();
+            } else {
+                drawOverview();
+            }
+            return;
+        }
         if (!overviewDragging) return;
         overviewDragging = false;
         afterViewChange();
     });
     overviewCanvas.addEventListener('mouseleave', () => {
+        if (overviewSelecting) {
+            overviewSelecting = false;
+            drawOverview();
+        }
         if (!overviewDragging) return;
         overviewDragging = false;
         afterViewChange();
@@ -2829,6 +2956,7 @@ document.addEventListener('keydown', e => {
             document.querySelectorAll('.finding-card').forEach(el => el.classList.remove('active'));
             showDetail(null);
             searchQuery = ''; searchKernelMatches.clear(); searchNvtxMatches.clear();
+            searchResults = []; searchGlobalCount = 0; clearTimeout(searchTimer);
             document.getElementById('searchInput').value = '';
             document.getElementById('searchHint').textContent = '';
             document.getElementById('gpuInfoPanel').style.display = 'none';
@@ -3199,6 +3327,7 @@ setTimeout(initData, 0);
 
 // ── Findings Evidence Layer ──
 let selectedFindingIdx = -1;
+let findingSeverityFilter = 'all';
 
 function _findingSevColor(sev) {
     if (sev === 'critical') return '#ff4444';
@@ -3258,6 +3387,30 @@ function findingIndicesForRender(renderState) {
     }
     renderState.hiddenInfoFindings = hiddenInfo;
     return visible;
+}
+
+// Pack annotation pills into a few compact rows so overlapping findings do not
+// hide one another. Critical and warning findings are assigned first.
+function findingLaneFor(index, indices) {
+    const ordered = indices.slice().sort((a, b) => {
+        const rank = { critical: 0, warning: 1, info: 2 };
+        return (rank[FINDINGS[a].severity] ?? 3) - (rank[FINDINGS[b].severity] ?? 3)
+            || FINDINGS[a].start_ns - FINDINGS[b].start_ns || a - b;
+    });
+    const laneEnds = [];
+    for (const i of ordered) {
+        const f = FINDINGS[i];
+        const x1 = Math.max(LABEL_W, nsToX(f.start_ns));
+        const x2 = Math.min(canvas.width / DPR, nsToX(f.end_ns ?? f.start_ns));
+        let lane = laneEnds.findIndex(end => end < x1 - 2);
+        if (lane < 0) {
+            lane = Math.min(laneEnds.length, Math.floor(FINDINGS_LANE_H / FINDING_ROW_H) - 1);
+            if (lane === laneEnds.length) laneEnds.push(0);
+        }
+        laneEnds[lane] = Math.max(x2, x1 + 24);
+        if (i === index) return lane;
+    }
+    return 0;
 }
 
 function drawFindings(W, H) {
@@ -3332,6 +3485,11 @@ function drawFindings(W, H) {
         const severityAlpha = renderState.mode === 'compact' && f.severity === 'info' ? 0.45 : 1;
         const baseAlpha = (hasActive && !isActive ? 0.1 : 1) * severityAlpha;
 
+        // Keep the overview quiet: only critical regions or the selected
+        // finding paint the stream area. All findings remain discoverable as
+        // compact pills and in the Evidence sidebar.
+        if (!isActive && f.severity !== 'critical') continue;
+
         if (f.type === 'region' || f.type === 'highlight') {
             ctx.globalAlpha = baseAlpha;
 
@@ -3399,21 +3557,25 @@ function drawFindings(W, H) {
             const baseAlpha = (hasActive && !isActive ? 0.2 : 1) * severityAlpha;
             const { y: targetY, h: targetH } = _findingStreamRange(f);
 
-            // ── Connecting dotted line from pill to target region ──
-            ctx.globalAlpha = baseAlpha * (isActive ? 0.6 : 0.25);
-            ctx.strokeStyle = sevCol;
-            ctx.lineWidth = isActive ? 1.5 : 1;
-            ctx.setLineDash(isActive ? [6, 3] : [3, 5]);
-            ctx.beginPath();
-            ctx.moveTo(midX, laneY + laneH);
-            ctx.lineTo(midX, targetY);
-            ctx.stroke();
-            ctx.setLineDash([]);
-            ctx.lineWidth = 1;
+            // Connecting lines are only useful for the active finding; drawing
+            // one for every pill creates a dense web over the timeline.
+            if (isActive) {
+                ctx.globalAlpha = baseAlpha * 0.6;
+                ctx.strokeStyle = sevCol;
+                ctx.lineWidth = 1.5;
+                ctx.setLineDash([6, 3]);
+                ctx.beginPath();
+                ctx.moveTo(midX, laneY + laneH);
+                ctx.lineTo(midX, targetY);
+                ctx.stroke();
+                ctx.setLineDash([]);
+                ctx.lineWidth = 1;
+            }
 
             // ── Pill bar in annotation lane ──
-            const pillH = laneH - 6;
-            const pillY = laneY + 3;
+            const lane = findingLaneFor(i, findingIndices);
+            const pillH = FINDING_ROW_H - 5;
+            const pillY = laneY + 3 + lane * FINDING_ROW_H;
             const pillX1 = Math.max(LABEL_W + 2, x1);
             const pillX2 = Math.min(W - 2, x2);
             let pillW = Math.max(pillX2 - pillX1, 24);  // min 24px
@@ -3515,14 +3677,21 @@ function _findingsHitTest(mx, my) {
     const laneH = findingsLaneH();
 
     // Check annotation lane pills
+    const renderState = timelineRenderState(canvas.width / DPR);
+    const findingIndices = findingIndicesForRender(renderState);
     if (laneH > 0 && my >= laneY && my <= laneY + laneH) {
-        for (let i = FINDINGS.length - 1; i >= 0; i--) {
+        for (let pos = findingIndices.length - 1; pos >= 0; pos--) {
+            const i = findingIndices[pos];
             const f = FINDINGS[i];
             const startNs = f.start_ns;
             const endNs = f.end_ns ?? startNs;
             if (endNs < viewStart || startNs > viewEnd) continue;
             const x1 = Math.max(LABEL_W, nsToX(startNs));
             const x2 = Math.min(canvas.width / DPR, nsToX(endNs));
+            const lane = findingLaneFor(i, findingIndices);
+            const pillH = FINDING_ROW_H - 5;
+            const pillY = laneY + 3 + lane * FINDING_ROW_H;
+            if (my < pillY || my > pillY + pillH) continue;
             const pillW = Math.max(x2 - x1, 24);
             const clampedX = Math.max(LABEL_W + 2, Math.min(x1, canvas.width / DPR - pillW - 2));
             if (mx >= clampedX && mx <= clampedX + pillW) {
@@ -3532,7 +3701,8 @@ function _findingsHitTest(mx, my) {
     }
 
     // Check stream-area region/highlight overlays
-    for (let i = FINDINGS.length - 1; i >= 0; i--) {
+    for (let pos = findingIndices.length - 1; pos >= 0; pos--) {
+        const i = findingIndices[pos];
         const f = FINDINGS[i];
         const startNs = f.start_ns;
         const endNs = f.end_ns ?? startNs;
@@ -3566,15 +3736,37 @@ function _initFindingsSidebar() {
     const badge = document.getElementById('findingsCount');
     if (badge) {
         const crit = FINDINGS.filter(f => f.severity === 'critical').length;
-        badge.textContent = FINDINGS.length + ' finding' + (FINDINGS.length !== 1 ? 's' : '');
+        const warn = FINDINGS.filter(f => f.severity === 'warning').length;
+        const info = FINDINGS.length - crit - warn;
+        badge.textContent = `${FINDINGS.length} · ${crit} critical · ${warn} warning · ${info} info`;
         if (crit) badge.style.background = 'rgba(255,68,68,0.2)';
     }
 
     const list = document.getElementById('findingsList');
     if (!list) return;
+    const filterBar = document.getElementById('findingsFilters');
+    if (filterBar && !filterBar.dataset.bound) {
+        filterBar.dataset.bound = '1';
+        filterBar.querySelectorAll('.evidence-filter').forEach(button => {
+            button.addEventListener('click', () => {
+                findingSeverityFilter = button.dataset.severity || 'all';
+                filterBar.querySelectorAll('.evidence-filter').forEach(item =>
+                    item.classList.toggle('active', item === button));
+                _initFindingsSidebar();
+            });
+        });
+    }
     list.innerHTML = '';  // Clear existing cards for re-initialization
 
-    FINDINGS.forEach((f, i) => {
+    const severityRank = { critical: 0, warning: 1, info: 2 };
+    const orderedIndices = FINDINGS.map((f, i) => i)
+      .filter(i => findingSeverityFilter === 'all' || FINDINGS[i].severity === findingSeverityFilter)
+      .sort((a, b) =>
+        (severityRank[FINDINGS[a].severity] ?? 3) - (severityRank[FINDINGS[b].severity] ?? 3)
+        || FINDINGS[a].start_ns - FINDINGS[b].start_ns || a - b
+    );
+    orderedIndices.forEach(i => {
+        const f = FINDINGS[i];
         const card = document.createElement('div');
         card.className = 'finding-card';
         card.dataset.idx = i;
@@ -3634,8 +3826,7 @@ function selectFinding(idx) {
                 (f.gpu_id != null ? ' · GPU ' + f.gpu_id : '') +
                 (f.stream != null ? ' · Stream ' + f.stream : '') +
             '</div>' +
-            (f.note ? '<div style="font-size:11px;color:#e6edf3;margin-top:6px;white-space:pre-wrap;line-height:1.5">' +
-                _esc(f.note) + '</div>' : '');
+            '<div style="font-size:10px;color:#8b949e;margin-top:6px">Full explanation is in the Evidence panel.</div>';
     }
 
     // ── Smart zoom: center the finding, range = 50% of viewport ──

--- a/src/nsys_ai/viewer.py
+++ b/src/nsys_ai/viewer.py
@@ -291,6 +291,7 @@ def generate_timeline_html(
     timeline_js_src: str = "/assets/timeline.js",
     api_prefix: str = "",
     profile_path: str = "",
+    profile_id: str | None = None,
     loop_mode: bool = False,
 ) -> str:
     """Generate a standalone HTML page with the horizontal timeline viewer.
@@ -302,6 +303,16 @@ def generate_timeline_html(
     from collections.abc import Sequence
 
     devices: list[int] = list(device) if isinstance(device, Sequence) else [device]
+
+    if profile_id is None:
+        try:
+            from .fingerprint import get_profile_id
+
+            profile_id = get_profile_id(
+                prof.query_conn(), fallback_path=getattr(prof, "path", None)
+            )
+        except Exception:
+            profile_id = ""
 
     # Build GPU info list (for dropdown) and compact label
     gpu_details = []
@@ -345,6 +356,7 @@ def generate_timeline_html(
     safe_profile_path_json = _escape_json_for_html_script(
         json.dumps(profile_path) if profile_path is not None else "null"
     )
+    safe_profile_id_json = _escape_json_for_html_script(json.dumps(profile_id or ""))
     safe_loop_trim_ns_json = _escape_json_for_html_script(loop_trim_ns_json)
 
     tmpl = _load_template("timeline.html")
@@ -360,6 +372,7 @@ def generate_timeline_html(
         API_PREFIX=api_prefix,
         FINDINGS_JSON=safe_findings_json,
         PROFILE_PATH=safe_profile_path_json,
+        PROFILE_ID=safe_profile_id_json,
         LOOP_TRIM_NS=safe_loop_trim_ns_json,
         LOOP_MODE="1" if loop_mode else "0",
     )

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -27,6 +27,9 @@ _log = logging.getLogger(__name__)
 
 _FINDINGS_LOCK = threading.Lock()
 _LOOP_LOCK = threading.Lock()
+# The progressive timeline starts serving kernels immediately.  NVTX is built
+# in the background so the first interactive request does not make a cold
+# load pay the full-profile annotation cost on the request thread.
 
 # Bounded thread pool: fixed worker count, request queue with max size.
 # Workers are released when each request finishes (finish_request + shutdown_request).
@@ -231,8 +234,12 @@ class _ViewerHandler(BaseHTTPRequestHandler):
     prof = None  # set by serve_timeline
     devices: list = []  # set by serve_timeline
     _prebuilt_data: list = []  # pre-built timeline payload per GPU
-    _prebuilt_nvtx_mode: str = "full"  # "full" (prebuilt has NVTX) or "tile" (compute per tile)
-    _tile_nvtx_cache: dict = {}  # (start_ns, end_ns, devices_tuple) -> {gpu_id: [nvtx_spans]}
+    _prebuilt_nvtx_mode: str = "full"  # "full" (baked) or "background" (progressive)
+    _full_nvtx_by_gpu: dict = {}  # device id -> full-range spans, sliced per request
+    _overview_bins: list[float] = []  # full-profile kernel activity for the overview strip
+    _overview_kernel_count: int = 0
+    _nvtx_prebuild_done: threading.Event | None = None
+    _nvtx_prebuild_error: str | None = None
     _asset_cache: dict[str, tuple[float, bytes]] = {}  # filename -> (mtime, body)
     _findings: list[dict] = []  # mutable findings state for evidence overlay
     _session_id: str | None = None  # SessionStore id (always set by serve_timeline)
@@ -332,6 +339,8 @@ class _ViewerHandler(BaseHTTPRequestHandler):
                 "time_range_ns": [t_start, t_end],
                 "gpus": gpu_infos,
                 "device_ids": devices,
+                "overview_bins": list(self.__class__._overview_bins),
+                "overview_kernel_count": self.__class__._overview_kernel_count,
             }
         )
 
@@ -369,39 +378,25 @@ class _ViewerHandler(BaseHTTPRequestHandler):
         )
         try:
             nvtx_spans_by_gpu = None
-            if self.__class__._prebuilt_nvtx_mode == "tile" and nvtx_requested:
+            if self.__class__._prebuilt_nvtx_mode == "background" and nvtx_requested:
                 annotate_devices = (
                     [gpu_filter]
                     if gpu_filter is not None and gpu_filter in self.__class__.devices
                     else self.__class__.devices
                 )
-                devices_key = tuple(annotate_devices)
-                tile_key = (start_ns, end_ns, devices_key)
-                nvtx_spans_by_gpu = self.__class__._tile_nvtx_cache.get(tile_key)
-                if nvtx_spans_by_gpu is None:
-                    t_nv = _time.monotonic()
-                    print(f"[tile] {start_s:.1f}s–{end_s:.1f}s  NVTX annotate...", flush=True)
-                    tile_nvtx_entries = build_timeline_gpu_data(
-                        self.__class__.prof,
-                        annotate_devices,
-                        (start_ns, end_ns),
-                        include_kernels=False,
-                        include_nvtx=True,
+                done = self.__class__._nvtx_prebuild_done
+                if done is not None:
+                    # A request arriving during the warm-up waits once for the
+                    # shared result; subsequent pans and zooms only slice lists.
+                    done.wait()
+                if self.__class__._nvtx_prebuild_error:
+                    raise RuntimeError(self.__class__._nvtx_prebuild_error)
+                nvtx_spans_by_gpu = {
+                    dev: _slice_nvtx_spans(
+                        self.__class__._full_nvtx_by_gpu.get(dev, []), start_ns, end_ns
                     )
-                    nvtx_spans_by_gpu = {
-                        e["id"]: e.get("nvtx_spans", []) for e in tile_nvtx_entries
-                    }
-                    self.__class__._tile_nvtx_cache[tile_key] = nvtx_spans_by_gpu
-                    # Keep memory bounded (simple LRU via insertion-ordered dict semantics).
-                    while len(self.__class__._tile_nvtx_cache) > 64:
-                        self.__class__._tile_nvtx_cache.pop(
-                            next(iter(self.__class__._tile_nvtx_cache))
-                        )
-                    print(
-                        f"[tile] {start_s:.1f}s–{end_s:.1f}s  NVTX done in "
-                        f"{_time.monotonic() - t_nv:.3f}s",
-                        flush=True,
-                    )
+                    for dev in annotate_devices
+                }
 
             # Filter pre-built data by time window
             gpu_entries = []
@@ -795,6 +790,40 @@ def _filter_nodes_by_time(nodes: list, start_ns: int, end_ns: int) -> list:
     return result
 
 
+def _slice_nvtx_spans(spans: list[dict], start_ns: int, end_ns: int) -> list[dict]:
+    """Return full-range NVTX spans overlapping a requested viewport."""
+    return [
+        span
+        for span in spans
+        if span.get("end", 0) >= start_ns and span.get("start", 0) <= end_ns
+    ]
+
+
+def _build_timeline_overview(
+    prebuilt_data: list[dict], time_range_ns: tuple[int, int], bin_count: int = 240
+) -> tuple[list[float], int]:
+    """Build a compact, full-profile kernel activity histogram for the web overview."""
+    if bin_count <= 0:
+        raise ValueError("bin_count must be positive")
+    range_start, range_end = time_range_ns
+    profile_span = max(range_end - range_start, 1)
+    bins = [0.0] * bin_count
+    kernel_count = 0
+    for gpu_entry in prebuilt_data:
+        for kernel in gpu_entry.get("kernels", []):
+            start_ns = kernel.get("start_ns")
+            end_ns = kernel.get("end_ns")
+            if start_ns is None or end_ns is None or end_ns < range_start or start_ns > range_end:
+                continue
+            kernel_count += 1
+            first = max(0, int((start_ns - range_start) / profile_span * bin_count))
+            last = min(bin_count - 1, int((end_ns - range_start) / profile_span * bin_count))
+            weight = max(1.0, min(8.0, float(kernel.get("duration_ms") or 1.0)))
+            for index in range(first, last + 1):
+                bins[index] += weight
+    return bins, kernel_count
+
+
 def _filter_timeline_gpu_entry(
     gpu_entry: dict,
     start_ns: int,
@@ -867,7 +896,11 @@ def serve_timeline(
     # Store prof + devices on handler for /api/meta queries
     _ViewerHandler.prof = prof
     _ViewerHandler.devices = devices
-    _ViewerHandler._tile_nvtx_cache = {}
+    _ViewerHandler._full_nvtx_by_gpu = {}
+    _ViewerHandler._overview_bins = []
+    _ViewerHandler._overview_kernel_count = 0
+    _ViewerHandler._nvtx_prebuild_done = None
+    _ViewerHandler._nvtx_prebuild_error = None
     _ViewerHandler._findings = findings_data or []
     _ViewerHandler._session_id = None
     _ViewerHandler._session_root = os.fspath(session_root)
@@ -948,11 +981,13 @@ def serve_timeline(
             timeline_css_href=_css_href,
             timeline_js_src=_js_src,
         )
-        _ViewerHandler._prebuilt_nvtx_mode = "tile"
+        _ViewerHandler._prebuilt_nvtx_mode = "background"
 
     _ViewerHandler.html_bytes = html.encode("utf-8")
     if _in_loop_mode:
         print(f"Loop UI loaded (assets v{_asset_v}) — hard-refresh if the panel looks outdated", flush=True)
+
+    nvtx_done: threading.Event | None = None
 
     # Pre-build full kernel-first timeline payload for all GPUs (progressive mode)
     if trim is None:
@@ -1030,10 +1065,63 @@ def serve_timeline(
                 except Exception as e:
                     print(f"Cache save failed: {e}", flush=True)
 
+        _ViewerHandler._overview_bins, _ViewerHandler._overview_kernel_count = (
+            _build_timeline_overview(prebuilt, prof.meta.time_range)
+        )
+
+        # NVTX is much more expensive than kernel filtering.  Warm the full
+        # profile after the cheap kernel payload is resident and before the
+        # server starts accepting browser requests.  The server itself is
+        # started immediately after this thread is launched, so a first NVTX
+        # request either receives the warm result or waits on the one shared
+        # build rather than rebuilding the requested tile.
+        nvtx_done = threading.Event()
+        _ViewerHandler._nvtx_prebuild_done = nvtx_done
+
+        def _warm_nvtx() -> None:
+            t_nv = _time.monotonic()
+            full_range = prof.meta.time_range
+            try:
+                print(
+                    f"Pre-building NVTX in background for {len(devices)} GPU(s) "
+                    f"({full_range[0] / 1e9:.1f}s–{full_range[1] / 1e9:.1f}s)...",
+                    flush=True,
+                )
+                entries = build_timeline_gpu_data(
+                    prof,
+                    devices,
+                    full_range,
+                    include_kernels=False,
+                    include_nvtx=True,
+                )
+                _ViewerHandler._full_nvtx_by_gpu = {
+                    entry["id"]: entry.get("nvtx_spans", []) for entry in entries
+                }
+                total = sum(len(spans) for spans in _ViewerHandler._full_nvtx_by_gpu.values())
+                print(
+                    f"NVTX background pre-build complete in {_time.monotonic() - t_nv:.1f}s "
+                    f"({total} spans)",
+                    flush=True,
+                )
+            except Exception as exc:
+                _ViewerHandler._nvtx_prebuild_error = str(exc)
+                _log.exception("Background NVTX pre-build failed")
+            finally:
+                nvtx_done.set()
+
+        threading.Thread(target=_warm_nvtx, name="timeline-nvtx-warmup", daemon=True).start()
+
     server = _ThreadedHTTPServer(("127.0.0.1", port), _ViewerHandler)
     actual_url = f"http://127.0.0.1:{server.server_address[1]}"
     print(f"Timeline viewer at {actual_url}")
-    _run_server(server, actual_url if open_browser else None, prof)
+    try:
+        _run_server(server, actual_url if open_browser else None, prof)
+    finally:
+        # Keep the Profile alive until the background worker has stopped using
+        # its DuckDB connection.  This also covers callers that replace
+        # _run_server in tests or embed the server lifecycle themselves.
+        if nvtx_done is not None:
+            nvtx_done.wait()
 
 
 # ── Mode 3: Evidence View ────────────────────────────────────────

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import queue
+import re
 import signal
 import socketserver
 import threading
@@ -238,6 +239,7 @@ class _ViewerHandler(BaseHTTPRequestHandler):
     _full_nvtx_by_gpu: dict = {}  # device id -> full-range spans, sliced per request
     _overview_bins: list[float] = []  # full-profile kernel activity for the overview strip
     _overview_kernel_count: int = 0
+    _profile_id: str = ""
     _nvtx_prebuild_done: threading.Event | None = None
     _nvtx_prebuild_error: str | None = None
     _asset_cache: dict[str, tuple[float, bytes]] = {}  # filename -> (mtime, body)
@@ -270,6 +272,9 @@ class _ViewerHandler(BaseHTTPRequestHandler):
             return
         if path == "/api/data":
             self._handle_data()
+            return
+        if path == "/api/search":
+            self._handle_search()
             return
         if path == "/api/findings":
             if self.__class__._session_id is not None:
@@ -341,8 +346,82 @@ class _ViewerHandler(BaseHTTPRequestHandler):
                 "device_ids": devices,
                 "overview_bins": list(self.__class__._overview_bins),
                 "overview_kernel_count": self.__class__._overview_kernel_count,
+                "profile_id": self.__class__._profile_id,
             }
         )
+
+    def _handle_search(self):
+        """Search the complete pre-built profile, including unloaded tiles."""
+        from urllib.parse import parse_qs, urlparse
+
+        qs = parse_qs(urlparse(self.path).query)
+        query = str(qs.get("q", [""])[0]).strip()
+        if len(query) > 256:
+            self._json_response({"error": "search query is limited to 256 characters"}, 400)
+            return
+        try:
+            limit = max(1, min(500, int(qs.get("limit", [100])[0])))
+        except (TypeError, ValueError):
+            limit = 100
+        regex = str(qs.get("regex", ["0"])[0]).lower() in ("1", "true", "yes")
+        if not query:
+            self._json_response({"query": "", "matches": [], "count": 0, "truncated": False})
+            return
+        done = self.__class__._nvtx_prebuild_done
+        if done is not None:
+            done.wait()
+        pattern = query
+        if not regex and query.startswith("/") and query.rfind("/") > 0:
+            slash = query.rfind("/")
+            pattern = query[1:slash]
+            regex = True
+        try:
+            matcher = re.compile(pattern, re.IGNORECASE) if regex else None
+        except re.error as exc:
+            self._json_response({"error": f"invalid regex: {exc}"}, 400)
+            return
+        needle = pattern.lower()
+        matches = []
+        total = 0
+        for gpu_entry in self.__class__._prebuilt_data:
+            gpu_id = gpu_entry.get("id")
+            for kernel in gpu_entry.get("kernels", []):
+                name = str(kernel.get("name", ""))
+                if (matcher.search(name) if matcher else needle in name.lower()):
+                    total += 1
+                    if len(matches) < limit:
+                        matches.append({
+                            "kind": "kernel",
+                            "gpu": gpu_id,
+                            "name": name,
+                            "start_ns": kernel.get("start_ns", 0),
+                            "end_ns": kernel.get("end_ns", 0),
+                            "stream": kernel.get("stream"),
+                            "path": kernel.get("path", ""),
+                        })
+            spans = self.__class__._full_nvtx_by_gpu.get(gpu_id, gpu_entry.get("nvtx_spans", []))
+            for span in spans:
+                name = str(span.get("name", ""))
+                if (matcher.search(name) if matcher else needle in name.lower()):
+                    total += 1
+                    if len(matches) < limit:
+                        matches.append({
+                            "kind": "nvtx",
+                            "gpu": gpu_id,
+                            "name": name,
+                            "start_ns": span.get("start", 0),
+                            "end_ns": span.get("end", 0),
+                            "stream": None,
+                            "path": span.get("path", ""),
+                        })
+        matches.sort(key=lambda item: (item["start_ns"], item["kind"], item["name"]))
+        self._json_response({
+            "query": query,
+            "matches": matches,
+            "count": total,
+            "truncated": total > limit,
+            "scope": "profile",
+        })
 
     def _handle_data(self):
         """Return kernel/NVTX data for a requested time window (from pre-built cache)."""
@@ -899,6 +978,7 @@ def serve_timeline(
     _ViewerHandler._full_nvtx_by_gpu = {}
     _ViewerHandler._overview_bins = []
     _ViewerHandler._overview_kernel_count = 0
+    _ViewerHandler._profile_id = ""
     _ViewerHandler._nvtx_prebuild_done = None
     _ViewerHandler._nvtx_prebuild_error = None
     _ViewerHandler._findings = findings_data or []
@@ -908,6 +988,14 @@ def serve_timeline(
 
     raw_path = prof.path if hasattr(prof, "path") else ""
     _profile_path = os.fspath(raw_path) if raw_path else ""
+    try:
+        from .fingerprint import get_profile_id
+
+        _ViewerHandler._profile_id = get_profile_id(
+            prof.query_conn(), fallback_path=_profile_path or None
+        )
+    except Exception as exc:
+        _log.debug("Could not derive profile id: %s", exc, exc_info=True)
 
     preset = detect_h100_replay_preset() if loop_h100_preset else None
     if preset:
@@ -964,6 +1052,7 @@ def serve_timeline(
             trim,
             findings_data=findings_data,
             profile_path=_profile_path,
+            profile_id=_ViewerHandler._profile_id,
             loop_mode=_in_loop_mode,
             timeline_css_href=_css_href,
             timeline_js_src=_js_src,
@@ -977,6 +1066,7 @@ def serve_timeline(
             None,
             findings_data=findings_data,
             profile_path=_profile_path,
+            profile_id=_ViewerHandler._profile_id,
             loop_mode=_in_loop_mode,
             timeline_css_href=_css_href,
             timeline_js_src=_js_src,

--- a/tests/test_timeline_web_data.py
+++ b/tests/test_timeline_web_data.py
@@ -161,6 +161,7 @@ def test_timeline_web_template_uses_external_assets(minimal_nsys_db_path):
     assert 'id="loopBtn"' in html
     assert 'id="loopSidebar"' in html
     assert "LOOP_TRIM_NS" in html
+    assert "PROFILE_ID" in html
 
 
 def test_timeline_web_template_has_nvtx_command_controls(minimal_nsys_db_path):

--- a/tests/test_timeline_web_data.py
+++ b/tests/test_timeline_web_data.py
@@ -8,6 +8,7 @@ from nsys_ai.viewer import (
     generate_timeline_html,
     write_timeline_html,
 )
+from nsys_ai.web import _build_timeline_overview, _slice_nvtx_spans
 
 
 def test_timeline_web_kernel_first_keeps_kernels_outside_nvtx(minimal_nsys_db_path):
@@ -34,6 +35,43 @@ def test_timeline_web_kernel_first_keeps_kernels_outside_nvtx(minimal_nsys_db_pa
 
         k_c = next(k for k in gpu0["kernels"] if k["name"] == "kernel_C")
         assert k_c["path"] == "kernel_C"
+
+
+def test_timeline_web_nvtx_slice_keeps_boundary_overlaps():
+    spans = [
+        {"name": "before", "start": 0, "end": 10},
+        {"name": "inside", "start": 20, "end": 30},
+        {"name": "after", "start": 40, "end": 50},
+    ]
+
+    assert [s["name"] for s in _slice_nvtx_spans(spans, 10, 40)] == [
+        "before",
+        "inside",
+        "after",
+    ]
+    assert [s["name"] for s in _slice_nvtx_spans(spans, 11, 39)] == ["inside"]
+
+
+def test_timeline_web_overview_covers_full_profile_without_loaded_tiles():
+    bins, kernel_count = _build_timeline_overview(
+        [
+            {
+                "id": 0,
+                "kernels": [
+                    {"start_ns": 100, "end_ns": 200, "duration_ms": 0.1},
+                    {"start_ns": 2_100, "end_ns": 2_300, "duration_ms": 0.2},
+                ],
+            }
+        ],
+        (0, 4_000),
+        bin_count=4,
+    )
+
+    assert kernel_count == 2
+    assert bins[0] > 0
+    assert bins[2] > 0
+    assert bins[1] == 0
+    assert bins[3] == 0
 
 
 def test_timeline_web_trim_uses_overlap_not_containment(minimal_nsys_db_path):
@@ -142,6 +180,11 @@ def test_timeline_web_template_has_nvtx_command_controls(minimal_nsys_db_path):
     assert 'id="setHierarchyLayout"' in html
     assert 'id="setRulerLabelMode"' in html
     assert 'id="detailResizeHandle"' in html
+    assert 'id="overviewCanvas"' in html
+    assert 'id="viewportReadout"' in html
+    assert 'id="viewBackBtn"' in html
+    assert 'id="gpuSel"' in html
+    assert 'id="focusBtn"' in html
     assert 'id="chatCapabilities"' in html
     assert "fit_nvtx_range" in html
     assert "Go to NVTX" in html


### PR DESCRIPTION
## Summary

- Make the timeline web viewer easier to navigate and understand on large, progressive profiles.
- Keep the first kernel view responsive while warming NVTX once in the background and slicing it per viewport.
- Reduce evidence-overlay overload with progressive disclosure: the canvas locates findings, while the Evidence panel explains them.
- Relates to #388.

## Changes

- Add a full-profile overview histogram and explicit viewport/zoom readout.
- Make overview Shift+drag select a zoom range, and keep all navigation profile-relative instead of assuming time starts at 0.
- Scope saved viewports by a stable content-derived `profile_id`, preventing one profile's viewport from leaking into another.
- Add viewport history, Go to time, overview dragging, GPU selection, focus mode, and clearer mouse/keyboard affordances.
- Bound browser tile memory, deduplicate in-flight tile requests, and correct exact tile-boundary loading.
- Use per-stream visible-window slices and topmost-first hit testing to avoid rescanning and to select the block users can actually see.
- Add server-side `/api/search` for profile-wide kernel/NVTX search, including unloaded progressive tiles; debounce browser requests and navigate to unloaded matches.
- Automatically switch between detailed, compact, and density rendering based on visible kernel volume; reduce repeated labels and de-emphasize low-severity findings when crowded.
- Rework Evidence presentation: severity-first ordering, All/Critical/Warning/Info filters, packed annotation rows, subdued non-active overlays, and full explanation in the sidebar only.
- Make finding navigation participate in viewport history and progressive tile loading.
- Build full-range NVTX once in the background, slice overlapping spans for requests, and wait for warmup completion before profile shutdown.
- Keep baked/trimmed HTML behavior backward compatible.

## UI design rationale

The Evidence panel follows overview+detail and master/detail patterns: the timeline preserves location and context, while the selected finding owns the detailed explanation. Progressive disclosure keeps secondary notes and connections out of the default visual field. Severity is represented by ordering, text, and symbols in addition to color. References: [overview+detail research](https://arxiv.org/abs/2008.09941), [Microsoft list/details pattern](https://learn.microsoft.com/en-us/windows/apps/develop/ui/controls/list-details), [IBM severity definitions](https://www.ibm.com/docs/en/spectrum-control/5.4.11?topic=alerting-alert-severities), and [progressive disclosure](https://www.uxpin.com/studio/blog/what-is-progressive-disclosure/).

## Backward compatibility

Yes. The new overview/profile metadata is additive, and baked/trimmed timeline exports retain their existing data path.

## Test plan

- [x] Full suite with `NSYS_TEST_PROFILE` — 2119 passed, 140 skipped
- [x] `tests/test_ci_coverage.py` with `NSYS_TEST_PROFILE` — 5 passed
- [x] `ruff check src/ tests/`
- [x] `bandit -r src/ -c pyproject.toml`
- [x] `python -m nsys_ai --help`
- [x] `node --check src/nsys_ai/templates/timeline.js`
- [x] `git diff --check`
- [x] Real-profile HTTP/API smoke against the supplied profile-results SQLite data, covering non-zero profile time range, overview metadata, profile-wide search, HTML controls, and tile response.

Browser automation was not available in the environment, so the real-profile check covered the served HTML/assets and HTTP API contract rather than pixel-level browser assertions.

## Follow-ups

- Add true server-side density/LOD payloads for very wide views so raw kernel transfer can be reduced further.
- Add iteration-group headers and previous/next iteration navigation.
- Add browser automation once a Playwright/Chromium runtime is available.
