### PR TITLE
release: 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] — 2026-08-10
+
+### Removed
+
+- `nsys-ai perfetto` and `open --viewer perfetto`. The command served the trace
+  from a local port with `Access-Control-Allow-Origin: *` so that
+  `ui.perfetto.dev` — a page this project does not run — could fetch it, which
+  meant the feature needed an internet connection on machines that often have
+  none, and the wide-open CORS header existed only to serve it. It could not
+  take part in the loop either: it received a flat list of kernels and NVTX
+  spans, read-only. **`nsys-ai export` is unchanged** — Chrome Trace Event JSON
+  is a format rather than a service, and the exported file can still be opened
+  in Perfetto by anyone who wants to. `open --viewer` now defaults to `web`.
 
 ### Added
+
+- `nsys-ai optimize <profile> --repo <path> -- <command>` carries one baseline
+  profile to a recorded decision in a single command: diagnose, propose, capture
+  the verification run from the proposal's own RunSpec, diff, decide. It writes
+  no new analysis — every step already existed and this composes them. It stops
+  before re-profiling when the proposal abstains, exits non-zero when the loop
+  does not complete, and resumes from the session store rather than from memory,
+  so an interrupted run does not repeat the capture it already made.
+- `nsys-ai diagnose <profile>` and `nsys-ai review` are thin verbs over the
+  evidence pack and the canonical diff. `diagnose` publishes findings to a
+  session and prints the next command with its arguments filled in; `review`
+  resumes a session and reports where its decision stands, or compares a pair
+  without owning a session. `review`'s pair output is byte-identical to
+  `diff --no-ai`.
+- `nsys-ai diff --session --accept/--reject --reason TEXT` records the decision
+  on the session's own `diff.json`, so a session that has findings, a proposal
+  and a diff can reach a decision without leaving the command line.
 
 - `nsys-ai warm <profile>` builds the Parquet cache and the NVTX kernel map in
   one step, so the stack sweep is paid deliberately up front rather than by
@@ -68,6 +97,23 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Fixed
 
+- A capture that recorded no GPU kernels is no longer reported as a large
+  improvement. Comparability drops to zero, the report states which side is
+  empty, and `--gate` exits non-zero: a comparison that could not be made has
+  not shown the absence of a regression. The LLM narrative is refused before the
+  model is consulted, so it cannot narrate the vanished kernels as a win beneath
+  the refusal. `--gate` / `--exit-on-regression` now also exit non-zero on any
+  inconclusive verdict, which will fail CI jobs that previously passed silently
+  on incomparable pairs.
+- `arithmetic_intensity` refuses an MFU above 100% instead of classifying it as
+  healthy. Achieved throughput above the peak it is measured against is
+  arithmetically impossible, so it abstains and names which input to check; a
+  non-positive FLOP count or peak abstains for the same reason.
+- `doctor`'s RunSpec check looks at the profile instead of reporting "no" for
+  every one, and its hint names a flag that exists.
+- The getting-started screen lists the optimization loop and shows forms that
+  run: five commands were advertised without a required `--trim`.
+
 - A missing profile path fails immediately with `ProfileNotFoundError` and a
   non-zero exit, instead of creating an empty database and cache directory and
   then reporting a misleading schema error.
@@ -92,6 +138,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ### Performance
 
+- Served responses are compressed when the client accepts it, cutting a cold
+  `timeline-web` load from 2,184,087 to 272,501 bytes (8.0x) and the Perfetto
+  trace from 1,022,424 to 100,320. Negotiated, never assumed: a client that does
+  not advertise gzip gets the plain body.
+
 - SQL sweep-line overlap analysis (about 3x faster on the analysis call), NVTX
   layer breakdown reduced from ~43s to ~1.4s, and automatic trimming of long
   profiles to a representative window.
@@ -113,5 +164,6 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 See `git log v0.2.3` for changes prior to the introduction of this
 changelog.
 
-[Unreleased]: https://github.com/GindaChen/nsys-ai/compare/v0.2.3...HEAD
+[Unreleased]: https://github.com/GindaChen/nsys-ai/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/GindaChen/nsys-ai/compare/v0.2.3...v0.3.0
 [0.2.3]: https://github.com/GindaChen/nsys-ai/releases/tag/v0.2.3

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 nsys-ai is an AI-powered terminal UI for analyzing NVIDIA Nsight Systems GPU profiles (`.sqlite` files). It provides Textual-based TUI viewers, a local web timeline, HTML export, a skill-based analysis system, and an LLM agent for automated GPU performance diagnosis.
 
-**Naming:** The PyPI package is `nsys-ai`, but the internal Python module is `nsys_ai` (historical). Both `nsys-ai` and `nsys-tui` CLI commands work.
+**Naming:** The PyPI package is `nsys-ai`, but the internal Python module is `nsys_ai` (historical). The CLI command is `nsys-ai`; the older `nsys-tui` entry point was dropped in the rename.
 
 ## Build & Development Commands
 
@@ -39,7 +39,7 @@ Core runtime dependencies are `duckdb` + `pyarrow` (Parquet cache acceleration) 
 
 ### Entry Point
 
-`src/nsys_ai/__main__.py` delegates to `nsys_ai.cli.app:main`; the argparse CLI is built in `cli/parsers.py` (~30 subcommands) and dispatched to `cli/handlers.py`. Two entry points registered in pyproject.toml: `nsys-ai` and `nsys-tui`, both point to `nsys_ai.__main__:main`.
+`src/nsys_ai/__main__.py` delegates to `nsys_ai.cli.app:main`; the argparse CLI is built in `cli/parsers.py` (~30 subcommands) and dispatched to `cli/handlers.py`. One entry point is registered in pyproject.toml: `nsys-ai`, pointing at `nsys_ai.__main__:main`.
 
 ### Core Data Model
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ bottlenecks with an evidence-first agent — from your browser or terminal.
 [![CI](https://github.com/GindaChen/nsys-ai/actions/workflows/ci.yml/badge.svg)](https://github.com/GindaChen/nsys-ai/actions)
 [![PyPI](https://img.shields.io/pypi/v/nsys-ai)](https://pypi.org/project/nsys-ai/)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10+-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](https://github.com/GindaChen/nsys-ai/blob/main/LICENSE)
 
 </div>
 
@@ -69,8 +69,8 @@ nsys profile --capture-range=cudaProfilerApi --trace=cuda,nvtx \
 API). `nvtx` adds the annotation hierarchy that drives the iteration, region,
 and layer views. To use the iteration tools (`iters`, `diff --iteration`),
 annotate each step with a consistent NVTX marker — see
-[Focused Profiling](docs/08-focused-profiling.md) and
-[NVTX Annotations](docs/03-nvtx-annotations.md).
+[Focused Profiling](https://github.com/GindaChen/nsys-ai/blob/main/docs/08-focused-profiling.md) and
+[NVTX Annotations](https://github.com/GindaChen/nsys-ai/blob/main/docs/03-nvtx-annotations.md).
 
 No workload handy? Download an example profile:
 
@@ -241,7 +241,7 @@ via `--against` or as the `before` positional.
 
 | Command | Description |
 |---------|-------------|
-| `open` | Quick-open a profile in the web UI, Perfetto, or TUI |
+| `open` | Quick-open a profile in the web UI or TUI |
 | `timeline-web` | Web multi-GPU timeline (progressive rendering) |
 | `timeline` | Timeline TUI |
 | `tui` | NVTX tree TUI |
@@ -347,7 +347,7 @@ A few common ones:
 | `profile_health_manifest` | One-shot health summary (run this first) |
 
 Skills are extensible — add one by dropping a Python file that exports a `SKILL`
-constant. See [`skill list`](docs/agent_skills/commands/skill.md) for the full
+constant. See [`skill list`](https://github.com/GindaChen/nsys-ai/blob/main/docs/agent_skills/commands/skill.md) for the full
 catalog.
 
 ## AI analysis (optional)
@@ -390,33 +390,33 @@ same answer shape with a deterministic Summary.
 nsys-ai ships as a [Claude Code](https://claude.com/claude-code) plugin: the
 `/nsys-ai` slash command turns a profile into a root cause, a proposed fix, and
 an annotated timeline. See
-[docs/claude-plugin-quickstart.md](docs/claude-plugin-quickstart.md) to install
-and [docs/claude-plugin.md](docs/claude-plugin.md) for the full reference.
+[docs/claude-plugin-quickstart.md](https://github.com/GindaChen/nsys-ai/blob/main/docs/claude-plugin-quickstart.md) to install
+and [docs/claude-plugin.md](https://github.com/GindaChen/nsys-ai/blob/main/docs/claude-plugin.md) for the full reference.
 
 ## Documentation
 
-Start with the **[User guide](docs/user-guide.md)** — one workload from capture to a recorded
+Start with the **[User guide](https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md)** — one workload from capture to a recorded
 decision, on the command line. To drive the same workflow in a browser instead, see
-[Guided loop setup](docs/guided-loop-setup.md).
+[Guided loop setup](https://github.com/GindaChen/nsys-ai/blob/main/docs/guided-loop-setup.md).
 
 The rest of the `docs/` directory mirrors the relevant NVIDIA Nsight Systems reference
 (capture, schema, NVTX, CUDA/NCCL trace) plus nsys-ai project guides:
 
 | Guide | Topic |
 |-------|-------|
-| [User guide](docs/user-guide.md) | Capture, diagnose, propose, diff, decide — end to end |
-| [doctor](docs/doctor.md) | Environment and profile health checks |
-| [NVIDIA nsys CLI](docs/01-cli-reference.md) | The upstream `nsys` profiler CLI (capture-time) |
-| [SQLite schema](docs/02-sqlite-schema.md) | Nsight export tables and queries |
-| [NVTX annotations](docs/03-nvtx-annotations.md) | Annotating your code (and iteration markers) |
-| [CUDA trace](docs/04-cuda-trace.md) | GPU kernel and memory tracing |
-| [NCCL tracing](docs/05-nccl-tracing.md) | Multi-GPU collective analysis |
-| [Python / PyTorch](docs/06-python-pytorch.md) | Profiling PyTorch workloads |
-| [Containers](docs/07-container-profiling.md) | Profiling inside Docker / Slurm |
-| [Focused profiling](docs/08-focused-profiling.md) | Capturing representative iterations |
-| [CUTracer](docs/cutracer-instruction-analysis.md) | Instruction-level drill-down for top kernels |
+| [User guide](https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md) | Capture, diagnose, propose, diff, decide — end to end |
+| [doctor](https://github.com/GindaChen/nsys-ai/blob/main/docs/doctor.md) | Environment and profile health checks |
+| [NVIDIA nsys CLI](https://github.com/GindaChen/nsys-ai/blob/main/docs/01-cli-reference.md) | The upstream `nsys` profiler CLI (capture-time) |
+| [SQLite schema](https://github.com/GindaChen/nsys-ai/blob/main/docs/02-sqlite-schema.md) | Nsight export tables and queries |
+| [NVTX annotations](https://github.com/GindaChen/nsys-ai/blob/main/docs/03-nvtx-annotations.md) | Annotating your code (and iteration markers) |
+| [CUDA trace](https://github.com/GindaChen/nsys-ai/blob/main/docs/04-cuda-trace.md) | GPU kernel and memory tracing |
+| [NCCL tracing](https://github.com/GindaChen/nsys-ai/blob/main/docs/05-nccl-tracing.md) | Multi-GPU collective analysis |
+| [Python / PyTorch](https://github.com/GindaChen/nsys-ai/blob/main/docs/06-python-pytorch.md) | Profiling PyTorch workloads |
+| [Containers](https://github.com/GindaChen/nsys-ai/blob/main/docs/07-container-profiling.md) | Profiling inside Docker / Slurm |
+| [Focused profiling](https://github.com/GindaChen/nsys-ai/blob/main/docs/08-focused-profiling.md) | Capturing representative iterations |
+| [CUTracer](https://github.com/GindaChen/nsys-ai/blob/main/docs/cutracer-instruction-analysis.md) | Instruction-level drill-down for top kernels |
 
-The [`docs/sqlite-explorer/`](docs/sqlite-explorer/) directory holds an
+The [`docs/sqlite-explorer/`](https://github.com/GindaChen/nsys-ai/tree/main/docs/sqlite-explorer/) directory holds an
 interactive HTML explorer for the Nsight SQLite schema — open
 `docs/sqlite-explorer/index.html` in a browser.
 
@@ -442,14 +442,14 @@ pytest tests/ -v
 ```
 
 **Guided optimization loop** (diagnose → propose → re-profile → diff → accept): see the
-[User guide](docs/user-guide.md) for the CLI path and
-[docs/guided-loop-setup.md](docs/guided-loop-setup.md) for the browser path.
+[User guide](https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md) for the CLI path and
+[docs/guided-loop-setup.md](https://github.com/GindaChen/nsys-ai/blob/main/docs/guided-loop-setup.md) for the browser path.
 
 ---
 
 ## License
 
-MIT — see [LICENSE](LICENSE).
+MIT — see [LICENSE](https://github.com/GindaChen/nsys-ai/blob/main/LICENSE).
 
 <div align="center">
 <sub>Built for GPU performance engineers.</sub>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "nsys-ai"
-version = "0.2.3"
+version = "0.3.0"
 description = "AI-powered analysis for NVIDIA Nsight Systems profiles — web viewer, timeline, kernel navigator, NVTX hierarchy"
 readme = "README.md"
 license = {text = "MIT"}
@@ -28,6 +28,13 @@ classifiers = [
     "Topic :: System :: Monitoring",
 ]
 
+[project.urls]
+Homepage = "https://github.com/GindaChen/nsys-ai"
+Repository = "https://github.com/GindaChen/nsys-ai"
+Issues = "https://github.com/GindaChen/nsys-ai/issues"
+Changelog = "https://github.com/GindaChen/nsys-ai/blob/main/CHANGELOG.md"
+Documentation = "https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md"
+
 [project.scripts]
 nsys-ai = "nsys_ai.__main__:main"
 
@@ -44,7 +51,16 @@ all = ["nsys-ai[agent,tui,chat,cutracer]"]
 where = ["src"]
 
 [tool.setuptools.package-data]
-nsys_ai = ["templates/*.html", "templates/*.css", "templates/*.js", "prompts/*.txt", "data/*.md"]
+nsys_ai = [
+    "templates/*.html",
+    "templates/*.css",
+    "templates/*.js",
+    "prompts/*.txt",
+    "data/*.md",
+    # persona.py reads this at import time, so a wheel without it cannot
+    # even import nsys_ai.agent.persona.
+    "agent/*.md",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -68,7 +68,7 @@ def show_help():
     print("    nsys-ai review --session ID              Where a session stands")
     print("    nsys-ai loop <before> --after <after>    Same loop, guided in the browser")
     print("    nsys-ai baseline list                    Named baselines to diff against")
-    print("    See docs/user-guide.md for the whole path end to end.")
+    print("    Full walkthrough: https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md")
     print()
     print("  Skills & Agent:")
     print("    nsys-ai skill list                       List analysis skills")

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -663,7 +663,7 @@ def _build_parser():
     p.set_defaults(handler=_cmd_review)
 
     # Public commands (simplified)
-    p = sub.add_parser("open", help="Open profile quickly in Perfetto/web/TUI")
+    p = sub.add_parser("open", help="Open profile quickly in the web viewer or TUI")
     p.add_argument("profile", help="Path to profile (.sqlite or .nsys-rep)")
     p.add_argument(
         "--gpu", type=int, default=None, help="GPU device ID (default: first GPU in profile)"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1134,3 +1134,37 @@ def test_the_perfetto_ui_integration_is_gone_but_the_export_remains():
         capture_output=True, text=True,
     )
     assert result.returncode != 0
+
+
+def test_no_help_text_offers_a_command_that_was_removed():
+    """A removal is not finished while the help still advertises it.
+
+    Deleting `nsys-ai perfetto` left two strings behind that six independent
+    end-to-end passes all found: the `open` subcommand description, and the same
+    row in README.md — which setuptools ships as the wheel's long description, so
+    it is the PyPI landing page.
+
+    `export`'s "Perfetto JSON traces" is deliberately still true: that names the
+    Chrome Trace Event format, which the export still produces.
+    """
+    from pathlib import Path
+
+    removed_offers = []
+    for line in _help_screen().splitlines() + subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "--help"], capture_output=True, text=True
+    ).stdout.splitlines():
+        if "erfetto" not in line:
+            continue
+        if line.strip().startswith("export") or "export" in line.split("Perfetto")[0]:
+            continue  # the format, not the command
+        removed_offers.append(line.strip())
+    assert not removed_offers, (
+        "help text still offers the removed perfetto viewer:\n  " + "\n  ".join(removed_offers)
+    )
+
+    readme = (Path(__file__).resolve().parents[1] / "README.md").read_text(encoding="utf-8")
+    open_rows = [
+        line for line in readme.splitlines()
+        if line.startswith("| `open`") and "erfetto" in line
+    ]
+    assert not open_rows, f"README still offers perfetto under `open`: {open_rows}"

--- a/tests/test_package_data.py
+++ b/tests/test_package_data.py
@@ -1,0 +1,95 @@
+"""Every non-Python file the package ships must be declared as package data.
+
+`persona.py` reads `persona.md` at module import time, and `agent/*.md` was not
+in `[tool.setuptools.package-data]`. Source installs worked because the file was
+simply there; the wheel could not import `nsys_ai.agent.persona` at all:
+
+    FileNotFoundError: .../site-packages/nsys_ai/agent/persona.md
+
+Nothing caught it, because every test runs against the source tree. This walks
+the package instead and checks each data file against the declared globs.
+"""
+
+from __future__ import annotations
+
+import ast
+import fnmatch
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKAGE = ROOT / "src" / "nsys_ai"
+
+#: Extensions that are build or editor droppings rather than shipped data.
+_IGNORED_SUFFIXES = {".pyc", ".pyo", ".so", ".pyd"}
+
+
+def _declared_globs() -> list[str]:
+    """Read the package-data globs without a TOML parser.
+
+    ``tomllib`` is 3.11+, and this repo supports 3.10. The value is a literal
+    list of strings in a known section, so a targeted match is enough — and it
+    fails loudly rather than silently returning nothing if the section moves.
+    """
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(
+        r"^\[tool\.setuptools\.package-data\]\s*$.*?^nsys_ai\s*=\s*(\[.*?\])",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match, "could not find [tool.setuptools.package-data] nsys_ai in pyproject.toml"
+    return ast.literal_eval(match.group(1))
+
+
+def test_every_shipped_data_file_is_declared_as_package_data():
+    globs = _declared_globs()
+    undeclared = []
+    for path in sorted(PACKAGE.rglob("*")):
+        if not path.is_file() or path.suffix == ".py":
+            continue
+        if path.suffix in _IGNORED_SUFFIXES or "__pycache__" in path.parts:
+            continue
+        relative = path.relative_to(PACKAGE).as_posix()
+        if not any(fnmatch.fnmatch(relative, pattern) for pattern in globs):
+            undeclared.append(relative)
+    assert not undeclared, (
+        "these files ship in the source tree but are not in "
+        "[tool.setuptools.package-data]; a wheel will not contain them:\n  "
+        + "\n  ".join(undeclared)
+        + f"\ndeclared globs: {globs}"
+    )
+
+
+def test_the_agent_persona_is_readable_the_way_persona_py_reads_it():
+    """Guards the specific import-time read, not just the declaration."""
+    from nsys_ai.agent import persona
+
+    assert persona.SYSTEM_PROMPT.strip(), "persona.md loaded but empty"
+    assert "{skill_catalog}" in persona.SYSTEM_PROMPT
+    assert persona.build_system_prompt().strip()
+
+
+def test_the_pypi_page_links_back_and_has_no_relative_links():
+    """README is shipped as the wheel's long description, so it *is* the PyPI page.
+
+    A relative link renders there as a dead link — 23 of them, including the
+    user guide this project points newcomers at. And with no [project.urls],
+    the page offered no route to the source, the issues or the changelog at all.
+    """
+    import re
+
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert "[project.urls]" in text, "PyPI page would have no link back to the project"
+    for required in ("Homepage", "Repository", "Issues"):
+        assert re.search(rf"^{required}\s*=", text, re.MULTILINE), f"missing {required} URL"
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    relative = [
+        target
+        for target in re.findall(r"\]\(([^)]+)\)", readme)
+        if not target.startswith(("http", "#", "mailto:"))
+    ]
+    assert not relative, (
+        "README is the PyPI long description; these links are dead there:\n  "
+        + "\n  ".join(sorted(set(relative)))
+    )


### PR DESCRIPTION
Closes #367.

125 commits since `v0.2.3`. Everything the loop milestone built has existed only on `main`; this is the
version bump and changelog close so it reaches PyPI.

### What ships

The optimization loop is the headline. `nsys-ai optimize <profile> --repo <path> -- <command>` carries
one baseline profile to a recorded decision in a single command — diagnose, propose, capture the
verification run from the proposal's own RunSpec, diff, decide — and `diagnose` / `review` / `propose`
/ `diff` expose the same loop step by step, with the session store as the single source of truth
between them. Measured end to end on local hardware: 2.9 s from baseline profile to a recorded reject.

Also in: `warm`, `baseline`, `doctor`, `nsys-ai profile`, the CLI user guide, response compression
(8.0x on a cold `timeline-web` load), and the two refusals that stop a confident wrong number reaching
a user — an empty capture read as a 535 ms improvement, and an MFU of 369% classified as healthy.

### Changelog

The `[Unreleased]` section was missing the last stretch of work. Added `optimize`, the `diagnose` and
`review` verbs, CLI decision recording, both refusals and the compression, then closed the section as
`[0.3.0]` and updated the link references.

### One correction found while verifying

`CLAUDE.md` stated in two places that both `nsys-ai` and `nsys-tui` work, and that "two entry points
[are] registered in pyproject.toml". Only `nsys-ai` is. `nsys-tui` pointed at the deleted `nsys_tui`
module and went with the rename in `2450a0e` back in March.

This surfaced by building the wheel and installing it into a clean venv rather than by reading
`pyproject.toml` — `nsys-tui` exits 127 there. Corrected in this PR.

### Verification

```
python -m build                     Successfully built nsys_ai-0.3.0.tar.gz and .whl
pip install <wheel> (clean venv)    rc=0
  nsys_ai.__version__               0.3.0
  nsys-ai --help                    rc=0
  optimize/diagnose/review/diff/doctor/warm --help   all rc=0
ruff check src/ tests/                                rc=0
pytest tests/test_cli.py            52 passed
```

The full suite is not re-run here — this commit changes `pyproject.toml`, `CHANGELOG.md` and
`CLAUDE.md` only, and CI runs it on all three Python versions regardless.

### After merge

Tagging `v0.3.0` triggers `workflow.yml`, which builds and publishes to PyPI. That is irreversible —
a version number cannot be reused — so the tag is deliberately not part of this PR.
