### PR TITLE
feat: name one shape for "cannot answer" and pin every surface against it

### DIFF
--- a/docs/notes/cannot-answer.md
+++ b/docs/notes/cannot-answer.md
@@ -1,0 +1,164 @@
+# One shape for "cannot answer"
+
+A consumer of this tool has to tell three states apart: *there is no problem here*, *here is the
+problem*, and *I could not look*. The third was said eight different ways, five of them at exit 0, so
+in practice it was indistinguishable from the first. That is the failure a verify-first tool can
+least afford: an analysis that could not run reads as a clean bill of health.
+
+This note decides the shape. It answers three questions and nothing else — it does not change what
+any analysis can answer, only how "cannot" is said. Issue #400 has the observed encodings; the matrix
+in `tests/test_cannot_answer.py` drives each of them and is what stops a ninth from appearing.
+
+---
+
+## 1. The payload marker
+
+**Decision.** Any JSON payload that cannot answer carries `_abstained: true` and a non-empty
+`reason`. This is the shape `skills.base.abstain` already produces at row level. It becomes canonical
+at every level: skill row, CLI JSON envelope, web route body.
+
+**The predicate**, one function, `nsys_ai.cannot_answer.is_cannot_answer(payload)`:
+
+| payload | true when |
+|---|---|
+| `dict` | `payload.get("_abstained") is True` |
+| `list` | non-empty and the first element is such a dict |
+| anything else | never |
+
+The list rule is `skills.base.is_abstention` called, not restated: `skills/base.py` stays the single
+definition site of the marker string, and `nsys_ai.cannot_answer` holds no copy of it — a guard test
+already fails on a second one. Its imports are deferred to call time, so reaching the predicate from
+a renderer or a web handler costs nothing at import. Ownership should invert when `skills/base.py` is
+next opened — a general contract should not live inside one of its consumers — which is a move to
+make alongside #345 rather than in the same change as the decision.
+
+**Which level carries the marker.** Ask the object you are about to read as an answer. If you are
+about to index `payload["findings"]`, ask the envelope; if you are about to index `row["total_ms"]`,
+ask the row. A payload marks itself when *it* is not an answer, and only then. Partial coverage is
+not an abstention: an envelope that produced some findings is an answer, and the analyses that could
+not run are recorded beside them.
+
+**Shapes that already exist, and what happens to each:**
+
+- `EvidenceReport.skipped[]` (`{analyzer, skill, reason}`) stays as it is. It is the record of
+  *partial* coverage and is deliberately kept out of `findings`, which is right. The envelope itself
+  becomes a cannot-answer payload — `_abstained: true` at the top level, `reason` naming the coverage
+  that was lost — only when it produced zero findings **and** at least one analysis was skipped, i.e.
+  exactly when "no findings" can no longer be read as "no problems".
+- `verdict: "inconclusive"` in `diff.json` stays. It is a domain value that says *which* of three
+  judgements was reached, and a consumer that knows about diffs should keep reading it. The marker
+  goes beside it, for the consumer that does not.
+- `proposal.json` carries `abstained` / `abstention_reason`. Those field names stay: the artifact has
+  a validated schema with a strict allowed-key check, and renaming a persisted field to gain a
+  leading underscore buys nothing. It is the one aliased shape. Whatever envelope reports a proposal
+  — a session projection, a web route — sets the marker from those two fields; the predicate itself
+  reads one key and only one.
+- A bare `error` key is **not** the marker and must not be treated as one. It says the tool broke, not
+  that the profile cannot support the question. Where the two were conflated (a missing table
+  surfacing as `{"error": ...}`), the fix is to abstain, not to teach the predicate a second key.
+
+---
+
+## 2. The exit code
+
+**Decision.** "Ran cleanly but cannot answer" **stays exit 0**. The payload marker is the only signal.
+No new exit code is introduced.
+
+**Why.** An abstention is a correct and complete answer to the question that was asked — "this
+profile cannot support that analysis, and here is the reason" — so failing the process would teach
+every wrapper to treat the truthful answer as a breakage, and would push callers to suppress the one
+output that explains itself. The single caller that genuinely needs a non-zero status is a gate that
+asked the tool to *prove* something, and that caller already has one, because there "could not judge"
+fails the assertion rather than the command.
+
+**So the exit status means:**
+
+| code | meaning |
+|---|---|
+| 0 | the command ran and produced its output. The output may be an answer, an empty answer, or a stated abstention — apply the predicate to find out |
+| 1 | the command did not run to completion (runtime error) |
+| 2 | the command was asked for something it cannot parse or accept (usage) |
+
+**The gate carve-out, stated so it is not read as a contradiction.** `diff --gate` exits non-zero on
+`inconclusive` and keeps doing so. The gate is not being asked "what happened", it is being asked to
+show that no regression is present, and a comparison that could not be made has not shown that. The
+non-zero status there reports a failed *assertion*, not a failed command. Because exit 1 then covers
+both "regression found" and "could not judge", the gate's JSON must carry the marker so the two are
+distinguishable — that is the payload doing the work the exit code cannot.
+
+**Consequence for a consumer that will not parse JSON.** There is none available, and this is
+deliberate: ask for a gate, whose whole purpose is to compress a judgement into a status. Every one of
+the eight encodings is a JSON surface or a human-readable one; on the human-readable surfaces an exit
+code would not have helped either, because the reader is a person and what they need is the sentence.
+
+---
+
+## 3. The web `limitation` shape
+
+**Decision.** Converge, keeping the existing keys as aliases. `_session_limitation` in `web.py` now
+returns:
+
+```json
+{"_abstained": true, "reason": "...", "error": "...", "limitation": true, "cli": "nsys-ai ..."}
+```
+
+`_abstained` and `reason` are the canonical pair and are what new code branches on. `limitation` and
+`error` are retained aliases for browser code already reading them. `cli` is retained because it
+carries something the marker does not: the command that *can* do the job. Keeping it is the point of
+the shape — a route that declines an action should name the way through, and "abstain with a reason"
+is exactly that contract stated in HTTP.
+
+**The HTTP status is unchanged (400) and is not the marker.** The status answers a transport question
+— was this request serviceable on this route — and these routes decline an action the server mode does
+not perform. The body answers the analysis question. A consumer branches on the body; a status code
+was never able to distinguish "your request was malformed" from "your request was fine and I cannot
+do it here", which is the same conflation this note removes from the CLI's exit codes.
+
+The two TUIs have a `_session_limitation` of the same name that raises a toast. It is a human surface
+with no payload, so the predicate does not apply to it and it is deliberately left alone.
+
+---
+
+## What to emit, for #399, #401 and #402
+
+- **#399 (diff verdict and comparability are computed but never shown).** Keep `verdict` and
+  `comparability_confidence` where they are. When `verdict == "inconclusive"`, the JSON payload also
+  carries `_abstained: true` and a `reason` — the sanity warnings already collected are the reason
+  text, and `diff.py` already has them. Terminal and markdown renderers print the reason instead of,
+  not beside, per-kernel deltas presented as findings. Exit stays 0 without `--gate`; with `--gate` it
+  stays non-zero, and now the payload says which kind of non-zero it was.
+- **#401 (ordinary mistakes produce tracebacks).** A missing required parameter, an unparsable trim, a
+  busy port and a non-TTY are **usage**, not abstentions: coded error, exit 2, no marker. Landed. The
+  row that still belongs here is the silent one — a command that cannot answer and prints nothing at
+  exit 0 must print the reason. In `--format json` that means a marked payload on stdout; in text
+  mode, a sentence.
+- **#402 (inputs that cannot support a comparison still produce a confident one).** Each new condition
+  lowers `comparability_confidence` as #384 established. When the product crosses
+  `MIN_COMPARABILITY_CONFIDENCE` the verdict is already `inconclusive`, so the marker follows from
+  #399's rule with no extra branch. The self-diff short circuit is the one case that is not an
+  abstention: the tool *can* answer, and the answer is "these are the same capture" — a `neutral`
+  verdict with a stated note, exit 0, no marker.
+- **#345, #283, #281 (the skill layer).** `abstain()` already produces the canonical shape, so these
+  need no new decision — they need the guard extended to the paths that currently return `[]`, an
+  untyped `error` row, or a raised database error.
+
+## State of the surfaces
+
+Measured on this worktree; each row is one test in `tests/test_cannot_answer.py`.
+
+| surface | today | conforms |
+|---|---|---|
+| skill row, `abstain()` | `_abstained: true` + `reason`, exit 0 | yes |
+| web session route body | marker plus retained aliases, HTTP 400 | yes, changed here |
+| `skill run` on a profile missing the table (SQL template) | `{"error": {...}}` on stdout, exit 1 | no — #345 |
+| `skill run` on a profile missing the table (`execute_fn`) | `[]`, exit 0 | no — #345 |
+| `sync_cost_analysis` with no synchronization table | zero-valued row with an `error` key, exit 0 | no — #345 |
+| `skill run` missing a required parameter | coded error, marked JSON on stdout, exit 2 | yes, since #401 |
+| `summary` on a profile with no kernel activity | no output at all on either stream, exit 0 | no — #401 |
+| `diff` on an incomparable pair | `inconclusive` + confidence 0.0 + warnings, no marker, exit 0 | no — #399 |
+
+A ninth encoding turned up while writing the matrix, which is the argument for having one:
+`nccl_payload_breakdown` returns `{"error": ..., "backend_limitation": true}` when the payload column
+cannot be read through the active backend, and a second `{"error": ..., "binary_data_rows": 0}` row
+when typed payloads were never captured. Both are abstentions wearing an untyped `error` key. They are
+the same class as #345's five and belong with them.

--- a/src/nsys_ai/cannot_answer.py
+++ b/src/nsys_ai/cannot_answer.py
@@ -1,0 +1,111 @@
+"""One shape for "I cannot answer", and one predicate that recognises it.
+
+A consumer has to tell three states apart: there is no problem here, here is
+the problem, and I could not look. The third was said eight different ways — a
+bare ``[]``, an untyped ``error`` key beside real-looking zeros, prose on
+stderr, a raised database error — and five of them at exit 0, which made "could
+not look" indistinguishable from "looked, found nothing". That is the failure a
+verify-first tool can least afford, because it reads as a clean bill of health.
+
+The decision, written down in ``docs/notes/cannot-answer.md``:
+
+* A payload that cannot answer carries the abstention marker and a non-empty
+  ``reason``, at whatever level could not answer — skill row, CLI envelope, or
+  web route body.
+* "Ran cleanly but cannot answer" stays **exit 0**. The payload is the only
+  signal, because an abstention is a correct and complete answer to the
+  question that was asked. Exit 1 stays "the command did not finish" and exit 2
+  stays "the command could not accept what it was given". A gate that was asked
+  to *prove* something still exits non-zero when it cannot judge — that reports
+  a failed assertion, not a failed command, which is why its payload must carry
+  the marker too.
+
+The shape is not new: ``skills.base.abstain`` has produced it at row level all
+along, and ``skills.base`` remains its single definition site — this module
+holds no copy of the marker string and builds nothing by hand, it delegates.
+What is new is that the shape is canonical *above* the skill layer, and that
+one predicate covers every level.
+
+Both imports of ``skills.base`` are deferred to call time. Importing this
+module therefore costs nothing, which matters: a contract nobody can reach
+cheaply is one that gets re-implemented inline and drifts, and that is how
+eight encodings happened in the first place.
+
+Ownership should invert when ``skills/base.py`` is next opened: the marker
+belongs here, with the skill layer importing it, rather than a general contract
+reaching down into one of its consumers. It is left alone here so this change
+stays a decision plus its test, and does not collide with the skill-layer work
+that #345 has open in that file.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "REASON_KEY",
+    "cannot_answer",
+    "cannot_answer_reason",
+    "is_cannot_answer",
+]
+
+#: The sentence that says why. Required: a marker with no reason is the silence
+#: this contract exists to remove, only typed.
+REASON_KEY = "reason"
+
+
+def cannot_answer(reason: str, **detail) -> dict:
+    """Build the payload for a level that ran cleanly and cannot answer.
+
+    The envelope-level companion to ``skills.base.abstain``, which returns the
+    same object wrapped in the one-row list a skill must return; this returns
+    the object itself, for an envelope or a route body. Extra keyword arguments
+    are carried through, so a caller keeps the fields its existing consumers
+    already read (see ``web.py``, which retains ``limitation``, ``error`` and
+    ``cli`` beside the marker).
+
+    ``reason`` must say something. Raises ``ValueError`` rather than asserting,
+    because assertions are stripped under ``python -O`` and would let an empty
+    reason reach a user precisely when the build is optimised.
+    """
+    if not isinstance(reason, str) or not reason.strip():
+        raise ValueError("a cannot-answer payload requires a non-empty reason")
+
+    from .skills.base import abstain
+
+    return abstain(reason, **detail)[0]
+
+
+def is_cannot_answer(payload) -> bool:
+    """True when ``payload`` says it could not answer, at any level.
+
+    Apply it to the object you are about to read as an answer: ask the envelope
+    before indexing ``payload["findings"]``, ask the row before indexing
+    ``row["total_ms"]``.
+
+    * ``dict``  — carries the marker itself.
+    * ``list``  — non-empty and its first element carries the marker. That is
+      what ``abstain()`` returns, and the rule is ``skills.base.is_abstention``
+      exactly, called rather than restated.
+    * anything else — never. ``None``, ``[]`` and ``""`` are not abstentions;
+      an empty result means "ran, nothing to report", which is precisely the
+      state the marker exists to distinguish from.
+    """
+    from .skills.base import is_abstention, is_abstention_row
+
+    if isinstance(payload, dict):
+        return is_abstention_row(payload)
+    if isinstance(payload, list):
+        return is_abstention(payload)
+    return False
+
+
+def cannot_answer_reason(payload) -> str:
+    """The reason ``payload`` gives, or ``""`` when it is not an abstention.
+
+    Exists so a renderer never re-implements the "is it a dict or the first row
+    of a list" branch to reach one string.
+    """
+    if not is_cannot_answer(payload):
+        return ""
+    source = payload if isinstance(payload, dict) else payload[0]
+    reason = source.get(REASON_KEY, "")
+    return reason if isinstance(reason, str) else str(reason)

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -588,13 +588,28 @@ class _ViewerHandler(BaseHTTPRequestHandler):
         return [f.to_dict() for f in snapshot.findings.findings]
 
     def _session_limitation(self, cli_command: str, detail: str) -> None:
-        """Return a stated limitation: reduced capability, never a silent no-op."""
+        """Return a stated limitation: reduced capability, never a silent no-op.
+
+        The body carries the canonical cannot-answer marker, built by
+        ``cannot_answer`` so this route and a skill row satisfy one predicate —
+        the decision is in ``docs/notes/cannot-answer.md``. ``limitation`` and
+        ``error`` are retained aliases for browser code already reading them,
+        and ``cli`` is retained because it carries what the marker cannot: the
+        command that *can* do the job.
+
+        The HTTP status stays 400 and is not the marker. A status answers a
+        transport question — was this request serviceable on this route — while
+        the body answers the analysis question. A consumer branches on the body.
+        """
+        from .cannot_answer import cannot_answer
+
         self._json_response(
-            {
-                "error": detail,
-                "limitation": True,
-                "cli": cli_command,
-            },
+            cannot_answer(
+                detail,
+                error=detail,
+                limitation=True,
+                cli=cli_command,
+            ),
             400,
         )
 

--- a/tests/test_cannot_answer.py
+++ b/tests/test_cannot_answer.py
@@ -1,0 +1,381 @@
+"""The matrix: every way this tool says "I cannot answer", driven end to end.
+
+"There is no problem here" and "I could not look" are different answers, and a
+consumer that cannot tell them apart reads the second as the first — a clean
+bill of health issued by an analysis that never ran. An automated pass over the
+installed package counted eight encodings of "could not look", five of them at
+exit 0 (#400).
+
+`docs/notes/cannot-answer.md` decides the shape:
+
+* one marker — `_abstained: True` plus a non-empty `reason`, on the payload
+  that could not answer, at whatever level that is;
+* one predicate — `nsys_ai.cannot_answer.is_cannot_answer(payload)`;
+* one exit code — **0**, because an abstention is a correct and complete answer
+  to the question that was asked. Exit 1 stays "the command did not finish",
+  exit 2 stays "the command could not accept what it was given".
+
+This file is the product of that decision, not a footnote to it. One test per
+row of #400's table, each driving the real path, each asserting the single
+predicate and the chosen exit code. Rows that do not conform yet are `xfail`
+with the issue that will fix them, `strict=True` so that fixing one turns this
+file red until the marker is removed — the ratchet is the point. Adding a ninth
+encoding means adding a row here first, which is where someone notices there is
+already a shape for it.
+
+A ninth turned up while this was being written and is recorded in the note:
+`nccl_payload_breakdown` returns `{"error": ..., "backend_limitation": True}`
+and `{"error": ..., "binary_data_rows": 0}` — abstentions wearing an untyped
+`error` key, the same class as #345's five. It needs a backend that raises on a
+BLOB read to reproduce, so it is documented rather than driven here.
+"""
+
+import json
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.cannot_answer import cannot_answer, cannot_answer_reason, is_cannot_answer
+
+ROOT = Path(__file__).resolve().parent.parent
+MOCK = ROOT / "tests" / "fixtures" / "mock.sqlite"
+
+# The decision, as constants, so a test reads as the contract rather than as a
+# magic number: a stated abstention is a successful run.
+EXIT_ANSWERED = 0
+EXIT_RUNTIME_ERROR = 1
+EXIT_USAGE = 2
+
+
+def _cli(*args: str, cwd: Path, timeout: float = 180.0) -> subprocess.CompletedProcess:
+    """Run the CLI as a real process, against *this* worktree's sources.
+
+    The package is installed editable from another checkout, so without the
+    PYTHONPATH prefix a subprocess would measure main rather than the branch.
+    """
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(ROOT / "src"), env.get("PYTHONPATH", "")) if part
+    )
+    return subprocess.run(
+        [sys.executable, "-m", "nsys_ai", *args],
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _stdout_json(result: subprocess.CompletedProcess):
+    """Parse stdout as JSON, failing with the actual output rather than a stack."""
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        pytest.fail(
+            f"stdout is not JSON ({exc}).\n"
+            f"exit={result.returncode}\nstdout={result.stdout[:400]!r}\n"
+            f"stderr={result.stderr[-800:]!r}"
+        )
+
+
+@pytest.fixture
+def profile_without_activity_tables(tmp_path: Path) -> Path:
+    """A profile whose CUPTI/NVTX tables are absent, not merely empty.
+
+    The distinction is the whole subject: a table that is missing means the
+    analysis *cannot run*, where a table that is present and empty means it ran
+    and found nothing. Both are copied out of the fixture so no cache artifact
+    lands beside the committed one.
+    """
+    path = tmp_path / "no_activity_tables.sqlite"
+    shutil.copy(MOCK, path)
+    conn = sqlite3.connect(path)
+    try:
+        names = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")]
+        dropped = [n for n in names if n.startswith("CUPTI_") or "NVTX" in n]
+        for name in dropped:
+            conn.execute(f'DROP TABLE "{name}"')
+        conn.commit()
+    finally:
+        conn.close()
+    if not dropped:
+        raise AssertionError("fixture premise broken: mock.sqlite had no activity tables to drop")
+    return path
+
+
+@pytest.fixture
+def profile_without_kernel_rows(tmp_path: Path) -> Path:
+    """A profile whose kernel table exists and is empty — a capture that recorded nothing."""
+    path = tmp_path / "no_kernel_rows.sqlite"
+    shutil.copy(MOCK, path)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("DELETE FROM CUPTI_ACTIVITY_KIND_KERNEL")
+        conn.commit()
+    finally:
+        conn.close()
+    return path
+
+
+@pytest.fixture
+def mock_copy(tmp_path: Path) -> Path:
+    """mock.sqlite, copied, so cache artifacts never land beside the committed fixture."""
+    path = tmp_path / "mock.sqlite"
+    shutil.copy(MOCK, path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The predicate itself
+# ---------------------------------------------------------------------------
+
+
+def test_the_predicate_agrees_with_the_skill_layer_it_generalises():
+    """One shape, not two. `abstain()` output must satisfy the general predicate.
+
+    `skills.base.is_abstention` is the row-list predicate that already exists;
+    `is_cannot_answer` is the same rule lifted to envelopes and route bodies. If
+    the two ever disagree, consumers at different levels reach different
+    conclusions about the same payload, which is the state #400 describes.
+    """
+    from nsys_ai.skills.base import abstain, is_abstention
+
+    rows = abstain("no NVTX_EVENTS table")
+
+    assert is_abstention(rows) is True
+    assert is_cannot_answer(rows) is True
+    assert is_cannot_answer(rows[0]) is True
+    assert cannot_answer_reason(rows) == "no NVTX_EVENTS table"
+
+
+def test_an_empty_result_is_not_an_abstention():
+    """The distinction the marker exists to make, asserted directly."""
+    assert is_cannot_answer([]) is False
+    assert is_cannot_answer([{"kernel": "gemm", "total_ms": 0.0}]) is False
+    assert is_cannot_answer({"findings": []}) is False
+    assert is_cannot_answer(None) is False
+    assert is_cannot_answer("could not run") is False
+
+
+def test_an_untyped_error_key_is_not_the_marker():
+    """A broken tool and an inapplicable analysis are different states.
+
+    Teaching the predicate to accept `error` would merge them again and make
+    every genuine failure look like a considered abstention.
+    """
+    assert is_cannot_answer({"error": "no such table: CUPTI_ACTIVITY_KIND_KERNEL"}) is False
+    assert is_cannot_answer([{"total_ms": 0.0, "error": "tables not found"}]) is False
+
+
+def test_a_marker_without_a_reason_cannot_be_built():
+    """Silence, only typed, is still silence."""
+    with pytest.raises(ValueError):
+        cannot_answer("")
+    with pytest.raises(ValueError):
+        cannot_answer("   ")
+
+
+# ---------------------------------------------------------------------------
+# The matrix — one test per row of #400's table
+# ---------------------------------------------------------------------------
+
+
+def test_row_1_a_skill_that_cannot_run_abstains_with_a_reason(mock_copy: Path, tmp_path: Path):
+    """Row 1: `abstain(reason)` — the intended encoding, and the reference for the rest.
+
+    `mock.sqlite` has no NVTX table, so NVTX-dependent skills cannot run at all.
+    Exit 0 is the decision, not an accident: the command ran and returned the
+    correct answer to the question asked.
+    """
+    result = _cli("skill", "run", "nvtx_kernel_map", str(mock_copy), "--format", "json", cwd=tmp_path)
+
+    assert result.returncode == EXIT_ANSWERED, result.stderr[-800:]
+    payload = _stdout_json(result)
+    assert is_cannot_answer(payload), payload
+    assert "NVTX" in cannot_answer_reason(payload)
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#345: execute_fn skills return a bare [] when the table is absent, "
+    "which reads identically to 'ran, found nothing'",
+)
+def test_row_2_a_bare_empty_list_when_the_table_is_absent(
+    profile_without_activity_tables: Path, tmp_path: Path
+):
+    """Row 2: `[]` in `--format json`, exit 0, indistinguishable from a real result.
+
+    `gpu_idle_gaps` needs kernel activity to find a gap between kernels. With no
+    kernel table at all it returns `[]` — the same output it gives for a profile
+    with no idle gaps, which is a compliment rather than a failure to look.
+    """
+    result = _cli(
+        "skill", "run", "gpu_idle_gaps", str(profile_without_activity_tables),
+        "--format", "json", cwd=tmp_path,
+    )
+
+    assert result.returncode == EXIT_ANSWERED, result.stderr[-800:]
+    payload = _stdout_json(result)
+    assert is_cannot_answer(payload), payload
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#345: sync_cost_analysis emits an untyped error key beside zero-valued "
+    "data columns, so a reader sees both an answer and a failure",
+)
+def test_row_3_an_error_key_beside_real_looking_zeros(
+    profile_without_activity_tables: Path, tmp_path: Path
+):
+    """Row 3: a data row whose numbers are zero because nothing was read.
+
+    The row carries `total_sync_wall_ms: 0.0` — which a consumer will plot — and
+    an `error` key it has no reason to look for. Zero synchronization cost is a
+    finding; not having looked is not.
+    """
+    result = _cli(
+        "skill", "run", "sync_cost_analysis", str(profile_without_activity_tables),
+        "--format", "json", cwd=tmp_path,
+    )
+
+    assert result.returncode == EXIT_ANSWERED, result.stderr[-800:]
+    payload = _stdout_json(result)
+    assert is_cannot_answer(payload), payload
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#345: a missing table surfaces as {'error': ...} at exit 1, reporting a "
+    "profile the tool cannot analyse as a tool that broke",
+)
+def test_row_4_a_missing_table_reported_as_a_runtime_error(
+    profile_without_activity_tables: Path, tmp_path: Path
+):
+    """Row 4: `{"error": ...}` on stdout, exit 1.
+
+    Nothing is wrong with the tool here: it was handed a profile that does not
+    contain the activity it was asked about. Under the decision that is an
+    abstention at exit 0, and exit 1 stays for the command that did not finish.
+    """
+    result = _cli(
+        "skill", "run", "top_kernels", str(profile_without_activity_tables),
+        "--format", "json", cwd=tmp_path,
+    )
+
+    payload = _stdout_json(result)
+    assert is_cannot_answer(payload), payload
+    assert result.returncode == EXIT_ANSWERED, result.stderr[-800:]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#401: a command that cannot answer prints nothing at all and exits 0, "
+    "which is the loudest form of the same ambiguity",
+)
+def test_row_5_a_command_that_cannot_answer_says_nothing_at_all(
+    profile_without_kernel_rows: Path, tmp_path: Path
+):
+    """Row 5: empty stdout, exit 0 — the human surface of the same bug.
+
+    `summary` on a capture that recorded no kernel activity produces zero bytes
+    on both streams and exits successfully. A person cannot tell that from a
+    successful run whose report scrolled past, and no exit code would have told
+    them either: what they need is the sentence.
+    """
+    result = _cli("summary", str(profile_without_kernel_rows), cwd=tmp_path)
+
+    assert result.returncode == EXIT_ANSWERED, result.stderr[-800:]
+    said = (result.stdout + result.stderr).strip()
+    assert said, "the command exited 0 having said nothing on either stream"
+    assert "kernel" in said.lower(), f"the reason is not stated: {said[:300]!r}"
+
+
+def test_row_6_a_raw_traceback_breaks_the_json_contract(mock_copy: Path, tmp_path: Path):
+    """Row 6: traceback, exit 1, empty stdout even under `--format json`.
+
+    This one is a usage error rather than an abstention — the caller omitted a
+    required parameter — so the decision puts it at exit 2 with a coded message.
+    What it must not do is emit a stack trace where a JSON document was
+    promised, because that fails the consumer before any predicate can run.
+    """
+    result = _cli("skill", "run", "region_mfu", str(mock_copy), "--format", "json", cwd=tmp_path)
+
+    assert "Traceback" not in result.stderr, result.stderr[-800:]
+    assert result.returncode == EXIT_USAGE, (
+        f"exit={result.returncode}; stderr={result.stderr[-400:]!r}"
+    )
+    payload = _stdout_json(result)
+    assert not is_cannot_answer(payload), "a usage error is not an abstention"
+
+
+def test_row_7_the_web_session_route_carries_the_marker():
+    """Row 7: the web `limitation` shape, converged onto the marker.
+
+    Driven through the handler method that builds every one of those bodies —
+    `_handle_loop_phase`, `_handle_loop_proposal`, `_handle_loop_reprofile`,
+    `_handle_loop_diagnose` and `_handle_loop_diff` all route through it — with
+    the response captured rather than sent, so the shape is asserted without
+    standing a server up and publishing a session first.
+
+    The status stays 400 and the aliases stay too: this is a convergence, not a
+    rename, and existing browser code keeps working.
+    """
+    from nsys_ai.web import _ViewerHandler
+
+    captured: dict = {}
+
+    class _Recorder:
+        def _json_response(self, obj, status=200):
+            captured["body"] = obj
+            captured["status"] = status
+
+    _ViewerHandler._session_limitation(
+        _Recorder(),
+        "nsys-ai evidence",
+        "session mode does not run diagnose in the browser",
+    )
+
+    body = captured["body"]
+    assert is_cannot_answer(body), body
+    assert cannot_answer_reason(body) == "session mode does not run diagnose in the browser"
+    # Retained: the command that *can* do the job is what the marker cannot carry.
+    assert body["cli"] == "nsys-ai evidence"
+    # Retained aliases — pinned so the convergence is not silently a rename.
+    assert body["limitation"] is True
+    assert body["error"] == body["reason"]
+    # The transport answer is separate from the analysis answer, on purpose.
+    assert captured["status"] == 400
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#399: diff computes verdict=inconclusive and comparability 0.0 and "
+    "persists both, but the payload carries no marker a general consumer can apply",
+)
+def test_row_8_an_inconclusive_diff_carries_the_marker(
+    mock_copy: Path, profile_without_kernel_rows: Path, tmp_path: Path
+):
+    """Row 8: `verdict: inconclusive` with comparability 0.0.
+
+    This row is already honest to a reader who knows the diff vocabulary — the
+    verdict and the warning both say so. The marker is for the reader who does
+    not, which is every generic consumer of a JSON envelope. Exit stays 0: no
+    gate was requested, so nothing was asserted and nothing failed.
+    """
+    result = _cli(
+        "diff", str(mock_copy), str(profile_without_kernel_rows),
+        "--format", "json", "--no-ai", cwd=tmp_path,
+    )
+
+    assert result.returncode == EXIT_ANSWERED, result.stderr[-800:]
+    payload = _stdout_json(result)
+    # Premise: this pair really is incomparable, or the row proves nothing.
+    assert payload["verdict"] == "inconclusive", payload["verdict"]
+    assert payload["comparability_confidence"] == 0.0
+    assert is_cannot_answer(payload), sorted(payload)


### PR DESCRIPTION
## Summary

- "There is no problem here" and "I could not look" are different answers, and this tool said the second eight different ways — a bare `[]`, an untyped `error` key beside real-looking zeros, prose on stderr, a raised database error — five of them at exit 0. A consumer could not tell an analysis that never ran from a clean bill of health.
- One marker, one predicate, one exit-code rule, written down and pinned by a test per observed encoding.
- A ninth encoding was found while writing the matrix and is recorded: `nccl_payload_breakdown` returns two abstentions wearing an untyped `error` key.

## Changes

- `docs/notes/cannot-answer.md` — the decision. One marker: the abstention shape `skills/base.py` already produces at row level becomes canonical at every level. One predicate: `nsys_ai.cannot_answer.is_cannot_answer(payload)`, for a row, an envelope or a route body alike. One exit code: "ran cleanly but cannot answer" stays 0, because an abstention is a correct and complete answer to the question asked; 1 stays "did not finish", 2 stays "could not accept what it was given"; a gate asked to prove something still exits non-zero when it cannot judge, which is why its payload must carry the marker too.
- `src/nsys_ai/cannot_answer.py` — the predicate. It holds no copy of the marker string and defers its imports, calling the skill-layer predicate, so there is exactly one definition site and reaching the contract costs nothing at import.
- `src/nsys_ai/web.py` — the `limitation` shape converges onto the marker, keeping `limitation`, `error` and `cli` as retained aliases and the HTTP status as the transport answer rather than the analysis answer.
- `tests/test_cannot_answer.py` — one test per observed encoding, each driving the real path and asserting the single predicate and the chosen exit code.

## Backward compatibility

Yes. Existing web keys are kept as aliases; the new key is added alongside. No exit code changes.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2239 passed, 140 skipped, 5 xfailed, 0 failed, rebased onto `main` with #411/#412/#414/#415 in it (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `pytest tests/test_cannot_answer.py` — 7 passed, 5 xfailed
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean

## Out of scope

Five rows do not conform yet and are `xfail(strict)` against the ticket that will fix them — #345 for the skill-layer guards, #401 for the silent command, #399 for the inconclusive diff.

Strict means fixing one turns this file red until its marker is removed, and that has already happened once, on purpose: #401's traceback row was `xfail(strict)` here, and merging that fix made it XPASS. The marker is gone and the row is now a plain passing test; `docs/notes/cannot-answer.md` records it as conforming. #399 merged and did **not** flip its row — that fix touches the renderers only and adds no marker to the JSON — so row 8 still xfails against it, correctly.

That is the mechanism working: adding a ninth encoding means adding a row here first, and that is where someone notices there is already a shape for it.

## Linked issues

Closes #400
