### PR TITLE
fix(diff): refuse a comparison the two captures cannot support

### DIFF
--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -121,7 +121,14 @@ def _register_profile_parser(sub):
     p.add_argument("--warmup-steps", type=_nonnegative_int, default=0)
     p.add_argument("--profile-steps", type=_positive_int, default=1)
     p.add_argument("--seed", type=_nonnegative_int, default=None)
-    p.add_argument("--expected-gpu-count", type=_positive_int, default=None)
+    p.add_argument(
+        "--expected-gpu-count",
+        type=_positive_int,
+        default=None,
+        help="Number of GPUs this capture is expected to record kernels on. The capture "
+        "fails validation if it records a different number, so declare the local "
+        "topology, not the job's",
+    )
     p.add_argument("--expected-rank-count", type=_positive_int, default=None)
     p.add_argument("--timeout", type=_positive_int, default=None, metavar="SECONDS")
     p.add_argument(

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -13,7 +13,7 @@ import logging
 from dataclasses import dataclass, field, replace
 
 from .annotation import TraceSelection
-from .fingerprint import get_profile_id
+from .fingerprint import get_profile_id, profile_id_is_capture_derived
 from .overlap import classify_kernel, launch_overhead_ms, overlap_analysis
 from .profile import Profile
 
@@ -22,6 +22,32 @@ _log = logging.getLogger(__name__)
 STEP_TIME_REGRESSION_PCT = 5.0
 MIN_COMPARABILITY_CONFIDENCE = 0.5
 DIFF_ID_VERSION = "diff1"
+
+#: Absolute step-time delta, in percent, below which the verdict is ``neutral``
+#: however tight a threshold the caller asks for.
+#:
+#: Two captures of an *unchanged* workload do not measure the same step time.
+#: Clock and power state, memory placement, and host scheduling move it by
+#: roughly a percent between runs, and one capture per side gives nothing to
+#: separate that from a real change: the pipeline sees a single number per
+#: side and no spread. Reporting "regression_likely" from a delta inside that
+#: band is a coin flip dressed as a measurement.
+#:
+#: 2.0 is a stated floor, not a measured one, and is deliberately crude. The
+#: honest version is a declared repeat count with a confidence interval over
+#: the per-run deltas, which needs k runs this pipeline does not yet take. It
+#: sits below the default 5% regression threshold, so it changes no verdict
+#: until a caller asks for a gate tighter than the noise.
+NOISE_FLOOR_STEP_TIME_PCT = 2.0
+
+#: Share of GPU time a device must account for before its presence on only one
+#: side is treated as changing what a node-wide total measures. Below this the
+#: topology difference is real but immaterial: an NCCL or cuDNN bootstrap that
+#: touches a second device for microseconds would otherwise refuse an
+#: otherwise-perfect diff, and a CI gate would fail on it. 1% is the point
+#: where a device's contribution starts to move a total by more than the
+#: run-to-run jitter the noise floor above already declines to judge.
+DEVICE_SHARE_MATERIAL_PCT = 1.0
 
 
 @dataclass(frozen=True)
@@ -60,6 +86,26 @@ class ProfileSummary:
     overlap: dict
     profile_id: str = ""
     product_version: str | None = None
+    #: Device ids that actually recorded kernels, ascending. This is the
+    #: capture's observed topology, and it is what makes "the after run lost a
+    #: GPU" visible: `gpu`/`kernel_rows` describe the *selected* scope, so a
+    #: node-wide diff whose two sides ran on different devices leaves no other
+    #: trace. Defaulted so payloads built without it stay constructible; an
+    #: empty tuple means the capture recorded no kernels on any device, which
+    #: `empty_kernel_sides` already refuses on; every check below treats it as
+    #: unknown rather than as a difference, so the two do not double up.
+    devices: tuple[int, ...] = ()
+    #: Whether ``profile_id`` was built from metadata that identifies a run.
+    #: An export carrying no ``TARGET_INFO_*`` / ``ANALYSIS_*`` tables still
+    #: gets a well-formed id, from the kernel row count alone — so equal ids
+    #: mean equal row counts, not the same capture. Defaulted False: a summary
+    #: that never asked has not earned an identity claim.
+    profile_id_is_capture_derived: bool = False
+    #: deviceId -> summed kernel ns, for the devices in ``devices``. Lets a
+    #: topology difference be weighed rather than only detected: a device that
+    #: recorded one microsecond is not the same finding as a rank that dropped
+    #: out. Empty means "not recorded", like ``devices``.
+    device_kernel_ns: dict[int, int] = field(default_factory=dict)
 
 
 @dataclass(frozen=True)
@@ -259,6 +305,7 @@ def build_profile_summary(
             overlap[k] = round(overlap[k], 2)
 
     pid = get_profile_id(prof.conn, fallback_path=prof.path)
+    pid_is_capture_derived = profile_id_is_capture_derived(prof.conn)
 
     return ProfileSummary(
         path=prof.path,
@@ -271,6 +318,9 @@ def build_profile_summary(
         nvtx=nvtx,
         overlap=overlap,
         profile_id=pid,
+        profile_id_is_capture_derived=pid_is_capture_derived,
+        devices=tuple(sorted(prof.meta.devices or ())),
+        device_kernel_ns=dict(prof.meta.device_kernel_ns or {}),
     )
 
 
@@ -286,6 +336,160 @@ def empty_side_subject(empty_sides: list[str]) -> str:
     return f"The {empty_sides[0]} profile contains"
 
 
+def same_capture(before: ProfileSummary, after: ProfileSummary) -> bool:
+    """True when both sides are the same capture, so every delta is self-noise.
+
+    One path pointing at one file is the plain case, and the one a user reaches
+    by rerunning ``diff`` with the same argument twice.
+
+    ``profile_id`` covers the rest: it is content-derived, so equal ids mean
+    the same capture even when the bytes moved — a re-export, a copy under
+    another name, a VACUUM. That is one string comparison, and it settles the
+    question without reading a kernel row.
+
+    Equal ids are not on their own enough to act on. The id degrades when a
+    profile carries no capture metadata — a hand-built fixture, a parquet-only
+    export — leaving the kernel row count as its only contribution, so two
+    unrelated captures with the same number of kernels hash the same. A real
+    The id must also have been built from capture metadata -- see
+    ``profile_id_is_capture_derived``. Every contribution to the id degrades
+    independently, so an export with none of the ``TARGET_INFO_*`` /
+    ``ANALYSIS_*`` tables still gets a well-formed id, from its kernel row
+    count alone, and two unrelated captures of the same size would share it.
+    The two totals are then required to agree as well, which costs nothing
+    because both summaries are already built.
+
+    The caller must also establish that the two sides were read through the
+    same time window: iteration 3 against iteration 40 of one capture is a real
+    comparison, and those two sides share a path and an id.
+    """
+    if before.path and before.path == after.path:
+        return True
+    if not before.profile_id or before.profile_id != after.profile_id:
+        return False
+    # The id has to have come from capture metadata. Schema version was the
+    # wrong proxy: it is read from META_DATA_EXPORT, a different table from the
+    # TARGET_INFO_* / ANALYSIS_* ones the id hashes, so a profile can carry a
+    # schema version while its id has degraded to a hash of its kernel row
+    # count -- and two unrelated captures of the same size then share an id.
+    if not (before.profile_id_is_capture_derived and after.profile_id_is_capture_derived):
+        return False
+    return before.kernel_rows == after.kernel_rows and before.total_gpu_ns == after.total_gpu_ns
+
+
+def same_capture_note() -> str:
+    """The sentence said when both sides are the same capture."""
+    return (
+        "Before and after are the same capture (identical profile id): both sides are the "
+        "same measurement, reached through the same path or through a copy of it, so every "
+        "delta below is self-noise rather than a change between two runs."
+    )
+
+
+def _unshared_device_share_pct(
+    before: ProfileSummary, after: ProfileSummary
+) -> float | None:
+    """GPU time held by devices present on one side only, as a percentage.
+
+    None when either side did not record per-device time, in which case the
+    magnitude is unknown and the caller must not act on it.
+    """
+    b_ns, a_ns = before.device_kernel_ns, after.device_kernel_ns
+    if not b_ns or not a_ns:
+        return None
+    shared = set(before.devices) & set(after.devices)
+    total = sum(b_ns.values()) + sum(a_ns.values())
+    if total <= 0:
+        return None
+    unshared = sum(ns for dev, ns in b_ns.items() if dev not in shared) + sum(
+        ns for dev, ns in a_ns.items() if dev not in shared
+    )
+    return 100.0 * unshared / total
+
+
+def _device_list(devices: tuple[int, ...]) -> str:
+    return "[" + ", ".join(str(d) for d in devices) + "]" if devices else "none"
+
+
+def _device_warnings(before: ProfileSummary, after: ProfileSummary) -> tuple[list[str], float]:
+    """Warn when the two captures did not observe the same GPUs.
+
+    A side that never recorded a device the other one did is the per-device
+    form of an empty capture: the kernels that device ran are missing from one
+    total, so the delta measures the gap in the capture and reads as a change
+    in the workload.
+
+    An empty ``devices`` tuple means the topology was not recorded, not that
+    the capture had no GPUs, so nothing is claimed from it.
+    """
+    warnings: list[str] = []
+    b_devs, a_devs = before.devices, after.devices
+    if not b_devs or not a_devs:
+        return warnings, 1.0
+
+    # Scoped to one device with `--gpu N`: the question is whether that device
+    # exists on both sides, not whether the two topologies match.
+    if before.gpu is not None and before.gpu == after.gpu:
+        dev = before.gpu
+        missing = [
+            label
+            for label, side in (("before", b_devs), ("after", a_devs))
+            if dev not in side
+        ]
+        if len(missing) == 2:
+            warnings.append(
+                f"GPU {dev} recorded no kernels in either profile (before recorded GPUs "
+                f"{_device_list(b_devs)}, after {_device_list(a_devs)}); the selection is "
+                "empty on both sides, so there is nothing to compare and no before/after "
+                "claim can be made."
+            )
+            return warnings, 0.0
+        if missing:
+            present = "after" if missing[0] == "before" else "before"
+            warnings.append(
+                f"GPU {dev} recorded kernels in the {present} profile but none in the "
+                f"{missing[0]} profile (before recorded GPUs {_device_list(b_devs)}, after "
+                f"{_device_list(a_devs)}); the delta on GPU {dev} is that missing capture, "
+                "not a change in the workload."
+            )
+            return warnings, 0.0
+        return warnings, 1.0
+
+    # Node-wide (no `--gpu`): every device on both sides lands in one total, so
+    # a difference in the device set silently changes what the total measures.
+    if before.gpu is None and after.gpu is None and b_devs != a_devs:
+        if len(b_devs) != len(a_devs):
+            share_pct = _unshared_device_share_pct(before, after)
+            if share_pct is not None and share_pct < DEVICE_SHARE_MATERIAL_PCT:
+                # Present on one side only, but holding almost none of the
+                # time: say so and keep comparing, rather than refuse a pair
+                # whose totals are the same measurement to four decimal places.
+                warnings.append(
+                    f"GPU count differs: the before profile recorded {len(b_devs)} device(s) "
+                    f"{_device_list(b_devs)}, the after profile {len(a_devs)} "
+                    f"{_device_list(a_devs)}. The devices on one side only hold "
+                    f"{share_pct:.3f}% of GPU time, under the "
+                    f"{DEVICE_SHARE_MATERIAL_PCT:.0f}% that would move the totals, so the "
+                    "comparison stands on the devices both sides share."
+                )
+                return warnings, 1.0
+            warnings.append(
+                f"GPU count differs: the before profile recorded {len(b_devs)} device(s) "
+                f"{_device_list(b_devs)}, the after profile {len(a_devs)} "
+                f"{_device_list(a_devs)}. Totals measured over different amounts of "
+                "hardware are not a before and an after — the difference is the missing "
+                "or extra devices."
+            )
+            return warnings, 0.0
+        warnings.append(
+            f"The two captures recorded different GPU ids (before {_device_list(b_devs)}, "
+            f"after {_device_list(a_devs)}) with the same device count; node-wide totals "
+            "still compare, but per-device deltas only mean anything for devices present "
+            "on both sides."
+        )
+    return warnings, 1.0
+
+
 def collect_sanity_warnings(
     before: ProfileSummary, after: ProfileSummary
 ) -> tuple[list[str], float]:
@@ -298,6 +502,13 @@ def collect_sanity_warnings(
     c_kernel_overlap = 1.0
     c_overlap = 1.0
 
+    # Devices first: when a requested GPU is missing from a side, the empty
+    # aggregation below is a consequence, and saying "the after profile
+    # contains no GPU kernel activity" about a profile that simply never ran on
+    # that device sends the reader to check the wrong thing.
+    device_warnings, c_devices = _device_warnings(before, after)
+    warnings.extend(device_warnings)
+
     # A side that recorded nothing is the signature of a failed capture: the
     # workload crashed, the trace was truncated, nsys was misconfigured, or the
     # wrong artifact was uploaded. Every ratio below is guarded against a zero
@@ -306,6 +517,14 @@ def collect_sanity_warnings(
     # it comparability zero — the same condition `nsys-ai profile` refuses to
     # publish with "local profile contains no GPU kernel activity".
     empty_sides = empty_kernel_sides(before, after)
+    # ...unless the device check already explained it. With `--gpu 5` on two
+    # profiles that both ran, the selected scope is empty on both sides, and
+    # "the profile contains no GPU kernel activity" is false about the profile
+    # and sends the reader to check whether the run executed. The device
+    # warning above names the actual cause; one cause, one sentence.
+    if empty_sides and c_devices == 0.0 and device_warnings:
+        empty_sides = []
+        c_empty = 0.0
     if empty_sides:
         warnings.append(
             f"{empty_side_subject(empty_sides)} no GPU kernel activity; there is nothing "
@@ -366,7 +585,11 @@ def collect_sanity_warnings(
         c_overlap = 0.0
 
     confidence = max(
-        0.0, min(1.0, c_schema * c_gpu * c_empty * c_workload * c_kernel_overlap * c_overlap)
+        0.0,
+        min(
+            1.0,
+            c_schema * c_gpu * c_empty * c_workload * c_kernel_overlap * c_overlap * c_devices,
+        ),
     )
     # Return unrounded — compute_verdict reads this and the 0.5 gate must
     # not be crossed by rounding artifacts (e.g. 0.4996 -> 0.5).
@@ -433,9 +656,25 @@ def compute_verdict(
     step_time_delta_pct: float | None,
     confidence: float,
     regression_pct: float = STEP_TIME_REGRESSION_PCT,
+    *,
+    is_same_capture: bool = False,
 ) -> str:
+    """Judge the pair: regression, improvement, neutral, or cannot judge.
+
+    Order matters. Comparability is asked first, because a pair that cannot be
+    compared has no verdict to reach — including a capture compared with
+    itself, where an empty or unreadable capture is still unreadable. Identity
+    comes next: the two sides being one measurement is an answer ("nothing
+    changed, because nothing was rerun"), not an abstention. The noise floor
+    comes last, over the thresholds, because it constrains what any threshold
+    is allowed to conclude.
+    """
     if confidence < MIN_COMPARABILITY_CONFIDENCE or step_time_delta_pct is None:
         return "inconclusive"
+    if is_same_capture:
+        return "neutral"
+    if abs(step_time_delta_pct) < NOISE_FLOOR_STEP_TIME_PCT:
+        return "neutral"
     if step_time_delta_pct >= regression_pct:
         return "regression_likely"
     if step_time_delta_pct <= -regression_pct:
@@ -918,6 +1157,15 @@ def diff_profiles(
     before = build_profile_summary(before_prof, gpu, t_before, nvtx_limit=nvtx_limit)
     after = build_profile_summary(after_prof, gpu, t_after, nvtx_limit=nvtx_limit)
     warnings, comparability_confidence = collect_sanity_warnings(before, after)
+    # Same capture on both sides, read through the same window. The trim check
+    # is what keeps an iteration diff — window A of a capture against window B
+    # of that same capture — a real comparison; only the identical window makes
+    # the two sides one measurement. Kept here rather than in
+    # collect_sanity_warnings because the windows are a property of this call,
+    # not of the two summaries.
+    is_same_capture = t_before == t_after and same_capture(before, after)
+    if is_same_capture:
+        warnings.append(same_capture_note())
 
     before_by_key = {k.key: k for k in before.kernels}
     after_by_key = {k.key: k for k in after.kernels}
@@ -1066,8 +1314,28 @@ def diff_profiles(
         if step_time_before_ms > 0:
             step_time_delta_pct = round(delta / step_time_before_ms * 100.0, 2)
     verdict = compute_verdict(
-        step_time_delta_pct, comparability_confidence, regression_pct=regression_pct
+        step_time_delta_pct,
+        comparability_confidence,
+        regression_pct=regression_pct,
+        is_same_capture=is_same_capture,
     )
+    # A caller who asked for a gate tighter than the noise floor gets neutral
+    # where their threshold alone would have called a regression. Say why, or
+    # the verdict looks like it ignored the number printed beside it.
+    if (
+        verdict == "neutral"
+        and not is_same_capture
+        and step_time_delta_pct is not None
+        and regression_pct < NOISE_FLOOR_STEP_TIME_PCT
+        and abs(step_time_delta_pct) >= regression_pct
+    ):
+        warnings.append(
+            f"Step time moved {step_time_delta_pct:+.2f}%, past the {regression_pct:.2f}% "
+            f"threshold asked for but inside the {NOISE_FLOOR_STEP_TIME_PCT:.2f}% "
+            "run-to-run noise floor that one capture per side cannot see through; "
+            "reported as neutral. Repeat the pair of runs to tell a change this small "
+            "from jitter."
+        )
     communication_summary = build_communication_summary(
         before_prof,
         after_prof,

--- a/src/nsys_ai/fingerprint.py
+++ b/src/nsys_ai/fingerprint.py
@@ -268,78 +268,24 @@ PROFILE_ID_VERSION = "nsys2"
 contributing columns or the canonical serialisation change."""
 
 
-def get_profile_id(
-    conn: typing.Any, *, fallback_path: str | os.PathLike[str] | None = None
-) -> str:
-    """Return a stable content-derived id for a Nsight Systems profile.
+def _part_is_empty(value: typing.Any) -> bool:
+    """A contribution that carried nothing, in any of the shapes it can take."""
+    return value is None or value == "" or value == [] or value == 0
 
-    The hash spans only fields stamped at *profile-capture* time, so it
-    survives ``.nsys-rep`` → ``.sqlite`` re-export, ``VACUUM``,
-    ``journal_mode`` changes, and filesystem moves:
 
-      - ``TARGET_INFO_SESSION_START_TIME.utcEpochNs``
-      - ``ANALYSIS_DETAILS`` rows (``duration / startTime / stopTime``)
-      - ``TARGET_INFO_GPU`` rows (``id``, ``name``)
-      - ``TARGET_INFO_GPU.uuid`` values when the column exists
-        (newer Nsight); older exports keep ``uuid`` on
-        ``TARGET_INFO_CUDA_DEVICE`` and that contribution degrades to
-        empty rather than failing
-      - distinct ``ANALYSIS_FILE.globalPid`` values
-      - resolved ``CUPTI_ACTIVITY_KIND_KERNEL[_Vn]`` row count
+#: The one contribution that is not capture metadata. An id resting on this
+#: alone identifies a row count, not a run.
+_NON_CAPTURE_ID_PART = "kernel_count"
 
-    Each contribution is JSON-encoded as a ``(label, value)`` pair before
-    hashing, so values containing ``|`` / ``;`` / ``\\n`` can never collide
-    with neighbouring values via separator ambiguity.
 
-    Format::
+def _profile_id_parts(conn: typing.Any) -> list[tuple[str, typing.Any]]:
+    """The ``(label, value)`` contributions the profile id hashes.
 
-        nsys2:sha256:<64-hex>   # preferred — content-derived
-        nsys2:path:<64-hex>     # fallback — when no Nsight metadata is reachable
-
-    The fallback fires for backends that expose only the parquet cache
-    (``backend='parquetdir'``) where META_DATA / TARGET_INFO tables were
-    never materialised. Callers should pass ``self.prof.conn`` (the
-    SQLite source where available); the function never reads
-    ``self.prof.db`` semantics — it just runs SQL.
-
-    ``fallback_path`` is hashed verbatim — pass an absolute path if you
-    want it to compare equal across working-directory changes.
-
-    .. note::
-       When *both* ``conn`` is None / empty and ``fallback_path`` is
-       None, the function returns ``nsys2:sha256:<sha256 of empty>``.
-       That is a recognisable null-id sentinel: every such caller
-       collapses to the same value. Always pass ``fallback_path`` if
-       cross-call distinguishability matters.
-
-    .. note::
-       ``NULLS LAST`` requires SQLite ≥ 3.30 (2019-10-04) and is native
-       in DuckDB. Older SQLite raises ``OperationalError`` on the
-       ``ORDER BY ... NULLS LAST`` clause; the offending contribution
-       is caught and degraded to empty rather than crashing.
+    Shared with :func:`profile_id_is_capture_derived` so that the id and any
+    question asked about the id read the same contributions rather than two
+    copies of the same SQL. Each contribution degrades to empty rather than
+    raising: an export missing a table loses that contribution, not the id.
     """
-    # Coerce ``fallback_path`` once: callers often pass ``pathlib.Path``
-    # (e.g. via ``Profile(Path(...))`` → ``Profile.path``). Both fallback
-    # branches below would otherwise crash with AttributeError on
-    # ``.encode("utf-8")``.
-    fallback_str = os.fspath(fallback_path) if fallback_path is not None else None
-
-    def _path_id(p: str) -> str:
-        digest = hashlib.sha256(p.encode("utf-8")).hexdigest()
-        return f"{PROFILE_ID_VERSION}:path:{digest}"
-
-    def _null_id() -> str:
-        """The shared null-id sentinel — same value whether ``conn`` is
-        None or merely empty, so consumers can detect "no usable
-        identity" with a single equality check."""
-        return f"{PROFILE_ID_VERSION}:sha256:{hashlib.sha256(b'').hexdigest()}"
-
-    # None-safe shortcut: wrap_connection(None) returns a SQLiteAdapter
-    # over None, whose .execute() raises AttributeError (not a DB error),
-    # so the loop's try/except wouldn't catch it. Skip the queries.
-    if conn is None:
-        return _path_id(fallback_str) if fallback_str else _null_id()
-
     adapter = wrap_connection(conn)
 
     def _scalar(sql: str) -> typing.Any:
@@ -435,10 +381,105 @@ def get_profile_id(
     # metadata (e.g. parquetdir backend). Fall back to a clearly-labelled
     # path-derived id rather than collapse every such profile to the
     # same constant hash.
-    def _empty(v: typing.Any) -> bool:
-        return v is None or v == "" or v == [] or v == 0
+    return parts
 
-    if all(_empty(v) for _, v in parts):
+
+def profile_id_is_capture_derived(conn: typing.Any) -> bool:
+    """True when the profile id was built from metadata identifying a run.
+
+    Every contribution degrades independently, so an export carrying none of
+    the ``TARGET_INFO_*`` / ``ANALYSIS_*`` tables still produces a well-formed
+    id — from the kernel row count alone. Equal ids then mean equal row counts,
+    which is not identity, and any caller acting on "these are the same
+    capture" has to ask this first.
+
+    Schema version is not a substitute: it comes from ``META_DATA_EXPORT``, a
+    different table, which can be present while every id contribution is not.
+    """
+    if conn is None:
+        return False
+    return any(
+        not _part_is_empty(value)
+        for label, value in _profile_id_parts(conn)
+        if label != _NON_CAPTURE_ID_PART
+    )
+
+
+def get_profile_id(
+    conn: typing.Any, *, fallback_path: str | os.PathLike[str] | None = None
+) -> str:
+    """Return a stable content-derived id for a Nsight Systems profile.
+
+    The hash spans only fields stamped at *profile-capture* time, so it
+    survives ``.nsys-rep`` → ``.sqlite`` re-export, ``VACUUM``,
+    ``journal_mode`` changes, and filesystem moves:
+
+      - ``TARGET_INFO_SESSION_START_TIME.utcEpochNs``
+      - ``ANALYSIS_DETAILS`` rows (``duration / startTime / stopTime``)
+      - ``TARGET_INFO_GPU`` rows (``id``, ``name``)
+      - ``TARGET_INFO_GPU.uuid`` values when the column exists
+        (newer Nsight); older exports keep ``uuid`` on
+        ``TARGET_INFO_CUDA_DEVICE`` and that contribution degrades to
+        empty rather than failing
+      - distinct ``ANALYSIS_FILE.globalPid`` values
+      - resolved ``CUPTI_ACTIVITY_KIND_KERNEL[_Vn]`` row count
+
+    Each contribution is JSON-encoded as a ``(label, value)`` pair before
+    hashing, so values containing ``|`` / ``;`` / ``\\n`` can never collide
+    with neighbouring values via separator ambiguity.
+
+    Format::
+
+        nsys2:sha256:<64-hex>   # preferred — content-derived
+        nsys2:path:<64-hex>     # fallback — when no Nsight metadata is reachable
+
+    The fallback fires for backends that expose only the parquet cache
+    (``backend='parquetdir'``) where META_DATA / TARGET_INFO tables were
+    never materialised. Callers should pass ``self.prof.conn`` (the
+    SQLite source where available); the function never reads
+    ``self.prof.db`` semantics — it just runs SQL.
+
+    ``fallback_path`` is hashed verbatim — pass an absolute path if you
+    want it to compare equal across working-directory changes.
+
+    .. note::
+       When *both* ``conn`` is None / empty and ``fallback_path`` is
+       None, the function returns ``nsys2:sha256:<sha256 of empty>``.
+       That is a recognisable null-id sentinel: every such caller
+       collapses to the same value. Always pass ``fallback_path`` if
+       cross-call distinguishability matters.
+
+    .. note::
+       ``NULLS LAST`` requires SQLite ≥ 3.30 (2019-10-04) and is native
+       in DuckDB. Older SQLite raises ``OperationalError`` on the
+       ``ORDER BY ... NULLS LAST`` clause; the offending contribution
+       is caught and degraded to empty rather than crashing.
+    """
+    # Coerce ``fallback_path`` once: callers often pass ``pathlib.Path``
+    # (e.g. via ``Profile(Path(...))`` → ``Profile.path``). Both fallback
+    # branches below would otherwise crash with AttributeError on
+    # ``.encode("utf-8")``.
+    fallback_str = os.fspath(fallback_path) if fallback_path is not None else None
+
+    def _path_id(p: str) -> str:
+        digest = hashlib.sha256(p.encode("utf-8")).hexdigest()
+        return f"{PROFILE_ID_VERSION}:path:{digest}"
+
+    def _null_id() -> str:
+        """The shared null-id sentinel — same value whether ``conn`` is
+        None or merely empty, so consumers can detect "no usable
+        identity" with a single equality check."""
+        return f"{PROFILE_ID_VERSION}:sha256:{hashlib.sha256(b'').hexdigest()}"
+
+    # None-safe shortcut: wrap_connection(None) returns a SQLiteAdapter
+    # over None, whose .execute() raises AttributeError (not a DB error),
+    # so the loop's try/except wouldn't catch it. Skip the queries.
+    if conn is None:
+        return _path_id(fallback_str) if fallback_str else _null_id()
+
+    parts = _profile_id_parts(conn)
+
+    if all(_part_is_empty(v) for _, v in parts):
         # Same shape as the ``conn is None`` branch above: path-fallback
         # if available, else the null-id sentinel. This keeps the
         # "no usable identity" check a single equality.

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -291,6 +291,10 @@ class ProfileMeta:
     nvtx_count: int
     tables: list[str]
     gpu_info: dict[int, GpuInfo] = field(default_factory=dict)  # deviceId -> GpuInfo
+    #: deviceId -> summed kernel duration in ns. Comes free from the pass that
+    #: already groups by device, and lets a caller ask how much of the capture
+    #: a device actually accounts for rather than only whether it appears.
+    device_kernel_ns: dict[int, int] = field(default_factory=dict)
 
 
 class Profile:
@@ -439,19 +443,22 @@ class Profile:
         devices: list[int] = []
         streams: dict[int, list[int]] = {}
         kcounts: dict[int, int] = {}
+        device_ns: dict[int, int] = {}
         kernel_count = 0
         min_start = None
         max_end = None
-        for dev, stream, mn, mx, cnt in self.adapter.execute(
-            f"SELECT deviceId, streamId, MIN(start), MAX([end]), COUNT(*) "
+        for dev, stream, mn, mx, cnt, dur in self.adapter.execute(
+            f"SELECT deviceId, streamId, MIN(start), MAX([end]), COUNT(*), SUM([end] - start) "
             f"FROM {kernel_table} GROUP BY deviceId, streamId ORDER BY deviceId, streamId"
         ).fetchall():
             if dev not in streams:
                 streams[dev] = []
                 kcounts[dev] = 0
+                device_ns[dev] = 0
                 devices.append(dev)
             streams[dev].append(stream)
             kcounts[dev] += cnt
+            device_ns[dev] += int(dur or 0)
             kernel_count += cnt
             if mn is not None:
                 min_start = mn if min_start is None else min(min_start, mn)
@@ -473,6 +480,7 @@ class Profile:
             nvtx_count=nc,
             tables=tables,
             gpu_info=self._gpu_info(devices, streams, tables, kcounts),
+            device_kernel_ns=device_ns,
         )
 
     def query_conn(self):

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -255,6 +255,57 @@ def build_local_profile_reference(
         raise ProfileError(str(exc)) from None
 
 
+def observed_gpu_count(path: str | os.PathLike[str]) -> int:
+    """Number of GPUs that recorded kernels in an exported profile.
+
+    Read from the kernel table's device ids, which is the only statement the
+    capture itself makes about how many GPUs the run used: a machine can expose
+    eight and a run can touch one.
+    """
+    connection = sqlite3.connect(os.fspath(path), check_same_thread=False)
+    try:
+        connection.execute("PRAGMA query_only = ON")
+        with Profile._from_conn(connection) as profile:
+            return len(profile.meta.devices or ())
+    finally:
+        connection.close()
+
+
+def check_expected_gpu_count(spec: RunSpec, sqlite_path: Path) -> str | None:
+    """Return why ``expected_gpu_count`` is unmet, or None when it holds.
+
+    ``expected_gpu_count`` was recorded into the RunSpec and never read, so a
+    single-GPU capture declared as eight was published with the declaration
+    intact and every consumer downstream — per-GPU scaling, MFU, the diff's
+    topology check — inherited a falsehood the artifact asserted about itself.
+    A declaration the capture contradicts fails the capture.
+
+    ``expected_rank_count`` stays unchecked here on purpose: a rank is a
+    process in a distributed job, one local capture watches one launch, and
+    counting processes in the export would answer a different question under
+    the same name.
+    """
+    expected = spec.expected_gpu_count
+    if expected is None:
+        return None
+    try:
+        observed = observed_gpu_count(sqlite_path)
+    except (NsysAiError, OSError, *DB_ERRORS) as exc:
+        # The declaration was asked for and cannot be checked, so it is not
+        # satisfied. Failing closed keeps "unverifiable" out of the success
+        # path, where it would be indistinguishable from "verified".
+        return (
+            f"declared expected_gpu_count={expected} could not be checked against the "
+            f"capture: {type(exc).__name__}"
+        )
+    if observed != expected:
+        return (
+            f"declared expected_gpu_count={expected} but the capture recorded kernels on "
+            f"{observed} GPU(s)"
+        )
+    return None
+
+
 @dataclass(frozen=True)
 class RunTimings:
     """Wall-clock durations for the stages completed by a run."""
@@ -542,6 +593,16 @@ class LocalProfileRunner:
                 report=report_path,
                 sqlite=sqlite_path,
                 detail=f"profile validation failed: {type(exc).__name__}",
+            )
+        gpu_count_detail = check_expected_gpu_count(spec, sqlite_path)
+        if gpu_count_detail is not None:
+            validation_seconds = time.monotonic() - validation_started
+            return result(
+                RunStatus.INVALID_PROFILE,
+                return_code=return_code,
+                report=report_path,
+                sqlite=sqlite_path,
+                detail=gpu_count_detail,
             )
         validation_seconds = time.monotonic() - validation_started
         return result(

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -3372,6 +3372,104 @@ def test_no_model_is_asked_to_narrate_a_pair_that_cannot_be_compared(tmp_path):
     assert not asked
     assert result.ai_narrative is None
     assert result.executive_summary
+def _kernels(dev, count, duration_ns, *, base_correlation=0):
+    return [
+        (i * 2_000_000, i * 2_000_000 + duration_ns, dev, 7, base_correlation + i, 1, 2)
+        for i in range(count)
+    ]
+
+
+def test_a_device_holding_almost_no_time_does_not_refuse_the_comparison(tmp_path):
+    """One microsecond on a second device is not a topology change.
+
+    An NCCL or cuDNN bootstrap can touch a device for microseconds. Refusing on
+    the device set alone turned that into comparability 0.00 and failed a CI
+    gate on a pair whose totals agree to four decimal places.
+    """
+    before = tmp_path / "boot_before.sqlite"
+    after = tmp_path / "boot_after.sqlite"
+    _make_profile(
+        str(before),
+        kernels=_kernels(0, 200, 1_000_000) + [(0, 1_000, 1, 7, 9_999, 1, 2)],
+    )
+    _make_profile(str(after), kernels=_kernels(0, 200, 1_000_000))
+
+    summary = _diff_summary(before, after, gpu=None, limit=10)
+    assert summary.comparability_confidence >= 0.5, summary.warnings
+    assert summary.verdict == "neutral", summary.verdict
+    # Still said, because it is still true -- just not fatal.
+    assert any("under the 1% that would move the totals" in w for w in summary.warnings), (
+        summary.warnings
+    )
+
+
+def test_a_rank_that_dropped_out_still_refuses_the_comparison(tmp_path):
+    """The immaterial-share exemption must not swallow the case it came from."""
+    before = tmp_path / "rank_before.sqlite"
+    after = tmp_path / "rank_after.sqlite"
+    _make_profile(
+        str(before),
+        kernels=_kernels(0, 200, 1_000_000) + _kernels(1, 200, 1_000_000, base_correlation=1000),
+    )
+    _make_profile(str(after), kernels=_kernels(0, 200, 1_000_000))
+
+    summary = _diff_summary(before, after, gpu=None, limit=10)
+    assert summary.comparability_confidence == 0.0, summary.warnings
+    assert summary.verdict == "inconclusive"
+    assert any("GPU count differs" in w for w in summary.warnings), summary.warnings
+
+
+def test_a_missing_gpu_selection_is_not_also_called_an_empty_capture(tmp_path):
+    """One cause, one sentence.
+
+    `--gpu 5` on two profiles that both ran used to print the device warning
+    and then "the profile contains no GPU kernel activity" -- false about the
+    profile, and it sends the reader off to check whether the run executed.
+    """
+    before = tmp_path / "sel_before.sqlite"
+    after = tmp_path / "sel_after.sqlite"
+    _make_profile(str(before), kernels=_kernels(0, 20, 1_000_000))
+    _make_profile(str(after), kernels=_kernels(0, 20, 1_000_000))
+
+    summary = _diff_summary(before, after, gpu=5, limit=10)
+    assert summary.comparability_confidence == 0.0
+    assert any("GPU 5 recorded no kernels" in w for w in summary.warnings), summary.warnings
+    assert not any("no GPU kernel activity" in w for w in summary.warnings), summary.warnings
+
+
+def test_two_different_captures_carrying_no_capture_metadata_are_not_called_one(tmp_path):
+    """Equal ids mean equal row counts when the metadata that names a run is absent.
+
+    `_make_profile` writes no TARGET_INFO_* / ANALYSIS_* tables, so the id
+    rests on the kernel row count alone. Keying the identity exemption on the
+    schema version let two unrelated captures of the same size be declared
+    "the same capture, every delta below is self-noise".
+    """
+    import sqlite3
+
+    from nsys_ai.fingerprint import get_profile_id, profile_id_is_capture_derived
+
+    before = tmp_path / "anon_before.sqlite"
+    after = tmp_path / "anon_after.sqlite"
+    # Same row count and same total duration, different distribution.
+    _make_profile(
+        str(before),
+        kernels=[(0, 40_000_000, 0, 7, 0, 1, 2), (50_000_000, 60_000_000, 0, 7, 1, 1, 2)],
+    )
+    _make_profile(
+        str(after),
+        kernels=[(0, 10_000_000, 0, 7, 0, 1, 2), (50_000_000, 90_000_000, 0, 7, 1, 1, 2)],
+    )
+    for path in (before, after):
+        conn = sqlite3.connect(str(path))
+        try:
+            assert not profile_id_is_capture_derived(conn), path
+            assert get_profile_id(conn, fallback_path=str(path))
+        finally:
+            conn.close()
+
+    summary = _diff_summary(before, after, gpu=0, limit=10)
+    assert not any("same capture" in w for w in summary.warnings), summary.warnings
 
 
 def test_executive_summary_never_signs_a_magnitude_after_a_direction_word(tmp_path):
@@ -3403,3 +3501,311 @@ def test_executive_summary_says_unchanged_rather_than_slower_by_zero(tmp_path):
     text = build_executive_summary(_diff_summary(before, after, gpu=0, limit=10))
     assert "Total GPU time was unchanged." in text, text
     assert "slower" not in text and "faster" not in text, text
+
+
+# ---------------------------------------------------------------------------
+# Inputs that cannot support a comparison: the same capture on both sides, a
+# side that never recorded a device, a GPU selection that does not exist, two
+# captures of different topologies, and a delta inside run-to-run noise.
+# ---------------------------------------------------------------------------
+
+
+def _lost_device_pair(tmp_path):
+    """before ran on GPUs 0 and 1; after recorded GPU 0 only.
+
+    Per-GPU work is identical, so every delta the pipeline finds is the device
+    the after side never captured.
+    """
+    ms = 1_000_000
+    before = tmp_path / "lost_before.sqlite"
+    after = tmp_path / "lost_after.sqlite"
+    _make_profile(
+        str(before),
+        kernels=[
+            (0, 50 * ms, 0, 7, 1, 1, 2),
+            (60 * ms, 110 * ms, 0, 7, 2, 3, 4),
+            (0, 50 * ms, 1, 7, 3, 1, 2),
+            (60 * ms, 110 * ms, 1, 7, 4, 3, 4),
+        ],
+    )
+    _make_profile(
+        str(after),
+        kernels=[
+            (0, 50 * ms, 0, 7, 1, 1, 2),
+            (60 * ms, 110 * ms, 0, 7, 2, 3, 4),
+        ],
+    )
+    return before, after
+
+
+def _all_gpu_summary(before, after, **kwargs):
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles_all_gpus
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        return diff_profiles_all_gpus(b, a, **kwargs)
+
+
+def test_a_side_that_lost_a_gpu_is_not_a_clean_win(tmp_path):
+    """Half the devices missing read as half the GPU time saved.
+
+    The all-GPU invocation is the one that matters: with no ``--gpu`` both
+    sides aggregate over whatever devices they happen to have, so the
+    empty-capture check never fires and the missing rank lands in the total as
+    an improvement.
+    """
+    before, after = _lost_device_pair(tmp_path)
+    global_summary, _ = _all_gpu_summary(before, after, limit=10)
+
+    assert global_summary.step_time_delta_pct == -50.0, "the fixture must show a large win"
+    assert global_summary.verdict == "inconclusive", global_summary.verdict
+    assert global_summary.comparability_confidence == 0.0
+    assert any(
+        "GPU count differs" in w and "[0, 1]" in w and "[0]" in w
+        for w in global_summary.warnings
+    ), global_summary.warnings
+
+
+def test_a_gpu_missing_from_one_side_names_the_side_and_the_device(tmp_path):
+    """Scoped to the lost device, the reason must not be "the profile is empty".
+
+    The empty-capture warning already fires on this path, and on its own it
+    sends the reader to check whether the run executed — when the run executed
+    fine and only that device was never captured.
+    """
+    before, after = _lost_device_pair(tmp_path)
+    summary = _diff_summary(before, after, gpu=1, limit=10)
+
+    assert summary.verdict == "inconclusive"
+    assert summary.comparability_confidence == 0.0
+    named = [w for w in summary.warnings if "GPU 1 recorded kernels in the before" in w]
+    assert named, summary.warnings
+    assert "none in the after profile" in named[0]
+    assert "not a change in the workload" in named[0]
+
+
+def test_a_gpu_present_in_neither_profile_says_so(tmp_path):
+    """``--gpu 5`` on two 2-GPU captures is an empty selection, not two empty captures."""
+    before, after = _lost_device_pair(tmp_path)
+    summary = _diff_summary(before, after, gpu=5, limit=10)
+
+    assert summary.verdict == "inconclusive"
+    assert summary.comparability_confidence == 0.0
+    named = [w for w in summary.warnings if "GPU 5 recorded no kernels in either profile" in w]
+    assert named, summary.warnings
+    assert "no before/after claim can be made" in named[0]
+
+
+def test_a_topology_mismatch_is_refused_rather_than_scored(tmp_path):
+    """2 GPUs against 4 is not a before and an after; it is different hardware."""
+    ms = 1_000_000
+    before = tmp_path / "topo_before.sqlite"
+    after = tmp_path / "topo_after.sqlite"
+    _make_profile(str(before), kernels=[(0, 50 * ms, d, 7, i, 1, 2) for i, d in enumerate([0, 1])])
+    _make_profile(
+        str(after), kernels=[(0, 50 * ms, d, 7, i, 1, 2) for i, d in enumerate([0, 1, 2, 3])]
+    )
+    global_summary, _ = _all_gpu_summary(before, after, limit=10)
+
+    assert global_summary.step_time_delta_pct == 100.0, "the fixture must show a large loss"
+    assert global_summary.verdict == "inconclusive"
+    assert global_summary.comparability_confidence == 0.0
+    assert any("GPU count differs" in w for w in global_summary.warnings), global_summary.warnings
+
+
+def test_matching_gpu_count_with_different_ids_warns_without_refusing(tmp_path):
+    """Same amount of hardware, different ordinals: comparable, worth saying."""
+    ms = 1_000_000
+    before = tmp_path / "ids_before.sqlite"
+    after = tmp_path / "ids_after.sqlite"
+    _make_profile(str(before), kernels=[(0, 50 * ms, d, 7, i, 1, 2) for i, d in enumerate([0, 1])])
+    _make_profile(str(after), kernels=[(0, 50 * ms, d, 7, i, 1, 2) for i, d in enumerate([2, 3])])
+    global_summary, _ = _all_gpu_summary(before, after, limit=10)
+
+    assert global_summary.verdict != "inconclusive", global_summary.warnings
+    assert global_summary.comparability_confidence >= 0.5
+    assert any(
+        "different GPU ids" in w and "[0, 1]" in w and "[2, 3]" in w
+        for w in global_summary.warnings
+    ), global_summary.warnings
+
+
+def test_matching_device_sets_add_no_warning(tmp_path):
+    """The gate must stay silent on a pair that recorded the same GPUs."""
+    ms = 1_000_000
+    before = tmp_path / "same_before.sqlite"
+    after = tmp_path / "same_after.sqlite"
+    _make_profile(str(before), kernels=[(0, 50 * ms, d, 7, i, 1, 2) for i, d in enumerate([0, 1])])
+    _make_profile(str(after), kernels=[(0, 52 * ms, d, 7, i, 1, 2) for i, d in enumerate([0, 1])])
+    global_summary, _ = _all_gpu_summary(before, after, limit=10)
+
+    assert global_summary.comparability_confidence == 1.0
+    assert not [w for w in global_summary.warnings if "GPU" in w], global_summary.warnings
+
+
+def test_a_profile_diffed_against_itself_is_self_noise_not_a_verdict(tmp_path):
+    """Same capture on both sides: the answer is "nothing was rerun"."""
+    before, _ = _lost_device_pair(tmp_path)
+    global_summary, _ = _all_gpu_summary(before, before, limit=10)
+
+    assert global_summary.verdict == "neutral"
+    assert any("the same capture" in w for w in global_summary.warnings), global_summary.warnings
+    assert any("self-noise" in w for w in global_summary.warnings), global_summary.warnings
+
+    scoped = _diff_summary(before, before, gpu=0, limit=10)
+    assert scoped.verdict == "neutral"
+    assert any("the same capture" in w for w in scoped.warnings), scoped.warnings
+
+
+def test_the_same_capture_is_recognised_through_a_copy_under_another_name(tmp_path):
+    """The id is content-derived, so a renamed copy is still the same capture."""
+    import shutil
+
+    copy = tmp_path / "renamed.sqlite"
+    shutil.copy(_MFU_BEFORE, copy)
+    global_summary, _ = _all_gpu_summary(_MFU_BEFORE, copy, limit=10)
+
+    assert global_summary.before.path != global_summary.after.path
+    assert global_summary.before.profile_id == global_summary.after.profile_id
+    assert global_summary.verdict == "neutral"
+    assert any("the same capture" in w for w in global_summary.warnings), global_summary.warnings
+
+
+def test_identity_is_not_claimed_from_a_profile_that_carries_no_capture_metadata(tmp_path):
+    """Two unrelated captures must never be called one.
+
+    A profile with no capture metadata contributes only its kernel row count to
+    the profile id, so two different runs with the same number of kernels hash
+    the same. The identity claim must not rest on that.
+    """
+    from nsys_ai.diff import same_capture
+
+    ms = 1_000_000
+    before = tmp_path / "meta_before.sqlite"
+    after = tmp_path / "meta_after.sqlite"
+    _make_profile(str(before), kernels=[(0, 50 * ms, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 50 * ms, 0, 7, 1, 3, 4)])
+    summary = _diff_summary(before, after, gpu=0, limit=10)
+
+    assert summary.before.profile_id == summary.after.profile_id, "the id collision is the setup"
+    assert summary.before.schema_version is None
+    assert not same_capture(summary.before, summary.after)
+    assert not [w for w in summary.warnings if "the same capture" in w], summary.warnings
+
+
+def test_two_windows_of_one_capture_are_still_compared(tmp_path):
+    """An iteration diff reads one capture twice through different windows.
+
+    Both sides share a path and an id, and it is a real comparison; only the
+    identical window makes the two sides one measurement.
+    """
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    ms = 1_000_000
+    path = tmp_path / "windows.sqlite"
+    _make_profile(
+        str(path),
+        kernels=[
+            (0, 50 * ms, 0, 7, 1, 1, 2),
+            (100 * ms, 190 * ms, 0, 7, 2, 1, 2),
+        ],
+    )
+    with profile_mod.open(str(path)) as b, profile_mod.open(str(path)) as a:
+        summary = diff_profiles(
+            b, a, gpu=0, trim_before=(0, 60 * ms), trim_after=(100 * ms, 200 * ms), limit=10
+        )
+
+    assert not [w for w in summary.warnings if "the same capture" in w], summary.warnings
+    assert summary.kernel_diffs[0].delta_ns != 0
+
+
+def test_a_step_time_delta_inside_the_noise_floor_stays_neutral():
+    """A gate tighter than run-to-run jitter cannot make a coin flip a verdict."""
+    from nsys_ai.diff import NOISE_FLOOR_STEP_TIME_PCT, compute_verdict
+
+    assert NOISE_FLOOR_STEP_TIME_PCT < 5.0, "the floor must not move the default verdict"
+    assert compute_verdict(1.0, 1.0, regression_pct=0.5) == "neutral"
+    assert compute_verdict(-1.0, 1.0, regression_pct=0.5) == "neutral"
+    # A change past the floor is still judged against the caller's threshold.
+    assert compute_verdict(3.0, 1.0, regression_pct=0.5) == "regression_likely"
+    assert compute_verdict(-3.0, 1.0, regression_pct=0.5) == "improvement_likely"
+    # And the floor never rescues an incomparable pair into neutral.
+    assert compute_verdict(0.1, 0.2, regression_pct=0.5) == "inconclusive"
+
+
+def test_the_noise_floor_says_why_it_overrode_the_threshold(tmp_path):
+    """Neutral beside a delta past the requested gate has to explain itself."""
+    ms = 1_000_000
+    before = tmp_path / "floor_before.sqlite"
+    after = tmp_path / "floor_after.sqlite"
+    _make_profile(str(before), kernels=[(0, 100 * ms, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 101 * ms, 0, 7, 1, 1, 2)])
+    summary = _diff_summary(before, after, gpu=0, limit=10, regression_pct=0.5)
+
+    assert summary.step_time_delta_pct is not None
+    assert 0.5 <= abs(summary.step_time_delta_pct) < 2.0, summary.step_time_delta_pct
+    assert summary.verdict == "neutral"
+    said = [w for w in summary.warnings if "noise floor" in w]
+    assert said, summary.warnings
+    assert "reported as neutral" in said[0]
+
+
+def test_a_default_gate_never_mentions_the_noise_floor(tmp_path):
+    """The floor sits under the default threshold, so it must stay invisible there."""
+    ms = 1_000_000
+    before = tmp_path / "quiet_before.sqlite"
+    after = tmp_path / "quiet_after.sqlite"
+    _make_profile(str(before), kernels=[(0, 100 * ms, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 101 * ms, 0, 7, 1, 1, 2)])
+    summary = _diff_summary(before, after, gpu=0, limit=10)
+
+    assert summary.verdict == "neutral"
+    assert not [w for w in summary.warnings if "noise floor" in w], summary.warnings
+
+
+def test_cli_refuses_a_pair_that_lost_a_gpu_and_fails_the_gate(tmp_path):
+    """End to end, through the surface a human reads and a CI job exits on."""
+    before, after = _lost_device_pair(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(after),
+            "--no-ai",
+            "--exit-on-regression",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 1, (result.returncode, result.stdout[-2000:], result.stderr[-2000:])
+    assert "Verdict: inconclusive" in result.stdout, result.stdout[:1200]
+    assert "No comparison was made" in result.stdout, result.stdout[:1200]
+    assert "GPU count differs" in result.stdout, result.stdout[:1200]
+    # The withheld tables must not come back through the per-GPU sections.
+    assert "Per-GPU Overview" not in result.stdout, result.stdout[:2000]
+
+
+def test_cli_self_diff_passes_the_gate_and_says_it_is_the_same_capture(tmp_path):
+    """A capture compared with itself is not a regression, and says why."""
+    before, _ = _lost_device_pair(tmp_path)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diff",
+            str(before),
+            str(before),
+            "--no-ai",
+            "--exit-on-regression",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, (result.returncode, result.stderr[-2000:])
+    assert "Verdict: neutral" in result.stdout, result.stdout[:1200]
+    assert "the same capture" in result.stdout, result.stdout[:1200]

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -647,3 +647,37 @@ def test_progress_model_is_frozen():
     progress = RunProgress(RunStage.CAPTURING, 1.0)
     with pytest.raises(FrozenInstanceError):
         progress.elapsed_seconds = 2.0
+
+
+def test_declared_gpu_count_the_capture_contradicts_fails_validation(tmp_path, fake_nsys):
+    """expected_gpu_count was recorded into the RunSpec and never read.
+
+    A one-GPU capture declared as eight used to be published with the
+    declaration intact, so every consumer downstream inherited a falsehood the
+    artifact asserted about itself.
+    """
+    result = _run(tmp_path, fake_nsys, expected_gpu_count=8)
+
+    assert result.status is RunStatus.INVALID_PROFILE
+    assert result.detail == (
+        "declared expected_gpu_count=8 but the capture recorded kernels on 1 GPU(s)"
+    )
+    # The artifacts still exist, so the mismatch can be inspected.
+    assert Path(result.sqlite_path).is_file()
+
+
+def test_declared_gpu_count_the_capture_meets_succeeds(tmp_path, fake_nsys):
+    """The check must not fail a capture that matches its declaration."""
+    result = _run(tmp_path, fake_nsys, expected_gpu_count=1)
+
+    assert result.status is RunStatus.SUCCEEDED, result.detail
+    assert result.profile is not None
+
+
+def test_observed_gpu_count_reads_the_devices_that_recorded_kernels(tmp_path, fake_nsys):
+    """A machine can expose eight GPUs and a run can touch one."""
+    from nsys_ai.profile_runner import observed_gpu_count
+
+    result = _run(tmp_path, fake_nsys)
+    assert result.status is RunStatus.SUCCEEDED
+    assert observed_gpu_count(result.sqlite_path) == 1


### PR DESCRIPTION
## Summary

Five inputs carried enough information to know no before/after claim could be made, and produced a confident one anyway.

- **Both sides the same capture.** Equal content-derived profile ids, or one path read twice, pin the verdict to `neutral` and state that the deltas below are self-noise. The identity claim is withheld from a profile carrying no capture metadata, whose id degrades to a hash of its kernel row count, and from an iteration diff, where two windows of one capture are a real comparison. The withholding is decided by `fingerprint.profile_id_is_capture_derived`, which asks whether any `TARGET_INFO_*` / `ANALYSIS_*` contribution to the id was non-empty. Schema version is not that question — it comes from `META_DATA_EXPORT`, a different table, and can be present while every id contribution is not.
- **A device recorded on one side only.** `ProfileSummary` now carries the devices that recorded kernels, so a node-wide diff whose after side lost a rank scores zero comparability instead of reporting half the GPU time as saved.
- **A `--gpu` selection missing from one or both profiles.** Named as the missing device rather than as an empty profile, which sent the reader off to check whether the run had executed.
- **Different GPU counts.** Totals measured over different amounts of hardware are not a before and an after — *when the odd devices hold enough time to move the totals*. An NCCL or cuDNN bootstrap touching a second device for a microsecond is a real topology difference and an immaterial one, and refusing on the device set alone turned a healthy pair (`neutral`, comparability 0.99, gate rc=0) into `inconclusive`, 0.00, rc=1. `ProfileMeta` now carries per-device kernel time from the pass that already groups by device — no new scan — and a device set difference below `DEVICE_SHARE_MATERIAL_PCT` (1%) is stated and then compared through. Matching counts with different ids stay comparable and say so.
- **A step-time delta inside run-to-run jitter.** A stated noise floor keeps a gate tighter than the floor from turning a coin flip into a verdict, and explains itself when it overrides the requested threshold. It sits below the default threshold, so no default verdict moves.

Separately: `expected_gpu_count` was recorded into every RunSpec and never read, so a one-GPU capture declared as eight was published asserting a falsehood about itself. Capture validation now fails on the contradiction.

## Changes

- `src/nsys_ai/diff.py` — the five refusals, each lowering comparability with a warning that names the cause. A missing `--gpu` selection no longer *also* prints "the profile contains no GPU kernel activity": that sentence is false about a profile that ran on other devices and sends the reader to check whether the run executed, which is the wrong check. One cause, one sentence.
- `src/nsys_ai/fingerprint.py` — `profile_id_is_capture_derived`, sharing the contribution builder with `get_profile_id` rather than a second copy of the same SQL.
- `src/nsys_ai/profile.py` — `ProfileMeta.device_kernel_ns`, one extra aggregate on the existing `GROUP BY deviceId, streamId`.
- `src/nsys_ai/diff_render.py`, `src/nsys_ai/ai/diff_narrative.py` — surfacing them.
- `src/nsys_ai/profile_runner.py` — `expected_gpu_count` is now read, and a capture that contradicts it fails validation.
- `tests/test_diff.py`, `tests/test_profile_runner.py` — one case per refusal, plus the pairs that must stay comparable.

## Backward compatibility

Yes for the payload shape. Verdicts change only for pairs that could not support one: a self-diff moves from `regression_likely` to `neutral` at confidence 1.0, and material topology mismatches move to `inconclusive` at comparability 0.00. A healthy pair is byte-identical to this branch's base in all three formats (terminal, json, markdown), and `--gate 5` on it still exits 0.

`compute_verdict` loses its `noise_floor_pct` parameter. No caller ever passed it, and a caller who did would have got an explanation naming the module constant instead of the value they supplied.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2254 passed, 140 skipped, 0 failed, rebased onto `main` with #411/#412/#414/#415 in it (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean
- [x] Manually exercised: all five conditions, plus the healthy-pair byte-identity check and `--gate 5` above. The three edges specifically: a 1 µs kernel on a second device → `neutral (0.99)`, rc=0; a rank that actually dropped out → `inconclusive (0.00)`, rc=1; `--gpu 5` on two profiles that both ran → one warning naming the missing device, zero occurrences of "no GPU kernel activity"

## Out of scope

- Verification from a single sample. The noise floor here refuses a verdict inside jitter; deciding *how many* runs a claim needs is separate.
- **#419**: `observed_gpu_count` re-opens the capture by path after the swap-guarded descriptor is closed, and re-runs a scan the caller already paid for. This PR is what started reading `expected_gpu_count`; where the observed count is read from is its own fix.

## Linked issues

Closes #402
