### PR TITLE
fix(loop): remove --after, which no loop surface ever registered

### DIFF
--- a/docs/guided-loop-setup.md
+++ b/docs/guided-loop-setup.md
@@ -65,7 +65,7 @@ nsys-ai loop --h100-preset --trim 49 90 --port 8144
 
 | Flag | Purpose |
 |------|---------|
-| `--h100-preset` | Auto-fill baseline + candidate paths from the HF cache |
+| `--h100-preset` | Auto-fill the baseline path from the HF cache |
 | `--trim START END` | **Viewer + diagnose** time window in **seconds** (optional but speeds up large traces) |
 | `--port` | HTTP port (default `8144`) |
 | `--no-browser` | Print URL only; do not open a tab |
@@ -90,7 +90,7 @@ Work top-to-bottom in the loop sidebar. The primary button advances the suggeste
 |------|--------|----------------|
 | **1. Diagnose** | Run diagnose on baseline | Local evidence builder runs; findings appear in the findings sidebar |
 | **2. Propose** | Enter change + expected impact, save | Text is stored in loop state (no code is modified) |
-| **3. Re-profile** | Set candidate `.sqlite` path | Registers the after profile (preset fills `perf_h100_sp1_fa3.sqlite` when using `--h100-preset`) |
+| **3. Re-profile** | Set candidate `.sqlite` path | The browser does not register a candidate. Capture with `nsys-ai profile`, then publish with `nsys-ai diff <before> <after> --session` |
 | **4. Diff** | Run diff | Compares baseline vs candidate; **All steps & status** panel appears with verdict and stats |
 | **5. Decide** | Accept or reject | Records your decision in session state only |
 

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -66,7 +66,7 @@ def show_help():
     print("    nsys-ai diff <before> <after>            Compare two profiles")
     print("    nsys-ai diff <before> <after> --session --accept --reason TEXT   Record it")
     print("    nsys-ai review --session ID              Where a session stands")
-    print("    nsys-ai loop <before> --after <after>    Same loop, guided in the browser")
+    print("    nsys-ai loop <profile>                   Render that session in a browser")
     print("    nsys-ai baseline list                    Named baselines to diff against")
     print("    See docs/user-guide.md for the whole path end to end.")
     print()

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1506,14 +1506,12 @@ def _cmd_loop(args, _profile):
 
     trim = _parse_trim(args)
     before_path = getattr(args, "before", None)
-    after_path = getattr(args, "after", None)
     if getattr(args, "h100_preset", False):
         from nsys_ai.loop_state import detect_h100_replay_preset
 
         preset = detect_h100_replay_preset()
         if preset:
             before_path = before_path or preset.get("before_path")
-            after_path = after_path or preset.get("after_path")
         elif not before_path:
             from nsys_ai.loop_state import h100_preset_download_hint
 
@@ -1530,17 +1528,10 @@ def _cmd_loop(args, _profile):
     if not Path(before_path).exists():
         print(f"Error: before profile not found: {before_path}", file=sys.stderr)
         print(
-            "Pass a real .sqlite/.nsys-rep path. Example: nsys-ai loop data/before.sqlite --after data/after.sqlite",
+            "Pass a real .sqlite/.nsys-rep path. Example: nsys-ai loop data/before.sqlite",
             file=sys.stderr,
         )
         sys.exit(1)
-    if after_path:
-        after_path = str(Path(after_path).expanduser())
-        if not Path(after_path).exists():
-            print(f"Error: after profile not found: {after_path}", file=sys.stderr)
-            print("Omit --after to enter the candidate path later in the web UI.", file=sys.stderr)
-            sys.exit(1)
-
     if args.surface == "timeline-web":
         from nsys_ai.web import serve_timeline
 
@@ -1562,7 +1553,6 @@ def _cmd_loop(args, _profile):
                 port=args.port,
                 open_browser=not args.no_browser,
                 loop_before=before_path,
-                loop_after=after_path,
                 loop_h100_preset=bool(getattr(args, "h100_preset", False)),
                 session=getattr(args, "session", None),
             )
@@ -1579,7 +1569,6 @@ def _cmd_loop(args, _profile):
             gpu,
             trim,
             min_ms=0,
-            loop_after=after_path,
             session=session,
         )
         return
@@ -1593,7 +1582,6 @@ def _cmd_loop(args, _profile):
         trim,
         max_depth=-1,
         min_ms=0,
-        loop_after=after_path,
         session=session,
     )
 

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -731,7 +731,6 @@ def _build_parser():
         nargs="?",
         help="Path to baseline profile (.sqlite or .nsys-rep); optional with --h100-preset",
     )
-    p.add_argument("--after", default=None, help="Path to candidate profile (.sqlite or .nsys-rep)")
     p.add_argument("--gpu", type=int, default=None, help="GPU device ID (default: first GPU)")
     p.add_argument(
         "--trim",
@@ -752,7 +751,7 @@ def _build_parser():
     p.add_argument(
         "--h100-preset",
         action="store_true",
-        help="Auto-fill H100 replay before/after paths when available",
+        help="Auto-fill the H100 replay baseline path when available",
     )
     p.add_argument(
         "--session",

--- a/src/nsys_ai/loop_state.py
+++ b/src/nsys_ai/loop_state.py
@@ -99,9 +99,8 @@ def h100_preset_download_hint() -> str:
         f"    profiles/perf_h100_sp1.sqlite profiles/perf_h100_sp1_fa3.sqlite\n"
         f"(requires the `hf` CLI: pip install -U huggingface_hub)\n"
         f"Expected cache layout: {H100_PRESET_CACHE}/<rev>/profiles/*.sqlite\n"
-        f"Or pass paths explicitly:\n"
-        f"  nsys-ai loop /path/to/perf_h100_sp1.sqlite "
-        f"--after /path/to/perf_h100_sp1_fa3.sqlite"
+        f"Or pass the baseline explicitly:\n"
+        f"  nsys-ai loop /path/to/perf_h100_sp1.sqlite"
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import sys
+from pathlib import Path
 
 
 def test_help():
@@ -183,13 +184,17 @@ def test_diff_subcommand_help():
 
 
 def test_loop_subcommand_help():
-    """loop subcommand should expose before/after workflow inputs."""
+    """loop should expose the baseline and surface inputs, and no candidate path.
+
+    The help used to say "Omit --after to enter the candidate path later in the
+    web UI", which /api/loop/reprofile refuses.
+    """
     result = subprocess.run(
         [sys.executable, "-m", "nsys_ai", "loop", "--help"], capture_output=True, text=True
     )
     assert result.returncode == 0
     assert "before" in result.stdout
-    assert "--after" in result.stdout
+    assert "--after" not in result.stdout
     assert "--surface" in result.stdout
     assert "--h100-preset" in result.stdout
 
@@ -342,6 +347,57 @@ def test_optimize_without_a_workload_exits_2(tmp_path):
     assert result.returncode == 2
     assert "a verification workload is required" in result.stderr
     assert "Traceback" not in result.stderr
+
+
+def test_loop_rejects_after(tmp_path):
+    """`loop --after` must fail as an unknown flag, not be accepted and dropped.
+
+    The session store is the loop's single source of truth: the CLI writes a
+    session and every loop surface only renders one, so a candidate passed here
+    lost to the session's own empty after profile without a word. A flag that is
+    parsed, validated and then discarded is the same promise in a costlier form,
+    so the flag is gone. The before profile is a real fixture: the rejection has
+    to come from the flag, not from a path that does not resolve.
+    """
+    fixtures = Path(__file__).resolve().parent / "fixtures"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "nsys_ai", "loop",
+            str(fixtures / "mfu_2gpu_before.sqlite"),
+            "--after", str(fixtures / "mfu_2gpu_after.sqlite"), "--no-browser",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 2, result.stderr
+    assert "unrecognized arguments: --after" in result.stderr, result.stderr
+    assert "Traceback" not in result.stderr, result.stderr
+
+
+def test_h100_preset_hint_names_a_command_that_parses():
+    """The only recovery instruction on the preset path must still be runnable.
+
+    `loop --h100-preset` with the dataset absent exits 1 after printing this
+    hint, so a command in it that the parser rejects leaves the caller with no
+    way forward. It named `--after` until that flag was removed.
+    """
+    import shlex
+
+    from nsys_ai.cli.parsers import _build_parser
+    from nsys_ai.loop_state import h100_preset_download_hint
+
+    commands = [
+        line.strip()
+        for line in h100_preset_download_hint().splitlines()
+        if line.strip().startswith("nsys-ai ")
+    ]
+    assert commands, "the hint stopped offering a command at all"
+    for command in commands:
+        argv = shlex.split(command)[1:]
+        # Reaching a Namespace at all is the assertion: argparse exits 2 on an
+        # unknown flag, which is exactly the failure this guards.
+        _build_parser().parse_args(argv)
 
 
 def test_loop_missing_profile_has_friendly_error(tmp_path):


### PR DESCRIPTION
## Summary

- `nsys-ai loop <before> --after <after>` parsed the candidate path, checked it existed, and then dropped it. The session store is the loop's single source of truth: the CLI is the only writer, every loop surface renders a session, and `/api/loop/reprofile` refuses a candidate that did not come from one. The path passed on the command line lost to the session's own empty after profile without a word.
- The flag is removed rather than annotated. A flag that is parsed, validated and then explained away is the same false promise in a costlier form.
- `loop --help` and the getting-started screen no longer advertise a candidate path this command cannot register.

## Changes

- `src/nsys_ai/cli/parsers.py` — drop `--after` from the `loop` parser.
- `src/nsys_ai/cli/handlers.py` — drop the candidate resolution, the `--h100-preset` after-path fill, and the existence check that fed it.
- `src/nsys_ai/cli/app.py` — the loop line on the getting-started screen reads `nsys-ai loop <profile>   Render that session in a browser`.
- `src/nsys_ai/loop_state.py` — `h100_preset_download_hint()` no longer ends by telling the reader to run `nsys-ai loop <before> --after <after>`. That hint is the only recovery instruction printed when `--h100-preset` cannot find the dataset, and this change had turned it into a command that exits 2.
- `src/nsys_ai/cli/parsers.py` — `--h100-preset` help now says it fills the baseline path, which is all it ever filled after the candidate fill was removed.
- `docs/guided-loop-setup.md` — the preset row no longer claims it fills a candidate; the re-profile step says the browser does not register one and names the CLI step instead (`/api/loop/reprofile` returns a limitation, it does not record).
- `tests/test_cli.py` — `loop --after` exits 2 with `unrecognized arguments`; the existing `loop --help` test now asserts `--after` is absent; and every `nsys-ai …` command inside the preset hint must parse, so a hint naming a removed flag fails the build.

## Backward compatibility

No. `nsys-ai loop <before> --after <after>` now exits 2 instead of serving the baseline and ignoring the candidate. The candidate path is the CLI one, which `diagnose` prints with the finding id filled in:

```
nsys-ai diagnose <before>
nsys-ai propose --session ID --finding-id ID --runspec runspec.json
nsys-ai diff <before> <after> --session
```

`nsys-ai loop <before>` is unchanged.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2132 passed, 140 skipped, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean
- [x] Manually exercised: `nsys-ai loop tests/fixtures/mfu_2gpu_before.sqlite --after tests/fixtures/mfu_2gpu_after.sqlite` → `rc=2`, `unrecognized arguments: --after`, no traceback

## Out of scope

- Letting a loop surface register a candidate. That is loop closure, not this.
- `timeline-web --loop-after`, which is the same defect one subcommand over: parsed, forwarded into `serve_timeline`/`run_tui`/`run_timeline`, and read by nothing. Removing it reaches six files across `web.py`, `tree/` and `timeline/`, so it is #417 rather than a rider here.

## Linked issues

Closes #397
