### PR TITLE
fix(diff): let the decision record be written outside the working directory

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -248,7 +248,9 @@ timestamp, and the decider taken from your git `user.email`, and moves the sessi
 phase. Use `--accept` for the other outcome. Either flag requires `--reason`, and a session accepts
 exactly one decision.
 
-Drop `--session` and the same flags write a `diff.json` in the working directory instead — the right
+Drop `--session` and the same flags write a `diff.json` in the working directory instead — or wherever
+`--decision-out PATH` names, which is what a CI job wants so the checkout it is testing stays clean.
+This is the right
 choice for a one-off comparison you are not tracking as a session.
 
 ## What the session directory holds

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -935,6 +935,10 @@ def _cmd_diff(args, _profile):
     # (no symlink dereference), matching SessionStore / build_local_profile_reference.
     session_before_path = None
     session_after_path = None
+    # Defaulted here rather than in the parser so the default stays visible next
+    # to the only code that writes it. A CI job runs in a checkout, so a record
+    # it cannot redirect is a record it cannot keep out of the repo under test.
+    decision_out_path = getattr(args, "decision_out", None) or "diff.json"
     if decision is not None:
         if getattr(args, "chat", False):
             print("Error: --accept/--reject cannot be used with --chat", file=sys.stderr)
@@ -943,10 +947,13 @@ def _cmd_diff(args, _profile):
             print("Error: --reason is required with --accept/--reject", file=sys.stderr)
             sys.exit(2)
         if getattr(args, "output", None) and os.path.abspath(args.output) == os.path.abspath(
-            "diff.json"
+            decision_out_path
         ):
             print(
-                "Error: --output diff.json conflicts with the decision record path",
+                f"Error: --output and the decision record would both write "
+                f"{decision_out_path}. -o writes the rendered report in --format; the "
+                "decision record is a separate JSON artifact. Point one of them "
+                "elsewhere with --decision-out.",
                 file=sys.stderr,
             )
             sys.exit(2)
@@ -1128,7 +1135,7 @@ def _cmd_diff(args, _profile):
                 gate_summary,
                 decision=decision,
                 reason=reason or "",
-                path="diff.json",
+                path=decision_out_path,
             )
         except ValueError as exc:
             print(f"Error: {exc}", file=sys.stderr)

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -931,6 +931,16 @@ def _cmd_diff(args, _profile):
     if session is not None and getattr(args, "chat", False):
         print("Error: --session cannot be combined with --chat", file=sys.stderr)
         sys.exit(2)
+    if session is not None and getattr(args, "decision_out", None):
+        # The session owns its own diff.json. Accepting the option here and
+        # writing nothing would leave a CI job reading a file that was never
+        # created, with nothing said about why.
+        print(
+            "Error: --decision-out cannot be combined with --session; the session "
+            "records its decision in its own store",
+            file=sys.stderr,
+        )
+        sys.exit(2)
     # Keep session profile paths as caller spelling normalized with abspath
     # (no symlink dereference), matching SessionStore / build_local_profile_reference.
     session_before_path = None
@@ -938,7 +948,12 @@ def _cmd_diff(args, _profile):
     # Defaulted here rather than in the parser so the default stays visible next
     # to the only code that writes it. A CI job runs in a checkout, so a record
     # it cannot redirect is a record it cannot keep out of the repo under test.
-    decision_out_path = getattr(args, "decision_out", None) or "diff.json"
+    # expanduser because the shell does not: CI invokes this without one, and a
+    # literal "~/..." would be created as a directory named "~" in the checkout
+    # this option exists to keep clean.
+    decision_out_path = os.path.expanduser(
+        getattr(args, "decision_out", None) or "diff.json"
+    )
     if decision is not None:
         if getattr(args, "chat", False):
             print("Error: --accept/--reject cannot be used with --chat", file=sys.stderr)
@@ -946,8 +961,13 @@ def _cmd_diff(args, _profile):
         if not reason or not reason.strip():
             print("Error: --reason is required with --accept/--reject", file=sys.stderr)
             sys.exit(2)
-        if getattr(args, "output", None) and os.path.abspath(args.output) == os.path.abspath(
-            decision_out_path
+        # Only when a record is actually written here. Under --session it goes
+        # into the store, so there is nothing for -o to collide with, and the
+        # remedy this names would move a path that is never written.
+        if (
+            session is None
+            and getattr(args, "output", None)
+            and os.path.abspath(args.output) == os.path.abspath(decision_out_path)
         ):
             print(
                 f"Error: --output and the decision record would both write "
@@ -1139,6 +1159,16 @@ def _cmd_diff(args, _profile):
             )
         except ValueError as exc:
             print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(2)
+        except OSError as exc:
+            # --decision-out is caller-supplied, so an unwritable directory, a
+            # path naming a directory, or a missing permission is a
+            # configuration problem: exit 2 like every other one here, never 1,
+            # which a CI job reads as "the gate failed".
+            print(
+                f"Error: cannot write the decision record to {decision_out_path}: {exc}",
+                file=sys.stderr,
+            )
             sys.exit(2)
         for warning in decision_warnings:
             print(f"Warning: {warning}", file=sys.stderr)

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -926,12 +926,20 @@ def _build_parser():
     decision.add_argument(
         "--accept",
         action="store_true",
-        help="Persist an accepted user decision to diff.json (requires --reason)",
+        help="Persist an accepted user decision (requires --reason; see --decision-out)",
     )
     decision.add_argument(
         "--reject",
         action="store_true",
-        help="Persist a rejected user decision to diff.json (requires --reason)",
+        help="Persist a rejected user decision (requires --reason; see --decision-out)",
+    )
+    p.add_argument(
+        "--decision-out",
+        default=None,
+        metavar="PATH",
+        help="Where --accept/--reject writes the decision record "
+        "(default: diff.json in the working directory). Distinct from -o, which "
+        "writes the rendered report in --format",
     )
     p.add_argument(
         "--reason",

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1,6 +1,7 @@
 import json
 import os
 import pathlib
+import site
 import sqlite3
 import subprocess
 import sys
@@ -1256,6 +1257,86 @@ def test_diff_cli_decision_defaults_to_the_working_directory(tmp_path):
 
     assert result.returncode == 0, result.stderr
     assert (tmp_path / "diff.json").exists()
+
+
+def test_diff_cli_unwritable_decision_path_is_a_configuration_error(tmp_path):
+    """Exit 2, not 1: a CI job reads 1 as "the performance gate failed".
+
+    ``--decision-out`` is caller-supplied, so an unwritable directory is a
+    misconfiguration. Letting the OSError escape gave a traceback and exit 1 --
+    indistinguishable from a real regression, on the exact path CI uses.
+    """
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+    unwritable = tmp_path / "readonly"
+    unwritable.mkdir()
+    unwritable.chmod(0o500)
+
+    try:
+        result = _run_diff_cli(
+            before, after, "--accept", "--reason", "verified",
+            "--decision-out", str(unwritable / "decision.json"),
+            cwd=tmp_path, env=_decision_cli_env(tmp_path),
+        )
+    finally:
+        unwritable.chmod(0o700)
+
+    assert result.returncode == 2, result.stderr
+    assert "cannot write the decision record" in result.stderr
+    assert "Traceback" not in result.stderr
+
+
+def test_diff_cli_decision_out_expands_a_home_relative_path(tmp_path):
+    """CI invokes this without a shell, so nothing else expands the tilde.
+
+    Left literal, ``atomic_write_bytes`` created a directory named ``~`` in the
+    working directory -- the pollution the option exists to prevent.
+    """
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+    home = tmp_path / "home"
+    home.mkdir()
+    env = _decision_cli_env(tmp_path)
+    env["HOME"] = str(home)
+    # Relocating HOME also relocates the per-user site-packages the runtime
+    # dependencies may live in, so keep the original one importable.
+    env["PYTHONPATH"] = os.pathsep.join([env["PYTHONPATH"], site.getusersitepackages()])
+
+    result = _run_diff_cli(
+        before, after, "--accept", "--reason", "verified",
+        "--decision-out", "~/artifacts/decision.json",
+        cwd=tmp_path, env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (home / "artifacts" / "decision.json").exists()
+    assert not (tmp_path / "~").exists(), "a directory named ~ was created in the CWD"
+
+
+def test_diff_cli_rejects_decision_out_with_session(tmp_path):
+    """The session owns its record; accepting the flag and writing nothing lies.
+
+    A CI job that passed both exited 0 and then failed reading a file that was
+    never created, with nothing in stderr explaining why.
+    """
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+
+    result = _run_diff_cli(
+        before, after, "--session", "--accept", "--reason", "verified",
+        "--decision-out", str(tmp_path / "elsewhere.json"),
+        cwd=tmp_path, env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 2, result.stderr
+    assert "--decision-out cannot be combined with --session" in result.stderr
+    assert not (tmp_path / "elsewhere.json").exists()
 
 
 def test_diff_cli_refuses_to_write_report_and_decision_to_one_path(tmp_path):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1212,6 +1212,75 @@ def test_diff_cli_decision_missing_reason_is_refused(tmp_path):
     assert not (tmp_path / "diff.json").exists()
 
 
+def test_diff_cli_decision_can_be_written_outside_the_working_directory(tmp_path):
+    """A tool advertised for CI must be able to run in a checkout without dirtying it.
+
+    The decision record was hardcoded to ``diff.json`` beside wherever the
+    command ran, with no way to redirect it. In CI that directory is the
+    repository under test.
+    """
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+    destination = tmp_path / "artifacts" / "decision.json"
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--accept",
+        "--reason",
+        "verified",
+        "--decision-out",
+        str(destination),
+        cwd=tmp_path,
+        env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(destination.read_text(encoding="utf-8"))["decision"]["status"] == "accepted"
+    assert not (tmp_path / "diff.json").exists(), "the record was still left in the CWD"
+
+
+def test_diff_cli_decision_defaults_to_the_working_directory(tmp_path):
+    """Without the flag nothing moves; this is a redirect, not a relocation."""
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+
+    result = _run_diff_cli(
+        before, after, "--accept", "--reason", "verified",
+        cwd=tmp_path, env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (tmp_path / "diff.json").exists()
+
+
+def test_diff_cli_refuses_to_write_report_and_decision_to_one_path(tmp_path):
+    """Two artifacts, one name: say which is which and how to separate them.
+
+    ``-o`` writes the rendered report in ``--format``; the decision record is a
+    separate JSON artifact. The old message named the collision without naming
+    a way out, because there was none.
+    """
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+
+    result = _run_diff_cli(
+        before, after, "--format", "json", "--accept", "--reason", "v",
+        "-o", "same.json", "--decision-out", "same.json",
+        cwd=tmp_path, env=_decision_cli_env(tmp_path),
+    )
+
+    assert result.returncode == 2
+    assert "--decision-out" in result.stderr, result.stderr
+    assert "Traceback" not in result.stderr
+
+
 def test_diff_cli_decision_low_comparability_stamps_inconclusive(tmp_path):
     before = tmp_path / "before.sqlite"
     after = tmp_path / "after.sqlite"


### PR DESCRIPTION
## Summary

- `diff --accept/--reject` wrote its decision record to `diff.json` beside wherever the command ran, with no way to redirect it. In CI that directory is the repository under test, and `--gate` and `--strict` are both advertised for CI.
- `--decision-out PATH` names where it goes. Without the flag nothing moves.

## What the issue reports, and what is actually there

The issue reads the record and `-o` as one artifact — "writes `./diff.json`, and does so even when `-o FILE` is given". Measured, they are two:

```console
$ nsys-ai diff before.sqlite after.sqlite --no-ai --accept --reason t -o out/decision.json
$ find . -type f
./diff.json            # the decision record: JSON, has a "decision" block
./out/decision.json    # the rendered report in --format (terminal text here)
```

So `-o` is not ignored; it writes something else. Making `-o` control the record would conflate a report with a record and silently overwrite one with the other — which is what the existing "conflicts with the decision record path" guard was defending against. The defect is that the record had no redirect of its own.

## Changes

- `src/nsys_ai/cli/parsers.py` — `--decision-out PATH`, and `--accept`/`--reject` help that points at it instead of naming `diff.json` as fixed.
- `src/nsys_ai/cli/handlers.py` — the record honours it; the default (`diff.json`) is set beside the only code that writes it, not in the parser.
- The collision error now names the resolution. It used to say `--output diff.json conflicts with the decision record path` and stop there, because there was no way out; now it says which artifact is which and points at `--decision-out`.
- `docs/user-guide.md` — the flag, and why CI wants it.
- `tests/test_diff.py` — redirect writes nothing into the CWD; the default is unchanged; the collision exits 2 naming `--decision-out`.

## Backward compatibility

Yes. No flag, no change: `./diff.json` as before.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2264 passed, 140 skipped, 5 xfailed, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean
- [x] Manually exercised all three: redirected (only the named file appears), collision (`rc=2`, names `--decision-out`), default (`diff.json`, unchanged)

## Out of scope

The issue lists five writers and asks for one policy — an artifact root every writing path honours — noting that #228's settings file would be its natural home. This PR fixes the one item it calls "a bug rather than a policy". Deliberately untouched:

- `.nsys-ai/` sessions and locks, which have their own root argument already.
- `<name>.nsys-cache/` and `*.nsys-cache.build.lock` beside the profile. The issue itself marks caches-beside-input as correct and documented, and the lock is part of that mechanism; removing it needs concurrency care that does not belong in this diff.

## Linked issues

Refs #404
