### PR TITLE
fix(cli): make --help complete and give the legacy routing set one home

### DIFF
--- a/src/nsys_ai/cli/app.py
+++ b/src/nsys_ai/cli/app.py
@@ -94,6 +94,8 @@ def show_help():
     print("    1. Profile:  nsys-ai profile -- python train.py")
     print("    2. Explore:  nsys-ai open <profile.sqlite>")
     print()
+    print("  This screen is a task-organised selection. `nsys-ai --help` lists every command.")
+    print()
 
 
 # ---------------------------------------------------------------------------
@@ -164,27 +166,12 @@ def _normalize_optimize_command(argv: list[str]) -> list[str]:
 
 
 def main():
-    from .parsers import _build_legacy_parser, _build_parser
+    from .parsers import LEGACY_ROUTED_COMMANDS, _build_legacy_parser, _build_parser
 
     sys.argv = _normalize_default_profile_command(sys.argv)
     sys.argv = _normalize_optimize_command(sys.argv)
 
-    legacy_commands = {
-        "analyze",
-        "summary",
-        "overlap",
-        "nccl",
-        "iters",
-        "tree",
-        "markdown",
-        "search",
-        "export-csv",
-        "export-json",
-        "viewer",
-        "timeline-html",
-        "tui",
-        "timeline",
-    }
+    legacy_commands = LEGACY_ROUTED_COMMANDS
     use_legacy_skill_mgmt = (
         len(sys.argv) > 2 and sys.argv[1] == "skill" and sys.argv[2] in {"add", "remove", "save"}
     )

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -483,10 +483,46 @@ def _register_agent_parser(sub):
 # ---------------------------------------------------------------------------
 
 
+#: The commands ``main()`` sends to the legacy parser instead of the primary
+#: one. This is a routing decision, not a registration fact: the legacy parser
+#: also registers ``doctor``, ``info``, ``skill`` and others that the primary
+#: parser owns, so it cannot be derived from that parser's choices. It lived as
+#: a literal inside ``main()``, where nothing tied it to either parser and
+#: nothing showed it to a user -- these commands work and were absent from
+#: ``--help``, leaving a reader unable to tell which of two lists was
+#: authoritative.
+LEGACY_ROUTED_COMMANDS = frozenset(
+    {
+        "analyze",
+        "summary",
+        "overlap",
+        "nccl",
+        "iters",
+        "tree",
+        "markdown",
+        "search",
+        "export-csv",
+        "export-json",
+        "viewer",
+        "timeline-html",
+        "tui",
+        "timeline",
+    }
+)
+
+
 def _build_parser():
     parser = argparse.ArgumentParser(
         prog="nsys-ai",
         description="Web-first Nsight Systems analysis CLI (with AI backend tools)",
+        # Named here because they are dispatched but not registered on this
+        # parser, so they were absent from `--help` while working perfectly.
+        epilog=(
+            "also available:\n  "
+            + ", ".join(sorted(LEGACY_ROUTED_COMMANDS))
+            + "\n\nrun `nsys-ai help` for a task-organised introduction."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     sub = parser.add_subparsers(
         dest="command",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Basic smoke tests for nsys-ai package."""
 
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -1032,32 +1033,67 @@ def test_every_dispatchable_command_is_visible_from_dash_dash_help():
         [sys.executable, "-m", "nsys_ai", "--help"], capture_output=True, text=True
     )
     assert result.returncode == 0
-    missing = sorted(
-        name for name in _declared_subcommands() if name not in result.stdout
+
+    # Read the two lists `--help` actually presents, rather than searching the
+    # whole page for each name. Searching false-passes on prose: `viewer`
+    # occurs in "Serve interactive web viewer" and `timeline` in "Open web
+    # timeline UI", so both stay "present" after the epilog naming them is
+    # deleted -- which is the regression this test exists to catch.
+    # Horizontal whitespace only: `\s` spans newlines, so a greedy run would
+    # swallow the following help line and drop the command it names.
+    listed = set(
+        re.findall(r"^[ \t]{2,}([a-z][a-z0-9-]*)[ \t]{2,}\S", result.stdout, re.MULTILINE)
     )
+    epilog = result.stdout.split("also available:", 1)
+    assert len(epilog) == 2, f"--help no longer carries the epilog:\n{result.stdout}"
+    also_available = {
+        name.strip() for name in epilog[1].split("\n\n", 1)[0].split(",") if name.strip()
+    }
+
+    missing = sorted(_declared_subcommands() - listed - also_available)
     assert not missing, (
         "these commands dispatch but are invisible from `--help`:\n  "
         + "\n  ".join(missing)
     )
+    stale = sorted(also_available - _declared_subcommands())
+    assert not stale, (
+        "`--help` advertises commands that do not dispatch:\n  " + "\n  ".join(stale)
+    )
 
 
 def test_the_legacy_routing_set_matches_the_parser_that_serves_it():
-    """A routed command that is not registered there is an `invalid choice`.
+    """The routed set is exactly the commands only the legacy parser has.
 
-    The set lived as a literal inside `main()`, tied to neither parser. It is
-    deliberately a subset -- the legacy parser also registers `doctor`, `info`
-    and `skill`, which the primary parser owns and must keep -- so it cannot be
-    derived, only checked.
+    Asserting equality rather than containment is the point. A subset check
+    passes for the two ways this actually breaks: a command routed to a parser
+    that does not register it (`invalid choice`), and a command only the legacy
+    parser registers that nothing routes to it (unreachable, and invisible on
+    every help surface). It also passes for the set derived the naive way --
+    every name the legacy parser registers -- which would silently reroute
+    `doctor`, `info`, `evidence`, `help` and `skill` to a different
+    implementation than the one users get today.
     """
-    from nsys_ai.cli.parsers import LEGACY_ROUTED_COMMANDS, _build_legacy_parser
+    from nsys_ai.cli.parsers import (
+        LEGACY_ROUTED_COMMANDS,
+        _build_legacy_parser,
+        _build_parser,
+    )
 
-    registered: set[str] = set()
-    for action in _build_legacy_parser()._subparsers._group_actions:  # noqa: SLF001
-        registered.update(action.choices)
+    def _subcommands(parser) -> set[str]:
+        names: set[str] = set()
+        for action in parser._subparsers._group_actions:  # noqa: SLF001
+            names.update(action.choices)
+        return names
 
-    unregistered = sorted(LEGACY_ROUTED_COMMANDS - registered)
-    assert not unregistered, (
-        f"routed to the legacy parser but not registered on it: {unregistered}"
+    legacy = _subcommands(_build_legacy_parser())
+    primary = _subcommands(_build_parser())
+
+    assert LEGACY_ROUTED_COMMANDS == legacy - primary, (
+        "the routing set must be exactly the commands only the legacy parser "
+        f"registers.\n  routed but unregistered: {sorted(LEGACY_ROUTED_COMMANDS - legacy)}"
+        f"\n  legacy-only but unreachable: {sorted(legacy - primary - LEGACY_ROUTED_COMMANDS)}"
+        f"\n  routed though the primary parser owns it: "
+        f"{sorted(LEGACY_ROUTED_COMMANDS & primary)}"
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1016,6 +1016,51 @@ def test_getting_started_screen_names_the_loop_verbs():
         assert f"nsys-ai {verb}" in screen, f"help screen does not name `{verb}`"
 
 
+def test_every_dispatchable_command_is_visible_from_dash_dash_help():
+    """`nsys-ai --help` must not omit a command that works.
+
+    `main()` picks between two parsers by command name, so `--help` rendered
+    only one of them: five working commands (`summary`, `tui`, `viewer`,
+    `timeline`, `export-csv`, ...) appeared on the getting-started screen and
+    nowhere in `--help`, and seven appeared in `--help` and not on the screen.
+    A reader had no way to tell which list was authoritative.
+
+    The getting-started screen stays a curated selection -- that is what it is
+    for, and it says so. `--help` is the one that must be complete.
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "nsys_ai", "--help"], capture_output=True, text=True
+    )
+    assert result.returncode == 0
+    missing = sorted(
+        name for name in _declared_subcommands() if name not in result.stdout
+    )
+    assert not missing, (
+        "these commands dispatch but are invisible from `--help`:\n  "
+        + "\n  ".join(missing)
+    )
+
+
+def test_the_legacy_routing_set_matches_the_parser_that_serves_it():
+    """A routed command that is not registered there is an `invalid choice`.
+
+    The set lived as a literal inside `main()`, tied to neither parser. It is
+    deliberately a subset -- the legacy parser also registers `doctor`, `info`
+    and `skill`, which the primary parser owns and must keep -- so it cannot be
+    derived, only checked.
+    """
+    from nsys_ai.cli.parsers import LEGACY_ROUTED_COMMANDS, _build_legacy_parser
+
+    registered: set[str] = set()
+    for action in _build_legacy_parser()._subparsers._group_actions:  # noqa: SLF001
+        registered.update(action.choices)
+
+    unregistered = sorted(LEGACY_ROUTED_COMMANDS - registered)
+    assert not unregistered, (
+        f"routed to the legacy parser but not registered on it: {unregistered}"
+    )
+
+
 def test_getting_started_screen_only_advertises_commands_that_exist():
     """Every `nsys-ai <verb>` the screen shows must be a real subcommand.
 


### PR DESCRIPTION
## Summary

- `nsys-ai help` and `nsys-ai --help` disagreed about what the tool can do. Measured on this branch's base: **5** commands on the getting-started screen were absent from `--help`, and **7** were in `--help` and not on the screen. A reader had no way to tell which list was authoritative.
- The cause is structural. `main()` picks between two parsers by command name, using its own hardcoded literal of which names go where — tied to neither parser, and shown to nobody.
- `--help` is now complete. The getting-started screen stays a curated selection and says so.

## Measured

```
on screen, not in --help: export-csv, summary, timeline, tui, viewer
in --help, not on screen: ask, chat, cutracer, diff-web, evidence, help, timeline-web
```

## Changes

- `src/nsys_ai/cli/parsers.py` — `LEGACY_ROUTED_COMMANDS`, the routing set, moved out of `main()` to sit beside the parsers it decides between.
- `src/nsys_ai/cli/parsers.py` — `--help` gains an epilog naming those commands. They dispatch and work; they were simply invisible from the parser that renders help.
- `src/nsys_ai/cli/app.py` — imports the set instead of restating it.
- `src/nsys_ai/cli/app.py` — the getting-started screen says what it is: "This screen is a task-organised selection. `nsys-ai --help` lists every command."
- `tests/test_cli.py` — the relationship test the issue asks for: every dispatchable command must appear in `--help`; the screen may curate. Plus a test that every routed name is registered on the parser it routes to.

## A design point worth stating

The routing set **cannot** be derived from the legacy parser, and I tried. That parser registers a superset — `doctor`, `info`, `skill`, `evidence` and `help` are on it as well as on the primary parser — so deriving the set would have silently rerouted five working commands to a different implementation. The literal is a routing decision, not a registration fact. It can be checked against the parser, which is what the second test does, but not replaced by it.

## Backward compatibility

Yes. Routing is byte-identical — the same fourteen names, moved not changed. Only help text is added.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` — 2263 passed, 140 skipped, 5 xfailed, 0 failed (`NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`)
- [x] `ruff check src/ tests/` clean; `bandit -r src/ -c pyproject.toml` clean
- [x] The new test is red without the epilog, listing the five commands by name

## Not done

Two of the issue's four disagreements are untouched, and this is `Refs` rather than `Closes`:

- **`diagnose` vs `report` on iteration count.** The issue says this "is a real analysis bug rather than presentation and needs its own investigation", and I could not reproduce it on `h100_2gpu_1s.sqlite` — `report` prints no iteration line there at all. It needs a profile that shows it.
- **The web diff page not showing the verdict, step time or comparability its own API returns.** That is `diff_web.py`, the fourth renderer of those deltas and the one #399 also left alone. Its own change.
- **`doctor` vs other surfaces on empty GPU metadata** — presentation of a missing capability, closest in kind to #418, and not a command-surface question.

## Linked issues

Refs #403
