### PR TITLE
fix(skills): preserve abstention across execute_fn consumers

### DIFF
--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -58,35 +58,19 @@ def _params_key(resolved: dict) -> str:
 # those four the guard never fires, at any profile, ever. Their uses are Python
 # f-strings inside ``execute_fn`` bodies, which the guard has no way to read.
 #
-# What those four do instead is per-skill, and mostly not the abstention
-# contract — issue #345 tracks closing that, and this note exists to keep the
-# gap visible until it is. ``nvtx_table`` is the nearest to right:
-# ``requires_nvtx``, ``requires_pushpop_nvtx`` and ``resolve_nvtx_table`` below
-# are the shared resolve-and-abstain helpers and seven skills abstain through one
-# of them — but ``gc_impact`` skips its NVTX half silently, and
-# ``host_sync_parent_ranges`` falls back to the literal ``NVTX_EVENTS`` and
-# reports the resulting failure as a data row with an ``error`` key.
-# For ``memset_table``, ``sync_table`` and ``sync_type_table`` nothing calls
-# ``abstain`` at all: ``pipeline_bubble_metrics`` skips, ``root_cause_matcher``
-# returns ``[]``, and ``sync_cost_analysis`` probes only the sync table and
-# returns a zero-valued ``error`` row when it is absent. ``sync_type_table`` is
-# the worst of the three, because it is unprobed and load-bearing: its resolved
-# name reaches the main query's ``LEFT JOIN {type_table}`` in
-# ``sync_cost_analysis``, under a local named ``type_table`` — which is why
-# grepping for ``sync_type`` does not find it. Drop ``ENUM_CUPTI_SYNC_TYPE``
-# from tests/fixtures/h100_2gpu_1s.sqlite and leave the sync table in place, and
-# the skill reports "Synchronization tables not found in profile" with zeroes,
-# naming the table that is present rather than the one that is not. So a missing
-# table on these paths is silence, an untyped error row, or a wrong one, rather
-# than either an abstention or a raised ``no such table`` — which is exactly the
-# ambiguity :func:`abstain` exists to remove.
+# The execute_fn paths now declare hard requirements on ``Skill.required_tables``
+# where the whole skill cannot answer without them: ``sync_cost_analysis``
+# requires both sync tables and ``host_sync_parent_ranges`` requires NVTX. The
+# NVTX half of ``gc_impact`` remains optional because its runtime-derived rows
+# are still useful without annotation. Likewise ``pipeline_bubble_metrics``
+# keeps its partial result when memset is absent, and the memset checker inside
+# ``root_cause_matcher`` returns an abstention that its parent filters rather
+# than turning into a finding. This distinction is intentional: partial
+# coverage is not the same as a skill-level abstention.
 #
-# Extending the guard is not a one-liner, which is why this is documented rather
-# than fixed here: an ``execute_fn`` builds its own SQL, so covering it needs a
-# per-skill declaration of the tables it requires.
-# ``test_the_table_guard_covers_only_sql_templates`` pins the split above so this
-# note cannot quietly go stale — a template that starts using one of the other
-# four makes it fail, and the note is what should be corrected.
+# ``test_the_table_guard_covers_only_sql_templates`` pins the split above, and
+# the execute_fn abstention tests pin the declared requirements and the two
+# legitimate partial-result cases.
 ACTIVITY_TABLE_PLACEHOLDERS: dict[str, tuple[str, str]] = {
     "kernel_table": ("kernel", "CUPTI_ACTIVITY_KIND_KERNEL"),
     "runtime_table": ("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME"),
@@ -466,6 +450,9 @@ class Skill:
         tags:        Search tags for skill discovery
         execute_fn:  Optional Python callable(conn, **kwargs) → list[dict].
                      When set, used instead of sql for execution.
+        required_tables: Activity-table resolver keys required before execution.
+                         Used for execute_fn skills whose SQL is not visible to
+                         the generic template guard.
     """
 
     name: str
@@ -478,6 +465,7 @@ class Skill:
     tags: list[str] = field(default_factory=list)
     execute_fn: Callable | None = None
     to_findings_fn: Callable | None = None
+    required_tables: tuple[str, ...] = ()
 
     def execute(self, conn: sqlite3.Connection, **kwargs) -> list[dict]:
         """Run the skill against a connection.
@@ -505,6 +493,28 @@ class Skill:
         from ..connection import wrap_connection
 
         adapter = wrap_connection(conn)
+
+        # SQL skills can infer required activity tables from their template,
+        # but execute_fn skills build SQL in Python and need to declare the
+        # same contract explicitly. Check before parameter resolution and
+        # memoization so a missing table is visible as an abstention rather
+        # than silence or an untyped database error.
+        if self.required_tables:
+            tables = adapter.resolve_activity_tables()
+            missing = [
+                canonical
+                for _placeholder, (table_key, canonical) in ACTIVITY_TABLE_PLACEHOLDERS.items()
+                if table_key in self.required_tables and not tables.get(table_key)
+            ]
+            if missing:
+                names = ", ".join(sorted(set(missing)))
+                return abstain(
+                    f"This profile has no {names} table, so '{self.name}' cannot "
+                    "run. Either the capture did not trace that activity kind, "
+                    "or the export names it something this version does not "
+                    "recognise as a variant.",
+                    missing_tables=sorted(set(missing)),
+                )
 
         # Apply parameter defaults and required checks for all skill types.
         # Start from the provided kwargs so we preserve any extra arguments.

--- a/src/nsys_ai/skills/builtins/critical_path.py
+++ b/src/nsys_ai/skills/builtins/critical_path.py
@@ -43,7 +43,7 @@ import logging
 
 from nsys_ai.connection import DB_ERRORS, is_safe_identifier, wrap_connection
 
-from ..base import Skill, SkillParam
+from ..base import Skill, SkillParam, is_abstention
 
 _log = logging.getLogger(__name__)
 
@@ -188,7 +188,7 @@ def _cpu_attribution(conn, device: int, trim) -> dict:
         sync_skill = get_skill("sync_cost_analysis")
         if sync_skill is not None:
             sync_rows = sync_skill.execute(conn, **passthrough)
-            if sync_rows and "error" not in sync_rows[0]:
+            if sync_rows and not is_abstention(sync_rows) and "error" not in sync_rows[0]:
                 attribution["sync_wall_ms"] = sync_rows[0].get("total_sync_wall_ms", 0.0)
     except Exception:
         _log.debug("critical_path sync attribution failed", exc_info=True)

--- a/src/nsys_ai/skills/builtins/gc_impact.py
+++ b/src/nsys_ai/skills/builtins/gc_impact.py
@@ -2,7 +2,7 @@
 
 from nsys_ai.connection import DB_ERRORS, wrap_connection
 
-from ..base import Skill
+from ..base import Skill, abstain
 
 
 def _format(rows):
@@ -27,43 +27,45 @@ def _format(rows):
 def _execute(conn, **kwargs):
     adapter = wrap_connection(conn)
     tables = adapter.resolve_activity_tables()
-    runtime_table = tables.get("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME")
+    runtime_table = tables.get("runtime")
 
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")
 
-    try:
-        adapter.execute(f"SELECT 1 FROM {runtime_table} LIMIT 1")
-    except DB_ERRORS:
-        return []
-
     # --- Part 1: CUDA Memory APIs from Runtime table ---
-    params_r = []
-    trim_clause_r = ""
-    if trim_start is not None and trim_end is not None:
-        trim_clause_r = 'AND r.start >= ? AND r."end" <= ?'
-        params_r.extend([trim_start, trim_end])
-
-    sql_runtime = f"""
-        SELECT
-            s.value AS event_name,
-            COUNT(*) AS occurrences,
-            ROUND(SUM(r."end" - r.start) / 1e6, 2) AS total_ms,
-            ROUND(MAX(r."end" - r.start) / 1e6, 2) AS max_ms,
-            ROUND(AVG(r."end" - r.start) / 1e6, 2) AS avg_ms
-        FROM {runtime_table} r
-        JOIN StringIds s ON r.nameId = s.id
-        WHERE (s.value LIKE '%cudaFree%'
-           OR s.value LIKE '%cuMemFree%'
-           OR s.value LIKE '%cudaMalloc%'
-           OR s.value LIKE '%cuMemAlloc%')
-          {trim_clause_r}
-        GROUP BY s.value
-        ORDER BY total_ms DESC, event_name ASC
-    """
-    rows_runtime = adapter.execute(sql_runtime, params_r).fetchall()
     cols = ["event_name", "occurrences", "total_ms", "max_ms", "avg_ms"]
-    results = [dict(zip(cols, r)) if isinstance(r, tuple) else dict(r) for r in rows_runtime]
+    results = []
+    if runtime_table:
+        params_r = []
+        trim_clause_r = ""
+        if trim_start is not None and trim_end is not None:
+            trim_clause_r = 'AND r.start >= ? AND r."end" <= ?'
+            params_r.extend([trim_start, trim_end])
+
+        sql_runtime = f"""
+            SELECT
+                s.value AS event_name,
+                COUNT(*) AS occurrences,
+                ROUND(SUM(r."end" - r.start) / 1e6, 2) AS total_ms,
+                ROUND(MAX(r."end" - r.start) / 1e6, 2) AS max_ms,
+                ROUND(AVG(r."end" - r.start) / 1e6, 2) AS avg_ms
+            FROM {runtime_table} r
+            JOIN StringIds s ON r.nameId = s.id
+            WHERE (s.value LIKE '%cudaFree%'
+               OR s.value LIKE '%cuMemFree%'
+               OR s.value LIKE '%cudaMalloc%'
+               OR s.value LIKE '%cuMemAlloc%')
+              {trim_clause_r}
+            GROUP BY s.value
+            ORDER BY total_ms DESC, event_name ASC
+        """
+        try:
+            rows_runtime = adapter.execute(sql_runtime, params_r).fetchall()
+        except DB_ERRORS:
+            rows_runtime = []
+        results.extend(
+            dict(zip(cols, r)) if isinstance(r, tuple) else dict(r) for r in rows_runtime
+        )
 
     # --- Part 2: NVTX events mentioning GC ---
     nvtx_table = tables.get("nvtx")
@@ -126,6 +128,12 @@ def _execute(conn, **kwargs):
     # total_ms alone would faithfully preserve whatever arbitrary order the
     # engine returned for tied rows.
     results.sort(key=lambda x: (-(x.get("total_ms") or 0), str(x.get("event_name") or "")))
+    if not runtime_table and not nvtx_table:
+        return abstain(
+            "This profile has neither a runtime nor an NVTX table, so GC and "
+            "memory-allocation stalls cannot be analysed.",
+            missing_tables=["CUPTI_ACTIVITY_KIND_RUNTIME", "NVTX_EVENTS"],
+        )
     return results
 
 

--- a/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
+++ b/src/nsys_ai/skills/builtins/host_sync_parent_ranges.py
@@ -239,6 +239,7 @@ SKILL = Skill(
     category="nvtx",
     execute_fn=_execute,
     format_fn=_format,
+    required_tables=("nvtx",),
     params=[
         SkillParam("limit", "Max parent ranges to return", "int", False, 5),
         SkillParam(

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -10,7 +10,7 @@ import logging
 
 from nsys_ai.connection import DB_ERRORS
 
-from ..base import Skill, SkillParam
+from ..base import Skill, SkillParam, is_abstention
 
 _log = logging.getLogger(__name__)
 
@@ -130,7 +130,7 @@ def _execute(conn, **kwargs):
         sync_skill = get_skill("sync_cost_analysis")
         if sync_skill:
             sync_data = sync_skill.execute(conn, **kwargs)
-            if sync_data and "error" not in sync_data[0]:
+            if sync_data and not is_abstention(sync_data) and "error" not in sync_data[0]:
                 result["sync_ms"] = sync_data[0].get("total_sync_wall_ms", 0)
     except Exception:
         _log.debug("Failed to enrich sync cost", exc_info=True)

--- a/src/nsys_ai/skills/builtins/pipeline_bubble_metrics.py
+++ b/src/nsys_ai/skills/builtins/pipeline_bubble_metrics.py
@@ -9,7 +9,7 @@ import sqlite3
 
 from nsys_ai.connection import wrap_connection
 
-from ..base import Skill, is_abstention
+from ..base import Skill, abstain, is_abstention
 
 logger = logging.getLogger(__name__)
 
@@ -49,9 +49,20 @@ def _format(rows):
 
 def _execute(conn, **kwargs):
     tables = wrap_connection(conn).resolve_activity_tables()
-    kernel_table = tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
+    kernel_table = tables.get("kernel")
     memcpy_table = tables.get("memcpy")
     memset_table = tables.get("memset")
+
+    if not kernel_table and not memcpy_table and not memset_table:
+        return abstain(
+            "This profile has no kernel, memcpy, or memset activity table, so "
+            "pipeline bubble metrics cannot be calculated.",
+            missing_tables=[
+                "CUPTI_ACTIVITY_KIND_KERNEL",
+                "CUPTI_ACTIVITY_KIND_MEMCPY",
+                "CUPTI_ACTIVITY_KIND_MEMSET",
+            ],
+        )
 
     trim_start = kwargs.get("trim_start_ns")
     trim_end = kwargs.get("trim_end_ns")

--- a/src/nsys_ai/skills/builtins/pipeline_bubble_metrics.py
+++ b/src/nsys_ai/skills/builtins/pipeline_bubble_metrics.py
@@ -9,7 +9,7 @@ import sqlite3
 
 from nsys_ai.connection import wrap_connection
 
-from ..base import Skill
+from ..base import Skill, is_abstention
 
 logger = logging.getLogger(__name__)
 
@@ -156,7 +156,6 @@ def _execute(conn, **kwargs):
                 "active_ms": round(active_ns / 1e6, 2),
                 "bubble_ms": round(bubble_ns / 1e6, 2),
                 "bubble_pct": round(bubble_pct, 2),
-                "sync_ms": 0.0,
             }
         )
 
@@ -168,7 +167,7 @@ def _execute(conn, **kwargs):
             sync_skill = get_skill("sync_cost_analysis")
             if sync_skill:
                 sync_data = sync_skill.execute(conn, **kwargs)
-                if sync_data and "error" not in sync_data[0]:
+                if sync_data and not is_abstention(sync_data) and "error" not in sync_data[0]:
                     results[0]["sync_ms"] = sync_data[0].get("total_sync_wall_ms", 0)
         except Exception as exc:
             logger.debug(f"Failed to fetch sync cost data: {exc}")

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -13,7 +13,7 @@ import dataclasses
 import logging
 from datetime import datetime, timezone
 
-from ..base import Skill, SkillParam, is_abstention_row
+from ..base import Skill, SkillParam, is_abstention, is_abstention_row
 
 _log = logging.getLogger(__name__)
 
@@ -533,7 +533,7 @@ def _execute(conn, **kwargs):
     sync_summary = {}
     try:
         sync_data = _safe_skill_run("sync_cost_analysis", conn, **trim_kwargs)
-        if sync_data and "error" not in sync_data[0]:
+        if sync_data and not is_abstention(sync_data) and "error" not in sync_data[0]:
             sync_summary = sync_data[0]
     except Exception as exc:
         _log.debug("manifest: sync_cost_analysis failed: %s", exc)

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -18,7 +18,7 @@ import sqlite3
 
 from nsys_ai.connection import DB_ERRORS, wrap_connection
 
-from ..base import Skill, SkillParam
+from ..base import Skill, SkillParam, abstain, is_abstention
 
 _log = logging.getLogger(__name__)
 
@@ -182,7 +182,7 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                 evidence += f" ({pct}% of profile)"
 
             # If Sync Cost Analysis indicates massive CPU blockage, overwrite the guess!
-            if sync_data and "error" not in sync_data[0]:
+            if sync_data and not is_abstention(sync_data) and "error" not in sync_data[0]:
                 sync_ms = sync_data[0].get("total_sync_wall_ms", 0)
                 sync_density = sync_data[0].get("sync_density_pct", 0)
                 # If sync time accounts for more than half of the idle time, or > 15% of profile:
@@ -449,7 +449,9 @@ def _execute(conn: sqlite3.Connection, **kwargs):
     findings += _check_sync_apis(conn, **kwargs)
     findings += _check_sync_memcpy(conn, **kwargs)
     findings += _check_pageable_memcpy(conn, **kwargs)
-    findings += _check_sync_memset(conn, **kwargs)
+    memset_findings = _check_sync_memset(conn, **kwargs)
+    if not is_abstention(memset_findings):
+        findings += memset_findings
 
     if not findings:
         findings.append(
@@ -933,7 +935,16 @@ def _check_sync_memset(conn: sqlite3.Connection, **kwargs):
     runtime_tbl = tables.get("runtime")
     memset_tbl = tables.get("memset")
     if not runtime_tbl or not memset_tbl:
-        return []
+        missing = []
+        if not runtime_tbl:
+            missing.append("CUPTI_ACTIVITY_KIND_RUNTIME")
+        if not memset_tbl:
+            missing.append("CUPTI_ACTIVITY_KIND_MEMSET")
+        return abstain(
+            "Synchronous memset detection cannot run because this profile has "
+            f"no {', '.join(missing)} table.",
+            missing_tables=missing,
+        )
 
     try:
         # Step 1: find nameIds for sync cudaMemset (NOT async)

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -269,6 +269,7 @@ SKILL = Skill(
     sql="",
     execute_fn=_execute_sync_analysis,
     format_fn=_format_sync_analysis,
+    required_tables=("sync", "sync_type"),
     params=[
         SkillParam(
             "device",

--- a/tests/test_cannot_answer.py
+++ b/tests/test_cannot_answer.py
@@ -225,20 +225,10 @@ def test_row_2_a_bare_empty_list_when_the_table_is_absent(
     assert is_cannot_answer(payload), payload
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="#345: sync_cost_analysis emits an untyped error key beside zero-valued "
-    "data columns, so a reader sees both an answer and a failure",
-)
 def test_row_3_an_error_key_beside_real_looking_zeros(
     profile_without_activity_tables: Path, tmp_path: Path
 ):
-    """Row 3: a data row whose numbers are zero because nothing was read.
-
-    The row carries `total_sync_wall_ms: 0.0` — which a consumer will plot — and
-    an `error` key it has no reason to look for. Zero synchronization cost is a
-    finding; not having looked is not.
-    """
+    """Row 3: the missing synchronization tables are a typed abstention."""
     result = _cli(
         "skill", "run", "sync_cost_analysis", str(profile_without_activity_tables),
         "--format", "json", cwd=tmp_path,

--- a/tests/test_execute_fn_abstention.py
+++ b/tests/test_execute_fn_abstention.py
@@ -22,6 +22,36 @@ def test_missing_required_execute_fn_table_abstains(skill_name):
     assert "no" in rows[0]["reason"].lower()
 
 
+def test_gc_keeps_nvtx_result_without_runtime_table():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+        CREATE TABLE NVTX_EVENTS (
+            start INTEGER, [end] INTEGER, text TEXT, textId INTEGER,
+            eventType INTEGER
+        );
+        INSERT INTO StringIds VALUES (1, 'GC collection generation 2');
+        INSERT INTO NVTX_EVENTS VALUES (100, 200, NULL, 1, 59);
+        """
+    )
+
+    rows = get_skill("gc_impact").execute(conn)
+
+    assert not is_abstention(rows)
+    assert rows[0]["event_name"] == "GC collection generation 2"
+
+
+def test_gc_abstains_without_runtime_or_nvtx_tables():
+    rows = get_skill("gc_impact").execute(sqlite3.connect(":memory:"))
+
+    assert is_abstention(rows)
+    assert set(rows[0]["missing_tables"]) == {
+        "CUPTI_ACTIVITY_KIND_RUNTIME",
+        "NVTX_EVENTS",
+    }
+
+
 def test_sync_cost_analysis_requires_sync_type_table():
     conn = sqlite3.connect(":memory:")
     conn.execute(
@@ -44,6 +74,20 @@ def test_pipeline_bubble_keeps_partial_result_without_memset(minimal_nsys_conn):
     assert rows
     assert not is_abstention(rows)
     assert "bubble_pct" in rows[0]
+
+
+def test_pipeline_bubble_abstains_without_any_activity_table(minimal_nsys_conn):
+    for table in (
+        "CUPTI_ACTIVITY_KIND_KERNEL",
+        "CUPTI_ACTIVITY_KIND_MEMCPY",
+        "CUPTI_ACTIVITY_KIND_MEMSET",
+    ):
+        minimal_nsys_conn.execute(f"DROP TABLE IF EXISTS {table}")
+
+    rows = get_skill("pipeline_bubble_metrics").execute(minimal_nsys_conn)
+
+    assert is_abstention(rows)
+    assert "CUPTI_ACTIVITY_KIND_KERNEL" in rows[0]["missing_tables"]
 
 
 def test_pipeline_bubble_does_not_fabricate_sync_zero(minimal_nsys_conn):

--- a/tests/test_execute_fn_abstention.py
+++ b/tests/test_execute_fn_abstention.py
@@ -1,0 +1,87 @@
+"""Every execute_fn table dependency must use the abstention contract."""
+
+import sqlite3
+
+import pytest
+
+from nsys_ai.skills.base import is_abstention
+from nsys_ai.skills.registry import get_skill
+
+
+@pytest.mark.parametrize(
+    "skill_name",
+    ["sync_cost_analysis", "host_sync_parent_ranges"],
+)
+def test_missing_required_execute_fn_table_abstains(skill_name):
+    conn = sqlite3.connect(":memory:")
+
+    rows = get_skill(skill_name).execute(conn)
+
+    assert is_abstention(rows), f"{skill_name} returned data: {rows[:1]}"
+    assert rows[0]["missing_tables"]
+    assert "no" in rows[0]["reason"].lower()
+
+
+def test_sync_cost_analysis_requires_sync_type_table():
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        "CREATE TABLE CUPTI_ACTIVITY_KIND_SYNCHRONIZATION "
+        "(start INTEGER, [end] INTEGER, syncType INTEGER)"
+    )
+
+    rows = get_skill("sync_cost_analysis").execute(conn)
+
+    assert is_abstention(rows)
+    assert rows[0]["missing_tables"] == ["ENUM_CUPTI_SYNC_TYPE"]
+
+
+def test_pipeline_bubble_keeps_partial_result_without_memset(minimal_nsys_conn):
+    """Memset is optional: kernels and memcpy still produce a useful metric."""
+    minimal_nsys_conn.execute("DROP TABLE CUPTI_ACTIVITY_KIND_MEMSET")
+
+    rows = get_skill("pipeline_bubble_metrics").execute(minimal_nsys_conn)
+
+    assert rows
+    assert not is_abstention(rows)
+    assert "bubble_pct" in rows[0]
+
+
+def test_pipeline_bubble_does_not_fabricate_sync_zero(minimal_nsys_conn):
+    minimal_nsys_conn.execute(
+        "DROP TABLE IF EXISTS CUPTI_ACTIVITY_KIND_SYNCHRONIZATION"
+    )
+    minimal_nsys_conn.execute("DROP TABLE IF EXISTS ENUM_CUPTI_SYNC_TYPE")
+
+    rows = get_skill("pipeline_bubble_metrics").execute(minimal_nsys_conn)
+
+    assert rows
+    assert "sync_ms" not in rows[0]
+
+
+def test_gc_keeps_runtime_result_without_nvtx():
+    """NVTX enrichment is optional; runtime GC rows remain answerable."""
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+        CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+            correlationId INTEGER, start INTEGER, [end] INTEGER, nameId INTEGER
+        );
+        INSERT INTO StringIds VALUES (1, 'cudaFree');
+        INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (1, 100, 200, 1);
+        """
+    )
+
+    rows = get_skill("gc_impact").execute(conn)
+
+    assert not is_abstention(rows)
+    assert rows[0]["event_name"] == "cudaFree"
+
+
+def test_root_cause_memset_checker_abstains_without_required_tables():
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_sync_memset
+
+    rows = _check_sync_memset(sqlite3.connect(":memory:"))
+
+    assert is_abstention(rows)
+    assert "CUPTI_ACTIVITY_KIND_MEMSET" in rows[0]["missing_tables"]

--- a/tests/test_skills_benchmarks.py
+++ b/tests/test_skills_benchmarks.py
@@ -100,7 +100,8 @@ def test_pipeline_bubble_metrics_duckdb(duckdb_conn):
 
 
 def test_pipeline_bubble_metrics_no_tables_graceful(minimal_nsys_conn):
-    """Test pipeline bubble metrics falls back gracefully if activity tables are omitted."""
+    """Test pipeline bubble metrics abstains if all activity tables are omitted."""
+    from nsys_ai.skills.base import is_abstention
     from nsys_ai.skills.registry import get_skill
 
     minimal_nsys_conn.execute("DROP TABLE CUPTI_ACTIVITY_KIND_KERNEL")
@@ -109,7 +110,7 @@ def test_pipeline_bubble_metrics_no_tables_graceful(minimal_nsys_conn):
 
     skill = get_skill("pipeline_bubble_metrics")
     rows = skill.execute(minimal_nsys_conn)
-    assert rows == []
+    assert is_abstention(rows)
 
 
 def _use_a100(conn):

--- a/tests/test_sync_cost_analysis.py
+++ b/tests/test_sync_cost_analysis.py
@@ -15,10 +15,14 @@ def sync_skill():
 def test_sync_analysis_without_tables(sync_skill):
     conn = sqlite3.connect(":memory:")
 
+    from nsys_ai.skills.base import is_abstention
+
     rows = sync_skill.execute(conn)
-    assert len(rows) == 1
-    assert "error" in rows[0]
-    assert "not found" in rows[0]["error"]
+    assert is_abstention(rows)
+    assert set(rows[0]["missing_tables"]) == {
+        "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION",
+        "ENUM_CUPTI_SYNC_TYPE",
+    }
 
 
 def test_sync_analysis_math(sync_skill):
@@ -204,7 +208,9 @@ def test_sync_analysis_device_filter_on_missing_tables_reports_not_found(sync_sk
     must still report 'Synchronization tables not found', not 'no deviceId column'.
     The latter message is misleading when the table itself is missing."""
     conn = sqlite3.connect(":memory:")
+    from nsys_ai.skills.base import is_abstention
+
     rows = sync_skill.execute(conn, device=0)
-    assert "error" in rows[0]
-    assert "not found" in rows[0]["error"].lower()
-    assert "deviceid" not in rows[0]["error"].lower()
+    assert is_abstention(rows)
+    assert "CUPTI_ACTIVITY_KIND_SYNCHRONIZATION" in rows[0]["missing_tables"]
+    assert "deviceid" not in rows[0]["reason"].lower()


### PR DESCRIPTION
## Summary

Make missing activity-table support an explicit abstention for execute_fn skills and keep downstream consumers from interpreting abstention rows as zero-valued evidence.

## Changes

- Add declarative `Skill.required_tables` checks for execute_fn skills whose dependencies are not visible in SQL templates.
- Make `sync_cost_analysis` and `host_sync_parent_ranges` return typed abstentions for missing required tables.
- Keep `gc_impact` runtime-derived results and `pipeline_bubble_metrics` partial results when optional activity tables are absent.
- Make critical-path, overlap, pipeline, manifest, and root-cause consumers recognize `is_abstention()` before reading sync metrics.
- Make the root-cause synchronous-memset checker abstain internally and prevent that marker from becoming a finding.
- Extend the abstention matrix and add execute_fn/consumer regression tests.

## Backward compatibility

- Existing successful analyses retain their result fields and calculations.
- Missing-table outputs change from empty/error/zero-like results to the canonical `_abstained` + `reason` shape.
- Optional runtime GC and pipeline-bubble coverage remains available without NVTX or memset data.

## Test plan

- [x] `pytest tests/test_execute_fn_abstention.py tests/test_sync_cost_analysis.py tests/test_host_sync_parent_ranges.py tests/test_skills_benchmarks.py tests/test_root_cause_abstention.py tests/test_abstention.py tests/test_critical_path.py tests/test_overlap_analysis.py tests/test_overlap_breakdown.py tests/test_profile_health_manifest.py tests/test_profile_health_manifest_findings.py tests/test_cannot_answer.py -q` — 257 passed, 4 expected failures.
- [x] `pytest tests/test_skills.py tests/test_skill_engine_parity.py tests/test_duckdb_path.py tests/test_duckdb_dataflow.py tests/test_sync_table_resolution.py tests/test_activity_table_memoization.py -q` — 166 passed.
- [x] `ruff check src tests/test_execute_fn_abstention.py tests/test_sync_cost_analysis.py tests/test_cannot_answer.py`.
- [x] `git diff --check`.
- [ ] Full suite — attempted with `NSYS_TEST_PROFILE`; 628 passed, 5 skipped, and 4 expected failures before two unrelated loop-after tests hit an occupied local HTTP port. Isolated PR CI is the verification gate.

## Out of scope

- The broader grounding and chat-tool migration in #283, #281, and #436.
- The shared runner, session transport, ingest, and diff-index work.

## Linked issues

Closes #345
