### PR TITLE
fix(loop): check the recorded workload and the supplied RunSpec instead of trusting them

### DIFF
--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -293,18 +293,37 @@ def run_optimize(
 
     snapshot = _load_snapshot(store, resolved_id)
     if snapshot is not None:
-        if _decision_recorded(snapshot):
-            print(
-                "Loop already complete; reporting the recorded decision.", file=stdout
-            )
-            _print_recorded_decision(resolved_id, snapshot, session_root, stdout=stdout)
-            return 0
+        # Before anything is reused or reported, the inputs this run was given
+        # must be the inputs the session was built from. The session records
+        # both; neither was compared to anything, so the recorded state won over
+        # a contradicting argument silently -- including on the completed-loop
+        # path below, which would report a decision reached by verifying a
+        # different workload than the caller just named.
         recorded_before = snapshot.state.before_profile
         if recorded_before is not None and recorded_before != before_ref:
             raise OptimizeCommandError(
                 f"session {resolved_id} was opened on a different before profile "
                 f"({recorded_before.path}); pass --session with a new id"
             )
+        recorded_runspec = snapshot.runspec
+        if (
+            recorded_runspec is not None
+            and workload
+            and tuple(recorded_runspec.argv) != tuple(workload)
+        ):
+            raise OptimizeCommandError(
+                f"session {resolved_id} verified a different workload.\n"
+                f"  recorded: {' '.join(recorded_runspec.argv)}\n"
+                f"  given:    {' '.join(workload)}\n"
+                "A decision recorded against one workload does not carry to another. "
+                "Pass --session with a new id to verify this one."
+            )
+        if _decision_recorded(snapshot):
+            print(
+                "Loop already complete; reporting the recorded decision.", file=stdout
+            )
+            _print_recorded_decision(resolved_id, snapshot, session_root, stdout=stdout)
+            return 0
 
     # Step 1 — diagnose.
     if snapshot is None or snapshot.findings is None:

--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -300,21 +300,28 @@ def run_optimize(
         # path below, which would report a decision reached by verifying a
         # different workload than the caller just named.
         recorded_before = snapshot.state.before_profile
-        if recorded_before is not None and recorded_before != before_ref:
+        # Compare identity, not the reference: the session id is derived from
+        # profile_id alone, so the same capture reached by another path -- a
+        # moved artifact directory, a symlink, a container mount -- resolves to
+        # this session and must not be told it is a different profile.
+        if (
+            recorded_before is not None
+            and recorded_before.profile_id != before_ref.profile_id
+        ):
             raise OptimizeCommandError(
                 f"session {resolved_id} was opened on a different before profile "
                 f"({recorded_before.path}); pass --session with a new id"
             )
         recorded_runspec = snapshot.runspec
-        if (
-            recorded_runspec is not None
-            and workload
-            and tuple(recorded_runspec.argv) != tuple(workload)
-        ):
+        # The recorded argv was built from the normalized workload, so the raw
+        # tokens are the wrong side of this comparison: normalization inserts
+        # the interpreter for the documented `train.py` shorthand, which would
+        # make every re-run of a Python workload look like a different one.
+        if recorded_runspec is not None and tuple(recorded_runspec.argv) != normalized:
             raise OptimizeCommandError(
                 f"session {resolved_id} verified a different workload.\n"
                 f"  recorded: {' '.join(recorded_runspec.argv)}\n"
-                f"  given:    {' '.join(workload)}\n"
+                f"  given:    {' '.join(normalized)}\n"
                 "A decision recorded against one workload does not carry to another. "
                 "Pass --session with a new id to verify this one."
             )
@@ -524,6 +531,7 @@ def _publish_proposal(
                 runspec_path=handle_path,
                 session_root=session_root,
                 stdout=stdout,
+                stderr=stderr,
                 environment=environment,
             )
         except (ProposeCommandError, RunSpecError, ProfileError, ValueError) as exc:

--- a/src/nsys_ai/propose_command.py
+++ b/src/nsys_ai/propose_command.py
@@ -9,7 +9,7 @@ import stat
 import sys
 from collections.abc import Mapping
 from dataclasses import dataclass
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Any, TextIO
 
 from .annotation import EvidenceReport, Finding, validate_evidence_report_payload
@@ -351,6 +351,51 @@ def _derive_session_id_from_profile(
     return resolve_session_id(None, before=before)
 
 
+def _capture_runspec_beside(profile_path: str | os.PathLike[str] | None) -> RunSpec | None:
+    """The RunSpec ``nsys-ai profile`` wrote beside a capture, if it is there."""
+    if not profile_path:
+        return None
+    try:
+        sibling = Path(os.fspath(profile_path)).resolve().parent / "runspec.json"
+        if not sibling.is_file():
+            return None
+        return RunSpec.from_dict(json.loads(sibling.read_text(encoding="utf-8")))
+    except (AttributeError, OSError, RunSpecError, TypeError, ValueError):
+        # The comparison below is advisory. An unreadable or foreign sibling
+        # means there is nothing to compare against, not that the supplied
+        # RunSpec is wrong.
+        return None
+
+
+def _unrelated_runspec_warning(supplied: RunSpec, captured: RunSpec) -> str | None:
+    """Say so when the supplied RunSpec cannot be verifying the same workload.
+
+    The recorded lineage was never compared to anything: a RunSpec from an
+    entirely different program was accepted and written into the proposal as
+    the path by which the change would be verified. This does not refuse it --
+    a caller may legitimately verify with a narrower harness than the capture
+    ran -- but an unrelated argv is worth saying out loud, because the proposal
+    asserts the opposite.
+    """
+    supplied_program = PurePosixPath(supplied.argv[0]).name if supplied.argv else ""
+    captured_program = PurePosixPath(captured.argv[0]).name if captured.argv else ""
+    if not supplied_program or not captured_program:
+        return None
+    if supplied_program == captured_program:
+        return None
+    shared = {token for token in supplied.argv if not token.startswith("-")} & {
+        token for token in captured.argv if not token.startswith("-")
+    }
+    if shared:
+        return None
+    return (
+        "the RunSpec names a workload with nothing in common with the capture "
+        f"this finding came from (given `{' '.join(supplied.argv)}`, captured "
+        f"`{' '.join(captured.argv)}`). The proposal records it as the way this "
+        "change will be verified; check that it is."
+    )
+
+
 def run_propose(
     *,
     finding_id: str,
@@ -424,6 +469,20 @@ def run_propose(
         except (TypeError, ValueError) as exc:
             detail = _redact_message(str(exc), resolved_secrets or {})
             raise ProposeCommandError(f"invalid evidence report: {detail}") from exc
+
+    # The findings name the capture they came from, and `nsys-ai profile` wrote
+    # that capture's own RunSpec beside it. Comparing the two is the only point
+    # in the loop where a supplied verification path can be checked against the
+    # workload it claims to verify. `--profile` is session-only, so the report
+    # is the source in both modes.
+    if runspec is not None and not adopted_runspec:
+        captured_runspec = _capture_runspec_beside(
+            profile_path or getattr(report, "profile_path", None)
+        )
+        if captured_runspec is not None:
+            lineage_warning = _unrelated_runspec_warning(runspec, captured_runspec)
+            if lineage_warning:
+                print(f"Warning: {lineage_warning}", file=sys.stderr)
 
     finding = _select_finding(report, finding_id)
     proposal = generate_proposal(

--- a/src/nsys_ai/propose_command.py
+++ b/src/nsys_ai/propose_command.py
@@ -406,6 +406,7 @@ def run_propose(
     output: str | os.PathLike[str] | None = None,
     session_root: str | os.PathLike[str] = ".nsys-ai/sessions",
     stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
     environment: Mapping[str, str] = os.environ,
 ) -> int:
     """Generate one Proposal from a findings file or a session findings artifact.
@@ -482,7 +483,9 @@ def run_propose(
         if captured_runspec is not None:
             lineage_warning = _unrelated_runspec_warning(runspec, captured_runspec)
             if lineage_warning:
-                print(f"Warning: {lineage_warning}", file=sys.stderr)
+                # The caller's stream, not the process one: a caller that sends
+                # stdout to a file still needs to see this.
+                print(f"Warning: {lineage_warning}", file=stderr)
 
     finding = _select_finding(report, finding_id)
     proposal = generate_proposal(
@@ -536,6 +539,7 @@ def run_propose_command(
     args: Any,
     *,
     stdout: TextIO = sys.stdout,
+    stderr: TextIO = sys.stderr,
     environment: Mapping[str, str] = os.environ,
 ) -> int:
     """Adapt an argparse Namespace to :func:`run_propose`."""
@@ -546,7 +550,7 @@ def run_propose_command(
     if findings is None and session is None:
         print(
             "nsys-ai propose: error: the following arguments are required: findings",
-            file=sys.stderr,
+            file=stderr,
         )
         return 2
     return run_propose(
@@ -557,5 +561,6 @@ def run_propose_command(
         runspec_path=getattr(args, "runspec", None),
         output=getattr(args, "output", None),
         stdout=stdout,
+        stderr=stderr,
         environment=environment,
     )

--- a/tests/test_optimize_command.py
+++ b/tests/test_optimize_command.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 import io
 import json
+import shutil
+import sys
 from pathlib import Path
 
 import pytest
@@ -160,9 +162,9 @@ def _stub_nsys_probe(monkeypatch):
 def _run(tmp_path, runner_factory, **overrides):
     stdout, stderr = io.StringIO(), io.StringIO()
     code = run_optimize(
-        before_path=BEFORE,
+        before_path=overrides.pop("before_path", BEFORE),
         repo=tmp_path,
-        workload=["./axpy", "20"],
+        workload=overrides.pop("workload", ["./axpy", "20"]),
         session_id=SESSION_ID,
         trim=None,
         session_root=_session_root(tmp_path),
@@ -304,7 +306,7 @@ def test_optimize_refuses_a_session_that_verified_another_workload(tmp_path):
     assert code == 0, err
     assert _snapshot(tmp_path).runspec.argv == ("./axpy", "20")
 
-    with pytest.raises(OptimizeCommandError, match="verified a different workload"):
+    with pytest.raises(OptimizeCommandError, match="verified a different workload") as excinfo:
         run_optimize(
             before_path=BEFORE,
             repo=tmp_path,
@@ -316,6 +318,60 @@ def test_optimize_refuses_a_session_that_verified_another_workload(tmp_path):
             stdout=io.StringIO(),
             stderr=io.StringIO(),
         )
+    # The refusal has to name both sides; "they differ" is not actionable.
+    message = str(excinfo.value)
+    assert "./axpy 20" in message
+    assert "./bench_matmul 4096" in message
+
+
+def test_optimize_resumes_a_python_workload_re_run_unchanged(tmp_path):
+    """The recorded argv is normalized, so the raw tokens cannot be compared.
+
+    `normalize_workload` inserts the interpreter for the documented `train.py`
+    shorthand. Comparing the recorded argv against the raw workload made every
+    re-run of a Python workload -- the primary case this tool exists for --
+    look like a different command and refused to resume.
+    """
+    _seed_findings(tmp_path)
+    after_reference = build_local_profile_reference(AFTER)
+    python_workload = ["train.py", "--epochs", "3"]
+
+    code, _out, err = _run(
+        tmp_path, _succeeding_runner(after_reference), workload=python_workload
+    )
+    assert code == 0, err
+    recorded = _snapshot(tmp_path).runspec.argv
+    assert recorded == (sys.executable, "train.py", "--epochs", "3")
+
+    # The byte-identical command again: the loop reports its decision, not an error.
+    code2, out2, err2 = _run(
+        tmp_path, _exploding_runner(), workload=python_workload
+    )
+    assert code2 == 0, err2
+    assert "Loop already complete" in out2
+
+
+def test_optimize_accepts_the_same_capture_reached_by_another_path(tmp_path):
+    """The session id derives from profile_id, so the path must not gate it.
+
+    A moved artifact directory, a symlink, or a container mount reaches the same
+    capture by a different absolute path. Comparing whole references -- which
+    carry `path` -- rejected the very session that path resolves to.
+    """
+    _seed_findings(tmp_path)
+    after_reference = build_local_profile_reference(AFTER)
+    code, _out, err = _run(tmp_path, _succeeding_runner(after_reference))
+    assert code == 0, err
+
+    relocated = tmp_path / "moved" / "before.sqlite"
+    relocated.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(BEFORE, relocated)
+
+    code2, out2, err2 = _run(
+        tmp_path, _exploding_runner(), before_path=relocated
+    )
+    assert code2 == 0, err2
+    assert "Loop already complete" in out2
 
 
 def test_optimize_reports_the_recorded_decision_for_the_same_workload(tmp_path):

--- a/tests/test_optimize_command.py
+++ b/tests/test_optimize_command.py
@@ -292,6 +292,43 @@ def test_optimize_refuses_a_session_opened_on_another_profile(tmp_path):
         )
 
 
+def test_optimize_refuses_a_session_that_verified_another_workload(tmp_path):
+    """A decision recorded against one workload does not carry to another.
+
+    The session records the RunSpec it verified, and nothing compared it to the
+    workload the caller just supplied — so resuming a completed session with a
+    different command reported the prior decision as though it applied.
+    """
+    after_reference = build_local_profile_reference(AFTER)
+    code, _out, err = _run(tmp_path, _succeeding_runner(after_reference))
+    assert code == 0, err
+    assert _snapshot(tmp_path).runspec.argv == ("./axpy", "20")
+
+    with pytest.raises(OptimizeCommandError, match="verified a different workload"):
+        run_optimize(
+            before_path=BEFORE,
+            repo=tmp_path,
+            workload=["./bench_matmul", "4096"],
+            session_id=SESSION_ID,
+            session_root=_session_root(tmp_path),
+            cwd=tmp_path,
+            runner_factory=_exploding_runner(),
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+        )
+
+
+def test_optimize_reports_the_recorded_decision_for_the_same_workload(tmp_path):
+    """The guard must not break resume, which is the whole point of the session."""
+    after_reference = build_local_profile_reference(AFTER)
+    code, _out, err = _run(tmp_path, _succeeding_runner(after_reference))
+    assert code == 0, err
+
+    code, out, _err = _run(tmp_path, _exploding_runner())
+    assert code == 0
+    assert "Loop already complete" in out
+
+
 def test_optimize_rejects_a_repo_that_is_not_a_directory(tmp_path):
     """--repo names the directory the verification run executes in."""
     missing = tmp_path / "not-a-repo"

--- a/tests/test_propose_command.py
+++ b/tests/test_propose_command.py
@@ -859,3 +859,116 @@ def test_output_io_failure_is_clean_and_preserves_the_directory(tmp_path):
     assert "could not write proposal artifact" in result.stderr
     assert "Traceback" not in result.stderr
     assert output.is_dir()
+
+
+# ── the supplied RunSpec against the capture's own ──────────────────────
+
+
+def _capture_with_runspec(directory: Path, argv: tuple[str, ...] | None) -> Path:
+    """A profile path, with the runspec `nsys-ai profile` writes beside it."""
+    directory.mkdir(parents=True, exist_ok=True)
+    profile = directory / "capture.sqlite"
+    profile.write_bytes(b"")
+    if argv is not None:
+        _write_runspec(directory / "runspec.json", argv=argv)
+    return profile
+
+
+def _evidence_for(path: Path, capture: Path) -> None:
+    """An evidence report naming *capture* as the profile it came from.
+
+    `--profile` is session-only, so in file mode the report is the only thing
+    that says which capture these findings describe.
+    """
+    payload = EvidenceReport(
+        "Auto-Analysis",
+        profile_path=str(capture),
+        profile_id="nsys2:sha256:" + "1" * 64,
+        findings=[_finding("f1")],
+    ).to_dict()
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_a_runspec_unrelated_to_the_capture_is_said_out_loud(tmp_path, capsys):
+    """The proposal records the RunSpec as the way the change will be verified.
+
+    A RunSpec from an entirely different program was accepted and written in as
+    that verification path, with nothing comparing it to anything. The capture's
+    own runspec.json sits beside it and was never read.
+    """
+    profile = _capture_with_runspec(tmp_path / "capture", ("python", "train.py"))
+    findings = tmp_path / "findings.json"
+    _evidence_for(findings, profile)
+    unrelated = tmp_path / "unrelated.json"
+    _write_runspec(unrelated, argv=("./bench_axpy", "--n", "1024"))
+
+    code = propose_command.run_propose(
+        finding_id="f1",
+        findings_path=str(findings),
+        runspec_path=str(unrelated),
+        output=str(tmp_path / "proposal.json"),
+        stdout=io.StringIO(),
+    )
+
+    assert code == 0
+    stderr = capsys.readouterr().err
+    assert "nothing in common with the capture" in stderr, stderr
+    assert "./bench_axpy --n 1024" in stderr
+    assert "python train.py" in stderr
+
+
+def test_a_runspec_that_matches_the_capture_says_nothing(tmp_path, capsys):
+    """Advisory means quiet when there is nothing to advise."""
+    profile = _capture_with_runspec(tmp_path / "capture", ("python", "train.py"))
+    findings = tmp_path / "findings.json"
+    _evidence_for(findings, profile)
+    same = tmp_path / "same.json"
+    _write_runspec(same, argv=("python", "train.py"))
+
+    propose_command.run_propose(
+        finding_id="f1",
+        findings_path=str(findings),
+        runspec_path=str(same),
+        output=str(tmp_path / "proposal.json"),
+        stdout=io.StringIO(),
+    )
+
+    assert "nothing in common" not in capsys.readouterr().err
+
+
+def test_a_narrower_harness_sharing_a_target_says_nothing(tmp_path, capsys):
+    """Verifying with a tighter harness than the capture ran is legitimate."""
+    profile = _capture_with_runspec(tmp_path / "capture", ("python", "train.py"))
+    findings = tmp_path / "findings.json"
+    _evidence_for(findings, profile)
+    narrow = tmp_path / "narrow.json"
+    _write_runspec(narrow, argv=("pytest", "train.py", "-k", "step"))
+
+    propose_command.run_propose(
+        finding_id="f1",
+        findings_path=str(findings),
+        runspec_path=str(narrow),
+        output=str(tmp_path / "proposal.json"),
+        stdout=io.StringIO(),
+    )
+
+    assert "nothing in common" not in capsys.readouterr().err
+
+
+def test_no_runspec_beside_the_capture_means_no_claim(tmp_path, capsys):
+    """Most captures have no sibling; absence must not read as a mismatch."""
+    profile = _capture_with_runspec(tmp_path / "bare", None)
+    findings = tmp_path / "findings.json"
+    _evidence_for(findings, profile)
+    spec = tmp_path / "spec.json"
+    _write_runspec(spec, argv=("./bench_axpy",))
+
+    propose_command.run_propose(
+        finding_id="f1",
+        findings_path=str(findings),
+        runspec_path=str(spec),
+        output=str(tmp_path / "proposal.json"),
+        stdout=io.StringIO(),
+    )
+
+    assert "nothing in common" not in capsys.readouterr().err

--- a/tests/test_propose_command.py
+++ b/tests/test_propose_command.py
@@ -889,7 +889,7 @@ def _evidence_for(path: Path, capture: Path) -> None:
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def test_a_runspec_unrelated_to_the_capture_is_said_out_loud(tmp_path, capsys):
+def test_a_runspec_unrelated_to_the_capture_is_said_out_loud(tmp_path):
     """The proposal records the RunSpec as the way the change will be verified.
 
     A RunSpec from an entirely different program was accepted and written in as
@@ -902,22 +902,26 @@ def test_a_runspec_unrelated_to_the_capture_is_said_out_loud(tmp_path, capsys):
     unrelated = tmp_path / "unrelated.json"
     _write_runspec(unrelated, argv=("./bench_axpy", "--n", "1024"))
 
+    stderr = io.StringIO()
     code = propose_command.run_propose(
         finding_id="f1",
         findings_path=str(findings),
         runspec_path=str(unrelated),
         output=str(tmp_path / "proposal.json"),
         stdout=io.StringIO(),
+        stderr=stderr,
     )
 
     assert code == 0
-    stderr = capsys.readouterr().err
-    assert "nothing in common with the capture" in stderr, stderr
-    assert "./bench_axpy --n 1024" in stderr
-    assert "python train.py" in stderr
+    # The warning goes to the caller's stream, not the process one, so a caller
+    # that redirects stdout to a file still sees it.
+    written = stderr.getvalue()
+    assert "nothing in common with the capture" in written, written
+    assert "./bench_axpy --n 1024" in written
+    assert "python train.py" in written
 
 
-def test_a_runspec_that_matches_the_capture_says_nothing(tmp_path, capsys):
+def test_a_runspec_that_matches_the_capture_says_nothing(tmp_path):
     """Advisory means quiet when there is nothing to advise."""
     profile = _capture_with_runspec(tmp_path / "capture", ("python", "train.py"))
     findings = tmp_path / "findings.json"
@@ -925,18 +929,20 @@ def test_a_runspec_that_matches_the_capture_says_nothing(tmp_path, capsys):
     same = tmp_path / "same.json"
     _write_runspec(same, argv=("python", "train.py"))
 
+    stderr = io.StringIO()
     propose_command.run_propose(
         finding_id="f1",
         findings_path=str(findings),
         runspec_path=str(same),
         output=str(tmp_path / "proposal.json"),
         stdout=io.StringIO(),
+        stderr=stderr,
     )
 
-    assert "nothing in common" not in capsys.readouterr().err
+    assert "nothing in common" not in stderr.getvalue()
 
 
-def test_a_narrower_harness_sharing_a_target_says_nothing(tmp_path, capsys):
+def test_a_narrower_harness_sharing_a_target_says_nothing(tmp_path):
     """Verifying with a tighter harness than the capture ran is legitimate."""
     profile = _capture_with_runspec(tmp_path / "capture", ("python", "train.py"))
     findings = tmp_path / "findings.json"
@@ -944,18 +950,20 @@ def test_a_narrower_harness_sharing_a_target_says_nothing(tmp_path, capsys):
     narrow = tmp_path / "narrow.json"
     _write_runspec(narrow, argv=("pytest", "train.py", "-k", "step"))
 
+    stderr = io.StringIO()
     propose_command.run_propose(
         finding_id="f1",
         findings_path=str(findings),
         runspec_path=str(narrow),
         output=str(tmp_path / "proposal.json"),
         stdout=io.StringIO(),
+        stderr=stderr,
     )
 
-    assert "nothing in common" not in capsys.readouterr().err
+    assert "nothing in common" not in stderr.getvalue()
 
 
-def test_no_runspec_beside_the_capture_means_no_claim(tmp_path, capsys):
+def test_no_runspec_beside_the_capture_means_no_claim(tmp_path):
     """Most captures have no sibling; absence must not read as a mismatch."""
     profile = _capture_with_runspec(tmp_path / "bare", None)
     findings = tmp_path / "findings.json"
@@ -963,12 +971,14 @@ def test_no_runspec_beside_the_capture_means_no_claim(tmp_path, capsys):
     spec = tmp_path / "spec.json"
     _write_runspec(spec, argv=("./bench_axpy",))
 
+    stderr = io.StringIO()
     propose_command.run_propose(
         finding_id="f1",
         findings_path=str(findings),
         runspec_path=str(spec),
         output=str(tmp_path / "proposal.json"),
         stdout=io.StringIO(),
+        stderr=stderr,
     )
 
-    assert "nothing in common" not in capsys.readouterr().err
+    assert "nothing in common" not in stderr.getvalue()


### PR DESCRIPTION
## Summary

Every artifact in the loop carries a content hash, and none was compared to anything. The lineage was recorded, then trusted. Both repros in the issue now behave.

- **`optimize` on resume ignored a changed workload.** The recorded state won over a contradicting input, silently, and the loop reported a prior decision as though it applied to the command just given.
- **`propose --runspec` accepted a RunSpec from an unrelated workload** and wrote it into the proposal as the path by which the change would be verified.

## The idea

Our sources are immutable — a capture is write-once and already content-addressed — so there is no delta propagation to do. The adaptation that fits: **use the fingerprints for trust rather than for cache reuse.** An edge whose ends do not match is not a stale computation to re-run, it is a claim the tool must not make silently. No new dependency; the values were already computed and stored, this makes them load-bearing.

## Changes

- `src/nsys_ai/optimize_command.py` — a resume whose workload differs from the session's recorded RunSpec argv raises, naming both:

  ```
  session <id> verified a different workload.
    recorded: ./axpy 20
    given:    ./bench_matmul 4096
  A decision recorded against one workload does not carry to another.
  ```

  Both this and the pre-existing before-profile check moved **above** the completed-loop short-circuit. That path returned before either ran, so a decision verified against one workload was reported for another — the check existed and was unreachable in exactly the case that mattered.

- `src/nsys_ai/propose_command.py` — a supplied RunSpec is compared against the one `nsys-ai profile` wrote beside the capture the findings came from:

  ```
  Warning: the RunSpec names a workload with nothing in common with the capture this
  finding came from (given `./bench_axpy --n 1024`, captured `python train.py --epochs 3`).
  The proposal records it as the way this change will be verified; check that it is.
  ```

  A warning, not a refusal, as the issue specifies: verifying with a narrower harness than the capture ran is legitimate. It fires only when the two share neither a program name nor any non-flag token. The capture path comes from the evidence report, since `--profile` is session-only.

## Acceptance criteria

- [x] The unrelated-RunSpec repro produces a stated warning — output above.
- [x] The changed-workload-on-resume repro produces an error naming the two argvs — output above.
- [x] A legitimate run is unchanged: resuming with the same workload still reports the recorded decision, a matching RunSpec is silent, a narrower harness sharing a target is silent, and a capture with no sibling `runspec.json` is silent. One test each.

## Not done, and why

The third bullet — `publish_after_profile` / `publish_diff` comparing the runspec that produced the after capture against `proposal.verification` — is not in this PR. It changes the store's publish contract rather than adding a check at a call site, and the issue's own acceptance criteria name only the two repros above. `Refs`, not `Closes`; the issue stays open for it.

## Backward compatibility

A resume that supplies a different workload now errors instead of reporting the old decision. That is the fix. Same workload, same behaviour.

No external project is named in code or comments.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2267 passed, 140 skipped, 5 xfailed, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean
- [x] Manually exercised both repros end to end against a real session

## Linked issues

Refs #405
