### PR TITLE
refactor(skills): centralize canonical skill packs

### DIFF
--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -13,6 +13,7 @@ import sqlite3
 
 from ..exceptions import NsysAiError, ProfileNotFoundError
 from ..profile import Profile
+from ..skill_packs import ASK_FALLBACK, ASK_KEYWORD_MAP, DIAGNOSE_DEFAULT
 from ..skills.base import is_abstention_row
 from ..skills.registry import get_skill, run_skill
 
@@ -46,88 +47,7 @@ class Agent:
     """
 
     # Keywords → skills mapping for non-LLM skill selection
-    _KEYWORD_MAP = {
-        "kernel": ["top_kernels", "kernel_launch_overhead"],
-        "hotspot": ["top_kernels"],
-        "slow": ["top_kernels", "gpu_idle_gaps"],
-        "bubble": ["gpu_idle_gaps"],
-        "idle": ["gpu_idle_gaps"],
-        "gap": ["gpu_idle_gaps"],
-        "stall": ["gpu_idle_gaps", "nccl_anomaly"],
-        "memory": ["memory_transfers", "memory_bandwidth"],
-        "transfer": ["memory_transfers", "memory_bandwidth"],
-        "h2d": ["memory_transfers", "memory_bandwidth"],
-        "copy": ["memory_transfers", "memory_bandwidth"],
-        "bandwidth": ["memory_bandwidth"],
-        "nccl": [
-            "nccl_breakdown",
-            "nccl_communicator_analysis",
-            "overlap_breakdown",
-            "kernel_overlap_matrix",
-            "nccl_anomaly",
-        ],
-        "allreduce": ["nccl_breakdown", "nccl_communicator_analysis", "nccl_anomaly"],
-        "collective": ["nccl_breakdown", "nccl_communicator_analysis", "nccl_anomaly"],
-        "distributed": [
-            "nccl_breakdown",
-            "nccl_communicator_analysis",
-            "overlap_breakdown",
-            "kernel_overlap_matrix",
-            "nccl_anomaly",
-        ],
-        "multi-gpu": [
-            "nccl_breakdown",
-            "nccl_communicator_analysis",
-            "overlap_breakdown",
-            "kernel_overlap_matrix",
-        ],
-        "communicator": ["nccl_communicator_analysis", "nccl_breakdown"],
-        "rank": ["nccl_communicator_analysis", "nccl_breakdown"],
-        "tensor parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
-        "pipeline parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
-        "data parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
-        "anomaly": ["nccl_anomaly"],
-        "outlier": ["nccl_anomaly"],
-        "overlap": ["overlap_breakdown", "kernel_overlap_matrix"],
-        "matrix": ["kernel_overlap_matrix"],
-        "contention": ["kernel_overlap_matrix", "stream_concurrency"],
-        "hidden": ["kernel_overlap_matrix", "overlap_breakdown"],
-        "nvtx": ["nvtx_kernel_map", "nvtx_layer_breakdown"],
-        "source": ["nvtx_kernel_map"],
-        "attribution": ["nvtx_kernel_map"],
-        "mapping": ["nvtx_kernel_map"],
-        "layer": ["nvtx_layer_breakdown"],
-        "launch": ["kernel_launch_overhead", "kernel_launch_pattern"],
-        "overhead": ["kernel_launch_overhead"],
-        "dispatch": ["kernel_launch_pattern"],
-        "pattern": ["kernel_launch_pattern"],
-        "burst": ["kernel_launch_pattern"],
-        "stream": ["stream_concurrency"],
-        "concurrency": ["stream_concurrency"],
-        "parallel": ["stream_concurrency"],
-        "serial": ["stream_concurrency"],
-        "cpu": ["thread_utilization", "cpu_gpu_pipeline"],
-        "thread": ["thread_utilization"],
-        "utilization": ["thread_utilization", "stream_concurrency"],
-        "pipeline": ["cpu_gpu_pipeline"],
-        "starvation": ["cpu_gpu_pipeline"],
-        "queue": ["cpu_gpu_pipeline"],
-        "schema": ["schema_inspect"],
-        "table": ["schema_inspect"],
-        "mfu": ["region_mfu", "theoretical_flops"],
-        "flops": ["theoretical_flops"],
-        "efficiency": ["region_mfu"],
-        "iteration": ["iteration_timing"],
-        "iter": ["iteration_timing"],
-        "training": ["iteration_timing"],
-        "step": ["iteration_timing"],
-        "diagnosis": ["root_cause_matcher"],
-        "root-cause": ["root_cause_matcher"],
-        "why": ["root_cause_matcher"],
-        "speedup": ["speedup_estimator"],
-        "estimate": ["speedup_estimator"],
-        "projection": ["speedup_estimator"],
-    }
+    _KEYWORD_MAP = ASK_KEYWORD_MAP
 
     def __init__(self, profile_path: str, trim_ns: tuple[int, int] | None = None):
         self.profile_path = profile_path
@@ -208,23 +128,7 @@ class Agent:
         evidence = {}
 
         # Always run these core skills
-        core_skills = [
-            "top_kernels",
-            "gpu_idle_gaps",
-            "memory_transfers",
-            "memory_bandwidth",
-            "nccl_breakdown",
-            "nccl_communicator_analysis",
-            "nccl_anomaly",
-            "kernel_launch_overhead",
-            "kernel_launch_pattern",
-            "stream_concurrency",
-            "overlap_breakdown",
-            "kernel_overlap_matrix",
-            "iteration_timing",
-            "nvtx_layer_breakdown",
-            "nccl_compile_context_breakdown",
-        ]
+        core_skills = DIAGNOSE_DEFAULT
 
         for skill_name in core_skills:
             try:
@@ -293,11 +197,11 @@ class Agent:
             if not selected:
                 selected = self._select_skills(question)
             if not selected:
-                selected = ["top_kernels", "gpu_idle_gaps"]
+                selected = list(ASK_FALLBACK)
         else:
             selected = self._select_skills(question)
             if not selected:
-                selected = ["top_kernels", "gpu_idle_gaps"]
+                selected = list(ASK_FALLBACK)
 
         # Stage 2: Deep Dive (Execute selected skills)
         for skill_name in selected:

--- a/src/nsys_ai/evidence_builder.py
+++ b/src/nsys_ai/evidence_builder.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 
 from .annotation import EvidenceReport, Finding, SkippedAnalysis, rank_findings
 from .profile import Profile
+from .skill_packs import EVIDENCE_OVERLAY
 
 _log = logging.getLogger(__name__)
 
@@ -76,30 +77,7 @@ class EvidenceBuilder:
         self.trim = trim or tuple(prof.meta.time_range)
 
     # Map analyzer_name -> (skill_name, params)
-    _SKILL_PIPELINE = {
-        "slow_iterations": ("iteration_timing", {}),
-        "idle_gaps": ("gpu_idle_gaps", {"limit": 5, "min_gap_ns": 1000000}),
-        "nccl_stalls": ("kernel_instances", {"name": "nccl", "limit": 3}),
-        "kernel_hotspots": ("kernel_instances", {"limit": 3}),
-        "top_kernel_aggregates": ("top_kernels", {"limit": 15}),
-        "overlap_ratio": ("overlap_breakdown", {}),
-        "memory_anomalies": ("memory_bandwidth", {"limit": 5}),
-        "h2d_spikes": ("h2d_distribution", {}),
-        "kernel_launch_overhead": ("kernel_launch_overhead", {}),
-        "nccl_breakdown": ("nccl_breakdown", {}),
-        "nccl_compile_context_breakdown": ("nccl_compile_context_breakdown", {}),
-        # Profile-level bound class. Contributes the verdict only and reports
-        # no headroom by design (the reasoning lives in
-        # critical_path._to_findings). It therefore ranks below every
-        # headroom-bearing finding — read the verdict from the finding itself,
-        # not from its position.
-        "bound_class": ("critical_path", {}),
-        # Roll-up characterization of the whole profile (comm-bound,
-        # sync-bound, idle-dominant, coverage gaps). Reads only the
-        # already-assembled manifest dict, so its findings are
-        # independent of the other pipeline entries' to_findings status.
-        "profile_health": ("profile_health_manifest", {}),
-    }
+    _SKILL_PIPELINE = EVIDENCE_OVERLAY
 
     def build(self, only: list[str] | None = None) -> EvidenceReport:
         """Run analyzers (via skill pipeline) and return a combined EvidenceReport.

--- a/src/nsys_ai/skill_packs.py
+++ b/src/nsys_ai/skill_packs.py
@@ -1,0 +1,150 @@
+"""Canonical skill packs shared by the analysis entry points.
+
+The packs describe which registered skills each entry point runs.  Execution
+still belongs to :mod:`nsys_ai.skills.registry`; this module only owns the
+selection and ordering so CLI, evidence generation, and ask fallback cannot
+silently drift apart.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+# The default Agent.analyze roster.  Keep this order stable: the textual
+# report and downstream evidence consumers use it as a deterministic order.
+DIAGNOSE_DEFAULT: Final[list[str]] = [
+    "top_kernels",
+    "gpu_idle_gaps",
+    "memory_transfers",
+    "memory_bandwidth",
+    "nccl_breakdown",
+    "nccl_communicator_analysis",
+    "nccl_anomaly",
+    "kernel_launch_overhead",
+    "kernel_launch_pattern",
+    "stream_concurrency",
+    "overlap_breakdown",
+    "kernel_overlap_matrix",
+    "iteration_timing",
+    "nvtx_layer_breakdown",
+    "nccl_compile_context_breakdown",
+]
+
+
+# Analyzer name -> (registered skill name, skill parameters) used to produce
+# timeline findings.  Analyzer names are part of the EvidenceReport contract.
+EVIDENCE_OVERLAY: Final[dict[str, tuple[str, dict]]] = {
+    "slow_iterations": ("iteration_timing", {}),
+    "idle_gaps": ("gpu_idle_gaps", {"limit": 5, "min_gap_ns": 1000000}),
+    "nccl_stalls": ("kernel_instances", {"name": "nccl", "limit": 3}),
+    "kernel_hotspots": ("kernel_instances", {"limit": 3}),
+    "top_kernel_aggregates": ("top_kernels", {"limit": 15}),
+    "overlap_ratio": ("overlap_breakdown", {}),
+    "memory_anomalies": ("memory_bandwidth", {"limit": 5}),
+    "h2d_spikes": ("h2d_distribution", {}),
+    "kernel_launch_overhead": ("kernel_launch_overhead", {}),
+    "nccl_breakdown": ("nccl_breakdown", {}),
+    "nccl_compile_context_breakdown": ("nccl_compile_context_breakdown", {}),
+    # Profile-level bound class.  It contributes the verdict but reports no
+    # headroom by design.
+    "bound_class": ("critical_path", {}),
+    # Roll-up characterization of the whole profile.
+    "profile_health": ("profile_health_manifest", {}),
+}
+
+
+# Used when triage and keyword selection produce no usable skill list.
+ASK_FALLBACK: Final[list[str]] = ["top_kernels", "gpu_idle_gaps"]
+
+
+# Deterministic fallback routing for questions without an LLM triage result.
+ASK_KEYWORD_MAP: Final[dict[str, list[str]]] = {
+    "kernel": ["top_kernels", "kernel_launch_overhead"],
+    "hotspot": ["top_kernels"],
+    "slow": ["top_kernels", "gpu_idle_gaps"],
+    "bubble": ["gpu_idle_gaps"],
+    "idle": ["gpu_idle_gaps"],
+    "gap": ["gpu_idle_gaps"],
+    "stall": ["gpu_idle_gaps", "nccl_anomaly"],
+    "memory": ["memory_transfers", "memory_bandwidth"],
+    "transfer": ["memory_transfers", "memory_bandwidth"],
+    "h2d": ["memory_transfers", "memory_bandwidth"],
+    "copy": ["memory_transfers", "memory_bandwidth"],
+    "bandwidth": ["memory_bandwidth"],
+    "nccl": [
+        "nccl_breakdown",
+        "nccl_communicator_analysis",
+        "overlap_breakdown",
+        "kernel_overlap_matrix",
+        "nccl_anomaly",
+    ],
+    "allreduce": ["nccl_breakdown", "nccl_communicator_analysis", "nccl_anomaly"],
+    "collective": ["nccl_breakdown", "nccl_communicator_analysis", "nccl_anomaly"],
+    "distributed": [
+        "nccl_breakdown",
+        "nccl_communicator_analysis",
+        "overlap_breakdown",
+        "kernel_overlap_matrix",
+        "nccl_anomaly",
+    ],
+    "multi-gpu": [
+        "nccl_breakdown",
+        "nccl_communicator_analysis",
+        "overlap_breakdown",
+        "kernel_overlap_matrix",
+    ],
+    "communicator": ["nccl_communicator_analysis", "nccl_breakdown"],
+    "rank": ["nccl_communicator_analysis", "nccl_breakdown"],
+    "tensor parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
+    "pipeline parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
+    "data parallel": ["nccl_communicator_analysis", "nccl_breakdown"],
+    "anomaly": ["nccl_anomaly"],
+    "outlier": ["nccl_anomaly"],
+    "overlap": ["overlap_breakdown", "kernel_overlap_matrix"],
+    "matrix": ["kernel_overlap_matrix"],
+    "contention": ["kernel_overlap_matrix", "stream_concurrency"],
+    "hidden": ["kernel_overlap_matrix", "overlap_breakdown"],
+    "nvtx": ["nvtx_kernel_map", "nvtx_layer_breakdown"],
+    "source": ["nvtx_kernel_map"],
+    "attribution": ["nvtx_kernel_map"],
+    "mapping": ["nvtx_kernel_map"],
+    "layer": ["nvtx_layer_breakdown"],
+    "launch": ["kernel_launch_overhead", "kernel_launch_pattern"],
+    "overhead": ["kernel_launch_overhead"],
+    "dispatch": ["kernel_launch_pattern"],
+    "pattern": ["kernel_launch_pattern"],
+    "burst": ["kernel_launch_pattern"],
+    "stream": ["stream_concurrency"],
+    "concurrency": ["stream_concurrency"],
+    "parallel": ["stream_concurrency"],
+    "serial": ["stream_concurrency"],
+    "cpu": ["thread_utilization", "cpu_gpu_pipeline"],
+    "thread": ["thread_utilization"],
+    "utilization": ["thread_utilization", "stream_concurrency"],
+    "pipeline": ["cpu_gpu_pipeline"],
+    "starvation": ["cpu_gpu_pipeline"],
+    "queue": ["cpu_gpu_pipeline"],
+    "schema": ["schema_inspect"],
+    "table": ["schema_inspect"],
+    "mfu": ["region_mfu", "theoretical_flops"],
+    "flops": ["theoretical_flops"],
+    "efficiency": ["region_mfu"],
+    "iteration": ["iteration_timing"],
+    "iter": ["iteration_timing"],
+    "training": ["iteration_timing"],
+    "step": ["iteration_timing"],
+    "diagnosis": ["root_cause_matcher"],
+    "root-cause": ["root_cause_matcher"],
+    "why": ["root_cause_matcher"],
+    "speedup": ["speedup_estimator"],
+    "estimate": ["speedup_estimator"],
+    "projection": ["speedup_estimator"],
+}
+
+
+__all__ = [
+    "ASK_FALLBACK",
+    "ASK_KEYWORD_MAP",
+    "DIAGNOSE_DEFAULT",
+    "EVIDENCE_OVERLAY",
+]

--- a/tests/test_skill_packs.py
+++ b/tests/test_skill_packs.py
@@ -1,0 +1,46 @@
+"""Contracts for the canonical skill-selection packs."""
+
+from nsys_ai.agent.loop import Agent
+from nsys_ai.evidence_builder import EvidenceBuilder
+from nsys_ai.skill_packs import (
+    ASK_FALLBACK,
+    ASK_KEYWORD_MAP,
+    DIAGNOSE_DEFAULT,
+    EVIDENCE_OVERLAY,
+)
+from nsys_ai.skills.registry import list_skills
+
+
+def test_canonical_packs_reference_registered_skills():
+    registered = set(list_skills())
+    selected = set(DIAGNOSE_DEFAULT) | set(ASK_FALLBACK)
+    selected.update(skill for skills in ASK_KEYWORD_MAP.values() for skill in skills)
+    selected.update(skill for skill, _params in EVIDENCE_OVERLAY.values())
+
+    assert selected <= registered, sorted(selected - registered)
+
+
+def test_consumers_use_the_canonical_pack_objects():
+    assert Agent._KEYWORD_MAP is ASK_KEYWORD_MAP
+    assert EvidenceBuilder._SKILL_PIPELINE is EVIDENCE_OVERLAY
+
+
+def test_default_packs_have_stable_order_and_expected_fallback():
+    assert DIAGNOSE_DEFAULT == [
+        "top_kernels",
+        "gpu_idle_gaps",
+        "memory_transfers",
+        "memory_bandwidth",
+        "nccl_breakdown",
+        "nccl_communicator_analysis",
+        "nccl_anomaly",
+        "kernel_launch_overhead",
+        "kernel_launch_pattern",
+        "stream_concurrency",
+        "overlap_breakdown",
+        "kernel_overlap_matrix",
+        "iteration_timing",
+        "nvtx_layer_breakdown",
+        "nccl_compile_context_breakdown",
+    ]
+    assert ASK_FALLBACK == ["top_kernels", "gpu_idle_gaps"]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1065,18 +1065,12 @@ def test_root_cause_readme_coverage_claim_matches_wiring():
     If this fails, docs/root-causes/README.md and the pipeline have diverged;
     update both together.
     """
-    import inspect
-    import re
+    from nsys_ai.skill_packs import DIAGNOSE_DEFAULT, EVIDENCE_OVERLAY
 
-    from nsys_ai.agent.loop import Agent
-    from nsys_ai.evidence_builder import EvidenceBuilder
+    core_skills = set(DIAGNOSE_DEFAULT)
+    assert len(core_skills) >= 10, f"DIAGNOSE_DEFAULT looks wrong: {core_skills}"
 
-    src = inspect.getsource(Agent.analyze)
-    body = src.split("core_skills = [", 1)[1].split("]", 1)[0]
-    core_skills = set(re.findall(r'"([a-z0-9_]+)"', body))
-    assert len(core_skills) >= 10, f"core_skills parse looks wrong: {core_skills}"
-
-    pipeline = {skill for skill, _params in EvidenceBuilder._SKILL_PIPELINE.values()}
+    pipeline = {skill for skill, _params in EVIDENCE_OVERLAY.values()}
     declared = core_skills | pipeline
 
     # "Five of the detection skills named above run on every `agent analyze`."


### PR DESCRIPTION
## Summary
- Centralize diagnose, evidence-overlay, and ask-fallback skill selection in `skill_packs.py`.
- Make the existing Agent and EvidenceBuilder consumers reference the same pack objects without changing their execution behavior.

## Changes
- `src/nsys_ai/skill_packs.py` — add `DIAGNOSE_DEFAULT`, `EVIDENCE_OVERLAY`, `ASK_FALLBACK`, and `ASK_KEYWORD_MAP`.
- `src/nsys_ai/agent/loop.py` — replace local skill lists/maps with canonical pack references while preserving compatibility aliases.
- `src/nsys_ai/evidence_builder.py` — use the canonical evidence overlay mapping.
- `tests/test_skill_packs.py` — verify pack membership, registry coverage, stable ordering, and consumer aliases.
- `tests/test_skills.py` — read the canonical pack instead of parsing a source-code list.

## Backward compatibility
Yes. Public Agent and EvidenceBuilder behavior, ordering, parameters, and class attributes remain compatible. No SQL, skill implementation, chat dispatch, or profile ingestion behavior changes.

## Test plan
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m pytest -p no:cacheprovider tests/test_skill_packs.py tests/test_skills.py tests/test_agent.py tests/test_evidence_build.py tests/test_evidence_skipped.py -q` — 95 passed
- [x] `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=src python3 -m ruff check src/nsys_ai/skill_packs.py src/nsys_ai/agent/loop.py src/nsys_ai/evidence_builder.py tests/test_skill_packs.py tests/test_skills.py` — passed
- [x] `git diff --cached --check` — passed
- [ ] Full suite — interrupted after 252 passed and 5 skipped because another pytest process was already running in the same checkout; no test failure was reported before interruption.
- [ ] Manually exercised the changed CLI / GUI path — no user-facing execution path changed.

## Out of scope
- Routing Web chat tools through the registry — follow-up issue #436.
- Typed execute-function abstention coverage — follow-up issues #345, #283, and #281.
- Shared agent runner, profile ingest policy, and session transport — separate migration issues.

## Linked issues
Closes #432
