### PR TITLE
fix(profile): read the observed GPU count from the guarded handle

### DIFF
--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -127,17 +127,24 @@ def _assert_profile_descriptor_unchanged(
         raise ProfileError("local profile changed during validation")
 
 
-def build_local_profile_reference(
+def read_local_profile_under_guard(
     path: str | os.PathLike[str],
     *,
     resolved_secrets: Mapping[str, str] | None = None,
-) -> LocalProfileReference:
-    """Validate an existing SQLite export and return its local reference.
+) -> tuple[LocalProfileReference, int]:
+    """Validate an existing SQLite export; return its reference and GPU count.
 
     The source profile is opened in direct, read-only analysis mode. The
     function does not export, copy, cache, or publish the profile or create a
     session. ``resolved_secrets`` lets callers reject a declared secret that
     would otherwise be persisted as part of the absolute local path.
+
+    The device count comes back alongside the reference because it is read here
+    and nowhere cheaper: this open goes through a pinned descriptor whose
+    identity is asserted unchanged afterwards, and ``profile.meta`` is already
+    materialised for ``kernel_count``. A caller that re-opens the path to count
+    devices pays for a second full ``GROUP BY deviceId`` scan and gets its
+    answer from a file the swap guard no longer covers.
     """
     path_conversion_failed = False
     try:
@@ -196,6 +203,7 @@ def build_local_profile_reference(
     validation_succeeded = False
     unexpected_error: Exception | None = None
     kernel_count = None
+    device_count = 0
     profile_id = None
     schema_version = None
     product_version = None
@@ -209,6 +217,7 @@ def build_local_profile_reference(
         connection.execute("PRAGMA query_only = ON")
         with Profile._from_conn(connection) as profile:
             kernel_count = profile.meta.kernel_count
+            device_count = len(profile.meta.devices or ())
             profile_id = get_profile_id(
                 profile.conn, fallback_path=str(profile_path)
             )
@@ -250,28 +259,25 @@ def build_local_profile_reference(
         kernel_count=kernel_count,
     )
     try:
-        return validate_local_profile_reference(reference, require_file=True)
+        validated = validate_local_profile_reference(reference, require_file=True)
     except (TypeError, ValueError) as exc:
         raise ProfileError(str(exc)) from None
+    return validated, device_count
 
 
-def observed_gpu_count(path: str | os.PathLike[str]) -> int:
-    """Number of GPUs that recorded kernels in an exported profile.
-
-    Read from the kernel table's device ids, which is the only statement the
-    capture itself makes about how many GPUs the run used: a machine can expose
-    eight and a run can touch one.
-    """
-    connection = sqlite3.connect(os.fspath(path), check_same_thread=False)
-    try:
-        connection.execute("PRAGMA query_only = ON")
-        with Profile._from_conn(connection) as profile:
-            return len(profile.meta.devices or ())
-    finally:
-        connection.close()
+def build_local_profile_reference(
+    path: str | os.PathLike[str],
+    *,
+    resolved_secrets: Mapping[str, str] | None = None,
+) -> LocalProfileReference:
+    """The reference alone, for the callers that do not need the GPU count."""
+    reference, _ = read_local_profile_under_guard(
+        path, resolved_secrets=resolved_secrets
+    )
+    return reference
 
 
-def check_expected_gpu_count(spec: RunSpec, sqlite_path: Path) -> str | None:
+def check_expected_gpu_count(spec: RunSpec, observed: int | None) -> str | None:
     """Return why ``expected_gpu_count`` is unmet, or None when it holds.
 
     ``expected_gpu_count`` was recorded into the RunSpec and never read, so a
@@ -288,15 +294,13 @@ def check_expected_gpu_count(spec: RunSpec, sqlite_path: Path) -> str | None:
     expected = spec.expected_gpu_count
     if expected is None:
         return None
-    try:
-        observed = observed_gpu_count(sqlite_path)
-    except (NsysAiError, OSError, *DB_ERRORS) as exc:
+    if observed is None:
         # The declaration was asked for and cannot be checked, so it is not
         # satisfied. Failing closed keeps "unverifiable" out of the success
         # path, where it would be indistinguishable from "verified".
         return (
             f"declared expected_gpu_count={expected} could not be checked against the "
-            f"capture: {type(exc).__name__}"
+            "capture"
         )
     if observed != expected:
         return (
@@ -582,7 +586,7 @@ class LocalProfileRunner:
         progress(RunStage.VALIDATING)
         validation_started = time.monotonic()
         try:
-            reference = build_local_profile_reference(
+            reference, observed_gpus = read_local_profile_under_guard(
                 sqlite_path, resolved_secrets=resolved_secrets
             )
         except (NsysAiError, OSError, *DB_ERRORS) as exc:
@@ -594,7 +598,7 @@ class LocalProfileRunner:
                 sqlite=sqlite_path,
                 detail=f"profile validation failed: {type(exc).__name__}",
             )
-        gpu_count_detail = check_expected_gpu_count(spec, sqlite_path)
+        gpu_count_detail = check_expected_gpu_count(spec, observed_gpus)
         if gpu_count_detail is not None:
             validation_seconds = time.monotonic() - validation_started
             return result(

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -277,7 +277,7 @@ def build_local_profile_reference(
     return reference
 
 
-def check_expected_gpu_count(spec: RunSpec, observed: int | None) -> str | None:
+def check_expected_gpu_count(spec: RunSpec, observed: int) -> str | None:
     """Return why ``expected_gpu_count`` is unmet, or None when it holds.
 
     ``expected_gpu_count`` was recorded into the RunSpec and never read, so a
@@ -290,18 +290,15 @@ def check_expected_gpu_count(spec: RunSpec, observed: int | None) -> str | None:
     process in a distributed job, one local capture watches one launch, and
     counting processes in the export would answer a different question under
     the same name.
+
+    The count is required rather than optional: it is read inside the guarded
+    window, which either yields a number or raises, and the caller turns that
+    raise into ``INVALID_PROFILE``. Accepting None here would restate a
+    fail-closed rule that no caller can reach and no test can pin.
     """
     expected = spec.expected_gpu_count
     if expected is None:
         return None
-    if observed is None:
-        # The declaration was asked for and cannot be checked, so it is not
-        # satisfied. Failing closed keeps "unverifiable" out of the success
-        # path, where it would be indistinguishable from "verified".
-        return (
-            f"declared expected_gpu_count={expected} could not be checked against the "
-            "capture"
-        )
     if observed != expected:
         return (
             f"declared expected_gpu_count={expected} but the capture recorded kernels on "

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -1,5 +1,6 @@
 import json
 import os
+import sqlite3
 import stat
 import threading
 import time
@@ -679,6 +680,29 @@ def test_declared_gpu_count_the_capture_meets_succeeds(tmp_path, fake_nsys):
 
     assert result.status is RunStatus.SUCCEEDED, result.detail
     assert result.profile is not None
+
+
+def test_an_unreadable_capture_fails_the_run_rather_than_the_declaration(
+    tmp_path, fake_nsys, monkeypatch
+):
+    """"Could not be checked" must never reach the success path.
+
+    The guarded read either yields a count or raises, so the fail-closed rule
+    lives here rather than in a "count is unknown" branch of the comparison,
+    which no caller could reach. A capture that cannot be read is invalid
+    whether or not a declaration was made.
+    """
+    from nsys_ai import profile_runner
+
+    def _explode(*_args, **_kwargs):
+        raise sqlite3.OperationalError("database disk image is malformed")
+
+    monkeypatch.setattr(profile_runner, "read_local_profile_under_guard", _explode)
+    result = _run(tmp_path, fake_nsys, expected_gpu_count=8)
+
+    assert result.status is RunStatus.INVALID_PROFILE
+    assert result.detail == "profile validation failed: OperationalError"
+    assert result.profile is None
 
 
 def test_the_gpu_count_is_read_from_the_guarded_handle(tmp_path, fake_nsys):

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -202,17 +202,24 @@ def test_success_returns_validated_reference_and_artifacts(tmp_path, fake_nsys):
 def test_runner_reuses_public_profile_reference_factory(
     tmp_path, fake_nsys, monkeypatch
 ):
+    """The runner must not re-implement the guarded read.
+
+    It goes through the shared reader, which pins a descriptor, asserts the
+    file did not change under it, and returns the reference and the device
+    count from that one open. `build_local_profile_reference` is the thin
+    wrapper over the same reader for callers that need only the reference.
+    """
     import nsys_ai.profile_runner as profile_runner
 
     calls = []
-    real_factory = profile_runner.build_local_profile_reference
+    real_reader = profile_runner.read_local_profile_under_guard
 
-    def recording_factory(path, *, resolved_secrets=None):
+    def recording_reader(path, *, resolved_secrets=None):
         calls.append((Path(path), dict(resolved_secrets or {})))
-        return real_factory(path, resolved_secrets=resolved_secrets)
+        return real_reader(path, resolved_secrets=resolved_secrets)
 
     monkeypatch.setattr(
-        profile_runner, "build_local_profile_reference", recording_factory
+        profile_runner, "read_local_profile_under_guard", recording_reader
     )
     result = _run(tmp_path, fake_nsys)
 
@@ -674,10 +681,42 @@ def test_declared_gpu_count_the_capture_meets_succeeds(tmp_path, fake_nsys):
     assert result.profile is not None
 
 
-def test_observed_gpu_count_reads_the_devices_that_recorded_kernels(tmp_path, fake_nsys):
-    """A machine can expose eight GPUs and a run can touch one."""
-    from nsys_ai.profile_runner import observed_gpu_count
+def test_the_gpu_count_is_read_from_the_guarded_handle(tmp_path, fake_nsys):
+    """A machine can expose eight GPUs and a run can touch one.
+
+    The count comes back from the same guarded open that builds the reference.
+    It used to be a second `sqlite3.connect` by path, made after the pinned
+    descriptor was closed -- so the number validation acted on was read from
+    whatever sat at that path by then, outside the swap guard, at the cost of a
+    second full `GROUP BY deviceId` scan.
+    """
+    from nsys_ai.profile_runner import read_local_profile_under_guard
 
     result = _run(tmp_path, fake_nsys)
     assert result.status is RunStatus.SUCCEEDED
-    assert observed_gpu_count(result.sqlite_path) == 1
+    reference, observed = read_local_profile_under_guard(result.sqlite_path)
+    assert observed == 1
+    assert reference.kernel_count > 0
+
+
+def test_the_capture_is_opened_once_for_reference_and_gpu_count(tmp_path, fake_nsys, monkeypatch):
+    """One guarded open, not two: the second was by path and unguarded."""
+    import sqlite3 as _sqlite3
+
+    from nsys_ai import profile_runner
+
+    result = _run(tmp_path, fake_nsys)
+    assert result.status is RunStatus.SUCCEEDED
+
+    opened: list[str] = []
+    real_connect = _sqlite3.connect
+
+    def _record(target, *args, **kwargs):
+        opened.append(str(target))
+        return real_connect(target, *args, **kwargs)
+
+    monkeypatch.setattr(profile_runner.sqlite3, "connect", _record)
+    profile_runner.read_local_profile_under_guard(result.sqlite_path)
+
+    by_path = [target for target in opened if not target.startswith("file:/proc/self/fd/")]
+    assert not by_path, f"the capture was reopened outside the descriptor guard: {by_path}"


### PR DESCRIPTION
## Summary

- `observed_gpu_count` re-opened the capture by path with `sqlite3.connect`, **after** the pinned, swap-guarded descriptor had been closed. The count that capture validation acted on came from whatever sat at that path by then, not from the file the guard had asserted unchanged.
- It also cost a second full `GROUP BY deviceId, streamId` scan of the kernel table — a scan `build_local_profile_reference` had just run, whose result was already materialised on `profile.meta`.
- Both are gone: the count comes back from the one guarded open, beside the reference.

## Changes

- `src/nsys_ai/profile_runner.py` — the guarded read is now `read_local_profile_under_guard`, returning `(reference, device_count)`. `build_local_profile_reference` becomes a thin wrapper over it for the fifteen callers that need only the reference, so no caller outside this file changes.
- `src/nsys_ai/profile_runner.py` — `check_expected_gpu_count(spec, observed)` takes the count instead of a path. The "could not be checked" branch stays and still fails closed: unverifiable must not land in the success path, where it is indistinguishable from verified.
- `tests/test_profile_runner.py` — the count comes from the guarded reader; a second test monkeypatches `sqlite3.connect` and asserts every open during the read goes through `file:/proc/self/fd/...`, so a path-based reopen fails rather than being re-argued.

## A note on the seam test

`test_runner_reuses_public_profile_reference_factory` asserted the runner goes through `build_local_profile_reference`. Its point is that the runner must not re-implement the guarded read, and that still holds — it now goes through `read_local_profile_under_guard`, which is where the guard lives. The test was repointed at that seam rather than deleted.

## Backward compatibility

`observed_gpu_count` is removed. It was added in the same milestone and has no caller outside this module and its test. `build_local_profile_reference` is unchanged in name, signature and return type.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2262 passed, 140 skipped, 5 xfailed, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean

## Out of scope

- What `--expected-gpu-count` means. This changes where the observed count is read from, not what it is compared against.

## Linked issues

Closes #419
