### PR TITLE
refactor(agent): route profile tools through skill registry

### DIFF
--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -42,6 +42,7 @@ from .ai.backend.profile_db_tool import (
     query_profile_db,
 )
 from .diff_tools import TOOLS_DIFF_OPENAI, build_diff_system_prompt
+from .skills.base import is_abstention_row
 
 _log = logging.getLogger(__name__)
 _telemetry_log = logging.getLogger("nsys_ai.telemetry")
@@ -164,7 +165,19 @@ def _tool_result_failed(content: str) -> bool:
         payload = json.loads(text)
     except (json.JSONDecodeError, TypeError):
         return False
-    return isinstance(payload, dict) and bool(payload.get("error"))
+
+    def _contains_unavailable(value) -> bool:
+        if is_abstention_row(value):
+            return True
+        if isinstance(value, dict):
+            return bool(value.get("error")) or any(
+                _contains_unavailable(child) for child in value.values()
+            )
+        if isinstance(value, list):
+            return any(_contains_unavailable(child) for child in value)
+        return False
+
+    return _contains_unavailable(payload)
 
 
 def _cannot_answer_from_profile(reason: str | None = None) -> str:
@@ -367,6 +380,7 @@ def run_agent_loop(
     query_runner: Callable[[str], str] | None = None,
     max_turns: int = 5,
     ui_context: dict | None = None,
+    dispatcher=None,
 ) -> tuple[str, list]:
     """Run a multi-turn agent loop until the model stops calling tools.
 
@@ -376,6 +390,9 @@ def run_agent_loop(
         tools:         OpenAI-style tool spec list; defaults to :func:`_tools_openai`.
         query_runner:  Callable ``(sql: str) -> str`` for ``query_profile_db``.
                        Pass ``None`` to treat DB calls as no-ops.
+        dispatcher: Optional canonical profile-tool dispatcher. Web callers
+                    provide this so non-streaming chat uses the same registry
+                    path as the streaming loop.
         max_turns:     Maximum number of LLM round-trips.
         ui_context:    Structured UI state available to ``answer_from_ui_context``.
 
@@ -394,6 +411,7 @@ def run_agent_loop(
     grounding_attempted = False
     evidence_ready = False
     grounding_failure: str | None = None
+    exploratory_query_succeeded = False
 
     for _ in range(max_turns):
         _compact_old_tool_results(api_messages)
@@ -464,6 +482,7 @@ def run_agent_loop(
         control_response: str | None = None
         turn_grounding_succeeded = False
         turn_tool_failed = False
+        compute_mfu_succeeded = False
         for tc_id, name, args_str in tc_list:
             if not name or not tc_id:
                 grounding_failure = "Invalid tool call: missing name or id."
@@ -510,7 +529,10 @@ def run_agent_loop(
                                 "supports the answer, state that the question cannot be answered.]"
                             )
                     else:
-                        turn_grounding_succeeded = True
+                        # Exploratory SQL is intentionally not sufficient to
+                        # ground a profile diagnosis. A registered analysis
+                        # skill must provide the evidence path.
+                        exploratory_query_succeeded = True
                         consecutive_db_errors = 0
                 else:
                     result = "Not executed (no profile loaded)."
@@ -525,23 +547,38 @@ def run_agent_loop(
                     }
                 )
             else:
-                # Tools only implemented in the streaming path get an explicit message
-                if name in {
-                    "get_gpu_peak_tflops",
-                    "compute_mfu",
-                    "compute_region_mfu",
-                    "compute_theoretical_flops",
-                }:
-                    tool_result = (
-                        f"Tool '{name}' is only supported in the streaming API path "
-                        "and cannot be executed in this non-streaming request."
-                    )
+                if dispatcher is not None and dispatcher.knows(name):
+                    dispatched = dispatcher.dispatch(name, args_str)
+                    tool_failed = _tool_result_failed(dispatched.content)
+                    if tool_failed:
+                        grounding_failure = dispatched.content
+                        turn_tool_failed = True
+                    if name in _PROFILE_GROUNDING_TOOLS:
+                        grounding_attempted = True
+                        if not tool_failed and name != "query_profile_db":
+                            turn_grounding_succeeded = True
+                    if name == "compute_mfu" and not tool_failed:
+                        compute_mfu_succeeded = True
+                    tool_result = dispatched.content
                 else:
-                    tool_result = "Not executed."
-                if name in _PROFILE_GROUNDING_TOOLS:
-                    grounding_attempted = True
-                grounding_failure = tool_result
-                turn_tool_failed = True
+                    # Tools unavailable to this compatibility wrapper get an
+                    # explicit response rather than silently being skipped.
+                    if name in {
+                        "get_gpu_peak_tflops",
+                        "compute_mfu",
+                        "compute_region_mfu",
+                        "compute_theoretical_flops",
+                    }:
+                        tool_result = (
+                            f"Tool '{name}' is only supported in the streaming API path "
+                            "and cannot be executed in this non-streaming request."
+                        )
+                    else:
+                        tool_result = "Not executed."
+                    if name in _PROFILE_GROUNDING_TOOLS:
+                        grounding_attempted = True
+                    grounding_failure = tool_result
+                    turn_tool_failed = True
                 api_messages.append(
                     {
                         "role": "tool",
@@ -550,6 +587,16 @@ def run_agent_loop(
                         "content": tool_result,
                     }
                 )
+
+        if (
+            not turn_tool_failed
+            and exploratory_query_succeeded
+            and compute_mfu_succeeded
+        ):
+            # The pure calculation is grounded because its profile-derived
+            # input was retrieved in this conversation, independent of tool
+            # call ordering within the batch.
+            turn_grounding_succeeded = True
 
         if turn_tool_failed:
             evidence_ready = False
@@ -709,6 +756,8 @@ def chat_completion(body_bytes: bytes) -> dict | None:
 
     if profile_path and conn:
         try:
+            from .tool_dispatch import ToolDispatcher
+
             content, actions = run_agent_loop(
                 model=model,
                 api_messages=api_messages,
@@ -716,6 +765,11 @@ def chat_completion(body_bytes: bytes) -> dict | None:
                 query_runner=query_runner,
                 max_turns=5,
                 ui_context=ui_context,
+                dispatcher=ToolDispatcher(
+                    conn=conn,
+                    sqlite_path=sqlite_path,
+                    query_runner=query_runner,
+                ),
             )
             return {"content": content, "actions": actions}
         except Exception as e:
@@ -933,6 +987,7 @@ def stream_agent_loop(
     grounding_attempted = False
     evidence_ready = False
     grounding_failure: str | None = None
+    exploratory_query_succeeded = False
 
     try:
         for _ in range(max_turns):
@@ -1106,6 +1161,7 @@ def stream_agent_loop(
             control_response: str | None = None
             turn_grounding_succeeded = False
             turn_tool_failed = False
+            compute_mfu_succeeded = False
             for tid, name, args_str in tc_list:
                 if not name or not tid:
                     grounding_failure = "Invalid tool call: missing name or id."
@@ -1140,8 +1196,21 @@ def stream_agent_loop(
                         turn_tool_failed = True
                     if name in grounding_tools:
                         grounding_attempted = True
-                        if not tool_failed:
+                        # Exploratory SQL can support a registered analysis,
+                        # but it cannot ground a diagnosis by itself.
+                        if not tool_failed and name != "query_profile_db":
                             turn_grounding_succeeded = True
+                        if name == "query_profile_db" and not tool_failed:
+                            exploratory_query_succeeded = True
+                    elif name == "query_profile_db":
+                        grounding_attempted = True
+                        if not tool_failed:
+                            exploratory_query_succeeded = True
+                    elif name == "compute_mfu":
+                        # A pure MFU calculation is grounded only when its
+                        # profile-derived input was retrieved first.
+                        if not tool_failed:
+                            compute_mfu_succeeded = True
                     yield from tr.events
                     if not tr.skip_tool_message:
                         api_messages.append(
@@ -1171,6 +1240,15 @@ def stream_agent_loop(
                             "content": "Not executed.",
                         }
                     )
+
+            if (
+                not turn_tool_failed
+                and exploratory_query_succeeded
+                and compute_mfu_succeeded
+            ):
+                # Resolve the dependency after the whole tool batch so the
+                # model's tool-call ordering cannot change grounding.
+                turn_grounding_succeeded = True
 
             if turn_tool_failed:
                 evidence_ready = False

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -760,6 +760,7 @@ def chat_completion(body_bytes: bytes) -> dict | None:
             api_messages.append({"role": m["role"], "content": m["content"]})
 
     if profile_path and conn:
+        dispatcher_events: list[dict] = []
         try:
             from .tool_dispatch import ToolDispatcher
 
@@ -772,7 +773,6 @@ def chat_completion(body_bytes: bytes) -> dict | None:
                 local_finding_counter += 1
                 return local_finding_counter
 
-            dispatcher_events: list[dict] = []
             content, actions = run_agent_loop(
                 model=model,
                 api_messages=api_messages,
@@ -795,10 +795,15 @@ def chat_completion(body_bytes: bytes) -> dict | None:
             ]
             return {"content": content, "actions": actions, "findings": findings}
         except Exception as e:
+            findings = [
+                event["finding"]
+                for event in dispatcher_events
+                if event.get("type") == "finding" and isinstance(event.get("finding"), dict)
+            ]
             return {
                 "content": f"LLM error: {_friendly_error(model, e)}",
                 "actions": [],
-                "findings": [],
+                "findings": findings,
             }
         finally:
             conn.close()

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -381,6 +381,7 @@ def run_agent_loop(
     max_turns: int = 5,
     ui_context: dict | None = None,
     dispatcher=None,
+    event_sink: list[dict] | None = None,
 ) -> tuple[str, list]:
     """Run a multi-turn agent loop until the model stops calling tools.
 
@@ -393,6 +394,8 @@ def run_agent_loop(
         dispatcher: Optional canonical profile-tool dispatcher. Web callers
                     provide this so non-streaming chat uses the same registry
                     path as the streaming loop.
+        event_sink: Optional list receiving dispatcher side-effect events,
+                    including finding overlays.
         max_turns:     Maximum number of LLM round-trips.
         ui_context:    Structured UI state available to ``answer_from_ui_context``.
 
@@ -549,6 +552,8 @@ def run_agent_loop(
             else:
                 if dispatcher is not None and dispatcher.knows(name):
                     dispatched = dispatcher.dispatch(name, args_str)
+                    if event_sink is not None:
+                        event_sink.extend(dispatched.events)
                     tool_failed = _tool_result_failed(dispatched.content)
                     if tool_failed:
                         grounding_failure = dispatched.content
@@ -725,7 +730,7 @@ def chat_completion(body_bytes: bytes) -> dict | None:
     try:
         payload = json.loads(body_bytes.decode("utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError):
-        return {"content": "Invalid request body.", "actions": []}
+        return {"content": "Invalid request body.", "actions": [], "findings": []}
 
     try:
         import litellm
@@ -747,7 +752,7 @@ def chat_completion(body_bytes: bytes) -> dict | None:
             profile_path, messages, ui_context
         )
     except (RuntimeError, NsysAiError) as e:
-        return {"content": f"Profile error: {e}", "actions": []}
+        return {"content": f"Profile error: {e}", "actions": [], "findings": []}
 
     api_messages = [{"role": "system", "content": system_prompt}]
     for m in messages:
@@ -758,6 +763,16 @@ def chat_completion(body_bytes: bytes) -> dict | None:
         try:
             from .tool_dispatch import ToolDispatcher
 
+            local_finding_counter = payload.get("findings_count", 0)
+            if not isinstance(local_finding_counter, int) or local_finding_counter < 0:
+                local_finding_counter = 0
+
+            def _next_finding_index() -> int:
+                nonlocal local_finding_counter
+                local_finding_counter += 1
+                return local_finding_counter
+
+            dispatcher_events: list[dict] = []
             content, actions = run_agent_loop(
                 model=model,
                 api_messages=api_messages,
@@ -765,15 +780,26 @@ def chat_completion(body_bytes: bytes) -> dict | None:
                 query_runner=query_runner,
                 max_turns=5,
                 ui_context=ui_context,
+                event_sink=dispatcher_events,
                 dispatcher=ToolDispatcher(
                     conn=conn,
                     sqlite_path=sqlite_path,
                     query_runner=query_runner,
+                    finding_counter=_next_finding_index,
                 ),
             )
-            return {"content": content, "actions": actions}
+            findings = [
+                event["finding"]
+                for event in dispatcher_events
+                if event.get("type") == "finding" and isinstance(event.get("finding"), dict)
+            ]
+            return {"content": content, "actions": actions, "findings": findings}
         except Exception as e:
-            return {"content": f"LLM error: {_friendly_error(model, e)}", "actions": []}
+            return {
+                "content": f"LLM error: {_friendly_error(model, e)}",
+                "actions": [],
+                "findings": [],
+            }
         finally:
             conn.close()
 
@@ -785,11 +811,15 @@ def chat_completion(body_bytes: bytes) -> dict | None:
             tool_choice="auto",
         )
     except Exception as e:
-        return {"content": f"LLM error: {_friendly_error(model, e)}", "actions": []}
+        return {
+            "content": f"LLM error: {_friendly_error(model, e)}",
+            "actions": [],
+            "findings": [],
+        }
 
     choice = response.choices[0] if response.choices else None
     if not choice:
-        return {"content": "", "actions": []}
+        return {"content": "", "actions": [], "findings": []}
     message = choice.message
     if isinstance(message, dict):
         content = (message.get("content") or "").strip()
@@ -809,7 +839,7 @@ def chat_completion(body_bytes: bytes) -> dict | None:
             action = _parse_tool_call(name, args_str)
             if action:
                 actions.append(action)
-    return {"content": content, "actions": actions}
+    return {"content": content, "actions": actions, "findings": []}
 
 
 # ---------------------------------------------------------------------------

--- a/src/nsys_ai/skills/__init__.py
+++ b/src/nsys_ai/skills/__init__.py
@@ -9,6 +9,7 @@ Public API:
     list_skills()          → list of all registered skill names
     get_skill(name)        → Skill object by name
     run_skill(skill_name, conn)  → execute a skill against a SQLite connection
+        (formatted text by default, raw rows with ``raw=True``)
 """
 
 from .registry import get_skill, list_skills, run_skill

--- a/src/nsys_ai/skills/builtins/nccl_breakdown.py
+++ b/src/nsys_ai/skills/builtins/nccl_breakdown.py
@@ -425,6 +425,7 @@ SKILL = Skill(
     execute_fn=_execute,
     format_fn=_format,
     to_findings_fn=_to_findings,
+    required_tables=("kernel",),
     params=[
         SkillParam("device", "GPU device ID", "int", False, 0),
     ],

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -509,6 +509,7 @@ SKILL = Skill(
     execute_fn=_execute,
     format_fn=_format,
     to_findings_fn=_to_findings,
+    required_tables=("kernel",),
     params=[SkillParam("device", "GPU device ID", "int", False, 0)],
     tags=[
         "overlap", "nccl", "compute", "communication", "distributed",

--- a/src/nsys_ai/skills/builtins/region_mfu.py
+++ b/src/nsys_ai/skills/builtins/region_mfu.py
@@ -7,7 +7,7 @@ resolution, kernel attribution, and interval math.
 Requires user-provided theoretical_flops (model FLOPs per step).
 """
 
-from ..base import Skill, SkillParam
+from ..base import Skill, SkillParam, requires_nvtx
 
 
 def _execute(conn, **kwargs):
@@ -16,6 +16,10 @@ def _execute(conn, **kwargs):
     name = kwargs.get("name", "")
     theoretical_flops = float(kwargs.get("theoretical_flops", 0))
     source = kwargs.get("source", "nvtx")
+    if source != "kernel":
+        unavailable = requires_nvtx(conn, needs="Region MFU attribution")
+        if unavailable:
+            return unavailable
     peak_tflops = kwargs.get("peak_tflops")
     if peak_tflops is not None:
         peak_tflops = float(peak_tflops)
@@ -28,7 +32,7 @@ def _execute(conn, **kwargs):
 
     result = compute_region_mfu_from_conn(
         conn,
-        profile_path=None,
+        profile_path=kwargs.get("profile_path"),
         name=name,
         theoretical_flops=theoretical_flops,
         source=source,
@@ -195,6 +199,7 @@ SKILL = Skill(
     execute_fn=_execute,
     format_fn=_format,
     to_findings_fn=_to_findings,
+    required_tables=("kernel",),
     params=[
         SkillParam("name", "NVTX region or kernel name to analyze", "str", True, None),
         SkillParam(

--- a/src/nsys_ai/skills/registry.py
+++ b/src/nsys_ai/skills/registry.py
@@ -67,12 +67,21 @@ def all_skills() -> list[Skill]:
     return sorted(_SKILLS.values(), key=lambda s: s.name)
 
 
-def run_skill(skill_name: str, conn: sqlite3.Connection, **kwargs) -> str:
-    """Look up and run a skill, returning formatted text.
+def run_skill(
+    skill_name: str,
+    conn: sqlite3.Connection,
+    *,
+    raw: bool = False,
+    **kwargs,
+) -> str | list[dict]:
+    """Look up and run a skill, returning formatted text or raw rows.
 
     The first parameter is ``skill_name`` (not ``name``) so it never collides
     with a skill that exposes its own ``name`` parameter (e.g. ``region_mfu``),
     which would otherwise raise "got multiple values for argument 'name'".
+
+    ``raw=True`` is for structured callers such as the chat tool dispatcher.
+    The default remains formatted text for the CLI and the public agent wrapper.
     """
     skill = get_skill(skill_name)
     if not skill:
@@ -81,7 +90,8 @@ def run_skill(skill_name: str, conn: sqlite3.Connection, **kwargs) -> str:
             f"Unknown skill '{skill_name}'. Available: {', '.join(available)}",
             available=available,
         )
-    return skill.run(conn, **kwargs)
+    rows = skill.execute(conn, **kwargs)
+    return rows if raw else skill.format_rows(rows)
 
 
 def skill_catalog() -> str:

--- a/src/nsys_ai/tool_dispatch.py
+++ b/src/nsys_ai/tool_dispatch.py
@@ -224,10 +224,8 @@ class ToolDispatcher:
         return ToolResult(content=json.dumps(result), events=events)
 
     def _handle_region_mfu(self, args: dict) -> ToolResult:
-        from .region_mfu import compute_region_mfu_from_conn
-
         events = [{"type": "system", "content": "Running compute_region_mfu..."}]
-        if self._conn is None or self._sqlite_path is None:
+        if self._conn is None:
             result = {
                 "error": {
                     "code": "PROFILE_NOT_LOADED",
@@ -266,27 +264,44 @@ class ToolDispatcher:
                     }
                 }
             else:
-                result = compute_region_mfu_from_conn(
-                    self._conn,
-                    self._sqlite_path,
-                    region_name,
-                    flops_val,
-                    source=str(args.get("source") or "nvtx"),
-                    peak_tflops=(
-                        float(args["peak_tflops"])
-                        if "peak_tflops" in args and args["peak_tflops"] is not None
-                        else None
-                    ),
-                    num_gpus=int(args.get("num_gpus") or 1),
-                    occurrence_index=int(args.get("occurrence_index") or 1),
-                    device_id=(
-                        int(args["device_id"])
-                        if "device_id" in args and args["device_id"] is not None
-                        else None
-                    ),
-                    match_mode=str(args.get("match_mode") or "contains"),
+                rows = self._run_registered_skill(
+                    "region_mfu",
+                    {
+                        "name": region_name,
+                        "theoretical_flops": flops_val,
+                        "profile_path": self._sqlite_path,
+                        "source": str(args.get("source") or "nvtx"),
+                        "peak_tflops": (
+                            float(args["peak_tflops"])
+                            if "peak_tflops" in args and args["peak_tflops"] is not None
+                            else None
+                        ),
+                        "num_gpus": int(args.get("num_gpus") or 1),
+                        "occurrence_index": int(args.get("occurrence_index") or 1),
+                        "device_id": (
+                            int(args["device_id"])
+                            if "device_id" in args and args["device_id"] is not None
+                            else None
+                        ),
+                        "match_mode": str(args.get("match_mode") or "contains"),
+                    },
                 )
+                result = rows[0] if len(rows) == 1 else rows
         return ToolResult(content=json.dumps(result), events=events)
+
+    def _run_registered_skill(self, skill_name: str, args: dict) -> list[dict]:
+        """Execute a profile skill through the canonical registry.
+
+        CLI callers keep the registry's formatted-text default. Chat tools need
+        the same rows as structured JSON, so the registry exposes that result
+        explicitly instead of each tool importing an analysis implementation.
+        """
+        if self._conn is None:
+            return [{"error": "No profile loaded"}]
+
+        from .skills import registry
+
+        return registry.run_skill(skill_name, self._conn, raw=True, **args)
 
     def _handle_submit_finding(self, args: dict) -> ToolResult:
         explicit_index = args.get("index")
@@ -313,75 +328,73 @@ class ToolDispatcher:
 
     def _handle_gpu_overlap_stats(self, args: dict) -> ToolResult:
         events = [{"type": "system", "content": "Computing GPU overlap stats..."}]
-        if not self._sqlite_path:
+        if self._conn is None:
             result = {"error": "No profile loaded"}
             return ToolResult(content=json.dumps(result), events=events)
 
         try:
-            from .overlap import overlap_analysis as _overlap_fn
             from .profile import Profile
+            from .skills.base import is_abstention
 
-            _prof = None
-            try:
-                _prof = Profile(self._sqlite_path)
-                _devices = _prof.meta.devices or [0]
-                _start_s = args.get("start_s")
-                _end_s = args.get("end_s")
-                _trim = (
-                    (int(float(_start_s) * 1e9), int(float(_end_s) * 1e9))
-                    if _start_s is not None and _end_s is not None
-                    else None
+            _prof = Profile._from_conn(self._conn)
+            _devices = _prof.meta.devices or [0]
+            _start_s = args.get("start_s")
+            _end_s = args.get("end_s")
+            _skill_args = {}
+            if _start_s is not None and _end_s is not None:
+                _skill_args["trim_start_ns"] = int(float(_start_s) * 1e9)
+                _skill_args["trim_end_ns"] = int(float(_end_s) * 1e9)
+
+            _per_gpu = []
+            _unavailable = []
+            for _dev in _devices:
+                _rows = self._run_registered_skill(
+                    "overlap_breakdown", {"device": _dev, **_skill_args}
                 )
-                _per_gpu = []
-                for _dev in _devices:
-                    _oa = _overlap_fn(_prof, _dev, _trim)
-                    if isinstance(_oa, dict) and "error" not in _oa:
+                if _rows and isinstance(_rows[0], dict):
+                    _oa = _rows[0]
+                    if is_abstention(_rows):
+                        _unavailable.extend(_rows)
+                    elif "error" not in _oa:
+                        _oa = dict(_oa)
                         _oa["gpu_id"] = _dev
                         _gpu_info = _prof.meta.gpu_info.get(_dev)
                         if _gpu_info:
                             _oa["gpu_name"] = _gpu_info.name
                         _per_gpu.append(_oa)
-                result = {
-                    "device_count": len(_devices),
-                    "per_gpu": _per_gpu,
-                }
-            finally:
-                if _prof is not None:
-                    _prof.close()
+            result = {
+                "device_count": len(_devices),
+                "per_gpu": _per_gpu,
+            }
+            if _unavailable:
+                result["unavailable"] = _unavailable
         except Exception as _e:
             result = {"error": str(_e)}
         return ToolResult(content=json.dumps(result), events=events)
 
     def _handle_nccl_breakdown(self, args: dict) -> ToolResult:
         events = [{"type": "system", "content": "Analyzing NCCL collectives..."}]
-        if not self._sqlite_path:
+        if self._conn is None:
             result = {"error": "No profile loaded"}
             return ToolResult(content=json.dumps(result), events=events)
 
         try:
-            from .overlap import nccl_breakdown as _nccl_fn
             from .profile import Profile
 
-            _prof = None
-            try:
-                _prof = Profile(self._sqlite_path)
-                _devices = _prof.meta.devices or [0]
-                _dev = args.get("device_id", _devices[0])
-                _start_s = args.get("start_s")
-                _end_s = args.get("end_s")
-                _trim = (
-                    (int(float(_start_s) * 1e9), int(float(_end_s) * 1e9))
-                    if _start_s is not None and _end_s is not None
-                    else None
-                )
-                _rows = _nccl_fn(_prof, int(_dev), _trim)
-                result = {
-                    "device_id": _dev,
-                    "collectives": _rows,
-                }
-            finally:
-                if _prof is not None:
-                    _prof.close()
+            _prof = Profile._from_conn(self._conn)
+            _devices = _prof.meta.devices or [0]
+            _dev = args.get("device_id", _devices[0])
+            _skill_args = {"device": int(_dev)}
+            _start_s = args.get("start_s")
+            _end_s = args.get("end_s")
+            if _start_s is not None and _end_s is not None:
+                _skill_args["trim_start_ns"] = int(float(_start_s) * 1e9)
+                _skill_args["trim_end_ns"] = int(float(_end_s) * 1e9)
+            _rows = self._run_registered_skill("nccl_breakdown", _skill_args)
+            result = {
+                "device_id": _dev,
+                "collectives": _rows,
+            }
         except Exception as _e:
             result = {"error": str(_e)}
         return ToolResult(content=json.dumps(result), events=events)

--- a/tests/ai_backend/test_scoped_loop.py
+++ b/tests/ai_backend/test_scoped_loop.py
@@ -41,7 +41,7 @@ def _make_text_response(text: str):
 
 
 def test_run_agent_loop_db_query_then_answer():
-    """Loop should execute query_profile_db once, then return final answer."""
+    """Exploratory SQL alone must not become a grounded final answer."""
     mock_lt = MagicMock()
     mock_lt.completion.side_effect = [
         _make_tool_response("query_profile_db", '{"sql_query":"SELECT 1"}', "db1"),
@@ -64,7 +64,8 @@ def test_run_agent_loop_db_query_then_answer():
             max_turns=3,
         )
 
-    assert content == "Done."
+    assert "cannot answer this profile question" in content
+    assert "Done." not in content
     assert actions == []
     assert queries == ["SELECT 1"]
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -348,6 +348,39 @@ def test_chat_completion_profile_finding_event_is_returned(monkeypatch):
     conn.close.assert_called_once()
 
 
+def test_chat_completion_preserves_findings_when_followup_llm_fails(monkeypatch):
+    """A later provider failure must not erase an already emitted finding."""
+    conn = MagicMock()
+    monkeypatch.setattr(
+        chat_mod,
+        "_prepare_session",
+        lambda *_args: (conn, "/profile.sqlite", "system", lambda _sql: "[]"),
+    )
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+
+    fn = MagicMock(name="function")
+    fn.name = "submit_finding"
+    fn.arguments = json.dumps({"label": "slow kernel"})
+    tc = MagicMock(id="finding-call", function=fn)
+    tool_response = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="", tool_calls=[tc]))]
+    )
+    mock_lt = MagicMock()
+    mock_lt.completion.side_effect = [tool_response, RuntimeError("provider unavailable")]
+
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        body = json.dumps(
+            {"profile_path": "/profile.sqlite", "messages": [{"role": "user", "content": "mark"}]}
+        ).encode("utf-8")
+        out = chat_mod.chat_completion(body)
+
+    assert out["findings"][0]["label"] == "slow kernel"
+    assert out["actions"] == []
+    conn.close.assert_called_once()
+
+
 def test_sse_event():
     """_sse_event produces valid SSE line format."""
     raw = chat_mod._sse_event("text", {"chunk": "hi"})

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -421,6 +421,100 @@ def test_run_agent_loop_query_error_rolls_back_failed_batch(monkeypatch):
     assert all(message.get("role") != "tool" for message in api_messages)
 
 
+def test_tool_result_failed_detects_nested_abstention():
+    assert chat_mod._tool_result_failed(
+        json.dumps(
+            {
+                "device_id": 0,
+                "collectives": [{"_abstained": True, "reason": "no NCCL tables"}],
+            }
+        )
+    )
+    assert not chat_mod._tool_result_failed(json.dumps({"collectives": []}))
+
+
+def test_run_agent_loop_sql_alone_cannot_ground_a_profile_answer():
+    query_fn = MagicMock()
+    query_fn.name = "query_profile_db"
+    query_fn.arguments = '{"sql_query": "SELECT 1"}'
+    query_call = MagicMock(id="db1", function=query_fn)
+    query_response = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="", tool_calls=[query_call]))]
+    )
+    answer_response = MagicMock(
+        choices=[
+            MagicMock(
+                message=MagicMock(
+                    content="SQL proves NCCL is the bottleneck.", tool_calls=[]
+                )
+            )
+        ]
+    )
+    mock_lt = MagicMock()
+    mock_lt.completion.side_effect = [query_response, answer_response]
+
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        content, _ = chat_mod.run_agent_loop(
+            model="gpt-4o",
+            api_messages=[{"role": "system", "content": "s"}],
+            query_runner=lambda _sql: "[{\"value\": 1}]",
+        )
+
+    assert "cannot answer this profile question" in content
+    assert "SQL proves" not in content
+    assert mock_lt.completion.call_count == 2
+
+
+def test_run_agent_loop_uses_registry_for_profile_tools(minimal_nsys_conn):
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    def tool_call(call_id, name, arguments):
+        fn = MagicMock()
+        fn.name = name
+        fn.arguments = json.dumps(arguments)
+        return MagicMock(id=call_id, function=fn)
+
+    # Deliberately put the pure calculation before the SQL call: grounding
+    # must not depend on provider tool-call ordering.
+    first = MagicMock(
+        choices=[
+            MagicMock(
+                message=MagicMock(
+                    content="",
+                    tool_calls=[
+                        tool_call(
+                            "mfu1",
+                            "compute_mfu",
+                            {
+                                "step_time_s": 1.0,
+                                "model_flops_per_step": 1e12,
+                                "peak_tflops": 100.0,
+                            },
+                        ),
+                        tool_call("db1", "query_profile_db", {"sql_query": "SELECT 1"}),
+                    ],
+                )
+            )
+        ]
+    )
+    final = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="Grounded web result.", tool_calls=[]))]
+    )
+    mock_lt = MagicMock()
+    mock_lt.completion.side_effect = [first, final]
+
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        content, _ = chat_mod.run_agent_loop(
+            model="gpt-4o",
+            api_messages=[{"role": "system", "content": "s"}],
+            query_runner=lambda _sql: "[{\"value\": 1}]",
+            dispatcher=ToolDispatcher(conn=minimal_nsys_conn),
+        )
+
+    assert content == "Grounded web result."
+    assert mock_lt.completion.call_count == 2
+
+
 def test_run_agent_loop_exits_after_navigate(monkeypatch):
     """run_agent_loop exits immediately after navigate_to_kernel (no extra LLM turn)."""
     fn1 = MagicMock()
@@ -1469,6 +1563,7 @@ def test_stream_agent_loop_sibling_failure_suppresses_valid_ui_response(monkeypa
 
 
 def test_stream_agent_loop_assembles_id_from_later_chunk(monkeypatch):
+    """A successfully assembled SQL call still cannot ground a diagnosis alone."""
     first_delta = {
         "content": None,
         "tool_calls": [
@@ -1532,7 +1627,8 @@ def test_stream_agent_loop_assembles_id_from_later_chunk(monkeypatch):
 
     text = "".join(event.get("content", "") for event in events if event["type"] == "text")
     assert queries == ["SELECT 1"]
-    assert text == "Grounded answer."
+    assert "cannot answer this profile question" in text
+    assert "Grounded answer." not in text
 
 
 def test_stream_agent_loop_rejects_diff_answer_without_tool_evidence():

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -307,6 +307,47 @@ def test_chat_completion_tool_calls_mock(monkeypatch):
     assert out["actions"][0]["target_name"] == "kernel_a"
 
 
+def test_chat_completion_profile_finding_event_is_returned(monkeypatch):
+    """Non-streaming chat propagates finding overlays and preserves the index."""
+    conn = MagicMock()
+    monkeypatch.setattr(
+        chat_mod,
+        "_prepare_session",
+        lambda *_args: (conn, "/profile.sqlite", "system", lambda _sql: "[]"),
+    )
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: ("gpt-4o", "key"))
+
+    fn = MagicMock(name="function")
+    fn.name = "submit_finding"
+    fn.arguments = json.dumps({"label": "slow kernel", "severity": "warning"})
+    tc = MagicMock(id="finding-call", function=fn)
+    tool_response = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="", tool_calls=[tc]))]
+    )
+    final_response = MagicMock(
+        choices=[MagicMock(message=MagicMock(content="done", tool_calls=[]))]
+    )
+    mock_lt = MagicMock()
+    mock_lt.completion.side_effect = [tool_response, final_response]
+
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        if "litellm" in chat_mod.__dict__:
+            del chat_mod.__dict__["litellm"]
+        body = json.dumps(
+            {
+                "profile_path": "/profile.sqlite",
+                "findings_count": 4,
+                "messages": [{"role": "user", "content": "mark it"}],
+            }
+        ).encode("utf-8")
+        out = chat_mod.chat_completion(body)
+
+    assert out["findings"][0]["index"] == 5
+    assert out["findings"][0]["label"] == "slow kernel"
+    assert out["actions"] == []
+    conn.close.assert_called_once()
+
+
 def test_sse_event():
     """_sse_event produces valid SSE line format."""
     raw = chat_mod._sse_event("text", {"chunk": "hi"})

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -1,0 +1,82 @@
+"""Registry boundaries for profile-backed chat tools."""
+
+import json
+import sqlite3
+
+import pytest
+
+
+def test_run_skill_can_return_raw_rows_without_changing_cli_default(minimal_nsys_conn):
+    from nsys_ai.skills.registry import run_skill
+
+    raw = run_skill("top_kernels", minimal_nsys_conn, raw=True, limit=1)
+    formatted = run_skill("top_kernels", minimal_nsys_conn, limit=1)
+
+    assert isinstance(raw, list)
+    assert isinstance(formatted, str)
+    assert raw
+
+
+def test_profile_tool_handlers_delegate_to_registered_skills(minimal_nsys_conn, monkeypatch):
+    from nsys_ai.skills import registry
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    calls = []
+
+    def fake_run_skill(skill_name, conn, *, raw=False, **kwargs):
+        calls.append((skill_name, conn, raw, kwargs))
+        if skill_name == "overlap_breakdown":
+            return [{"total_ms": 12.0, "compute_only_ms": 8.0}]
+        if skill_name == "nccl_breakdown":
+            return [{"collective": "AllReduce", "total_ms": 4.0}]
+        if skill_name == "region_mfu":
+            return [{"matched_text": "train_step", "mfu_pct_kernel_union": 42.0}]
+        raise AssertionError(f"unexpected skill: {skill_name}")
+
+    monkeypatch.setattr(registry, "run_skill", fake_run_skill)
+    dispatcher = ToolDispatcher(conn=minimal_nsys_conn, sqlite_path="/profile.sqlite")
+
+    region = dispatcher.dispatch(
+        "compute_region_mfu",
+        json.dumps({"name": "train_step", "theoretical_flops": 1e12}),
+    )
+    overlap = dispatcher.dispatch("get_gpu_overlap_stats", json.dumps({}))
+    nccl = dispatcher.dispatch("get_nccl_breakdown", json.dumps({"device_id": 0}))
+
+    assert json.loads(region.content)["matched_text"] == "train_step"
+    assert json.loads(overlap.content)["per_gpu"][0]["total_ms"] == 12.0
+    assert json.loads(nccl.content)["collectives"][0]["collective"] == "AllReduce"
+    assert [call[0] for call in calls] == [
+        "region_mfu",
+        "overlap_breakdown",
+        "nccl_breakdown",
+    ]
+    assert all(call[2] is True for call in calls)
+    assert calls[0][3]["profile_path"] == "/profile.sqlite"
+
+
+@pytest.mark.parametrize("skill_name", ["region_mfu", "overlap_breakdown", "nccl_breakdown"])
+def test_profile_skills_abstain_when_kernel_activity_is_missing(skill_name):
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.registry import run_skill
+
+    conn = sqlite3.connect(":memory:")
+    try:
+        rows = run_skill(skill_name, conn, raw=True)
+    finally:
+        conn.close()
+
+    assert is_abstention(rows)
+    assert "KERNEL" in rows[0]["reason"]
+
+
+def test_query_profile_db_remains_exploratory_tool(minimal_nsys_conn):
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    dispatcher = ToolDispatcher(
+        conn=minimal_nsys_conn,
+        query_runner=lambda sql: f"exploratory:{sql}",
+    )
+    result = dispatcher.dispatch("query_profile_db", '{"sql_query":"SELECT 1"}')
+
+    assert result.content == "exploratory:SELECT 1"


### PR DESCRIPTION
## Summary

- Route `compute_region_mfu`, `get_gpu_overlap_stats`, and `get_nccl_breakdown` through the canonical skill registry.
- Preserve structured chat tool output while keeping the existing formatted `run_skill` CLI behavior.
- Use the same registry-backed dispatcher from streaming and non-streaming profile chat paths.
- Keep `query_profile_db` exploratory: SQL alone cannot ground a profile diagnosis; a registered analysis path is required.
- Preserve abstention and required-table contracts, including nested abstention detection and MFU profile provenance.

Fixes #436

## Verification

- `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite PYTHONPATH=/home/rich-wsl/nsys-ai-436/src python3 -m pytest tests/ -q --tb=short` — 2321 passed, 140 skipped, 4 xfailed
- `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite PYTHONPATH=/home/rich-wsl/nsys-ai-436/src python3 -m pytest tests/test_ci_coverage.py -v --tb=short` — 5 passed
- Focused chat/dispatcher/abstention tests — 81 passed
- `ruff check src/ tests/` — passed
- Changed-file Bandit scan — passed
- `python3 -m nsys_ai --help` — passed
- `git diff --check` — passed
