### PR TITLE
fix(cli): answer ordinary mistakes with a coded error instead of a traceback or a hang

### DIFF
--- a/docs/agent_skills/commands/skill.md
+++ b/docs/agent_skills/commands/skill.md
@@ -9,11 +9,20 @@ Manage and run builtin analysis skills against Nsight Systems profiles.
 
 ### `nsys-ai skill list`
 
-List all registered skills with name, category, and description.
+List all registered skills with name, category, and description. A name marked
+`*` cannot run without a parameter; the footer names the flag and where to look
+up which parameter. In `--format json` the same information is the `required`
+field on each entry in `params`.
 
 ```bash
 nsys-ai skill list                   # human-readable table
 nsys-ai skill list --format json     # JSON array (for programmatic use)
+```
+
+```
+theoretical_flops *             kernels          Computes exact theoretical FLOPs ...
+
+* needs a required parameter: nsys-ai skill run <name> <profile> -p KEY=VALUE (see: nsys-ai skill info <name>)
 ```
 
 ### `nsys-ai skill run`

--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -217,7 +217,9 @@ def main():
         else:
             # Human-readable output
             print(f"Error [{e.error_code}]: {e}", file=sys.stderr)
-        sys.exit(1)
+        # 1 = the command did not run to completion; 2 = it was asked for
+        # something it cannot parse or accept.
+        sys.exit(e.exit_code)
     except RuntimeError as e:
         # Backward compatibility: catch plain RuntimeError from legacy code
         print(f"Error: {e}", file=sys.stderr)

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -437,6 +437,57 @@ def _parse_trim(args):
     return None
 
 
+def _check_trim_window(trim, prof):
+    """Reject a --trim window that selects no part of *prof*.
+
+    ``--trim`` is read on the capture clock, which does not start at zero, so
+    ``--trim 0 1`` on a profile whose first event is at 60 s silently selects
+    nothing.  Name both windows rather than producing an empty result.
+    """
+    if trim is None:
+        return
+    start_ns, end_ns = trim
+    time_range = getattr(getattr(prof, "meta", None), "time_range", None)
+    if not time_range:
+        return
+    lo_ns, hi_ns = time_range
+    if hi_ns <= lo_ns:
+        return
+    # end > start as well as overlapping: --trim 156 156 sits inside the
+    # profile and still selects nothing, which is the same empty result under
+    # a different arithmetic.
+    if end_ns > start_ns and start_ns < hi_ns and end_ns > lo_ns:
+        return
+    from nsys_ai.exceptions import TrimOutOfRangeError
+
+    raise TrimOutOfRangeError(
+        f"--trim {start_ns / 1e9:.3f} {end_ns / 1e9:.3f} selects no part of this "
+        f"profile, whose window is {lo_ns / 1e9:.3f} s to {hi_ns / 1e9:.3f} s on the "
+        f"capture clock. Use a window inside that range, or omit --trim."
+    )
+
+
+def _check_trim_window_for_path(trim, path, _profile):
+    """``_check_trim_window`` for handlers that have not opened the profile yet."""
+    if trim is None:
+        return
+    with _profile.open(path) as prof:
+        _check_trim_window(trim, prof)
+
+
+def _required_param_names(skill):
+    """Parameter names *skill* cannot run without.
+
+    ``required`` with a default never stops execution, so the listing and the
+    error message both read the same condition ``Skill.execute`` reads.
+    """
+    return [
+        p.name
+        for p in getattr(skill, "params", ()) or ()
+        if getattr(p, "required", False) and getattr(p, "default", None) is None
+    ]
+
+
 def _coerce_param_value(raw_value, param_type):
     """Coerce a raw string CLI parameter to the type expected by the skill.
 
@@ -654,6 +705,7 @@ def _cmd_analyze(args, _profile):
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         data = run_analyze(prof, args.gpu, trim)
         print(format_report_terminal(data))
         if getattr(args, "output", None):
@@ -736,6 +788,7 @@ def _cmd_analyze_json(args, _profile):
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         device = getattr(args, "gpu", 0) or 0
         builder = EvidenceBuilder(prof, device=device, trim=trim)
         report = builder.build()
@@ -1305,6 +1358,7 @@ def _cmd_summary(args, _profile):
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         gpus = [args.gpu] if args.gpu is not None else prof.meta.devices
         for gpu in gpus:
             s = gpu_summary(prof, gpu, trim)
@@ -1318,14 +1372,18 @@ def _cmd_overlap(args, _profile):
     from nsys_ai.overlap import format_overlap, overlap_analysis
 
     with _profile.open(args.profile) as prof:
-        print(format_overlap(overlap_analysis(prof, args.gpu, _parse_trim(args))))
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
+        print(format_overlap(overlap_analysis(prof, args.gpu, trim)))
 
 
 def _cmd_nccl(args, _profile):
     from nsys_ai.overlap import format_nccl, nccl_breakdown
 
     with _profile.open(args.profile) as prof:
-        print(format_nccl(nccl_breakdown(prof, args.gpu, _parse_trim(args))))
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
+        print(format_nccl(nccl_breakdown(prof, args.gpu, trim)))
 
 
 def _cmd_iters(args, _profile):
@@ -1335,14 +1393,18 @@ def _cmd_iters(args, _profile):
         device = (
             args.gpu if args.gpu is not None else (prof.meta.devices[0] if prof.meta.devices else 0)
         )
-        print(format_iterations(detect_iterations(prof, device, _parse_trim(args))))
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
+        print(format_iterations(detect_iterations(prof, device, trim)))
 
 
 def _cmd_tree(args, _profile):
     from nsys_ai.tree import build_nvtx_tree, format_text
 
     with _profile.open(args.profile) as prof:
-        roots = build_nvtx_tree(prof, args.gpu, _parse_trim(args))
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
+        roots = build_nvtx_tree(prof, args.gpu, trim)
         print(format_text(roots))
 
 
@@ -1350,7 +1412,9 @@ def _cmd_markdown(args, _profile):
     from nsys_ai.tree import build_nvtx_tree, format_markdown
 
     with _profile.open(args.profile) as prof:
-        roots = build_nvtx_tree(prof, args.gpu, _parse_trim(args))
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
+        roots = build_nvtx_tree(prof, args.gpu, trim)
         print(format_markdown(roots))
 
 
@@ -1359,6 +1423,7 @@ def _cmd_search(args, _profile):
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         if args.parent or args.type == "hierarchy":
             if args.gpu is None or not trim:
                 print("Error: hierarchical search requires --gpu and --trim")
@@ -1378,6 +1443,7 @@ def _cmd_export_csv(args, _profile):
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         content = to_csv(prof, args.gpu, trim, args.output)
         if not args.output:
             print(content)
@@ -1392,6 +1458,7 @@ def _cmd_export_json(args, _profile):
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         if args.summary:
             data = to_summary_json(prof, args.gpu, trim, args.output)
         else:
@@ -1407,6 +1474,7 @@ def _cmd_export(args, _profile):
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         os.makedirs(args.output, exist_ok=True)
         gpus = [args.gpu] if args.gpu is not None else prof.meta.devices
         for gpu in gpus:
@@ -1425,7 +1493,9 @@ def _cmd_viewer(args, _profile):
     from nsys_ai.viewer import write_html
 
     with _profile.open(args.profile) as prof:
-        write_html(prof, args.gpu, _parse_trim(args), args.output)
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
+        write_html(prof, args.gpu, trim, args.output)
         print(f"Written to {args.output} ({os.path.getsize(args.output) // 1024} KB)")
 
 
@@ -1433,7 +1503,9 @@ def _cmd_timeline_html(args, _profile):
     from nsys_ai.viewer import write_timeline_html
 
     with _profile.open(args.profile) as prof:
-        write_timeline_html(prof, args.gpu, _parse_trim(args), args.output)
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
+        write_timeline_html(prof, args.gpu, trim, args.output)
         print(f"Written to {args.output} ({os.path.getsize(args.output) // 1024} KB)")
 
 
@@ -1441,7 +1513,9 @@ def _cmd_web(args, _profile):
     from nsys_ai.web import serve
 
     with _profile.open(args.profile) as prof:
-        serve(prof, args.gpu, _parse_trim(args), port=args.port, open_browser=not args.no_browser)
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
+        serve(prof, args.gpu, trim, port=args.port, open_browser=not args.no_browser)
 
 
 def _cmd_open(args, _profile):
@@ -1452,9 +1526,9 @@ def _cmd_open(args, _profile):
         gpu = (
             args.gpu if args.gpu is not None else (prof.meta.devices[0] if prof.meta.devices else 0)
         )
-        if args.trim:
-            trim_ns = (int(args.trim[0] * 1e9), int(args.trim[1] * 1e9))
-        else:
+        trim_ns = _parse_trim(args)
+        _check_trim_window(trim_ns, prof)
+        if trim_ns is None:
             trim_ns = (int(prof.meta.time_range[0]), int(prof.meta.time_range[1]))
         port = args.port if args.port is not None else 8142
         if args.viewer == "web":
@@ -1469,6 +1543,8 @@ def _cmd_timeline_web(args, _profile):
     from nsys_ai.web import serve_timeline
 
     with _profile.open(args.profile) as prof:
+        trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         if args.gpu is not None:
             devices = args.gpu
         else:
@@ -1488,7 +1564,7 @@ def _cmd_timeline_web(args, _profile):
         serve_timeline(
             prof,
             devices,
-            _parse_trim(args),
+            trim,
             port=args.port,
             open_browser=not args.no_browser,
             findings_path=getattr(args, "findings", None),
@@ -1601,17 +1677,38 @@ def _cmd_loop(args, _profile):
 def _cmd_tui(args, _profile):
     from nsys_ai.tree import run_tui
 
-    run_tui(args.profile, args.gpu, _parse_trim(args), max_depth=args.depth, min_ms=args.min_ms)
+    trim = _parse_trim(args)
+    _check_trim_window_for_path(trim, args.profile, _profile)
+    run_tui(args.profile, args.gpu, trim, max_depth=args.depth, min_ms=args.min_ms)
 
 
 def _cmd_timeline(args, _profile):
     from nsys_ai.timeline import run_timeline
 
     gpu = args.gpu if args.gpu is not None else 0
-    run_timeline(args.profile, gpu, _parse_trim(args), min_ms=args.min_ms)
+    trim = _parse_trim(args)
+    _check_trim_window_for_path(trim, args.profile, _profile)
+    run_timeline(args.profile, gpu, trim, min_ms=args.min_ms)
 
 
 def _cmd_chat(args, _profile):
+    # This check has to happen here, before Textual starts. Once the app is
+    # running, Textual replaces the standard streams with a capture object
+    # whose isatty() answers True unconditionally, so an in-app check cannot
+    # see that there is no terminal — and the app then waits forever for input
+    # that a script, a pipe or a CI runner will never send.
+    from nsys_ai.exceptions import NotATerminalError
+
+    # stdin only. Textual renders through stderr, so `nsys-ai chat p.sqlite >
+    # log` is a real and working invocation; it is stdin with nothing on it
+    # that leaves the app waiting forever.
+    if not sys.stdin.isatty():
+        raise NotATerminalError(
+            "chat is an interactive terminal app and stdin is not a terminal. "
+            "Run it from a terminal, or use 'nsys-ai ask <profile> "
+            "\"<question>\"' for a single non-interactive answer."
+        )
+
     try:
         from nsys_ai.tui_textual import run_chat_tui
     except ImportError:
@@ -1657,6 +1754,7 @@ def _cmd_evidence(args, _profile):
 
     with _profile.open(profile_path) as prof:
         trim = _parse_trim(args)
+        _check_trim_window(trim, prof)
         device = getattr(args, "gpu", 0) or 0
         builder = EvidenceBuilder(prof, device=device, trim=trim)
 
@@ -1743,7 +1841,7 @@ def _apply_max_rows_truncation(rows: list, max_rows: int) -> list:
 def _cmd_skill(args, _profile):
     import json as _json
 
-    from nsys_ai.exceptions import SkillExecutionError, SkillNotFoundError
+    from nsys_ai.exceptions import SkillExecutionError, SkillNotFoundError, SkillParameterError
     from nsys_ai.skills.registry import all_skills, get_skill, load_custom_skills_dir
     from nsys_ai.skills.registry import run_skill as _run_skill
 
@@ -1780,10 +1878,23 @@ def _cmd_skill(args, _profile):
                 )
             )
         else:
-            print(f"{'Name':<25s}  {'Category':<15s}  Description")
+            # A skill with a required parameter cannot be run by name alone, so
+            # the listing has to say which ones those are — otherwise the only
+            # way to find out is to run it and read the error.
+            marked = {s.name for s in skills if _required_param_names(s)}
+            labels = {s.name: (f"{s.name} *" if s.name in marked else s.name) for s in skills}
+            width = max([25] + [len(v) for v in labels.values()])
+            print(f"{'Name':<{width}s}  {'Category':<15s}  Description")
             print("-" * 80)
             for s in skills:
-                print(f"{s.name:<25s}  {s.category:<15s}  {s.description[:60]}")
+                print(f"{labels[s.name]:<{width}s}  {s.category:<15s}  {s.description[:60]}")
+            if marked:
+                print()
+                print(
+                    "* needs a required parameter: "
+                    "nsys-ai skill run <name> <profile> -p KEY=VALUE "
+                    "(see: nsys-ai skill info <name>)"
+                )
     elif args.skill_action == "info":
         skill = get_skill(args.skill_name)
         if skill is None:
@@ -1966,6 +2077,22 @@ def _cmd_skill(args, _profile):
                 print(_json.dumps(rows, indent=2))
             else:
                 print(_run_skill(args.skill_name, conn, **full_kwargs))
+        except SkillParameterError as e:
+            # A missing required parameter is a usage mistake, not a crash and
+            # not an abstention: say which parameter, how to pass it, and exit 2.
+            payload = e.to_dict()
+            payload["error"]["message"] = (
+                f"{e}; pass it with -p {e.parameter}=VALUE "
+                f"(see: nsys-ai skill info {e.skill_name})"
+            )
+            if fmt == "json":
+                print(_json.dumps(payload))
+            else:
+                print(
+                    f"Error [{e.error_code}]: {payload['error']['message']}",
+                    file=sys.stderr,
+                )
+            sys.exit(e.exit_code)
         except SkillNotFoundError as e:
             if fmt == "json":
                 print(_json.dumps(e.to_dict()))

--- a/src/nsys_ai/diff_web.py
+++ b/src/nsys_ai/diff_web.py
@@ -17,7 +17,7 @@ from .diff import ProfileDiffSummary, diff_profiles
 from .diff_render import to_diff_json
 from .profile import Profile
 from .viewer import build_timeline_gpu_data, generate_timeline_html
-from .web import _TEMPLATE_DIR, _run_server, _ThreadedHTTPServer
+from .web import _TEMPLATE_DIR, _bind_local_server, _run_server
 
 
 class _DiffHandler(BaseHTTPRequestHandler):
@@ -506,13 +506,7 @@ def serve_diff_web(
     _DiffHandler.trim = trim
     _DiffHandler.summary = summary
 
-    try:
-        server = _ThreadedHTTPServer(("127.0.0.1", port), _DiffHandler)
-    except OSError:
-        if port == 0:
-            raise
-        server = _ThreadedHTTPServer(("127.0.0.1", 0), _DiffHandler)
-        print(f"Port {port} in use, using port {server.server_address[1]} instead.")
+    server = _bind_local_server(port, _DiffHandler)
 
     open_url = f"http://127.0.0.1:{server.server_address[1]}" if open_browser else None
     _run_server(server, open_url, before)

--- a/src/nsys_ai/exceptions.py
+++ b/src/nsys_ai/exceptions.py
@@ -15,9 +15,14 @@ class NsysAiError(Exception):
 
     Attributes:
         error_code: Machine-readable error code (e.g. ``"PROFILE_NOT_FOUND"``).
+        exit_code:  Process status the CLI exits with when this escapes a
+                    handler.  ``1`` means the command did not run to
+                    completion; ``2`` means the command was asked for
+                    something it cannot parse or accept (a usage mistake).
     """
 
     error_code: str = "NSYS_AI_ERROR"
+    exit_code: int = 1
 
     def __init__(self, message: str = "", *, error_code: str | None = None):
         if error_code is not None:
@@ -27,6 +32,34 @@ class NsysAiError(Exception):
     def to_dict(self) -> dict:
         """Structured error payload for JSON serialization / AI agent consumption."""
         return {"error": {"code": self.error_code, "message": str(self)}}
+
+
+# ── Usage errors ───────────────────────────────────────────────────────
+
+
+class UsageError(NsysAiError):
+    """The command was asked for something it cannot parse or accept.
+
+    These are ordinary mistakes — a missing argument, a window that selects
+    nothing, a terminal that cannot host an interactive app — not failures of
+    the tool.  They exit 2 so a caller can tell them apart from a run that
+    started and then broke.
+    """
+
+    error_code = "USAGE_ERROR"
+    exit_code = 2
+
+
+class TrimOutOfRangeError(UsageError):
+    """``--trim`` selects a window that lies entirely outside the profile."""
+
+    error_code = "TRIM_OUT_OF_RANGE"
+
+
+class NotATerminalError(UsageError):
+    """An interactive command was started without a terminal to draw on."""
+
+    error_code = "NOT_A_TERMINAL"
 
 
 # ── Profile errors ─────────────────────────────────────────────────────
@@ -106,6 +139,30 @@ class SkillNotFoundError(SkillError, KeyError):
         d = super().to_dict()
         if self.available:
             d["error"]["available_skills"] = self.available
+        return d
+
+
+class SkillParameterError(SkillError, ValueError):
+    """A skill was run without one of its required parameters.
+
+    Inherits ``ValueError`` because that is what ``Skill.execute`` raised
+    before this type existed, and callers still catch it that way.
+    """
+
+    error_code = "SKILL_PARAMETER_REQUIRED"
+    exit_code = 2
+
+    def __init__(self, message: str = "", *, skill_name: str = "", parameter: str = ""):
+        self.skill_name = skill_name
+        self.parameter = parameter
+        super().__init__(message, error_code=self.error_code)
+
+    def to_dict(self) -> dict:
+        d = super().to_dict()
+        if self.skill_name:
+            d["error"]["skill"] = self.skill_name
+        if self.parameter:
+            d["error"]["parameter"] = self.parameter
         return d
 
 

--- a/src/nsys_ai/propose_command.py
+++ b/src/nsys_ai/propose_command.py
@@ -435,13 +435,25 @@ def run_propose(
     if session_id is not None:
         from .session_cli import publish_session_proposal
 
-        publish_session_proposal(
-            session_id=session_id,
-            proposal=proposal,
-            runspec=None if adopted_runspec else runspec,
-            resolved_secrets=resolved_secrets,
-            root=session_root,
-        )
+        try:
+            publish_session_proposal(
+                session_id=session_id,
+                proposal=proposal,
+                runspec=None if adopted_runspec else runspec,
+                resolved_secrets=resolved_secrets,
+                root=session_root,
+            )
+        except ValueError as exc:
+            # SessionStore enforces the phase order and the immutability of
+            # already-published artifacts, and raises ValueError for both.
+            # Re-running propose against a session that has moved on is an
+            # ordinary mistake, not a crash. TypeError stays uncaught: it means
+            # this function was handed the wrong type, which is our bug, not
+            # the caller's mistake, and reading it as one would hide it.
+            detail = _redact_message(str(exc), resolved_secrets or {})
+            raise ProposeCommandError(
+                f"could not publish the proposal into session {session_id}: {detail}"
+            ) from exc
         print(
             f"Proposal published to session {session_id}",
             file=stdout,

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -516,7 +516,13 @@ class Skill:
             if p.default is not None:
                 resolved[p.name] = p.default
             elif p.required:
-                raise ValueError(f"Skill '{self.name}' requires parameter '{p.name}'")
+                from ..exceptions import SkillParameterError
+
+                raise SkillParameterError(
+                    f"skill '{self.name}' requires parameter '{p.name}'",
+                    skill_name=self.name,
+                    parameter=p.name,
+                )
 
         # Handle {trim_clause} injection before execute_fn so {overhead_ns} can be computed correctly
         trim_start = resolved.get("trim_start_ns")

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -827,6 +827,23 @@ class _ViewerHandler(BaseHTTPRequestHandler):
         pass
 
 
+def _bind_local_server(port: int, handler):
+    """Bind 127.0.0.1:*port*, falling back to a free port when it is taken.
+
+    A busy port is an ordinary condition — another viewer is already running —
+    so every local server here answers it the same way instead of letting the
+    bind error reach the user as a traceback.
+    """
+    try:
+        return _ThreadedHTTPServer(("127.0.0.1", port), handler)
+    except OSError:
+        if port == 0:
+            raise
+        server = _ThreadedHTTPServer(("127.0.0.1", 0), handler)
+        print(f"Port {port} in use, using port {server.server_address[1]} instead.")
+        return server
+
+
 def serve(prof, device: int, trim: tuple[int, int], *, port: int = 8142, open_browser: bool = True):
     """Start a local HTTP server serving the interactive HTML viewer.
     If the requested port is in use, tries port 0 (system assigns a free port) and opens that URL.
@@ -834,13 +851,7 @@ def serve(prof, device: int, trim: tuple[int, int], *, port: int = 8142, open_br
     html = generate_html(prof, device, trim)
     _ViewerHandler.html_bytes = html.encode("utf-8")
 
-    try:
-        server = _ThreadedHTTPServer(("127.0.0.1", port), _ViewerHandler)
-    except OSError:
-        if port == 0:
-            raise
-        server = _ThreadedHTTPServer(("127.0.0.1", 0), _ViewerHandler)
-        print(f"Port {port} in use, using port {server.server_address[1]} instead.")
+    server = _bind_local_server(port, _ViewerHandler)
     open_url = f"http://127.0.0.1:{server.server_address[1]}" if open_browser else None
     _run_server(server, open_url, prof)
 
@@ -1197,10 +1208,13 @@ def serve_timeline(
 
         threading.Thread(target=_warm_nvtx, name="timeline-nvtx-warmup", daemon=True).start()
 
-    server = _ThreadedHTTPServer(("127.0.0.1", port), _ViewerHandler)
-    actual_url = f"http://127.0.0.1:{server.server_address[1]}"
-    print(f"Timeline viewer at {actual_url}")
     try:
+        # Binding is inside the try: if it fails, the caller's `with` closes the
+        # Profile, and closing a DuckDB connection out from under the background
+        # worker is a segfault rather than an exception.
+        server = _bind_local_server(port, _ViewerHandler)
+        actual_url = f"http://127.0.0.1:{server.server_address[1]}"
+        print(f"Timeline viewer at {actual_url}")
         _run_server(server, actual_url if open_browser else None, prof)
     finally:
         # Keep the Profile alive until the background worker has stopped using
@@ -1346,7 +1360,7 @@ def serve_evidence(
     _EvidenceHandler._prebuilt_data = prebuilt
     _ViewerHandler._prebuilt_nvtx_mode = "full"
 
-    server = _ThreadedHTTPServer(("127.0.0.1", port), _EvidenceHandler)
+    server = _bind_local_server(port, _EvidenceHandler)
     actual_url = f"http://127.0.0.1:{server.server_address[1]}"
     print(f"Evidence viewer at {actual_url}")
     print(f"  {len(findings_data)} finding(s): {title}")

--- a/tests/test_cli_usage_errors.py
+++ b/tests/test_cli_usage_errors.py
@@ -1,0 +1,419 @@
+"""Ordinary mistakes must produce an error, not a traceback and not a hang.
+
+Every case here was reproduced against the shipped CLI: a typo, a busy port, a
+terminal that is not a terminal. Each one is a *usage* mistake — the command was
+asked for something it cannot accept — so each is answered with the coded error
+line the rest of the CLI already uses and with exit status 2.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+from nsys_ai import profile as _profile
+from nsys_ai import web
+
+ROOT = Path(__file__).resolve().parents[1]
+PROFILE = ROOT / "tests" / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+def _environment() -> dict[str, str]:
+    """Environment whose PYTHONPATH reaches this checkout's sources first."""
+    environment = dict(os.environ)
+    source = str(ROOT / "src")
+    current = environment.get("PYTHONPATH")
+    environment["PYTHONPATH"] = source if not current else f"{source}{os.pathsep}{current}"
+    return environment
+
+
+def _run_cli(*args: str, timeout: float = 180.0, cwd: Path | None = None):
+    return subprocess.run(
+        [sys.executable, "-m", "nsys_ai", *args],
+        cwd=str(cwd) if cwd is not None else str(ROOT),
+        env=_environment(),
+        capture_output=True,
+        text=True,
+        stdin=subprocess.DEVNULL,
+        timeout=timeout,
+        check=False,
+    )
+
+
+def _profile_window_seconds() -> tuple[float, float]:
+    with _profile.open(str(PROFILE)) as prof:
+        lo_ns, hi_ns = prof.meta.time_range
+    return lo_ns / 1e9, hi_ns / 1e9
+
+
+# ── A missing required skill parameter ─────────────────────────────────
+
+
+def test_skill_run_without_a_required_parameter_is_a_coded_usage_error():
+    """`skill run <name> <profile>` is the documented form; 7 skills need more.
+
+    It used to end in a ValueError traceback, which a user cannot tell apart
+    from a bug in the tool.
+    """
+    result = _run_cli("skill", "run", "region_mfu", str(PROFILE))
+
+    assert result.returncode == 2, (result.returncode, result.stdout, result.stderr)
+    combined = result.stdout + result.stderr
+    assert "Traceback" not in combined, combined
+    assert "Error [SKILL_PARAMETER_REQUIRED]:" in result.stderr, result.stderr
+    # The message has to name the parameter, the way to pass it, and where to
+    # look the rest up — that is what turns the error into a next step.
+    assert "'name'" in result.stderr, result.stderr
+    assert "-p name=VALUE" in result.stderr, result.stderr
+    assert "nsys-ai skill info region_mfu" in result.stderr, result.stderr
+
+
+def test_skill_run_without_a_required_parameter_stays_parseable_json():
+    """In --format json a machine consumer must still get JSON on stdout."""
+    result = _run_cli("skill", "run", "region_mfu", str(PROFILE), "--format", "json")
+
+    assert result.returncode == 2, (result.returncode, result.stdout, result.stderr)
+    assert "Traceback" not in result.stdout + result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["error"]["code"] == "SKILL_PARAMETER_REQUIRED", payload
+    assert payload["error"]["skill"] == "region_mfu", payload
+    assert payload["error"]["parameter"] == "name", payload
+    # A usage mistake is not an abstention: the profile could have answered.
+    assert "_abstained" not in payload, payload
+
+
+def test_skill_list_marks_the_skills_that_need_a_parameter():
+    """Discoverable beforehand, so the error above is rarely reached at all."""
+    result = _run_cli("skill", "list")
+
+    assert result.returncode == 0, result.stderr
+    lines = result.stdout.splitlines()
+    marked = [ln for ln in lines if ln.startswith("region_mfu ")]
+    assert marked and marked[0].split()[1] == "*", result.stdout
+    plain = [ln for ln in lines if ln.startswith("top_kernels ")]
+    assert plain and plain[0].split()[1] != "*", result.stdout
+    assert "-p KEY=VALUE" in result.stdout, result.stdout
+    assert "nsys-ai skill info <name>" in result.stdout, result.stdout
+
+
+def test_skill_list_marks_only_the_parameters_that_stop_execution():
+    """`required` with a default never stops a run, so it must not be marked.
+
+    The text marker reads the same condition ``Skill.execute`` reads, not the
+    ``required`` flag on its own — otherwise it would warn about parameters
+    that resolve themselves.
+    """
+    from nsys_ai.cli.handlers import _required_param_names
+    from nsys_ai.skills.registry import get_skill
+
+    region_mfu = get_skill("region_mfu")
+    declared = {p.name for p in region_mfu.params if p.required}
+    blocking = set(_required_param_names(region_mfu))
+    assert "name" in blocking
+    assert blocking <= declared
+    assert {p.name for p in region_mfu.params if p.required and p.default is not None}.isdisjoint(
+        blocking
+    )
+    assert _required_param_names(get_skill("top_kernels")) == []
+
+
+# ── A --trim window that selects nothing ───────────────────────────────
+
+
+def test_trim_outside_the_profile_window_names_both_windows():
+    """`--trim 0 1` reads on the capture clock, which does not start at zero.
+
+    It used to exit 0 after printing a single newline, which reads as "nothing
+    to see here" rather than "you asked for a window this profile never had".
+    """
+    result = _run_cli("tui", str(PROFILE), "--gpu", "0", "--trim", "0", "1")
+
+    assert result.returncode == 2, (result.returncode, result.stdout, result.stderr)
+    assert "Traceback" not in result.stdout + result.stderr
+    assert "Error [TRIM_OUT_OF_RANGE]:" in result.stderr, result.stderr
+    lo_s, hi_s = _profile_window_seconds()
+    assert f"{lo_s:.3f}" in result.stderr, result.stderr
+    assert f"{hi_s:.3f}" in result.stderr, result.stderr
+    assert "--trim 0.000 1.000" in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize("command", ["tree", "open", "overlap", "nccl", "search", "summary"])
+def test_trim_outside_the_window_is_refused_by_every_single_profile_command(command):
+    """One command guarded is not the contract; the reader picks the command.
+
+    `tree` is `tui`'s non-interactive twin and reproduced the reported symptom
+    verbatim -- exit 0, one byte of output -- while `tui` next to it exited 2.
+    `open` was worse: it re-derived the nanosecond window inline and never
+    reached the check at all.
+    """
+    extra = ["--query", "x"] if command == "search" else []
+    if command == "open":
+        extra = ["--viewer", "web", "--no-browser"]
+    result = _run_cli(command, str(PROFILE), "--gpu", "0", "--trim", "0", "1", *extra)
+
+    assert result.returncode == 2, (command, result.returncode, result.stdout, result.stderr)
+    assert "Traceback" not in result.stdout + result.stderr, result.stderr
+    assert "Error [TRIM_OUT_OF_RANGE]:" in result.stderr, result.stderr
+
+
+def test_a_zero_width_trim_window_is_out_of_range():
+    """`--trim 156 156` sits inside the profile and still selects nothing.
+
+    Same empty result as a window that misses entirely, reached by different
+    arithmetic, so it gets the same answer.
+    """
+    lo_s, _ = _profile_window_seconds()
+    midpoint = f"{lo_s + 0.5:.6f}"
+    result = _run_cli("export-csv", str(PROFILE), "--gpu", "0", "--trim", midpoint, midpoint)
+
+    assert result.returncode == 2, (result.returncode, result.stdout, result.stderr)
+    assert "Error [TRIM_OUT_OF_RANGE]:" in result.stderr, result.stderr
+
+
+def test_trim_inside_the_profile_window_is_untouched(tmp_path: Path):
+    """The check must reject only a window that misses the profile entirely."""
+    lo_s, hi_s = _profile_window_seconds()
+    out = tmp_path / "kernels.csv"
+    result = _run_cli(
+        "export-csv",
+        str(PROFILE),
+        "--gpu",
+        "0",
+        "--trim",
+        f"{lo_s:.6f}",
+        f"{hi_s:.6f}",
+        "-o",
+        str(out),
+    )
+
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert out.is_file()
+
+
+def test_trim_overlapping_only_partly_is_accepted():
+    """A window that starts before the profile still selects real events."""
+    from argparse import Namespace
+
+    from nsys_ai.cli.handlers import _check_trim_window, _parse_trim
+
+    with _profile.open(str(PROFILE)) as prof:
+        lo_ns, _ = prof.meta.time_range
+        trim = _parse_trim(Namespace(trim=[0.0, lo_ns / 1e9 + 0.5]))
+        _check_trim_window(trim, prof)  # must not raise
+
+
+# ── chat without a terminal ────────────────────────────────────────────
+
+
+def test_chat_without_a_terminal_refuses_before_the_app_starts():
+    """It used to draw a screen into the pipe and then wait for input forever.
+
+    The check has to sit in the handler: once Textual is running its stream
+    capture answers isatty() True unconditionally, so a later check sees a
+    terminal that is not there.
+    """
+    started = time.monotonic()
+    try:
+        result = _run_cli("chat", str(PROFILE), timeout=30.0)
+    except subprocess.TimeoutExpired:  # pragma: no cover - the bug being fixed
+        pytest.fail("chat hung with no terminal instead of refusing")
+    elapsed = time.monotonic() - started
+
+    assert elapsed < 15.0, f"chat took {elapsed:.1f}s to refuse"
+    assert result.returncode == 2, (result.returncode, result.stdout, result.stderr)
+    assert "Traceback" not in result.stdout + result.stderr
+    assert "Error [NOT_A_TERMINAL]:" in result.stderr, result.stderr
+    # Refusing is only half an answer; the message names the way through.
+    assert "nsys-ai ask" in result.stderr, result.stderr
+
+
+def test_chat_accepts_a_terminal_whose_stdout_is_redirected(monkeypatch, tmp_path: Path):
+    """`nsys-ai chat p.sqlite > log` is a working invocation, not a mistake.
+
+    Textual draws through stderr, so with a real terminal the UI is usable
+    while stdout goes to a file. Gating on stdout as well as stdin would refuse
+    it -- a case that worked before the hang was fixed.
+    """
+    from argparse import Namespace
+
+    from nsys_ai import tui_textual
+    from nsys_ai.cli import handlers
+
+    started: list[str] = []
+    monkeypatch.setattr(tui_textual, "run_chat_tui", lambda path: started.append(path))
+
+    class _Terminal:
+        @staticmethod
+        def isatty():
+            return True
+
+    monkeypatch.setattr(sys, "stdin", _Terminal())
+    # ...while stdout is a plain file, as it is under a shell redirect.
+    monkeypatch.setattr(sys, "stdout", (tmp_path / "log").open("w"))
+    try:
+        handlers._cmd_chat(Namespace(profile=str(PROFILE)), None)
+    finally:
+        sys.stdout.close()
+
+    assert started == [str(PROFILE)]
+
+
+# ── a busy port ────────────────────────────────────────────────────────
+
+
+def test_bind_local_server_falls_back_when_the_port_is_taken():
+    holder = socket.socket()
+    holder.bind(("127.0.0.1", 0))
+    holder.listen(1)
+    busy = holder.getsockname()[1]
+    try:
+        server = web._bind_local_server(busy, web._ViewerHandler)
+    finally:
+        holder.close()
+    try:
+        assert server.server_address[1] != busy
+    finally:
+        server.server_close()
+
+
+def test_timeline_web_survives_a_busy_port(tmp_path: Path, monkeypatch):
+    """`web` and `diff-web` already stepped aside; timeline-web raised instead."""
+    # serve_timeline writes a timeline cache next to the profile, which must
+    # not land on a committed fixture.
+    profile_copy = tmp_path / "profile.sqlite"
+    shutil.copyfile(PROFILE, profile_copy)
+
+    holder = socket.socket()
+    holder.bind(("127.0.0.1", 0))
+    holder.listen(1)
+    busy = holder.getsockname()[1]
+
+    bound: dict[str, int] = {}
+
+    def _capture_instead_of_serving(server, open_url, prof):
+        bound["port"] = server.server_address[1]
+        server.server_close()
+
+    monkeypatch.setattr(web, "_run_server", _capture_instead_of_serving)
+    monkeypatch.chdir(tmp_path)
+
+    try:
+        with _profile.open(str(profile_copy)) as prof:
+            web.serve_timeline(prof, [0], None, port=busy, open_browser=False)
+    finally:
+        holder.close()
+
+    assert bound.get("port") not in (None, busy), bound
+
+
+def test_timeline_web_bind_failure_waits_for_the_background_worker(tmp_path: Path, monkeypatch):
+    """A bind that still fails must not leave the NVTX worker running.
+
+    serve_timeline starts a background thread on the profile's DuckDB
+    connection before it binds. If the bind escapes, the caller's ``with``
+    closes that connection under the running thread, which segfaults the
+    process instead of raising — the error is then invisible.
+    """
+    import threading
+
+    profile_copy = tmp_path / "profile.sqlite"
+    shutil.copyfile(PROFILE, profile_copy)
+
+    def _always_fails(port, handler):
+        raise OSError("bind refused")
+
+    monkeypatch.setattr(web, "_bind_local_server", _always_fails)
+    monkeypatch.chdir(tmp_path)
+
+    with _profile.open(str(profile_copy)) as prof:
+        with pytest.raises(OSError):
+            web.serve_timeline(prof, [0], None, port=0, open_browser=False)
+        alive = [
+            t
+            for t in threading.enumerate()
+            if t.name == "timeline-nvtx-warmup" and t.is_alive()
+        ]
+        assert not alive, "the background worker still holds the connection being closed"
+
+
+# ── propose into a session that has moved on ───────────────────────────
+
+
+def test_propose_reports_a_session_conflict_as_a_coded_error(tmp_path: Path):
+    """Re-running the command `diagnose` prints used to raise a bare ValueError."""
+    from nsys_ai.diagnose_command import run_diagnose
+    from nsys_ai.propose_command import ProposeCommandError, run_propose
+    from nsys_ai.runspec import RunSpec
+
+    profile_copy = tmp_path / "profile.sqlite"
+    shutil.copyfile(PROFILE, profile_copy)
+    root = tmp_path / "sessions"
+    session_id = "propose-conflict"
+
+    assert (
+        run_diagnose(
+            profile_path=str(profile_copy),
+            session_id=session_id,
+            gpu=0,
+            session_root=root,
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+        == 0
+    )
+    report = json.loads((root / session_id / "findings.json").read_text())
+    finding_id = next(f["id"] for f in report["findings"] if f.get("id"))
+
+    # First proposal: no RunSpec, so the session records "no verification path".
+    assert (
+        run_propose(
+            finding_id=finding_id,
+            session_id=session_id,
+            session_root=root,
+            stdout=io.StringIO(),
+        )
+        == 0
+    )
+
+    runspec_path = tmp_path / "runspec.json"
+    runspec_path.write_text(json.dumps(RunSpec(argv=["python", "train.py"]).to_dict()))
+
+    with pytest.raises(ProposeCommandError) as caught:
+        run_propose(
+            finding_id=finding_id,
+            session_id=session_id,
+            runspec_path=str(runspec_path),
+            session_root=root,
+            stdout=io.StringIO(),
+        )
+    assert caught.value.error_code == "PROPOSE_COMMAND_INVALID"
+    assert session_id in str(caught.value)
+
+
+# ── the shape of the contract itself ───────────────────────────────────
+
+
+def test_usage_errors_exit_two_and_runtime_errors_exit_one():
+    """Exit 1 means the command broke; exit 2 means it was asked wrongly."""
+    from nsys_ai.exceptions import NsysAiError, ProfileNotFoundError, UsageError
+
+    assert NsysAiError.exit_code == 1
+    assert ProfileNotFoundError.exit_code == 1
+    assert UsageError.exit_code == 2
+
+
+def test_a_missing_profile_still_exits_one():
+    """The established runtime-error status must not shift under this change."""
+    result = _run_cli("summary", "nope.sqlite")
+
+    assert result.returncode == 1, (result.returncode, result.stdout, result.stderr)
+    assert "Error [PROFILE_NOT_FOUND]:" in result.stderr, result.stderr


### PR DESCRIPTION
## Summary

- Ordinary user mistakes — a typo, a busy port, a terminal that is not a TTY — produced Python tracebacks or hangs. Five rows, all collected from end-to-end passes against the installed wheel.
- Each fix feeds the error convention that already exists (`.error_code` rendered as `Error [CODE]: ...` at `cli/app.py`) rather than inventing formatting, and copies a sibling command that already handles the case.
- Exit codes are settled: 2 means the command was asked wrongly, 1 means it broke.

## Changes

| Mistake | Before | Now |
|---|---|---|
| `skill run region_mfu <profile>` — the form the front door advertises, and 7 of 38 skills require a parameter | 15-line traceback, exit 1 | `Error [SKILL_PARAMETER_REQUIRED]: skill 'region_mfu' requires parameter 'name'; pass it with -p name=VALUE (see: nsys-ai skill info region_mfu)`, exit 2 |
| `propose` re-run against a session that has moved on — the command `diagnose` prints | `ValueError: runspec.json cannot change after proposal phase` traceback | `Error [PROPOSE_COMMAND_INVALID]: could not publish the proposal into session s1: runspec.json cannot change after proposal phase`, exit 1 |
| `timeline-web` with the port taken | `OSError: [Errno 98]` traceback, then a **segfault** — the NVTX pre-build thread outlives the dying main thread | falls back to a free port and serves, as `web` and `diff-web` already do |
| `chat <profile>` with no TTY (script, CI, pipe) | **hangs forever**, spewing escape codes | `Error [NOT_A_TERMINAL]: ... use 'nsys-ai ask <profile> "<question>"' for a single non-interactive answer`, exit 2 in ~1 s. Gated on stdin only: Textual draws through stderr, so `nsys-ai chat p.sqlite > log` is a working invocation and must not be refused |
| `tui --gpu 0 --trim 0 1` on a profile whose window starts at 155 s | exit 0, one byte of output | `Error [TRIM_OUT_OF_RANGE]: --trim 0.000 1.000 selects no part of this profile, whose window is 155.360 s to 156.321 s on the capture clock.`, exit 2 |

- `src/nsys_ai/exceptions.py` — `UsageError` (exit 2) and the coded subclasses; `NsysAiError`/`ProfileNotFoundError` keep exit 1.
- `src/nsys_ai/skills/base.py` — the required-parameter `ValueError` becomes `SkillParameterError` carrying the skill and parameter name.
- `src/nsys_ai/cli/handlers.py` — the out-of-range trim check on **every** command that opens one profile and takes `--trim` (18 call sites, not the six the ticket listed: `tree` is `tui`'s non-interactive twin and reproduced the reported symptom verbatim, and `open` re-derived the nanosecond window inline and never reached the check at all). A zero-width window is out of range too — `--trim 156 156` sits inside the profile and still selects nothing. Plus the TTY refusal for `chat` in the handler before Textual starts, and coded rendering for the skill-parameter case. The TTY check has to be there: inside a running app `Textual`'s `_PrintCapture.isatty()` returns `True` unconditionally, which is the trap that killed the original #332 gate.
- `src/nsys_ai/web.py` — `serve_timeline` gets the port fallback its siblings have, and waits for the background worker before exiting on a bind failure. `serve_evidence` picks it up too, so a busy port there stops raising.
- `src/nsys_ai/diff_web.py` — drops its own copy of the port fallback for the shared one.
- `src/nsys_ai/propose_command.py` — a session-phase conflict is an ordinary mistake, not a crash. Catches `ValueError` only: `TypeError` from that call means this function was handed the wrong type, which is our bug, and reading it as the caller's mistake would hide it.
- `src/nsys_ai/cli/app.py`, `skill list` — required-parameter skills are marked, so the encounter is rare in the first place. `docs/agent_skills/commands/skill.md` documents the marker.
- `tests/test_cli_usage_errors.py` — new; one subprocess test per row plus the exit-code contract itself.

## Backward compatibility

Mostly, and three exit codes move — all from a wrong answer to a right one:

- `skill run` without a required parameter: exit 1 (traceback) → exit 2.
- An out-of-range or zero-width `--trim`: exit 0 with an empty result → exit 2. A script that treated that exit 0 as success was being told the wrong thing.
- `serve_evidence` with the port taken: exit 1 (traceback) → binds a free port and serves, matching every other local server here.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2152 passed, 140 skipped, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean
- [x] Manually exercised: all five rows reproduced against the unfixed tree and re-run against this branch; the numbers in the table above are from those runs

## Out of scope

- Redesigning `--trim` semantics (relative vs absolute). This makes the mistake survivable and explained, not different.
- The JSON-mode variants of these errors. #400 settles the "cannot answer / cannot run" shape; the human-readable stderr lines here did not need to wait for it.
- `diff --trim`, which takes two profiles. The check here is per-profile; deciding what an out-of-range window means when the two captures have different windows is its own question.
- The profile window the check compares against is the kernel table's. A `--trim` covering only an annotated setup phase before the first kernel launch would be refused. `info` reports the same kernel-derived window, so the error is at least consistent with what the tool advertises, but a wider definition is a separate change.

## Linked issues

Closes #401, closes #386
