### PR TITLE
fix(skills): report Tensor Core achievement as unknown when it cannot be measured

### DIFF
--- a/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py
@@ -463,6 +463,13 @@ def _execute(conn, **kwargs):
             "nccl_ns": 0,
             "tc_eligible_ns": 0,
             "tc_active_ns": 0,
+            # Tracked apart from the sums, because "nothing was eligible" and
+            # "eligibility could not be measured" are different answers that
+            # both total zero. Summing `tc_elig or 0` conflated them on the
+            # first row and left the guard below unreachable, so a connection
+            # with no Tensor Core columns reported 0.0% achieved where the
+            # cache reported 100.0% for the same regions.
+            "tc_unmeasurable": False,
             "count": 0,
             "max_ns": 0,
             "nvtx_depth": -1,
@@ -511,8 +518,14 @@ def _execute(conn, **kwargs):
         stats["total_ns"] += total_ns or 0
         stats["compute_ns"] += compute_ns or 0
         stats["nccl_ns"] += nccl_ns or 0
-        stats["tc_eligible_ns"] += tc_elig or 0
-        stats["tc_active_ns"] += tc_act or 0
+        if tc_elig is None or tc_act is None:
+            # Absorbing: a group that mixes measured and unmeasured leaves
+            # cannot be averaged without understating the denominator, and a
+            # quiet understatement reads as a real low achievement.
+            stats["tc_unmeasurable"] = True
+        else:
+            stats["tc_eligible_ns"] += tc_elig
+            stats["tc_active_ns"] += tc_act
         stats["count"] += count
         if (max_ns or 0) > stats["max_ns"]:
             stats["max_ns"] = max_ns or 0
@@ -564,9 +577,9 @@ def _execute(conn, **kwargs):
                 "compute_ms": round(compute_ns / 1e6, 2),
                 "nccl_ms": round(nccl_ns / 1e6, 2),
                 "nccl_pct": round(100 * nccl_ns / total_ns, 1) if total_ns > 0 else 0,
-                "tc_achieved_pct": round(100 * tc_act / tc_elig, 1)
-                if tc_elig
-                else (None if tc_elig is None else 0.0),
+                "tc_achieved_pct": None
+                if stats["tc_unmeasurable"]
+                else (round(100 * tc_act / tc_elig, 1) if tc_elig else 0.0),
                 "avg_kernel_ms": round(total_ns / count / 1e6, 3) if count else 0,
                 "max_kernel_ms": round(stats["max_ns"] / 1e6, 3),
                 "top_kernels": top_kernels,

--- a/tests/test_nvtx_layer_breakdown.py
+++ b/tests/test_nvtx_layer_breakdown.py
@@ -517,3 +517,52 @@ def test_root_cause_layer_outlier_no_fire():
     ]
     findings = _check_layer_outlier(layer_data)
     assert len(findings) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tensor Core attribution: unmeasurable is not zero
+# ---------------------------------------------------------------------------
+
+
+def test_tc_achieved_is_unknown_not_zero_without_the_capability(tmp_path):
+    """A connection that cannot classify kernels must not report 0% achieved.
+
+    The cache's ``kernels`` view synthesises ``is_tc_eligible`` / ``uses_tc`` by
+    matching kernel names; a raw sqlite3 connection has neither column, so the
+    skill's fallback yields None for both totals. Those Nones were summed as
+    ``tc_elig or 0``, which erased the unknown on the first row and made the
+    guard that checked for it unreachable -- so the same regions of the same
+    profile read 0.0% on sqlite3 and 100.0% through the cache, with nothing to
+    tell the reader which they had.
+    """
+    import shutil
+    import sqlite3 as _sqlite3
+    from pathlib import Path
+
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.skills.registry import get_skill
+
+    source = Path(__file__).resolve().parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    profile_path = tmp_path / source.name
+    shutil.copyfile(source, profile_path)
+
+    skill = get_skill("nvtx_layer_breakdown")
+    plain = _sqlite3.connect(str(profile_path))
+    try:
+        rows = [r for r in skill.execute(plain) if isinstance(r, dict)]
+    finally:
+        plain.close()
+
+    assert rows, "fixture produced no layer rows to judge"
+    reported = [r["tc_achieved_pct"] for r in rows if "tc_achieved_pct" in r]
+    assert reported, "the column vanished; this test no longer guards anything"
+    assert all(value is None for value in reported), (
+        f"unmeasurable Tensor Core achievement reported as a number: {reported[:6]}"
+    )
+
+    # ...and the engine that *can* measure it still does, so this is a fix for
+    # the wrong answer rather than the removal of a right one.
+    with profile_mod.open(str(profile_path)) as prof:
+        cached = [r for r in skill.execute(prof.query_conn()) if isinstance(r, dict)]
+    measured = [r.get("tc_achieved_pct") for r in cached]
+    assert any(isinstance(value, (int, float)) for value in measured), measured

--- a/tests/test_skill_engine_parity.py
+++ b/tests/test_skill_engine_parity.py
@@ -50,11 +50,11 @@ ENGINE_DEPENDENT_SKILLS = {"schema_inspect"}
 # abstains outright there. Teaching the SQLite path to classify kernel names is
 # a feature, not an arithmetic fix, so these cells stay out of the comparison.
 #
-# ``tc_achieved_pct`` is NOT in that category and is excluded under protest:
-# ``nvtx_layer_breakdown`` reports 0.0 on sqlite3 and 100.0 on the cache for the
-# same regions, because a missing capability is summed as zero instead of
-# staying unknown. That is a wrong answer, not an unavailable one -- issue #418.
-# It is listed here so the rest of the sweep can run; remove it with the fix.
+# ``tc_achieved_pct`` joined that category rather than leaving it. It used to
+# read 0.0 on sqlite3 against 100.0 on the cache -- a wrong answer, not an
+# unavailable one, because the missing capability was summed as zero (#418).
+# With that fixed the sqlite3 side reports None, and the divergence is now the
+# honest one this list is for: one engine measures, the other says it cannot.
 CAPABILITY_COLUMNS = frozenset(
     {
         "is_tc_eligible",


### PR DESCRIPTION
## Summary

- `nvtx_layer_breakdown` reported `tc_achieved_pct = 0.0` on a plain `sqlite3` connection and `100.0` through the cache, for the same regions of the same profile, with nothing to tell a reader which they had.
- The cause was an unknown summed as zero: `tc_eligible_ns` accumulated `tc_elig or 0`, which erased the `None` the fallback path yields on a connection with no Tensor Core columns — and made the guard that checked for `None` unreachable.
- Now the unmeasurable case reports `None`. The engine that *can* measure still measures.

## Measured

`h100_2gpu_1s.sqlite`, first four layer rows:

| | before | after |
|---|---|---|
| `sqlite3` | `[None, 0.0, 0.0, 0.0]` | `[None, None, None, None]` |
| DuckDB over the cache | `[None, 100.0, 100.0, 100.0]` | `[None, 100.0, 100.0, 100.0]` |

## Changes

- `src/nsys_ai/skills/builtins/nvtx_layer_breakdown.py` — `tc_unmeasurable` is tracked as a flag beside the sums rather than inferred from them, because "nothing was eligible" and "eligibility could not be measured" are different answers that both total zero. It is absorbing within a group: a group mixing measured and unmeasured leaves cannot be averaged without understating the denominator, and a quiet understatement reads as a real low achievement.
- `tests/test_nvtx_layer_breakdown.py` — the pure-SQLite path reports `None` for every layer row, and the cached path still reports a number. Both halves matter: the second stops this being "fixed" by deleting a measurement.
- `tests/test_skill_engine_parity.py` — comment only, see below.

## This PR changes the issue's second acceptance criterion

#418 asked for `tc_achieved_pct` to come out of `CAPABILITY_COLUMNS` with the parity sweep staying green. It cannot, and should not. With the unknown preserved, the cache emits a number where `sqlite3` emits `None`, so the sweep's shape assertion fires:

```
nvtx_layer_breakdown on h100_2gpu_1s.sqlite: different result shapes
  Only in the cache: [(1, 'tc_achieved_pct'), (2, 'tc_achieved_pct'), ...]
```

That is the right outcome. The column always belonged in that list — it just did not *behave* like a capability column, because the missing capability was being summed as zero. Fixing the number moved it **into** the category rather than out of it. The entry stays; its comment now says that instead of describing itself as a cover-up. Recorded on the issue too, rather than diverging from it silently.

## Backward compatibility

A consumer reading `tc_achieved_pct` on the pure-SQLite path now gets `None` where it got `0.0`. `0.0` was wrong — it asserted zero Tensor Core achievement for regions the connection could not classify at all.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2262 passed, 140 skipped, 5 xfailed, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised: both engines on both committed fixtures, numbers in the table above

## Out of scope

- Teaching the SQLite path to classify kernel names. That is a feature; this is a wrong number.

## Linked issues

Closes #418
