### PR TITLE
fix(loop): make the tree and timeline surfaces run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,14 @@ uv.lock
 # Local baseline snapshot store (nsys-ai baseline tag)
 .nsys-ai-baselines/
 
+# Session store the loop writes into whatever directory it is run from:
+# .nsys-ai/sessions/<id>/{session,findings,proposal,diff}.json plus lock files.
+# The captures under .nsys-ai/profiles/ are already covered by *.sqlite above;
+# these JSON artifacts were not, so running `loop` or `diagnose --session` in a
+# checkout left untracked files behind. A runtime store, not configuration --
+# a settings file would live at .nsys-ai.toml, which this does not match.
+.nsys-ai/
+
 # Agent tool state — contributor-local, not part of the repo.
 # .claude/ holds per-machine permission allowlists and live git worktrees
 # (~85 MB of checked-out profiles) alongside any local skills; .agent/ is the

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -467,6 +467,34 @@ def _check_trim_window(trim, prof):
     )
 
 
+def _resolve_trim_window(trim, prof) -> tuple[int, int]:
+    """Check *trim* against *prof*, and turn "no trim" into the whole capture.
+
+    Always returns a pair. Every consumer subscripts it without checking --
+    ``viewer.generate_html`` does ``trim[0] / 1e9`` (viewer.py:81) and
+    ``_build_single_thread_tree`` does ``trim[0] - pad`` (nvtx_tree.py:120) --
+    so handing back None turns a degenerate capture into the same
+    ``'NoneType' object is not subscriptable`` this function exists to prevent.
+    ``open`` used to inline exactly this and always produced a pair; keeping
+    that guarantee is the whole point of centralising it.
+
+    The span is passed through as-is rather than special-cased. A capture with
+    no kernels already yields ``(0, 0)`` because ``ProfileMeta.time_range`` is
+    ``(min_start or 0, max_end or 0)`` (profile.py:478), and intercepting a
+    degenerate span to return ``(0, 0)`` instead would be a narrower window
+    than the caller had before -- ``(0, 0)`` is a truthy pair, so
+    ``Profile.kernels`` filters on it rather than reading it as "no window".
+    """
+    _check_trim_window(trim, prof)
+    if trim is not None:
+        return trim
+    time_range = getattr(getattr(prof, "meta", None), "time_range", None)
+    if not time_range:
+        return (0, 0)
+    lo_ns, hi_ns = time_range
+    return (int(lo_ns), int(hi_ns))
+
+
 def _check_trim_window_for_path(trim, path, _profile):
     """``_check_trim_window`` for handlers that have not opened the profile yet."""
     if trim is None:
@@ -1564,10 +1592,7 @@ def _cmd_open(args, _profile):
         gpu = (
             args.gpu if args.gpu is not None else (prof.meta.devices[0] if prof.meta.devices else 0)
         )
-        trim_ns = _parse_trim(args)
-        _check_trim_window(trim_ns, prof)
-        if trim_ns is None:
-            trim_ns = (int(prof.meta.time_range[0]), int(prof.meta.time_range[1]))
+        trim_ns = _resolve_trim_window(_parse_trim(args), prof)
         port = args.port if args.port is not None else 8142
         if args.viewer == "web":
             serve(prof, gpu, trim_ns, port=port, open_browser=not args.no_browser)
@@ -1673,10 +1698,34 @@ def _cmd_loop(args, _profile):
 
     session = getattr(args, "session", None)
 
+    # Resolve the window before the surface starts, the way `open` does. These
+    # surfaces cannot represent "no trim", and the profile is closed first so
+    # the TUI does not run with a live connection open behind it.
+    try:
+        prof_ctx = _profile.open(before_path)
+    except Exception as exc:
+        print(f"Error: could not open before profile: {before_path}", file=sys.stderr)
+        print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
+        sys.exit(1)
+    # Only the open is guarded. _resolve_trim_window raises TrimOutOfRangeError,
+    # an NsysAiError that cli/app.py renders with its code, its exit status and
+    # the NSYS_AI_AGENT JSON form -- catching it here would relabel a bad
+    # --trim as "could not open before profile" and lose all three.
+    with prof_ctx as prof:
+        trim = _resolve_trim_window(trim, prof)
+        # Default to a device the capture actually recorded on, the way `open`
+        # does. A run pinned to GPUs 1-7 -- one rank per device, rank 0 driving
+        # elsewhere -- has no device 0, and defaulting to it printed
+        # "GPU 0  0 kernels" for a capture holding 6460 kernels.
+        gpu = (
+            args.gpu
+            if args.gpu is not None
+            else (prof.meta.devices[0] if prof.meta.devices else 0)
+        )
+
     if args.surface == "timeline":
         from nsys_ai.timeline import run_timeline
 
-        gpu = args.gpu if args.gpu is not None else 0
         run_timeline(
             before_path,
             gpu,
@@ -1688,7 +1737,6 @@ def _cmd_loop(args, _profile):
 
     from nsys_ai.tree import run_tui
 
-    gpu = args.gpu if args.gpu is not None else 0
     run_tui(
         before_path,
         gpu,

--- a/src/nsys_ai/timeline/__init__.py
+++ b/src/nsys_ai/timeline/__init__.py
@@ -20,17 +20,29 @@ def run_timeline(
     device: int,
     trim: tuple[int, int] | None,
     min_ms: float = 0,
+    session: str | None = None,
 ) -> None:
     """Launch the Textual horizontal timeline browser.
 
     Falls back to a text kernel summary when stdout is not a TTY (e.g. piped).
     """
     if not sys.stdout.isatty():
+        # See the note in nsys_ai.tree.run_tui: the summary opens no session,
+        # so silently accepting --session would report success for work that
+        # never happened.
+        if session is not None:
+            named = f"--session {session}" if session else "--session"
+            print(
+                f"Warning: {named} was ignored: stdout is not a "
+                "terminal, so the static summary ran instead of the loop "
+                "surface. No session was opened and no decision was recorded.",
+                file=sys.stderr,
+            )
         _print_static_summary(db_path, device, trim, min_ms)
         return
     from .app import run_timeline as _run
 
-    _run(db_path, device, trim, min_ms=min_ms)
+    _run(db_path, device, trim, min_ms=min_ms, session=session)
 
 
 def _print_static_summary(
@@ -51,8 +63,12 @@ def _print_static_summary(
 
     try:
         with _profile.open(db_path) as prof:
-            trim_ns = trim or (prof.meta.time_range[0], prof.meta.time_range[1])
-            raw = prof.kernels(device, trim_ns)
+            # `Profile.kernels` reads a falsy window as the whole capture
+            # (profile.py:590), so no resolution is needed here. The copy that
+            # used to sit on this line is why the static timeline quietly
+            # worked while the interactive one rendered nothing from the same
+            # argument: only one of the two knew the rule.
+            raw = prof.kernels(device, trim)
             # Filter by min_ms (duration in ms)
             min_ns = int(min_ms * 1e6)
             kernels = [k for k in raw if (k["end"] - k["start"]) >= min_ns]

--- a/src/nsys_ai/tree/__init__.py
+++ b/src/nsys_ai/tree/__init__.py
@@ -49,17 +49,31 @@ def run_tui(
     trim: tuple[int, int] | None,
     max_depth: int = -1,
     min_ms: float = 0,
+    session: str | None = None,
 ) -> None:
     """Launch the Textual NVTX tree browser.
 
     Falls back to a Rich static tree when stdout is not a TTY (e.g. piped).
     """
     if not sys.stdout.isatty():
+        # Say so. The static tree opens no session and records no decision, so
+        # a caller that passed --session and read exit 0 would otherwise
+        # conclude the loop had run. Unlike max_depth and min_ms, which only
+        # shape the render, this discards what the caller asked the command to
+        # do.
+        if session is not None:
+            named = f"--session {session}" if session else "--session"
+            print(
+                f"Warning: {named} was ignored: stdout is not a "
+                "terminal, so the static tree ran instead of the loop surface. "
+                "No session was opened and no decision was recorded.",
+                file=sys.stderr,
+            )
         _print_static_tree(db_path, device, trim)
         return
     from .app import run_tui as _run
 
-    _run(db_path, device, trim, max_depth=max_depth, min_ms=min_ms)
+    _run(db_path, device, trim, max_depth=max_depth, min_ms=min_ms, session=session)
 
 
 def _print_static_tree(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,13 @@
 """Basic smoke tests for nsys-ai package."""
 
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
 
 
 def test_help():
@@ -374,6 +378,227 @@ def test_loop_rejects_after(tmp_path):
     assert result.returncode == 2, result.stderr
     assert "unrecognized arguments: --after" in result.stderr, result.stderr
     assert "Traceback" not in result.stderr, result.stderr
+
+
+@pytest.mark.parametrize("surface", ["tree", "timeline"])
+def test_loop_runs_every_surface_it_advertises(tmp_path, surface):
+    """Two of `loop`'s three surfaces died on the way in, with no test either.
+
+    The handler passes `session=` to the package-level `run_tui`/`run_timeline`,
+    and neither wrapper accepted it -- so `--surface tree` and
+    `--surface timeline` raised `TypeError` before doing any work, for every
+    profile and every invocation. `--surface` is advertised in `loop --help`,
+    which is the only reason anyone would type it.
+
+    stdout is captured here, so both surfaces take their non-TTY fallback.
+    That is the path CI and any piped use hits, and it is where the second
+    failure lived: the static tree read the trim window as a pair and `loop`
+    passes none, so it printed "Error loading profile" and still exited 0.
+    """
+    fixtures = Path(__file__).resolve().parent / "fixtures"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "nsys_ai", "loop",
+            str(fixtures / "mfu_2gpu_before.sqlite"),
+            "--surface", surface,
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    # Not `stderr == ""`: a cold Parquet cache writes "[nsys-ai] Cache ready"
+    # there, so a fresh clone would fail this on progress output rather than on
+    # a defect. Match the sibling tests and assert the absence of a crash.
+    assert "Traceback" not in result.stderr, result.stderr
+    assert "Error loading profile" not in result.stderr, result.stderr
+
+    # Assert a non-zero count, not merely non-empty output. An empty timeline
+    # still prints "Timeline summary: GPU 0  0 kernels", so `stdout.strip()`
+    # is satisfied by exactly the failure this test exists to catch. (An empty
+    # tree does render as "", so that half would have bitten -- the asymmetry
+    # is the point.)
+    if surface == "timeline":
+        counts = re.findall(r"(\d+) kernels", result.stdout)
+        assert counts, result.stdout
+        assert int(counts[0]) > 0, f"timeline reported {counts[0]} kernels"
+    else:
+        assert "📦" in result.stdout, result.stdout[:400]
+
+
+@pytest.mark.parametrize(
+    ("surface", "entry"),
+    [("tree", "run_tui"), ("timeline", "run_timeline")],
+)
+def test_loop_hands_its_surfaces_a_resolved_trim_window(monkeypatch, surface, entry):
+    """The surfaces cannot represent "no trim", so the handler must resolve it.
+
+    `build_nvtx_tree` subscripts the window, and both TUI apps coerce None to
+    `(0, 0)` -- which selects nothing on a capture clock that starts at 60 s.
+    So passing None through rendered an empty tree and an empty timeline, and
+    the capture in front of the user simply looked like it had no work in it.
+
+    This asserts at the handler rather than through the CLI on purpose: a
+    subprocess captures stdout, which sends both surfaces down their non-TTY
+    fallback, so it cannot see what the interactive path is handed.
+    """
+    import nsys_ai.timeline as timeline_pkg
+    import nsys_ai.tree as tree_pkg
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.cli import handlers
+
+    fixture = Path(__file__).resolve().parent / "fixtures" / "mfu_2gpu_before.sqlite"
+    with profile_mod.open(str(fixture)) as prof:
+        expected = (int(prof.meta.time_range[0]), int(prof.meta.time_range[1]))
+
+    seen = {}
+
+    def _capture(_path, _gpu, trim, **kwargs):
+        seen["trim"] = trim
+
+    monkeypatch.setattr(tree_pkg, "run_tui", _capture)
+    monkeypatch.setattr(timeline_pkg, "run_timeline", _capture)
+
+    args = SimpleNamespace(
+        before=str(fixture), surface=surface, gpu=None, trim=None,
+        session=None, h100_preset=False, port=None, no_browser=True,
+    )
+    handlers._cmd_loop(args, profile_mod)
+
+    assert seen["trim"] == expected, (
+        f"{entry} was handed {seen['trim']!r}; the whole capture is {expected!r}"
+    )
+
+
+@pytest.mark.parametrize("surface", ["tree", "timeline"])
+def test_loop_defaults_to_a_device_the_capture_recorded_on(monkeypatch, tmp_path, surface):
+    """Defaulting to GPU 0 renders nothing for a capture that has no GPU 0.
+
+    A rank pinned across GPUs 1-7 is ordinary in a distributed run, and every
+    committed fixture happens to record on device 0 -- so the whole test corpus
+    could not express this, and `--surface timeline` reported
+    "GPU 0  0 kernels" against a real 7-GPU capture full of work.
+
+    The fixture is copied and remapped rather than read, because the committed
+    ones are not to be written to.
+    """
+    import sqlite3
+
+    import nsys_ai.timeline as timeline_pkg
+    import nsys_ai.tree as tree_pkg
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.cli import handlers
+
+    source = Path(__file__).resolve().parent / "fixtures" / "mfu_2gpu_before.sqlite"
+    remapped = tmp_path / "no_gpu_zero.sqlite"
+    shutil.copyfile(source, remapped)
+    with sqlite3.connect(remapped) as conn:
+        # 0 -> 3 and 1 -> 4, applied high-to-low so the two do not collide.
+        conn.execute("UPDATE CUPTI_ACTIVITY_KIND_KERNEL SET deviceId = 4 WHERE deviceId = 1")
+        conn.execute("UPDATE CUPTI_ACTIVITY_KIND_KERNEL SET deviceId = 3 WHERE deviceId = 0")
+    with profile_mod.open(str(remapped)) as prof:
+        assert prof.meta.devices == [3, 4], prof.meta.devices
+
+    seen = {}
+
+    def _capture(_path, gpu, _trim, **kwargs):
+        seen["gpu"] = gpu
+
+    monkeypatch.setattr(tree_pkg, "run_tui", _capture)
+    monkeypatch.setattr(timeline_pkg, "run_timeline", _capture)
+
+    args = SimpleNamespace(
+        before=str(remapped), surface=surface, gpu=None, trim=None,
+        session=None, h100_preset=False, port=None, no_browser=True,
+    )
+    handlers._cmd_loop(args, profile_mod)
+
+    assert seen["gpu"] == 3, f"defaulted to GPU {seen['gpu']}, which recorded nothing"
+
+
+@pytest.mark.parametrize("surface", ["tree", "timeline"])
+def test_loop_says_so_when_a_piped_surface_cannot_run_the_session(tmp_path, surface):
+    """Exit 0 with a rendered view would otherwise read as "the loop ran".
+
+    Piped, both surfaces fall back to a static render that opens no session and
+    records no decision -- verified: no `.nsys-ai/` is created. The session is
+    what `loop` is for, so dropping it silently reports success for work that
+    did not happen.
+    """
+    fixtures = Path(__file__).resolve().parent / "fixtures"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "nsys_ai", "loop",
+            str(fixtures / "mfu_2gpu_before.sqlite"),
+            "--surface", surface, "--session", "piped-demo",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "piped-demo" in result.stderr, result.stderr
+    assert "was ignored" in result.stderr, result.stderr
+    assert not (tmp_path / ".nsys-ai").exists(), "a session was opened after all"
+
+
+def test_trim_resolution_always_yields_a_pair(tmp_path):
+    """Consumers subscript the window without checking, so None is not an option.
+
+    `viewer.generate_html` does `trim[0] / 1e9` and `_build_single_thread_tree`
+    does `trim[0] - pad`. Returning None for a capture whose kernel span is
+    degenerate turned `open --viewer web` into the same
+    "'NoneType' object is not subscriptable" the resolution exists to prevent.
+    """
+    import sqlite3
+
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.cli.handlers import _resolve_trim_window
+
+    source = Path(__file__).resolve().parent / "fixtures" / "mfu_2gpu_before.sqlite"
+    degenerate = tmp_path / "degenerate.sqlite"
+    shutil.copyfile(source, degenerate)
+    with sqlite3.connect(degenerate) as conn:
+        conn.execute(
+            "DELETE FROM CUPTI_ACTIVITY_KIND_KERNEL WHERE rowid NOT IN "
+            "(SELECT rowid FROM CUPTI_ACTIVITY_KIND_KERNEL LIMIT 1)"
+        )
+        conn.execute("UPDATE CUPTI_ACTIVITY_KIND_KERNEL SET [end] = start")
+
+    with profile_mod.open(str(degenerate)) as prof:
+        lo, hi = prof.meta.time_range
+        assert hi <= lo, f"fixture is not degenerate: {(lo, hi)}"
+        window = _resolve_trim_window(None, prof)
+
+    # A pair, and the same pair `open` produced before the resolution moved
+    # into a helper. Narrowing a degenerate span to (0, 0) would be a behaviour
+    # change, not a safety net: (0, 0) is truthy, so it filters rather than
+    # meaning "no window".
+    assert window == (int(lo), int(hi)), window
+
+
+def test_loop_reports_a_bad_trim_as_a_trim_error(tmp_path):
+    """A window outside the capture is not "could not open before profile".
+
+    `_resolve_trim_window` raises TrimOutOfRangeError, which cli/app.py renders
+    with its error code and exit status. Catching it beside the profile open
+    relabelled it and dropped both, so `loop` disagreed with `tui` about the
+    same mistake.
+    """
+    fixtures = Path(__file__).resolve().parent / "fixtures"
+    result = subprocess.run(
+        [
+            sys.executable, "-m", "nsys_ai", "loop",
+            str(fixtures / "mfu_2gpu_before.sqlite"),
+            "--surface", "tree", "--trim", "0", "1",
+        ],
+        capture_output=True,
+        text=True,
+        cwd=tmp_path,
+    )
+    assert result.returncode == 2, result.stderr
+    assert "TRIM_OUT_OF_RANGE" in result.stderr, result.stderr
+    assert "could not open before profile" not in result.stderr, result.stderr
 
 
 def test_timeline_web_rejects_loop_after(tmp_path):


### PR DESCRIPTION
`nsys-ai loop --surface tree` and `--surface timeline` raised `TypeError: run_tui() got an unexpected keyword argument 'session'` on every invocation, for every profile. The handler passes `session=`, the app-level `run_tui`/`run_timeline` accept it, and the package-level wrappers in between did not. Two of the three surfaces `loop --help` advertises were dead, and no test covered either one.

Reproduced on `main` at `ad24937` and again at `eb380e4`:

```
$ nsys-ai loop tests/fixtures/mfu_2gpu_before.sqlite --surface tree
  File ".../cli/handlers.py", line 1662, in _cmd_loop
    run_tui(
TypeError: run_tui() got an unexpected keyword argument 'session'
```

Fixing the crash exposed two more defects behind it, both on the same path and both invisible until the surface got far enough to run.

## The window

`loop` passed `trim=None` into surfaces that cannot represent "no trim". `build_nvtx_tree` subscripts the window (`nvtx_tree.py:120`), and both TUI apps coerce `None` to `(0, 0)` (`tree/app.py:152`, `timeline/app.py:178`). `(0, 0)` is a truthy pair, so it filters rather than meaning "unset" — and on a capture clock that starts at 60 s it selects nothing. Measured on `tests/fixtures/mfu_2gpu_before.sqlite`:

| window | NVTX roots | kernels |
|---|---|---|
| `(0, 0)` | 0 | 0 |
| capture span | 1427 | 1993 |

The tree's own title bar reads `full` while rendering nothing.

`open` already resolved this inline, and `_print_static_summary` carried a third copy of the same idiom in a different spelling — so the rule existed twice and neither app knew it. That is why the static timeline quietly worked while the interactive one rendered nothing from the same argument. This adds one `_resolve_trim_window(trim, prof)` used by both `open` and `loop`, and deletes the copy in the timeline fallback, where `Profile.kernels` (`profile.py:590`) already reads a falsy window as the whole capture.

Resolving in the handler rather than in the surfaces is deliberate: it is where `open` already did it, it fixes the interactive and non-TTY paths together, and a subprocess test cannot reach the interactive one because capturing stdout sends both surfaces down their fallback.

## The device

`loop` defaulted to GPU 0. A capture from a run pinned to GPUs 1-7 — `devices = [1,2,3,4,5,6,7]`, no device 0 — reported:

```
$ nsys-ai loop megatron_distca.sqlite --surface timeline
Timeline summary: GPU 0  0 kernels      # 6460 kernels of work, exit 0
```

Both surfaces exited 0 and looked like they had succeeded. It now defaults to the first recorded device, as `open` does. Every committed fixture records on device 0, so the test corpus could not express this at all; the regression test remaps a copy of one.

Same profile after the fix: tree renders 8591 lines of NCCL kernels, timeline reports `GPU 1  6460 kernels` across five streams.

## The dropped session

The non-TTY fallback opens no session and records no decision. Piped, `loop --session x --surface tree` printed a tree, exited 0, and created no `.nsys-ai/` — reporting success for work that never happened. This path previously crashed, so there was no prior behaviour to preserve; both wrappers now say when they drop `--session`.

## Scope

`.nsys-ai/` is added to `.gitignore`. The captures under it are already covered by the existing `*.sqlite` rule; the session JSON artifacts were not, so running `loop` or `diagnose --session` in a checkout left untracked files behind. This only protects this repo — a user running the tool in their own checkout still gets them, which is the artifact-root half of #404 and stays out of scope here. Inventoried and proposed in #430.

Not addressed, deliberately:

- The `(0, 0)` sentinel in both apps is untouched. Handler-side resolution keeps it disarmed for every caller that can reach it today (`tui` and `timeline` both require `--trim`, so neither can pass `None` from the CLI), but it remains a landmine for the next caller that does.
- `_print_static_tree` and `_print_static_summary` swallow every exception and still exit 0. That is what let both of these bugs stay hidden, and it deserves its own change.
- `loop --surface timeline-web` still validates `--trim` differently from the other two surfaces.

## Verification

Full gate from a **cold Parquet cache**, so the first-run path is exercised rather than skipped:

- `ruff check src/ tests/` — clean
- `bandit -r src/ -c pyproject.toml` — no issues
- `NSYS_TEST_PROFILE=… pytest tests/` — 2298 passed, 140 skipped, 5 xfailed, 0 failed
- `pytest tests/test_ci_coverage.py` — 5 passed
- `bash scripts/smoke_test.sh` against this branch — all checks passed
- committed fixtures unchanged after the run; no untracked files left behind

Real captures, not just fixtures — `megatron_distca.sqlite` (46 MB, GPUs 1-7) and `fastvideo.sqlite` (56 MB, 31770 kernels): both surfaces render, and `sha256` of each profile is identical before and after, so nothing was written back.

Each of the seven new tests was run against the unfixed code first and confirmed to fail there.

Closes #428
