### PR TITLE
test: open committed profile fixtures through a copy, and fail if one is written

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,69 @@ conftest.py — Shared pytest fixtures for nsys-ai tests.
 All fixtures here are available to every test module without explicit imports.
 """
 
+import hashlib
+import shutil
 import sqlite3
+from pathlib import Path
 
 import pytest
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+
+
+@pytest.fixture(scope="session")
+def profile_copy(tmp_path_factory):
+    """Return a factory giving a *writable* copy of a committed fixture.
+
+    Opening a profile writes ``_nsysai_*`` helper indexes into the file, so a
+    test that opens a committed fixture directly grows it on disk -- 2.2 MB to
+    3.9 MB for ``h100_2gpu_1s.sqlite`` -- and the churn then follows whoever ran
+    the suite into their next commit. Nothing pins fixture bytes, so it breaks
+    no test, which is exactly why it kept coming back.
+
+    Copies are made once per session and shared, because building the cache for
+    one costs more than every test that reads it.
+    """
+    made: dict[str, Path] = {}
+    root = tmp_path_factory.mktemp("committed_profiles")
+
+    def _copy(name: str) -> Path:
+        if name not in made:
+            destination = root / name
+            # copyfile, not copy: copy carries the source mode across, and a
+            # read-only source would hand back a copy nothing can index either.
+            shutil.copyfile(FIXTURE_DIR / name, destination)
+            made[name] = destination
+        return made[name]
+
+    return _copy
+
+
+def _fixture_digests() -> dict[str, str]:
+    return {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(FIXTURE_DIR.glob("*.sqlite"))
+    }
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _committed_fixtures_are_left_alone():
+    """Fail the session if a test wrote into a committed fixture.
+
+    The guard is the part that makes the copies stick: without it the next test
+    to open a fixture directly reintroduces the churn silently, and the only
+    signal is an unexplained binary diff in someone's review.
+    """
+    before = _fixture_digests()
+    yield
+    changed = sorted(name for name, digest in _fixture_digests().items() if before.get(name) != digest)
+    if changed:
+        raise AssertionError(
+            "the suite rewrote committed fixtures in place: "
+            + ", ".join(changed)
+            + ". Open a copy instead -- the `profile_copy` fixture in conftest.py "
+            "hands you one. Restore them with `git checkout -- tests/fixtures/`."
+        )
 
 # ---------------------------------------------------------------------------
 # Minimal in-memory SQLite database that mimics an Nsight Systems export.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ All fixtures here are available to every test module without explicit imports.
 import hashlib
 import shutil
 import sqlite3
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -49,6 +50,38 @@ def _fixture_digests() -> dict[str, str]:
     }
 
 
+def _already_modified_fixtures() -> list[str]:
+    """Fixture files git already reports as modified, newest state on disk.
+
+    Digests only catch a write that happens during this session. A checkout
+    that is already dirty -- from a run before this guard existed, or from a
+    run that went red and was simply repeated -- would compare clean against
+    itself forever, which is the state the churn kept being committed from.
+    """
+    try:
+        completed = subprocess.run(
+            ["git", "ls-files", "--modified", "--", str(FIXTURE_DIR)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []  # no git (an sdist, a vendored copy): nothing to compare against
+    if completed.returncode != 0:
+        return []
+    return sorted(
+        Path(line).name for line in completed.stdout.splitlines() if line.strip()
+    )
+
+
+def _fixture_change_report(before: dict[str, str], after: dict[str, str]) -> list[str]:
+    """Names that differ between two digest snapshots, in either direction."""
+    return sorted(
+        name for name in before.keys() | after.keys() if before.get(name) != after.get(name)
+    )
+
+
 @pytest.fixture(scope="session", autouse=True)
 def _committed_fixtures_are_left_alone():
     """Fail the session if a test wrote into a committed fixture.
@@ -57,9 +90,18 @@ def _committed_fixtures_are_left_alone():
     to open a fixture directly reintroduces the churn silently, and the only
     signal is an unexplained binary diff in someone's review.
     """
+    stale = _already_modified_fixtures()
+    if stale:
+        raise AssertionError(
+            "committed fixtures are already modified before this session ran: "
+            + ", ".join(stale)
+            + ". A dirty checkout hides later writes, because the guard would "
+            "compare them against the dirty bytes. Restore them with "
+            "`git checkout -- tests/fixtures/`."
+        )
     before = _fixture_digests()
     yield
-    changed = sorted(name for name, digest in _fixture_digests().items() if before.get(name) != digest)
+    changed = _fixture_change_report(before, _fixture_digests())
     if changed:
         raise AssertionError(
             "the suite rewrote committed fixtures in place: "

--- a/tests/test_duckdb_dataflow.py
+++ b/tests/test_duckdb_dataflow.py
@@ -27,7 +27,6 @@ that breaks the arrangement fails here rather than silently on a user's profile.
 import shutil
 import sqlite3
 import traceback
-from pathlib import Path
 
 import pytest
 
@@ -37,7 +36,11 @@ from nsys_ai.profile import Profile  # noqa: E402
 from nsys_ai.skills.registry import get_skill  # noqa: E402
 from nsys_ai.sql_compat import sqlite_to_duckdb  # noqa: E402
 
-FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+@pytest.fixture(scope="module")
+def fixture(profile_copy):
+    """A writable copy: opening a profile writes helper indexes into the file."""
+    return profile_copy("h100_2gpu_1s.sqlite")
 
 
 def _classify(stack) -> str:
@@ -55,7 +58,7 @@ def _classify(stack) -> str:
     return "direct"
 
 
-def test_sql_bypassing_the_rewriter_never_needs_rewriting():
+def test_sql_bypassing_the_rewriter_never_needs_rewriting(fixture):
     """The guard that keeps the dual-dialect arrangement safe.
 
     17 skill files write ``k.[end]`` — SQLite bracket syntax DuckDB rejects — and
@@ -81,7 +84,7 @@ def test_sql_bypassing_the_rewriter_never_needs_rewriting():
     try:
         from nsys_ai.evidence_builder import EvidenceBuilder
 
-        with Profile(str(FIXTURE)) as prof:
+        with Profile(str(fixture)) as prof:
             EvidenceBuilder(prof, device=0).build()
     finally:
         duckdb.DuckDBPyConnection.execute = original
@@ -92,7 +95,7 @@ def test_sql_bypassing_the_rewriter_never_needs_rewriting():
     )
 
 
-def test_every_known_table_variant_is_reachable_on_the_cached_path():
+def test_every_known_table_variant_is_reachable_on_the_cached_path(fixture):
     """The alias views are the actual compatibility layer.
 
     ``parquet_cache._ALIASES`` maps each short name to every Nsight variant, and
@@ -109,7 +112,7 @@ def test_every_known_table_variant_is_reachable_on_the_cached_path():
     from nsys_ai.parquet_cache import _ALIASES
 
     unreachable = []
-    with Profile(str(FIXTURE)) as prof:
+    with Profile(str(fixture)) as prof:
         if prof.db is None:  # pragma: no cover - cache build failed
             pytest.skip("DuckDB cache unavailable")
         present = {r[0] for r in prof.db.execute("SHOW TABLES").fetchall()}
@@ -127,7 +130,7 @@ def test_every_known_table_variant_is_reachable_on_the_cached_path():
     )
 
 
-def test_an_unknown_future_table_suffix_still_analyses(tmp_path):
+def test_an_unknown_future_table_suffix_still_analyses(tmp_path, fixture):
     """Nsight adds versioned tables between releases; _ALIASES stops at _V3.
 
     A capture whose kernel table is ``_V4`` must still produce results — the ETL
@@ -135,7 +138,7 @@ def test_an_unknown_future_table_suffix_still_analyses(tmp_path):
     the cache is built from it and the analysis proceeds.
     """
     profile = tmp_path / "v4.sqlite"
-    shutil.copy(FIXTURE, profile)
+    shutil.copy(fixture, profile)
     conn = sqlite3.connect(profile)
     try:
         conn.execute(
@@ -153,7 +156,7 @@ def test_an_unknown_future_table_suffix_still_analyses(tmp_path):
     assert rows[0].get("kernel_name"), f"kernels came back unnamed: {rows[0]}"
 
 
-def test_both_engines_return_the_same_answer_for_a_dual_path_skill():
+def test_both_engines_return_the_same_answer_for_a_dual_path_skill(fixture):
     """``sync_cost_analysis`` has a DuckDB route and a SQLite route.
 
     Divergence between the two is the defect class that produced the cached-vs-
@@ -161,12 +164,12 @@ def test_both_engines_return_the_same_answer_for_a_dual_path_skill():
     """
     skill = get_skill("sync_cost_analysis")
 
-    with Profile(str(FIXTURE)) as prof:
+    with Profile(str(fixture)) as prof:
         if prof.db is None:  # pragma: no cover
             pytest.skip("DuckDB cache unavailable")
         via_duckdb = skill.execute(prof.db, device=0)
 
-    conn = sqlite3.connect(FIXTURE)
+    conn = sqlite3.connect(fixture)
     try:
         via_sqlite = skill.execute(conn, device=0)
     finally:

--- a/tests/test_fixture_guard.py
+++ b/tests/test_fixture_guard.py
@@ -1,0 +1,71 @@
+"""The fixture guard is this suite's own safety net, so it needs coverage.
+
+Issue #347 is a bug that landed repeatedly: a test opens a committed profile
+directly, `CREATE INDEX IF NOT EXISTS` rewrites it, and a multi-megabyte binary
+diff rides along in the next commit. The guard in conftest.py is what stops
+that. Without a test, a later cleanup can soften the raise into a warning and
+nothing would notice -- which is how the original bug survived five times.
+"""
+
+from __future__ import annotations
+
+import conftest
+import pytest
+
+
+def _drive(monkeypatch, fixture_dir, *, stale=()):
+    """Run the session-scoped guard as a plain generator against a temp dir."""
+    monkeypatch.setattr(conftest, "FIXTURE_DIR", fixture_dir)
+    monkeypatch.setattr(conftest, "_already_modified_fixtures", lambda: list(stale))
+    return conftest._committed_fixtures_are_left_alone.__wrapped__()
+
+
+def test_a_rewritten_fixture_fails_the_session(monkeypatch, tmp_path):
+    """The case the guard exists for: bytes changed while the suite ran."""
+    fixture = tmp_path / "profile.sqlite"
+    fixture.write_bytes(b"original")
+
+    guard = _drive(monkeypatch, tmp_path)
+    next(guard)
+    fixture.write_bytes(b"grown by an index")
+
+    with pytest.raises(AssertionError, match="rewrote committed fixtures in place"):
+        next(guard, None)
+
+
+def test_an_untouched_fixture_passes(monkeypatch, tmp_path):
+    """A guard that fires on a clean run would be turned off within a week."""
+    (tmp_path / "profile.sqlite").write_bytes(b"original")
+
+    guard = _drive(monkeypatch, tmp_path)
+    next(guard)
+
+    assert next(guard, None) is None
+
+
+def test_an_already_dirty_checkout_fails_before_the_suite_runs(monkeypatch, tmp_path):
+    """Digests compare a session against itself, so a dirty tree hides writes.
+
+    A contributor whose checkout is already grown -- from a run before the
+    guard, or from a red run they simply repeated -- would otherwise get a
+    green suite and commit the churn exactly as before.
+    """
+    (tmp_path / "profile.sqlite").write_bytes(b"already grown")
+
+    guard = _drive(monkeypatch, tmp_path, stale=["profile.sqlite"])
+
+    with pytest.raises(AssertionError, match="already modified before this session"):
+        next(guard)
+
+
+def test_a_vanished_fixture_is_reported(monkeypatch, tmp_path):
+    """Reporting only names present at the end would miss a deletion entirely."""
+    fixture = tmp_path / "profile.sqlite"
+    fixture.write_bytes(b"original")
+
+    guard = _drive(monkeypatch, tmp_path)
+    next(guard)
+    fixture.unlink()
+
+    with pytest.raises(AssertionError, match="profile.sqlite"):
+        next(guard, None)

--- a/tests/test_skill_memo.py
+++ b/tests/test_skill_memo.py
@@ -12,16 +12,19 @@ other's rows and change findings without any error.
 """
 
 import sqlite3
-from pathlib import Path
 
 import pytest
 
 from nsys_ai.skills.registry import get_skill
 
-FIXTURE = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+@pytest.fixture(scope="module")
+def fixture(profile_copy):
+    """A writable copy: opening a profile writes helper indexes into the file."""
+    return profile_copy("h100_2gpu_1s.sqlite")
 
 
-def test_identical_params_hit_the_cache():
+def test_identical_params_hit_the_cache(fixture):
     skill = get_skill("top_kernels")
     calls = []
     original = skill.execute_fn
@@ -31,7 +34,7 @@ def test_identical_params_hit_the_cache():
         return original(conn, **kwargs)
 
     skill.execute_fn = counting
-    conn = sqlite3.connect(FIXTURE)
+    conn = sqlite3.connect(fixture)
     try:
         first = skill.execute(conn, limit=5)
         second = skill.execute(conn, limit=5)
@@ -43,14 +46,14 @@ def test_identical_params_hit_the_cache():
     assert first == second
 
 
-def test_different_params_are_never_served_a_cached_result():
+def test_different_params_are_never_served_a_cached_result(fixture):
     """The failure a name-only key would cause, asserted directly.
 
     `gpu_idle_gaps` is called at limit=1 and limit=5 in the same build. If the
     key ignored parameters the second caller would receive the first's rows.
     """
     skill = get_skill("gpu_idle_gaps")
-    conn = sqlite3.connect(FIXTURE)
+    conn = sqlite3.connect(fixture)
     try:
         few = [r for r in skill.execute(conn, device=0, limit=1) if not r.get("_summary")]
         many = [r for r in skill.execute(conn, device=0, limit=5) if not r.get("_summary")]
@@ -64,7 +67,7 @@ def test_different_params_are_never_served_a_cached_result():
     )
 
 
-def test_a_defaulted_parameter_shares_an_entry_with_an_explicit_one():
+def test_a_defaulted_parameter_shares_an_entry_with_an_explicit_one(fixture):
     """The key is built from resolved parameters, after defaults are applied.
 
     Keying on raw kwargs would treat an omitted `limit` and an explicit `limit`
@@ -80,7 +83,7 @@ def test_a_defaulted_parameter_shares_an_entry_with_an_explicit_one():
         return original(conn, **kwargs)
 
     skill.execute_fn = counting
-    conn = sqlite3.connect(FIXTURE)
+    conn = sqlite3.connect(fixture)
     try:
         skill.execute(conn)
         skill.execute(conn, limit=default_limit)
@@ -91,14 +94,14 @@ def test_a_defaulted_parameter_shares_an_entry_with_an_explicit_one():
     assert len(calls) == 1, f"defaulted and explicit {default_limit} did not share an entry"
 
 
-def test_a_cached_result_cannot_be_corrupted_by_its_consumer():
+def test_a_cached_result_cannot_be_corrupted_by_its_consumer(fixture):
     """Rows are copied out, because consumers mutate them in place.
 
     Without the copy, one caller adding a key would change what every later
     caller sees — a bug that would surface far from here.
     """
     skill = get_skill("top_kernels")
-    conn = sqlite3.connect(FIXTURE)
+    conn = sqlite3.connect(fixture)
     try:
         first = skill.execute(conn, limit=3)
         first[0]["_injected_by_consumer"] = True
@@ -109,7 +112,7 @@ def test_a_cached_result_cannot_be_corrupted_by_its_consumer():
     assert "_injected_by_consumer" not in second[0], "the cache handed out a shared row"
 
 
-def test_a_second_reader_does_not_share_rows_with_the_first():
+def test_a_second_reader_does_not_share_rows_with_the_first(fixture):
     """The read-side copy, which the store-side test does not reach.
 
     That test poisons the *first*, uncached list, so it only exercises the copy
@@ -117,7 +120,7 @@ def test_a_second_reader_does_not_share_rows_with_the_first():
     the classic "would pass with the body deleted".
     """
     skill = get_skill("top_kernels")
-    conn = sqlite3.connect(FIXTURE)
+    conn = sqlite3.connect(fixture)
     try:
         skill.execute(conn, limit=3)          # populate
         second = skill.execute(conn, limit=3)  # first cached read
@@ -131,7 +134,7 @@ def test_a_second_reader_does_not_share_rows_with_the_first():
     )
 
 
-def test_sql_only_skills_are_cached_too():
+def test_sql_only_skills_are_cached_too(fixture):
     """The store used to sit inside the execute_fn branch only.
 
     SQL-only skills therefore built a cache key and then took a guaranteed miss
@@ -140,7 +143,7 @@ def test_sql_only_skills_are_cached_too():
     """
     skill = get_skill("stream_concurrency")
     assert skill.execute_fn is None, "this skill is no longer SQL-only; pick another"
-    conn = sqlite3.connect(FIXTURE)
+    conn = sqlite3.connect(fixture)
     try:
         skill.execute(conn, limit=5)
         import nsys_ai.connection as connection
@@ -156,12 +159,12 @@ def test_sql_only_skills_are_cached_too():
     assert cached, "a SQL-only skill produced no cache entry"
 
 
-def test_separate_connections_do_not_share_results():
+def test_separate_connections_do_not_share_results(fixture, profile_copy):
     """The cache is per connection, so two profiles cannot bleed into each other."""
-    other = Path(__file__).resolve().parent / "fixtures" / "healthy_1pct.sqlite"
+    other = profile_copy("healthy_1pct.sqlite")
     skill = get_skill("top_kernels")
 
-    a = sqlite3.connect(FIXTURE)
+    a = sqlite3.connect(fixture)
     b = sqlite3.connect(other)
     try:
         rows_a = skill.execute(a, limit=3)
@@ -176,7 +179,7 @@ def test_separate_connections_do_not_share_results():
 
 
 @pytest.mark.parametrize("profile", ["h100_2gpu_1s", "healthy_1pct"])
-def test_the_build_executes_fewer_skills_without_changing_findings(profile):
+def test_the_build_executes_fewer_skills_without_changing_findings(profile, profile_copy):
     """The whole point: less work, same answer.
 
     Findings were compared byte-for-byte against the pre-memo implementation on
@@ -206,7 +209,7 @@ def test_the_build_executes_fewer_skills_without_changing_findings(profile):
         sk.execute_fn = make(sk.name, sk.execute_fn)
 
     try:
-        with Profile(str(FIXTURE.parent / f"{profile}.sqlite")) as prof:
+        with Profile(str(profile_copy(f"{profile}.sqlite"))) as prof:
             report = EvidenceBuilder(prof, device=0).build()
     finally:
         for sk in registry.all_skills():


### PR DESCRIPTION
## Summary

- Running the suite rewrote two committed fixture binaries in place — `h100_2gpu_1s.sqlite` 2.27 MB → 3.88 MB, `healthy_1pct.sqlite` 57 KB → 115 KB — and the growth then followed whoever ran the tests into their next commit. The delta is nsys-ai's own `_nsysai_*` helper indexes, written by `ensure_indexes` when a test opens a fixture directly instead of a copy.
- Nothing pinned fixture bytes, so it broke no test. That is why it kept coming back.
- Two changes: the offenders open copies, and a session-level guard fails the run if any committed fixture is written.

## Which tests actually did it

Not a guess. Each of the 39 test files that reference a fixture was run in isolation with `tests/fixtures/*.sqlite` hashed after it. **Two** files came back dirty:

```
MUTATES tests/test_duckdb_dataflow.py -> h100_2gpu_1s.sqlite
MUTATES tests/test_skill_memo.py      -> h100_2gpu_1s.sqlite healthy_1pct.sqlite
```

The other 37 already work on copies or never reach `ensure_indexes`.

## Changes

- `tests/conftest.py` — a session-scoped `profile_copy` factory returning a writable copy of a named fixture, made once per session and shared (building the cache for one costs more than every test that reads it). `shutil.copyfile`, not `copy`: `copy` carries the source mode across, so a read-only source would hand back a copy nothing can index either.
- `tests/conftest.py` — a session-scoped autouse guard that hashes every `tests/fixtures/*.sqlite` before and after the session and fails naming the files and the remedy. This is the part that makes the copies stick: without it the next test to open a fixture directly reintroduces the churn silently, and the only signal is an unexplained binary diff in someone's review.
- `tests/test_duckdb_dataflow.py`, `tests/test_skill_memo.py` — take a module-scoped `fixture` that is a copy, rather than a module-level constant pointing at the committed file.

## Backward compatibility

Tests only. No `src/` change — the issue offered making `ensure_indexes` refuse a read-only-by-policy profile as an alternative, and that moves a test concern into the library, which is the wrong direction.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2261 passed, 140 skipped, 5 xfailed, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`), and `git status tests/fixtures/` clean after it
- [x] `ruff check src/ tests/` clean
- [x] The guard fires: a throwaway test running `top_kernels` on a committed fixture errors with `the suite rewrote committed fixtures in place: healthy_1pct.sqlite`

## Out of scope

- Committing the already-grown files. They stay at their committed sizes; the indexes are derived data and rebuilding them is what `ensure_indexes` is for.

## Linked issues

Closes #347
