### PR TITLE
fix(cli): remove --loop-after and the parameter no surface read

### DIFF
--- a/docs/notes/session-wiring-design.md
+++ b/docs/notes/session-wiring-design.md
@@ -2,6 +2,11 @@
 
 Design-only gate for issue #268. No production code in this change.
 
+The design has since landed, so the "measured absence today" readings below are a
+record of the state it was designed against, not of current code. Where they name
+`loop_after`, that parameter no longer exists: the session store replaced it and
+the surfaces now open a session instead.
+
 AST-counted on this worktree (`feat/issue-268-session-wiring`):
 
 | type | fields | source |

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1571,7 +1571,6 @@ def _cmd_timeline_web(args, _profile):
             findings_path=getattr(args, "findings", None),
             auto_findings=auto_findings,
             loop_before=getattr(args, "loop_before", None),
-            loop_after=getattr(args, "loop_after", None),
             loop_h100_preset=getattr(args, "h100_preset", False),
             session=getattr(args, "session", None),
         )

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -712,11 +712,10 @@ def _build_parser():
         "--auto-analyze", action="store_true", help="Run AI analysis on startup and show findings"
     )
     p.add_argument("--loop-before", default=None, help="Loop mode before profile path")
-    p.add_argument("--loop-after", default=None, help="Loop mode after profile path")
     p.add_argument(
         "--h100-preset",
         action="store_true",
-        help="Auto-fill H100 replay before/after paths when available",
+        help="Auto-fill the H100 replay baseline path when available",
     )
     p.add_argument(
         "--session",

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -308,7 +308,6 @@ def _open_session_web(
                 port=port,
                 open_browser=open_browser,
                 loop_before=before_path,
-                loop_after=after_path,
                 session=session_id,
                 session_root=session_root,
             )

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -199,14 +199,12 @@ def _resume_review(
 
     if web:
         before = snapshot.state.before_profile
-        after = snapshot.state.after_profile
         if before is None:
             raise ReviewCommandError(
                 f"session {session_id} has no before profile to open in --web"
             )
         return _open_session_web(
             before_path=before.path,
-            after_path=after.path if after is not None else None,
             session_id=session_id,
             gpu=None,
             trim=None,
@@ -284,7 +282,6 @@ def _print_decision_path(
 def _open_session_web(
     *,
     before_path: str,
-    after_path: str | None,
     session_id: str,
     gpu: int | None,
     trim: tuple[int, int] | None,

--- a/src/nsys_ai/timeline/__init__.py
+++ b/src/nsys_ai/timeline/__init__.py
@@ -20,7 +20,6 @@ def run_timeline(
     device: int,
     trim: tuple[int, int] | None,
     min_ms: float = 0,
-    loop_after: str | None = None,
 ) -> None:
     """Launch the Textual horizontal timeline browser.
 
@@ -31,7 +30,7 @@ def run_timeline(
         return
     from .app import run_timeline as _run
 
-    _run(db_path, device, trim, min_ms=min_ms, loop_after=loop_after)
+    _run(db_path, device, trim, min_ms=min_ms)
 
 
 def _print_static_summary(

--- a/src/nsys_ai/timeline/app.py
+++ b/src/nsys_ai/timeline/app.py
@@ -165,7 +165,6 @@ class NsysTimelineApp(App):
         trim: tuple[int, int] | None = None,
         min_ms: float = 0,
         json_roots: list[dict] | None = None,
-        loop_after: str | None = None,
         session: str | None = None,
     ) -> None:
         super().__init__()
@@ -1039,11 +1038,10 @@ def run_timeline(
     device: int,
     trim: tuple[int, int] | None,
     min_ms: float = 0,
-    loop_after: str | None = None,
     session: str | None = None,
 ) -> None:
     """Launch the Textual horizontal timeline browser."""
     app = NsysTimelineApp(
-        db_path, device, trim, min_ms=min_ms, loop_after=loop_after, session=session
+        db_path, device, trim, min_ms=min_ms, session=session
     )
     app.run()

--- a/src/nsys_ai/tree/__init__.py
+++ b/src/nsys_ai/tree/__init__.py
@@ -49,7 +49,6 @@ def run_tui(
     trim: tuple[int, int] | None,
     max_depth: int = -1,
     min_ms: float = 0,
-    loop_after: str | None = None,
 ) -> None:
     """Launch the Textual NVTX tree browser.
 
@@ -60,7 +59,7 @@ def run_tui(
         return
     from .app import run_tui as _run
 
-    _run(db_path, device, trim, max_depth=max_depth, min_ms=min_ms, loop_after=loop_after)
+    _run(db_path, device, trim, max_depth=max_depth, min_ms=min_ms)
 
 
 def _print_static_tree(

--- a/src/nsys_ai/tree/app.py
+++ b/src/nsys_ai/tree/app.py
@@ -144,7 +144,6 @@ class NsysTreeApp(App):
         max_depth: int = -1,
         min_ms: float = 0,
         json_roots: list[dict] | None = None,
-        loop_after: str | None = None,
         session: str | None = None,
     ) -> None:
         super().__init__()
@@ -892,7 +891,6 @@ def run_tui(
     trim: tuple[int, int] | None,
     max_depth: int = -1,
     min_ms: float = 0,
-    loop_after: str | None = None,
     session: str | None = None,
 ) -> None:
     """Launch the Textual NVTX tree browser."""
@@ -902,7 +900,6 @@ def run_tui(
         trim,
         max_depth=max_depth,
         min_ms=min_ms,
-        loop_after=loop_after,
         session=session,
     )
     app.run()

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -963,7 +963,6 @@ def serve_timeline(
     findings_path: str | None = None,
     auto_findings: list[dict] | None = None,
     loop_before: str | None = None,
-    loop_after: str | None = None,
     loop_h100_preset: bool = False,
     session: str | None = None,
     session_root: str | os.PathLike[str] = ".nsys-ai/sessions",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -375,6 +375,46 @@ def test_loop_rejects_after(tmp_path):
     assert "Traceback" not in result.stderr, result.stderr
 
 
+def test_timeline_web_rejects_loop_after(tmp_path):
+    """The same dead flag one subcommand over, and the last way to reach it.
+
+    `--loop-after` was parsed, forwarded through `serve_timeline`, `run_tui` and
+    `run_timeline`, and read by none of them -- the session store replaced it.
+    Since `loop`'s default surface is `timeline-web`, it was also the only
+    remaining way to hand a loop surface a candidate it cannot register.
+    """
+    fixtures = Path(__file__).resolve().parent / "fixtures"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "nsys_ai", "timeline-web",
+            str(fixtures / "mfu_2gpu_before.sqlite"),
+            "--loop-after", str(fixtures / "mfu_2gpu_after.sqlite"), "--no-browser",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 2, result.stderr
+    assert "unrecognized arguments: --loop-after" in result.stderr, result.stderr
+    assert "Traceback" not in result.stderr, result.stderr
+
+
+def test_no_surface_still_takes_a_candidate_it_cannot_register(tmp_path):
+    """The parameter is gone from the whole chain, not just from the parser.
+
+    A flag removed while the parameter it fed survives is half a fix: the next
+    caller re-adds the flag because the plumbing still looks ready for it.
+    """
+    src = Path(__file__).resolve().parents[1] / "src" / "nsys_ai"
+    offenders = [
+        f"{path.relative_to(src)}:{i}"
+        for path in src.rglob("*.py")
+        for i, line in enumerate(path.read_text().splitlines(), 1)
+        if "loop_after" in line
+    ]
+    assert not offenders, f"loop_after survives at: {offenders}"
+
+
 def test_h100_preset_hint_names_a_command_that_parses():
     """The only recovery instruction on the preset path must still be runnable.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -414,6 +414,20 @@ def test_no_surface_still_takes_a_candidate_it_cannot_register(tmp_path):
     ]
     assert not offenders, f"loop_after survives at: {offenders}"
 
+    # The name is only half of it. `_open_session_web` kept an `after_path`
+    # parameter after its one use was deleted, and its caller kept computing a
+    # value to hand it -- plumbing that still looks ready for the flag, which
+    # is exactly how the flag comes back. Ruff's enabled rules do not flag an
+    # unused argument, so nothing else catches this.
+    import inspect
+
+    from nsys_ai.review_command import _open_session_web
+
+    accepted = set(inspect.signature(_open_session_web).parameters)
+    assert not accepted & {"after_path", "after", "loop_after"}, (
+        f"_open_session_web still takes a candidate it cannot register: {sorted(accepted)}"
+    )
+
 
 def test_h100_preset_hint_names_a_command_that_parses():
     """The only recovery instruction on the preset path must still be runnable.


### PR DESCRIPTION
## Summary

- `timeline-web --loop-after` was parsed, forwarded through four layers, and read by nothing. The session store replaced it; the flag outlived the plumbing.
- Since `loop`'s default surface **is** `timeline-web`, it was also the last remaining way to hand a loop surface a candidate it cannot register — the same promise #397 removed one subcommand over.
- The flag and the parameter both go, together. Removing only the flag leaves a parameter that looks ready for a caller, which is how the flag comes back.

## Changes

- `src/nsys_ai/cli/parsers.py` — drop `--loop-after`. Also: `timeline-web --h100-preset` claimed to "Auto-fill H100 replay before/after paths"; `serve_timeline` only ever used the preset for the baseline, so the help now says that.
- `src/nsys_ai/cli/handlers.py`, `src/nsys_ai/review_command.py` — stop passing it.
- `src/nsys_ai/web.py`, `src/nsys_ai/tree/__init__.py`, `src/nsys_ai/tree/app.py`, `src/nsys_ai/timeline/__init__.py`, `src/nsys_ai/timeline/app.py` — drop the parameter from `serve_timeline`, `run_tui`, `run_timeline` and both app constructors.
- `docs/notes/session-wiring-design.md` — its "measured absence today" readings name `loop_after` as live. The note records a design decision at a point in time, so rather than rewrite the measurements the section is marked as a record of the state it was designed against, with the parameter's removal stated.
- `tests/test_cli.py` — `timeline-web --loop-after` exits 2 with `unrecognized arguments`, and a second test walks `src/` asserting the identifier appears nowhere.

## Backward compatibility

No. `nsys-ai timeline-web <profile> --loop-after <path>` now exits 2 instead of serving and discarding the path. Nothing else changes: the surface behaved identically with and without the flag, because no code read it. Publishing a candidate is the CLI path, which `diagnose` prints with the finding id filled in.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2263 passed, 140 skipped, 5 xfailed, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean
- [x] Manually exercised: `timeline-web <fixture> --loop-after <fixture> --no-browser` → `rc=2`, `unrecognized arguments: --loop-after`, no traceback

## Out of scope

- How a surface *should* register a candidate. That is loop closure; this only removes a flag that promised something no code did.

## Linked issues

Closes #417
