### PR TITLE
chore(web): drop the Perfetto UI integration, keep the trace export

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,6 @@ via `--against` or as the `before` positional.
 | `cutracer` | Instruction-level drill-down (`check`, `install`, `plan`, `run`, `analyze`) |
 | `export` / `export-csv` / `export-json` | Perfetto JSON, flat CSV, flat JSON |
 | `viewer` / `timeline-html` | Interactive HTML report / timeline |
-| `perfetto` | Open the trace in the Perfetto UI |
 
 Run `nsys-ai <command> --help` for flags.
 

--- a/docs/agent_skills/INDEX.md
+++ b/docs/agent_skills/INDEX.md
@@ -83,7 +83,6 @@ nsys-ai report profile.sqlite --gpu 0 --trim 1.0 5.0 -o report.md
 | `nsys-ai nccl <profile> [--gpu N] [--trim S E]` | NCCL collective breakdown | Network communication profiling |
 | `nsys-ai iters <profile> [--gpu N] [--trim S E]` | Detect training iterations | Find stable steps and warmup |
 | `nsys-ai export <profile> [--gpu N] [--trim S E] [-o DIR]` | Export Perfetto JSON | Post-processing / sharing |
-| `nsys-ai perfetto <profile> [--gpu N] [--trim S E] [--port P]` | Open trace in Perfetto UI | Direct Perfetto trace viewer |
 | `nsys-ai export-json <profile> [--gpu N] [--trim S E] [-o out.json] [--summary]` | Export kernel data as flat JSON | Easy programmatic ingestion |
 | `nsys-ai export-csv <profile> [--gpu N] [--trim S E] [-o out.csv]` | Export kernel data as flat CSV | Statistical analysis pipelines |
 | `nsys-ai viewer <profile> [--gpu N] [--trim S E] [-o out.html]` | Generate interactive HTML viewer | Shareable web report |

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -182,7 +182,6 @@ def main():
         "export-json",
         "viewer",
         "timeline-html",
-        "perfetto",
         "tui",
         "timeline",
     }

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1446,7 +1446,7 @@ def _cmd_web(args, _profile):
 
 def _cmd_open(args, _profile):
     from nsys_ai.tree import run_tui
-    from nsys_ai.web import serve, serve_perfetto
+    from nsys_ai.web import serve
 
     with _profile.open(args.profile) as prof:
         gpu = (
@@ -1456,24 +1456,13 @@ def _cmd_open(args, _profile):
             trim_ns = (int(args.trim[0] * 1e9), int(args.trim[1] * 1e9))
         else:
             trim_ns = (int(prof.meta.time_range[0]), int(prof.meta.time_range[1]))
-        port = args.port if args.port is not None else (8143 if args.viewer == "perfetto" else 8142)
-        if args.viewer == "perfetto":
-            serve_perfetto(prof, gpu, trim_ns, port=port, open_browser=not args.no_browser)
-        elif args.viewer == "web":
+        port = args.port if args.port is not None else 8142
+        if args.viewer == "web":
             serve(prof, gpu, trim_ns, port=port, open_browser=not args.no_browser)
         else:
             profile_path = prof.path
     if args.viewer == "tui":
         run_tui(profile_path, gpu, trim_ns, max_depth=-1, min_ms=0)
-
-
-def _cmd_perfetto(args, _profile):
-    from nsys_ai.web import serve_perfetto
-
-    with _profile.open(args.profile) as prof:
-        serve_perfetto(
-            prof, args.gpu, _parse_trim(args), port=args.port, open_browser=not args.no_browser
-        )
 
 
 def _cmd_timeline_web(args, _profile):

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -38,7 +38,6 @@ from .handlers import (
     _cmd_open,
     _cmd_optimize,
     _cmd_overlap,
-    _cmd_perfetto,
     _cmd_profile,
     _cmd_propose,
     _cmd_report,
@@ -679,15 +678,15 @@ def _build_parser():
     )
     p.add_argument(
         "--viewer",
-        choices=["perfetto", "web", "tui"],
-        default="perfetto",
-        help="Viewer to use (default: perfetto)",
+        choices=["web", "tui"],
+        default="web",
+        help="Viewer to use (default: web)",
     )
     p.add_argument(
-        "--port", type=int, default=None, help="HTTP port for perfetto/web (default: 8143/8142)"
+        "--port", type=int, default=None, help="HTTP port for the web viewer (default: 8142)"
     )
     p.add_argument(
-        "--no-browser", action="store_true", help="Don't auto-open browser (perfetto/web)"
+        "--no-browser", action="store_true", help="Don't auto-open browser (web)"
     )
     p.set_defaults(handler=_cmd_open)
 
@@ -1313,12 +1312,6 @@ def _register_legacy_commands(sub):
     _add_gpu_trim(p)
     p.add_argument("-o", "--output", default="timeline.html", help="Output HTML file")
     p.set_defaults(handler=_cmd_timeline_html)
-
-    p = sub.add_parser("perfetto", help="Open trace in Perfetto UI")
-    _add_gpu_trim(p)
-    p.add_argument("--port", type=int, default=8143, help="HTTP port for trace (default: 8143)")
-    p.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
-    p.set_defaults(handler=_cmd_perfetto)
 
     p = sub.add_parser("tui", help="Terminal tree view; press A for AI chat")
     _add_gpu_trim(p)

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -1,13 +1,11 @@
 """
 web.py — Serve profiles via local HTTP servers.
 
-Provides two modes:
+Provides:
   1. `serve`          — Serve the built-in interactive HTML viewer.
-  2. `serve_perfetto` — Serve Perfetto JSON and open ui.perfetto.dev.
 
 Usage:
     nsys-ai web      profile.sqlite --gpu 0 --trim 39 42
-    nsys-ai perfetto profile.sqlite --gpu 0 --trim 39 42
 """
 
 import gzip
@@ -21,7 +19,6 @@ import threading
 import time as _time
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from urllib.parse import quote
 
 _log = logging.getLogger(__name__)
 
@@ -143,7 +140,6 @@ class _ThreadedHTTPServer(_ThreadPoolMixIn, socketserver.ThreadingMixIn, HTTPSer
     allow_reuse_address = True
 
 
-from .export import gpu_trace  # noqa: E402
 from .viewer import (  # noqa: E402
     build_timeline_gpu_data,
     generate_evidence_html,
@@ -1177,62 +1173,3 @@ def serve_evidence(
     print(f"Evidence viewer at {actual_url}")
     print(f"  {len(findings_data)} finding(s): {title}")
     _run_server(server, actual_url if open_browser else None, prof)
-
-
-# ── Mode 4: Perfetto UI ─────────────────────────────────────────
-
-
-class _PerfettoHandler(BaseHTTPRequestHandler):
-    """Serve Perfetto JSON trace with CORS so ui.perfetto.dev can fetch it."""
-
-    trace_bytes: bytes = b""
-
-    def do_OPTIONS(self):
-        """Handle CORS preflight."""
-        self.send_response(204)
-        self._cors_headers()
-        self.end_headers()
-
-    def do_GET(self):
-        # The Perfetto trace is the largest thing this server hands out, and it
-        # crosses the network to ui.perfetto.dev's fetch. CORS headers are set
-        # first so they survive on the compressed response too.
-        _send_body(
-            self,
-            self.trace_bytes,
-            "application/json",
-            extra_headers={
-                "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Methods": "GET, OPTIONS",
-                "Access-Control-Allow-Headers": "*",
-            },
-        )
-
-    def _cors_headers(self):
-        self.send_header("Access-Control-Allow-Origin", "*")
-        self.send_header("Access-Control-Allow-Methods", "GET, OPTIONS")
-        self.send_header("Access-Control-Allow-Headers", "*")
-
-    def log_message(self, format, *args):
-        pass
-
-
-def serve_perfetto(
-    prof, device: int, trim: tuple[int, int], *, port: int = 8143, open_browser: bool = True
-):
-    """Generate Perfetto JSON, serve it locally, and open ui.perfetto.dev."""
-    events = gpu_trace(prof, device, trim)
-    trace = json.dumps({"traceEvents": events, "displayTimeUnit": "ms"})
-    _PerfettoHandler.trace_bytes = trace.encode("utf-8")
-
-    nk = sum(1 for e in events if e.get("cat") == "gpu_kernel")
-    nn = sum(1 for e in events if e.get("cat") == "nvtx_projected")
-    print(f"Trace: {nk} kernels, {nn} NVTX, {len(trace) // 1024} KB")
-
-    server = HTTPServer(("127.0.0.1", port), _PerfettoHandler)
-    actual_port = server.server_address[1]
-    trace_url = f"http://127.0.0.1:{actual_port}/trace.json"
-    perfetto_url = f"https://ui.perfetto.dev/#!/?url={quote(trace_url, safe='')}"
-
-    print(f"Perfetto UI: {perfetto_url}")
-    _run_server(server, perfetto_url if open_browser else None, prof)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1108,3 +1108,29 @@ def test_every_advertised_invocation_parses():
             message = stderr.getvalue().strip().splitlines()
             failures.append(f"{shown!r} -> {message[-1] if message else 'SystemExit'}")
     assert not failures, "help screen shows invocations that do not parse:\n  " + "\n  ".join(failures)
+
+
+def test_the_perfetto_ui_integration_is_gone_but_the_export_remains():
+    """We do not ship an integration with someone else's hosted service.
+
+    `nsys-ai perfetto` served the trace locally with `Access-Control-Allow-Origin: *`
+    and opened ui.perfetto.dev, a page we do not run, over a link the user may not
+    have. It could not participate in the loop either -- no findings overlay, no
+    session, nothing came back. The Chrome Trace Event export stays: it is a format,
+    not a service, and anyone who wants Perfetto can open the file there themselves.
+    """
+    import nsys_ai.web as web_module
+
+    assert not hasattr(web_module, "serve_perfetto")
+    assert not hasattr(web_module, "_PerfettoHandler")
+    assert "ui.perfetto.dev" not in _help_screen()
+
+    declared = _declared_subcommands()
+    assert "perfetto" not in declared
+    assert "export" in declared, "the trace export must survive"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "perfetto", "p.sqlite"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode != 0


### PR DESCRIPTION
`nsys-ai perfetto` served the trace from a local port and opened `ui.perfetto.dev` — a page we do not
run. This removes that integration and keeps the export.

### Why

**It is someone else's service.** The trace bytes never left the machine (the browser fetched
localhost directly), but the page came from a third party, so the feature needed an internet
connection — on a GPU cluster, which is exactly where profiles live and often exactly where there
isn't one.

**It needed a wide-open CORS header to work.** `Access-Control-Allow-Origin: *` on a local server
holding profile data, so that an `https://` page could fetch `http://127.0.0.1`. Narrow window — the
server only lives for the length of the command — but the header existed solely to serve that page,
and it is now gone from the codebase entirely.

**It could not take part in the loop.** `timeline-web` serves `/api/findings`, `/api/analyze` and the
seven `/api/loop/*` routes — diagnose, proposal, reprofile, diff, decision, phase, state. Perfetto got
a flat list of kernels and NVTX spans, read-only, with nothing coming back. A `grep` for `perfetto`
outside `export/`, `web/` and `cli/` returns nothing: it was never wired into anything.

It was also inconsistent with itself — `nsys-ai <profile>` opened `timeline-web` while
`nsys-ai open <profile>` opened Perfetto, and `open` could not reach `timeline-web` at all.

### What stays

`nsys-ai export` and `export.py`, untouched. Chrome Trace Event JSON is a **format, not a service**:
PyTorch Profiler and Chrome tracing read the same shape. Anyone who wants Perfetto can open the
exported file at `ui.perfetto.dev` themselves — their choice, made deliberately, rather than ours made
for them silently.

### Scope

`open --viewer` loses `perfetto` and now defaults to `web`. Removing the integration left `gpu_trace`
and `quote` unused in `web.py`; ruff caught both and they are gone.

This is a breaking change — `nsys-ai perfetto` no longer exists and `--viewer perfetto` is rejected.
It belongs in the 0.3.0 minor bump rather than after it, and the repo's convention is not to keep a
deprecated alias for our own past.

### Verification

Full suite 2127 passed, 140 skipped, exit 0. `ruff` clean; `bandit -r src/ -c pyproject.toml` 0/0/0.
`nsys-ai perfetto p.sqlite` exits 2; `nsys-ai export` still produces `trace_gpu0.json` /
`trace_gpu1.json`. A test pins both halves — the integration absent, the export present — and fails
when the removal is reverted.
