### PR TITLE
fix(diff): show the verdict and comparability, and refuse an incomparable pair

### DIFF
--- a/src/nsys_ai/ai/diff_narrative.py
+++ b/src/nsys_ai/ai/diff_narrative.py
@@ -60,8 +60,14 @@ def build_executive_summary(summary: ProfileDiffSummary) -> str:
         )
 
     delta_ns = summary.after.total_gpu_ns - summary.before.total_gpu_ns
-    direction = "faster" if delta_ns < 0 else "slower"
-    total_str = f"Total GPU time went {direction} by {_fmt_delta_ns(delta_ns)}."
+    if delta_ns == 0:
+        total_str = "Total GPU time was unchanged."
+    else:
+        # The direction word carries the sign, so the magnitude must not carry
+        # it again: "went faster by -46.37ms" is a double negative that reads
+        # as the opposite of what was measured.
+        direction = "faster" if delta_ns < 0 else "slower"
+        total_str = f"Total GPU time went {direction} by {_fmt_ns(abs(delta_ns))}."
 
     parts = [total_str]
 
@@ -128,12 +134,16 @@ def generate_diff_narrative(
     """
     executive_summary = build_executive_summary(summary)
 
-    # An empty side is refused before the model is ever asked. The prompt payload
-    # lists "Top improvements" from the same deltas, and the instruction tells the
-    # model to mention them, so an LLM handed this would narrate the vanished
-    # kernels as a win directly beneath the deterministic refusal. There is
-    # nothing here to narrate: no comparison was made.
-    if empty_kernel_sides(summary.before, summary.after):
+    # An empty side, or a pair under the comparability minimum, is refused
+    # before the model is ever asked. The prompt payload lists "Top
+    # improvements" from the same deltas, and the instruction tells the model to
+    # mention them, so an LLM handed this would narrate arithmetic as a win
+    # directly beneath the deterministic refusal -- which the renderers then
+    # discard, so the call is billed and shown to nobody. There is nothing here
+    # to narrate: no comparison was made.
+    from nsys_ai.diff_render import is_incomparable
+
+    if empty_kernel_sides(summary.before, summary.after) or is_incomparable(summary):
         return DiffNarrative(
             executive_summary=executive_summary,
             ai_narrative=None,

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -846,6 +846,7 @@ def _cmd_diff(args, _profile):
     )
     from nsys_ai.diff_decision import write_diff_decision_json
     from nsys_ai.diff_render import (
+        _fmt_confidence,
         format_diff_markdown,
         format_diff_markdown_multi,
         format_diff_terminal,
@@ -1192,7 +1193,7 @@ def _cmd_diff(args, _profile):
             f"verdict={gate_summary.verdict} "
             f"step_time_delta_ms={gate_summary.step_time_delta_ms:+.3f} "
             f"step_time_delta_pct={gate_summary.step_time_delta_pct:+.2f}% "
-            f"comparability_confidence={gate_summary.comparability_confidence:.3f} "
+            f"comparability_confidence={_fmt_confidence(gate_summary.comparability_confidence)} "
             f"gate_pct={regression_pct:.2f}%.",
             file=sys.stderr,
         )
@@ -1206,7 +1207,7 @@ def _cmd_diff(args, _profile):
         print(
             "Diff gate could not be evaluated: "
             f"verdict={gate_summary.verdict} "
-            f"comparability_confidence={gate_summary.comparability_confidence:.3f} "
+            f"comparability_confidence={_fmt_confidence(gate_summary.comparability_confidence)} "
             f"(minimum {MIN_COMPARABILITY_CONFIDENCE:.2f}). "
             f"{reason} "
             "Exiting non-zero: a comparison that could not be made has not shown "

--- a/src/nsys_ai/diff_render.py
+++ b/src/nsys_ai/diff_render.py
@@ -5,10 +5,11 @@ diff_render.py — Render structured diff payloads for CLI outputs.
 from __future__ import annotations
 
 import json
+from decimal import ROUND_FLOOR, Decimal
 
 from .ai.diff_narrative import DiffNarrative
 from .annotation import PRODUCER, SCHEMA_VERSION, DiffLineage, _producer_version
-from .diff import ProfileDiffSummary
+from .diff import MIN_COMPARABILITY_CONFIDENCE, ProfileDiffSummary
 
 
 def _fmt_ns(ns: int) -> str:
@@ -34,6 +35,112 @@ def _fmt_delta_ns(ns: int) -> str:
 
 def _fmt_pct(x: float) -> str:
     return f"{x * 100:.2f}%"
+
+
+def _fmt_confidence(confidence: float) -> str:
+    """Two decimals, truncated rather than rounded.
+
+    Rounding would let a score below the gate display as though it had reached
+    it — 0.4996 shown as "0.50" beside an "inconclusive" verdict reads as a
+    contradiction.
+
+    Decimal, not ``math.floor(x * 100)``: the multiply carries binary error the
+    other way, and 0.29 * 100 is 28.999999999999996, so a third of the
+    two-decimal values would truncate one hundredth low. Quantising the decimal
+    repr is exact at both ends.
+    """
+    clamped = max(0.0, min(1.0, confidence))
+    return str(Decimal(str(clamped)).quantize(Decimal("0.01"), rounding=ROUND_FLOOR))
+
+
+def verdict_line(data: ProfileDiffSummary) -> str:
+    """The judgement and how much it can be trusted, on one line.
+
+    Both numbers were already computed, persisted to ``diff.json`` and gating
+    CI; only the terminal reader was left to infer them from the deltas.
+    """
+    return (
+        f"Verdict: {data.verdict}  "
+        f"(comparability {_fmt_confidence(data.comparability_confidence)})"
+    )
+
+
+def is_incomparable(data: ProfileDiffSummary) -> bool:
+    """True when the pair scored below the confidence a verdict requires."""
+    return data.comparability_confidence < MIN_COMPARABILITY_CONFIDENCE
+
+
+def incomparable_reason(data: ProfileDiffSummary) -> str:
+    """Why no before/after claim can be made. Never empty.
+
+    The sanity warnings usually name a specific cause, but not always — a
+    workload-size ratio between 0.33 and 0.5 lowers confidence past the gate
+    without tripping any warning threshold. The score against the gate is
+    therefore the reason, and the warnings refine it.
+    """
+    return (
+        f"Comparability scored {_fmt_confidence(data.comparability_confidence)}, under the "
+        f"{MIN_COMPARABILITY_CONFIDENCE:.2f} minimum — these two captures cannot be read "
+        "as a before and an after."
+    )
+
+
+#: Said on every surface that withholds the tables, so the reader knows the
+#: numbers still exist and where to get them.
+_WITHHELD_NOTE = (
+    "Per-kernel and per-range deltas are withheld: across profiles this different",
+    "they are arithmetic, not findings. --format json still carries every number.",
+)
+
+
+def _refusal_terminal(data: ProfileDiffSummary) -> list[str]:
+    lines = ["No comparison was made", "─" * 60, incomparable_reason(data)]
+    if data.warnings:
+        lines.append("")
+        lines.extend(f"- {w}" for w in data.warnings)
+    lines.append("")
+    lines.extend(_WITHHELD_NOTE)
+    return lines
+
+
+def _refusal_markdown(data: ProfileDiffSummary) -> list[str]:
+    md = ["### No comparison was made", "", incomparable_reason(data), ""]
+    if data.warnings:
+        md.extend(f"- {w}" for w in data.warnings)
+        md.append("")
+    md.append(f"_{' '.join(_WITHHELD_NOTE)}_")
+    md.append("")
+    return md
+
+def _split_comparable_devices(
+    per_gpu: dict[int, ProfileDiffSummary],
+) -> tuple[list[tuple[int, ProfileDiffSummary]], list[tuple[int, ProfileDiffSummary]]]:
+    """Devices whose own slice supports a claim, and those whose does not.
+
+    A node-wide score can clear the gate while one device's slice does not --
+    a rank that dropped out, or one whose kernel set barely overlaps. Its
+    deltas are then the same arithmetic the global refusal withholds, and
+    rendering them per device reinstates exactly what was refused. Splitting
+    here rather than at each table keeps the two multi-GPU renderers agreeing
+    on which devices they will speak for.
+    """
+    comparable: list[tuple[int, ProfileDiffSummary]] = []
+    withheld: list[tuple[int, ProfileDiffSummary]] = []
+    for dev, summary in sorted(per_gpu.items()):
+        (withheld if is_incomparable(summary) else comparable).append((dev, summary))
+    return comparable, withheld
+
+
+def _withheld_devices_note(withheld: list[tuple[int, ProfileDiffSummary]]) -> str:
+    """One line naming the devices left out of the tables, and their scores."""
+    scored = ", ".join(
+        f"GPU {dev} ({_fmt_confidence(summary.comparability_confidence)})"
+        for dev, summary in withheld
+    )
+    return (
+        f"Withheld, below the {MIN_COMPARABILITY_CONFIDENCE:.2f} minimum on their own: "
+        f"{scored}. --format json still carries every number."
+    )
 
 
 def _axis_summary_to_dict(axis):
@@ -104,7 +211,16 @@ def format_diff_terminal(
     lines.append(f"Before: {data.before.path}")
     lines.append(f"After:  {data.after.path}")
     lines.append(f"GPU:    {data.before.gpu}")
+    lines.append(verdict_line(data))
     lines.append("")
+
+    # Below the gate the deltas are still arithmetic, but presenting them as
+    # regressions and improvements makes them read as findings from a
+    # comparison that was never valid. State the refusal instead of decorating
+    # it with tables.
+    if is_incomparable(data):
+        lines.extend(_refusal_terminal(data))
+        return "\n".join(lines).rstrip() + "\n"
 
     if narrative:
         lines.append("Executive Summary")
@@ -250,15 +366,23 @@ def format_diff_terminal_multi(
         gl_lines = processed
     parts.append(header + "\n".join(gl_lines).rstrip() + "\n")
 
+    # The global block is already the refusal; the per-GPU overview and per-GPU
+    # regressions below are the same deltas sliced by device, so they would
+    # reinstate exactly what the refusal withheld.
+    if is_incomparable(global_summary):
+        return "\n".join(parts).rstrip() + "\n"
+
+    comparable_devices, withheld_devices = _split_comparable_devices(per_gpu)
+
     # 2) Per-GPU overview table
-    if per_gpu:
+    if comparable_devices:
         parts.append("Per-GPU Overview")
         parts.append("─" * 60)
         parts.append(
             f"{'GPU':>3} | {'Before Total':>13} | {'After Total':>13} | {'Δ':>10} | {'Overlap % (B→A)':>18}"
         )
         parts.append(f"{'-' * 3}-+-{'-' * 13}-+-{'-' * 13}-+-{'-' * 10}-+-{'-' * 18}")
-        for dev, summary in sorted(per_gpu.items()):
+        for dev, summary in comparable_devices:
             b = summary.before
             a = summary.after
             delta_ns = a.total_gpu_ns - b.total_gpu_ns
@@ -274,8 +398,12 @@ def format_diff_terminal_multi(
             )
         parts.append("")
 
+    if withheld_devices:
+        parts.append(_withheld_devices_note(withheld_devices))
+        parts.append("")
+
     # 3) Per-GPU top regressions (short)
-    for dev, summary in sorted(per_gpu.items()):
+    for dev, summary in comparable_devices:
         if not summary.top_regressions:
             continue
         parts.append(f"Top regressions (GPU {dev})")
@@ -300,7 +428,15 @@ def format_diff_markdown(
     md.append(f"- **Before**: `{data.before.path}`")
     md.append(f"- **After**: `{data.after.path}`")
     md.append(f"- **GPU**: `{data.before.gpu}`")
+    md.append(
+        f"- **Verdict**: `{data.verdict}` "
+        f"(comparability `{_fmt_confidence(data.comparability_confidence)}`)"
+    )
     md.append("")
+
+    if is_incomparable(data):
+        md.extend(_refusal_markdown(data))
+        return "\n".join(md).rstrip() + "\n"
 
     if narrative:
         md.append("### Executive Summary")
@@ -417,7 +553,15 @@ def format_diff_markdown_multi(
     md.append("")
     md.append(f"- **Before**: `{g.before.path}`")
     md.append(f"- **After**: `{g.after.path}`")
+    md.append(
+        f"- **Verdict**: `{g.verdict}` "
+        f"(comparability `{_fmt_confidence(g.comparability_confidence)}`)"
+    )
     md.append("")
+
+    if is_incomparable(g):
+        md.extend(_refusal_markdown(g))
+        return "\n".join(md).rstrip() + "\n"
 
     if narrative:
         md.append("### Executive Summary")
@@ -483,15 +627,17 @@ def format_diff_markdown_multi(
     add_global_axis(g.communication_summary)
     add_global_axis(g.idle_summary)
 
+    comparable_devices, withheld_devices = _split_comparable_devices(per_gpu)
+
     # 2) Per-GPU breakdown table
-    if per_gpu:
+    if comparable_devices:
         md.append("### 2. Per-GPU Breakdown (Load Balancing)")
         md.append("")
         md.append(
             "| GPU | Total Time (Before) | Total Time (After) | Δ | Overlap % (Before → After) |"
         )
         md.append("|---:|---:|---:|---:|---:|")
-        for dev, summary in sorted(per_gpu.items()):
+        for dev, summary in comparable_devices:
             b = summary.before
             a = summary.after
             delta_ns = a.total_gpu_ns - b.total_gpu_ns
@@ -505,6 +651,10 @@ def format_diff_markdown_multi(
                 f"| `{dev}` | `{_fmt_ns(b.total_gpu_ns)}` | `{_fmt_ns(a.total_gpu_ns)}` | "
                 f"`{_fmt_delta_ns(delta_ns)}` | `{ov_str}` |"
             )
+        md.append("")
+
+    if withheld_devices:
+        md.append(f"_{_withheld_devices_note(withheld_devices)}_")
         md.append("")
 
     # 3) Global top regressions / improvements (reuse existing tables)
@@ -533,7 +683,7 @@ def format_diff_markdown_multi(
         md.append("")
         md.append("### 4. Per-GPU Top Regressions")
         md.append("")
-        for dev, summary in sorted(per_gpu.items()):
+        for dev, summary in comparable_devices:
             if not summary.top_regressions:
                 continue
             md.append(f"#### GPU {dev}")

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -815,7 +815,10 @@ def test_diff_cli_exit_on_regression_fails_gate(tmp_path):
     assert "Diff gate failed" in result.stderr
     assert "step_time_delta_ms=+2.000" in result.stderr
     assert "step_time_delta_pct=+20.00%" in result.stderr
-    assert "comparability_confidence=1.000" in result.stderr
+    # Two decimals, truncated, matching the report's own rendering: the gate
+    # message used to round to three, so a score of 0.4996 printed as 0.500
+    # beside "(minimum 0.50)" on the same line that refused it.
+    assert "comparability_confidence=1.00 " in result.stderr
 
 
 def test_diff_cli_exit_on_regression_allows_improvement(tmp_path):
@@ -3074,3 +3077,329 @@ def test_v01_diff_id_is_stable_across_runs(tmp_path):
 
     assert d1.diff_id == d2.diff_id
     assert d1.diff_id.startswith("diff1:sha256:")
+
+
+# ---------------------------------------------------------------------------
+# The verdict and comparability score are shown, and an incomparable pair is
+# refused instead of decorated with delta tables.
+# ---------------------------------------------------------------------------
+
+_MFU_BEFORE = pathlib.Path(__file__).parent / "fixtures" / "mfu_2gpu_before.sqlite"
+_MFU_AFTER = pathlib.Path(__file__).parent / "fixtures" / "mfu_2gpu_after.sqlite"
+
+
+def _incomparable_pair(tmp_path, *, before_n=12, after_n=2):
+    """A pair whose only difference is workload size, scoring below the gate.
+
+    ``collect_sanity_warnings`` derives comparability from min/max kernel rows,
+    so 12 vs 2 lands at 0.167 — well under MIN_COMPARABILITY_CONFIDENCE.
+    """
+    before = tmp_path / "incomp_before.sqlite"
+    after = tmp_path / "incomp_after.sqlite"
+
+    def _k(n):
+        return [(i * 10_000_000, i * 10_000_000 + 5_000_000, 0, 7, i, 1, 2) for i in range(n)]
+
+    _make_profile(str(before), kernels=_k(before_n))
+    _make_profile(str(after), kernels=_k(after_n))
+    return before, after
+
+
+def _diff_summary(before, after, **kwargs):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        return diff_profiles(b, a, **kwargs)
+
+
+def test_diff_terminal_states_the_verdict_and_comparability(tmp_path):
+    """The judgement is shown, not left for the reader to infer from deltas.
+
+    Both numbers were already computed, persisted to diff.json and gating CI;
+    the terminal was the one consumer never told.
+    """
+    from nsys_ai.diff_render import format_diff_markdown, format_diff_terminal
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 12_000_000, 0, 7, 1, 1, 2)])
+    summary = _diff_summary(before, after, gpu=0, limit=10)
+    assert summary.comparability_confidence >= 0.5
+
+    terminal = format_diff_terminal(summary)
+    assert f"Verdict: {summary.verdict}" in terminal
+    assert "(comparability 1.00)" in terminal
+
+    markdown = format_diff_markdown(summary)
+    assert f"**Verdict**: `{summary.verdict}`" in markdown
+    assert "comparability `1.00`" in markdown
+
+
+def test_diff_cli_shows_the_verdict_that_contradicts_the_headline():
+    """The reported case: headline says faster, the verdict says neutral.
+
+    Runs the issue's own invocation on the committed pair, so the two numbers
+    have to appear together in the output a human actually reads.
+    """
+    if not _MFU_BEFORE.is_file() or not _MFU_AFTER.is_file():
+        raise FileNotFoundError(f"missing fixture profiles: {_MFU_BEFORE} / {_MFU_AFTER}")
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "diff", str(_MFU_BEFORE), str(_MFU_AFTER), "--no-ai"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "Verdict: neutral" in result.stdout, result.stdout[:800]
+    assert "comparability 0.89" in result.stdout, result.stdout[:800]
+
+
+def test_comparability_is_truncated_not_rounded_across_the_gate():
+    """A score under the gate must never display as though it had reached it."""
+    from nsys_ai.diff_render import _fmt_confidence
+
+    assert _fmt_confidence(0.4996) == "0.49"
+    assert _fmt_confidence(0.894) == "0.89"
+    assert _fmt_confidence(1.0) == "1.00"
+    assert _fmt_confidence(0.0) == "0.00"
+
+
+def test_diff_terminal_refuses_an_incomparable_pair_instead_of_tabulating_it(tmp_path):
+    """Below the gate the deltas are arithmetic; printed as tables they read as findings."""
+    from nsys_ai.diff_render import format_diff_terminal
+
+    before, after = _incomparable_pair(tmp_path)
+    summary = _diff_summary(before, after, gpu=0, limit=10)
+    assert summary.comparability_confidence < 0.5
+    assert summary.verdict == "inconclusive"
+
+    out = format_diff_terminal(summary)
+
+    assert "Verdict: inconclusive" in out
+    assert "No comparison was made" in out
+    assert "Kernel row counts differ a lot" in out
+    # The tables that would have been read as findings are gone, not merely
+    # preceded by a caveat.
+    for section in ("Executive Summary", "Overall", "Top regressions", "Top improvements"):
+        assert section not in out, f"{section!r} survived the refusal:\n{out}"
+
+
+def test_diff_markdown_refuses_an_incomparable_pair(tmp_path):
+    from nsys_ai.diff_render import format_diff_markdown
+
+    before, after = _incomparable_pair(tmp_path)
+    summary = _diff_summary(before, after, gpu=0, limit=10)
+
+    out = format_diff_markdown(summary)
+    assert "### No comparison was made" in out
+    assert "Kernel row counts differ a lot" in out
+    for section in ("### Top regressions", "### Top improvements", "### Overall"):
+        assert section not in out, f"{section!r} survived the refusal:\n{out}"
+
+
+def test_incomparable_refusal_states_a_reason_when_no_warning_fired(tmp_path):
+    """The refusal must never be a bare verdict word.
+
+    A workload ratio between 0.33 and 0.5 drops confidence under the gate
+    without tripping the 3x warning threshold, so ``warnings`` is empty and the
+    score against the gate is the only reason available.
+    """
+    from nsys_ai.diff_render import format_diff_terminal, incomparable_reason, is_incomparable
+
+    before, after = _incomparable_pair(tmp_path, before_n=12, after_n=5)
+    summary = _diff_summary(before, after, gpu=0, limit=10)
+    assert summary.warnings == [], summary.warnings
+    assert is_incomparable(summary)
+
+    reason = incomparable_reason(summary)
+    assert reason.strip()
+    assert "0.41" in reason and "0.50" in reason
+
+    out = format_diff_terminal(summary)
+    assert "No comparison was made" in out
+    assert reason in out
+
+
+def test_diff_terminal_multi_withholds_per_gpu_tables_when_incomparable(tmp_path):
+    """Per-GPU tables are the same deltas sliced by device; they must not survive."""
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles_all_gpus
+    from nsys_ai.diff_render import format_diff_terminal_multi
+
+    before, after = _incomparable_pair(tmp_path)
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        global_summary, per_gpu = diff_profiles_all_gpus(b, a, limit=10)
+    assert global_summary.comparability_confidence < 0.5
+
+    out = format_diff_terminal_multi(global_summary, per_gpu)
+    assert "No comparison was made" in out
+    assert "Per-GPU Overview" not in out, out
+    assert "Top regressions" not in out, out
+
+
+def _mixed_comparability_pair(tmp_path):
+    """A node whose GPU 0 slice is sound and whose GPU 1 slice is not.
+
+    Comparability is derived per slice from min/max kernel rows, so GPU 0 at
+    100 vs 100 clears the gate while GPU 1 at 3 vs 40 lands at 0.075. The
+    node-wide score stays above the gate, which is the case that matters: the
+    global refusal never fires, so nothing else stops GPU 1's deltas.
+    """
+    before = tmp_path / "mixed_before.sqlite"
+    after = tmp_path / "mixed_after.sqlite"
+
+    def _k(dev, n, base):
+        return [
+            (base + i * 10_000_000, base + i * 10_000_000 + 5_000_000, dev, 7, i, 1, 2)
+            for i in range(n)
+        ]
+
+    _make_profile(str(before), kernels=_k(0, 100, 0) + _k(1, 3, 0))
+    _make_profile(str(after), kernels=_k(0, 100, 0) + _k(1, 40, 0))
+    return before, after
+
+
+def test_diff_terminal_multi_withholds_only_the_devices_that_cannot_be_compared(tmp_path):
+    """A node-wide pass must not carry an incomparable device's deltas with it.
+
+    The global guard is not enough: a rank that dropped out, or one whose
+    kernel set barely overlaps, scores below the gate on its own while the node
+    total clears it. Its per-device rows are then the same arithmetic the
+    refusal exists to withhold.
+    """
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles_all_gpus
+    from nsys_ai.diff_render import format_diff_terminal_multi, is_incomparable
+
+    before, after = _mixed_comparability_pair(tmp_path)
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        global_summary, per_gpu = diff_profiles_all_gpus(b, a, limit=10)
+
+    assert not is_incomparable(global_summary), global_summary.comparability_confidence
+    assert not is_incomparable(per_gpu[0]), per_gpu[0].comparability_confidence
+    assert is_incomparable(per_gpu[1]), per_gpu[1].comparability_confidence
+
+    out = format_diff_terminal_multi(global_summary, per_gpu)
+    assert "Per-GPU Overview" in out, out
+    overview = out.split("Per-GPU Overview", 1)[1].split("\n\n", 1)[0]
+    assert "\n  0 |" in overview, overview
+    assert "\n  1 |" not in overview, overview
+    assert "Top regressions (GPU 1)" not in out, out
+    # Named, not silently dropped -- the device exists and its numbers are in JSON.
+    assert "GPU 1 (0.07)" in out, out
+
+
+def test_diff_markdown_multi_withholds_only_the_devices_that_cannot_be_compared(tmp_path):
+    """The markdown renderer is the one multi-GPU path with no refusal test."""
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles_all_gpus
+    from nsys_ai.diff_render import format_diff_markdown_multi
+
+    before, after = _mixed_comparability_pair(tmp_path)
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        global_summary, per_gpu = diff_profiles_all_gpus(b, a, limit=10)
+
+    out = format_diff_markdown_multi(global_summary, per_gpu)
+    assert "| `0` |" in out, out
+    assert "| `1` |" not in out, out
+    assert "#### GPU 1" not in out, out
+    assert "GPU 1 (0.07)" in out, out
+
+
+def test_diff_markdown_multi_refuses_an_incomparable_pair(tmp_path):
+    """The whole-node refusal, on the renderer the other tests did not cover."""
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles_all_gpus
+    from nsys_ai.diff_render import format_diff_markdown_multi
+
+    before, after = _incomparable_pair(tmp_path)
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        global_summary, per_gpu = diff_profiles_all_gpus(b, a, limit=10)
+
+    out = format_diff_markdown_multi(global_summary, per_gpu)
+    assert "No comparison was made" in out
+    assert "Per-GPU Breakdown" not in out, out
+    assert "Per-GPU Top Regressions" not in out, out
+
+
+def test_comparability_display_never_reads_one_hundredth_low():
+    """Truncation must not inherit the multiply's binary error.
+
+    math.floor(0.29 * 100) is 28, because 0.29 * 100 is 28.999999999999996.
+    Three of the hundred two-decimal values were displayed a hundredth below
+    the score the gate actually used.
+    """
+    from decimal import Decimal
+
+    from nsys_ai.diff_render import _fmt_confidence
+
+    for hundredths in range(101):
+        exact = Decimal(hundredths) / 100
+        assert _fmt_confidence(float(exact)) == f"{exact:.2f}", hundredths
+
+
+def test_no_model_is_asked_to_narrate_a_pair_that_cannot_be_compared(tmp_path):
+    """The refusal discards the narrative, so requesting one is billed for nothing.
+
+    An empty side was already refused here for the stronger reason that the
+    model would narrate vanished kernels as a win. Low comparability is the
+    same condition one step weaker.
+    """
+    from nsys_ai import chat_config
+    from nsys_ai.ai import diff_narrative as narrative_mod
+
+    before, after = _incomparable_pair(tmp_path)
+    summary = _diff_summary(before, after, gpu=0, limit=10)
+    assert summary.comparability_confidence < 0.5
+
+    asked = []
+
+    # generate_diff_narrative resolves the model lazily from chat_config, so
+    # this is the last gate before any provider call. Reaching it at all is the
+    # failure.
+    def _refuse_to_be_asked(*args, **kwargs):
+        asked.append(args)
+        raise AssertionError("an incomparable pair must not reach the provider")
+
+    original = chat_config._get_model_and_key
+    chat_config._get_model_and_key = _refuse_to_be_asked
+    try:
+        result = narrative_mod.generate_diff_narrative(summary)
+    finally:
+        chat_config._get_model_and_key = original
+
+    assert not asked
+    assert result.ai_narrative is None
+    assert result.executive_summary
+
+
+def test_executive_summary_never_signs_a_magnitude_after_a_direction_word(tmp_path):
+    """"went faster by -46.37ms" is a double negative that inverts the claim."""
+    import re
+
+    from nsys_ai.ai.diff_narrative import build_executive_summary
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 20_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    faster = build_executive_summary(_diff_summary(before, after, gpu=0, limit=10))
+    assert "went faster by 10.00ms" in faster, faster
+    assert not re.search(r"went (faster|slower) by -", faster), faster
+
+    slower = build_executive_summary(_diff_summary(after, before, gpu=0, limit=10))
+    assert "went slower by 10.00ms" in slower, slower
+    assert not re.search(r"went (faster|slower) by -", slower), slower
+
+
+def test_executive_summary_says_unchanged_rather_than_slower_by_zero(tmp_path):
+    from nsys_ai.ai.diff_narrative import build_executive_summary
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    text = build_executive_summary(_diff_summary(before, after, gpu=0, limit=10))
+    assert "Total GPU time was unchanged." in text, text
+    assert "slower" not in text and "faster" not in text, text


### PR DESCRIPTION
## Summary

- The verdict and the comparability score were computed, written to `diff.json` and used to gate CI, but never printed. A reader saw only the deltas, so a `neutral` verdict at comparability 0.89 arrived looking like a result, and a pair scoring 0.00 still produced per-kernel regression and improvement tables that read as findings.
- Both numbers now head the terminal and markdown reports. Under the comparability minimum the renderers say no comparison was made, give the score against the minimum and any sanity warnings as the reason, and withhold the delta tables rather than caption them.
- The headline no longer negates itself: `went faster by -46.37ms` now reads `went faster by 46.37ms`.

## Changes

- `src/nsys_ai/diff_render.py` — verdict and comparability header; the low-comparability branch, which also withholds the per-GPU overview and per-GPU tables in the all-GPU renderers (the same deltas sliced by device). A **node-wide** score can clear the gate while one device's slice does not — a rank that dropped out, or one whose kernel set barely overlaps — so the two multi-GPU renderers now split comparable devices from withheld ones per device, and name what was withheld with its own score rather than dropping it silently. Comparability is truncated for display via `Decimal`, so a value below the minimum can never render as though it had reached it; `math.floor(x * 100)` could not do that job, because `0.29 * 100` is `28.999999999999996` and three of the hundred two-decimal values displayed a hundredth low.
- `src/nsys_ai/ai/diff_narrative.py` — the direction word carries the sign, the magnitude is unsigned, and a zero delta says the time was unchanged. An incomparable pair no longer reaches the provider at all: the refusal discards the narrative, so the call was billed and shown to nobody. An empty side was already refused here for the stronger reason that the model would narrate vanished kernels as a win.
- `src/nsys_ai/cli/handlers.py` — the `--exit-on-regression` messages render comparability the same way the report does. They used `:.3f`, which rounds, so a score of 0.4996 printed as `comparability_confidence=0.500` on the same line as `(minimum 0.50)` while refusing it.
- `tests/test_diff.py` — header present in both formats; tables withheld under the minimum; per-device withholding on both multi-GPU renderers; the whole-node refusal on `format_diff_markdown_multi`, which had no test; the reason names the score and the minimum; the display is exact across all 101 two-decimal values; no provider call on an incomparable pair; headline sign cases.

## Backward compatibility

Yes for consumers, no for anyone diffing terminal output. The JSON payload is unchanged — both fields were always there. `review` and `diff --no-ai` share these renderers and stay byte-identical to each other (verified with `cmp`: 132 lines, identical).

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2144 passed, 140 skipped, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean
- [x] Manually exercised: healthy pair prints `Verdict: neutral  (comparability 0.89)`; an incomparable pair leads with `No comparison was made` then `Comparability scored 0.00, under the 0.50 minimum`, and prints no delta tables

## Out of scope

- The inputs that *should* score low and currently do not — that is #402, which builds on this branch.
- `diff_web.py`, the HTML compare UI. It builds the same regression and improvement tables from a payload carrying both fields and reads neither — the fourth renderer of these deltas, and now the only one that shows an incomparable pair as a result. Its own change.

## Linked issues

Closes #399
