### PR TITLE
feat(agent): persist chat findings in sessions

### DIFF
--- a/src/nsys_ai/ai/backend/chat_tools.py
+++ b/src/nsys_ai/ai/backend/chat_tools.py
@@ -304,6 +304,15 @@ TOOL_SUBMIT_FINDING = {
                     "enum": ["critical", "warning", "info"],
                     "description": "critical=red, warning=yellow, info=blue",
                 },
+                "confidence": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1,
+                    "description": (
+                        "Optional confidence in this stated finding. "
+                        "If omitted, no confidence is recorded."
+                    ),
+                },
                 "note": {
                     "type": "string",
                     "description": "Explanation text shown in sidebar card and tooltip",

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -13,6 +13,7 @@ Public names are re-exported from the sub-modules so that existing callers
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -138,6 +139,74 @@ _DIFF_GROUNDING_TOOLS = frozenset(
         "get_gpu_peak_tflops",
     }
 )
+
+
+def _prompt_sha256(messages: list) -> str:
+    """Fingerprint the initial model prompt for durable LLM provenance."""
+    canonical = json.dumps(
+        messages, ensure_ascii=False, sort_keys=True, separators=(",", ":"), default=str
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _finding_from_tool_payload(payload: dict):
+    """Convert the visual-tool payload into the validated Finding model."""
+    from .annotation import Finding
+
+    required = {"type", "label", "start_ns", "severity"}
+    missing = sorted(required - payload.keys())
+    if missing:
+        raise ValueError(f"finding is missing required fields: {', '.join(missing)}")
+    normalized = dict(payload)
+    if isinstance(normalized.get("stream"), int):
+        normalized["stream"] = str(normalized["stream"])
+    return Finding.from_dict(normalized)
+
+
+def _session_finding_sink(
+    session_id: str | None,
+    session_root: str | None,
+    *,
+    profile_path: str | None = None,
+):
+    """Return a sink that appends one LLM finding through SessionStore."""
+    if not session_id:
+        return None
+
+    from .annotation import EvidenceReport
+    from .session_store import SessionStore
+
+    store = SessionStore(session_root or ".nsys-ai/sessions")
+
+    def publish(payload: dict) -> None:
+        # Acquire the writer before reading the snapshot so concurrent chat
+        # requests cannot append from the same stale findings list.
+        with store.writer(session_id) as writer:
+            snapshot = store.load(session_id)
+            before = snapshot.state.before_profile
+            if before is None:
+                raise ValueError("LLM finding publication requires a before profile")
+            if profile_path and os.path.abspath(os.path.expanduser(profile_path)) != os.path.abspath(
+                os.path.expanduser(before.path)
+            ):
+                raise ValueError("LLM finding profile does not match the session before profile")
+            existing = snapshot.findings
+            finding = _finding_from_tool_payload(payload)
+            report = EvidenceReport(
+                title=existing.title if existing is not None else "LLM findings",
+                profile_path=before.path,
+                profile_id=before.profile_id,
+                findings=[
+                    *(existing.findings if existing is not None else []),
+                    finding,
+                ],
+                skipped=list(existing.skipped) if existing is not None else [],
+            )
+            writer.publish_findings(report, before_profile=before)
+
+    return publish
+
+
 _CONTROL_RESPONSE_TOOLS = frozenset(
     {"request_clarification", "answer_from_ui_context"}
 )
@@ -724,7 +793,7 @@ def _prepare_session(
 def chat_completion(body_bytes: bytes) -> dict | None:
     """Handle a POST ``/api/chat`` request body.
 
-    Returns ``{"content": str, "actions": list}`` or ``None`` for 501
+    Returns content, actions, and findings, or None for 501
     (LLM not configured / not installed).
     """
     try:
@@ -744,6 +813,8 @@ def chat_completion(body_bytes: bytes) -> dict | None:
     messages = payload.get("messages") or []
     ui_context = payload.get("ui_context") or {}
     profile_path = payload.get("profile_path")
+    session_id = payload.get("session_id")
+    session_root = payload.get("session_root")
 
     from nsys_ai.exceptions import NsysAiError
 
@@ -761,6 +832,14 @@ def chat_completion(body_bytes: bytes) -> dict | None:
 
     if profile_path and conn:
         dispatcher_events: list[dict] = []
+        finding_sink = _session_finding_sink(
+            session_id, session_root, profile_path=profile_path
+        )
+        finding_provenance = {
+            "source": "llm",
+            "model": model,
+            "prompt_sha256": _prompt_sha256(api_messages),
+        }
         try:
             from .tool_dispatch import ToolDispatcher
 
@@ -786,6 +865,8 @@ def chat_completion(body_bytes: bytes) -> dict | None:
                     sqlite_path=sqlite_path,
                     query_runner=query_runner,
                     finding_counter=_next_finding_index,
+                    finding_sink=finding_sink,
+                    finding_provenance=finding_provenance,
                 ),
             )
             findings = [
@@ -901,6 +982,8 @@ def stream_agent_loop(
     max_turns: int = 5,
     skill_names: list[str] | None = None,
     findings_count: int = 0,
+    session_id: str | None = None,
+    session_root: str | None = None,
 ):
     """UI-agnostic streaming agent loop — yields event dicts.
 
@@ -943,6 +1026,8 @@ def stream_agent_loop(
     provided, their contents are concatenated and appended to the system
     prompt as a SESSION SKILL CONTEXT block.  Uses ``prompt_loader``
     internally; missing files are silently ignored.
+    *session_id* / *session_root* — when supplied, submit_finding appends
+    through SessionStore instead of remaining a UI-only overlay.
     """
     try:
         import litellm
@@ -1014,6 +1099,14 @@ def stream_agent_loop(
         sqlite_path=sqlite_path,
         query_runner=query_runner,
         finding_counter=_next_finding_index,
+        finding_sink=_session_finding_sink(
+            session_id, session_root, profile_path=profile_path
+        ),
+        finding_provenance={
+            "source": "llm",
+            "model": model,
+            "prompt_sha256": _prompt_sha256(api_messages),
+        },
         mode="diff" if use_diff else "profile",
         diff_context=diff_context,
     )
@@ -1401,6 +1494,8 @@ def chat_completion_stream(body_bytes: bytes):
     messages = payload.get("messages") or []
     ui_context = payload.get("ui_context") or {}
     profile_path = payload.get("profile_path")
+    session_id = payload.get("session_id")
+    session_root = payload.get("session_root")
     # skill_context: optional list of skill paths (e.g. ["skills/mfu.md"]).
     # When provided, those files are loaded from src/nsys_ai/agent_skills/ and appended
     # to the system prompt as SESSION SKILL CONTEXT. Unknown paths are silently ignored.
@@ -1422,6 +1517,8 @@ def chat_completion_stream(body_bytes: bytes):
             max_turns=5,
             skill_names=skill_context,
             findings_count=findings_count,
+            session_id=session_id,
+            session_root=session_root,
         ):
             t = ev.get("type")
             if t == "text":

--- a/src/nsys_ai/timeline/app.py
+++ b/src/nsys_ai/timeline/app.py
@@ -377,6 +377,8 @@ class NsysTimelineApp(App):
             device=self._device,
             ui_context_fn=self._build_ui_context,
             on_action_fn=self._handle_ai_action,
+            session_id=self._session_id,
+            session_root=self._session_root,
         )
         yield Footer()
 

--- a/src/nsys_ai/tool_dispatch.py
+++ b/src/nsys_ai/tool_dispatch.py
@@ -76,6 +76,8 @@ class ToolDispatcher:
         sqlite_path: str | None = None,
         query_runner: Callable[[str], str] | None = None,
         finding_counter: Callable[[], int] | None = None,
+        finding_sink: Callable[[dict], None] | None = None,
+        finding_provenance: dict | None = None,
         max_consecutive_db_errors: int = 3,
         mode: str = "profile",
         diff_context=None,
@@ -84,6 +86,8 @@ class ToolDispatcher:
         self._sqlite_path = sqlite_path
         self._query_runner = query_runner
         self._finding_counter = finding_counter
+        self._finding_sink = finding_sink
+        self._finding_provenance = dict(finding_provenance or {})
         self._consecutive_db_errors = 0
         self._max_consecutive_db_errors = max_consecutive_db_errors
         self._mode = mode
@@ -314,6 +318,12 @@ class ToolDispatcher:
 
         finding_payload = dict(args)
         finding_payload["index"] = finding_index
+
+        if self._finding_sink is not None:
+            persisted_payload = dict(args)
+            persisted_payload["provenance"] = dict(self._finding_provenance)
+            self._finding_sink(persisted_payload)
+            finding_payload["provenance"] = dict(self._finding_provenance)
 
         events = [{"type": "finding", "finding": finding_payload}]
         result = {

--- a/src/nsys_ai/tree/app.py
+++ b/src/nsys_ai/tree/app.py
@@ -201,6 +201,8 @@ class NsysTreeApp(App):
             device=self._device,
             ui_context_fn=self._build_ui_context,
             on_action_fn=self._handle_ai_action,
+            session_id=self._session_id,
+            session_root=self._session_root,
         )
         yield Footer()
 

--- a/src/nsys_ai/tree/chat.py
+++ b/src/nsys_ai/tree/chat.py
@@ -64,6 +64,8 @@ class ChatPanel(Widget):
         device: int = 0,
         ui_context_fn: Callable[[], dict] | None = None,
         on_action_fn: Callable[[dict], None] | None = None,
+        session_id: str | None = None,
+        session_root: str = ".nsys-ai/sessions",
         **kwargs: object,
     ) -> None:
         super().__init__(**kwargs)
@@ -71,6 +73,8 @@ class ChatPanel(Widget):
         self._device = device
         self._ui_context_fn = ui_context_fn or (lambda: {})
         self._on_action_fn = on_action_fn or (lambda _: None)
+        self._session_id = session_id
+        self._session_root = session_root
         self._history: list[dict] = []
         self._lock = threading.Lock()
         self._cancel_event = threading.Event()
@@ -200,6 +204,8 @@ class ChatPanel(Widget):
                 tools=chat_mod._tools_openai(),
                 profile_path=self._db_path,
                 max_turns=5,
+                session_id=self._session_id,
+                session_root=self._session_root,
             )
             for ev in stream:
                 if self._cancel_event.is_set():

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -793,6 +793,10 @@ class _ViewerHandler(BaseHTTPRequestHandler):
         try:
             payload = json.loads(body.decode("utf-8"))
             stream_requested = payload.get("stream") is True
+            if isinstance(payload, dict) and self.__class__._session_id is not None:
+                payload["session_id"] = self.__class__._session_id
+                payload["session_root"] = self.__class__._session_root
+                body = json.dumps(payload).encode("utf-8")
         except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
             pass
         try:

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -381,6 +381,53 @@ def test_chat_completion_preserves_findings_when_followup_llm_fails(monkeypatch)
     conn.close.assert_called_once()
 
 
+def test_session_finding_sink_publishes_validated_llm_report(tmp_path):
+    from nsys_ai.profile_reference import LocalProfileReference
+    from nsys_ai.session_store import SessionStore
+
+    before_path = tmp_path / "before.sqlite"
+    before_path.write_bytes(b"before")
+    before = LocalProfileReference(
+        path=str(before_path),
+        profile_id="nsys2:sha256:" + "b" * 64,
+        schema_version="3.25.0",
+        product_version="2026.2.1.106",
+        kernel_count=1,
+    )
+    store = SessionStore(tmp_path / "sessions")
+    store.create("llm-findings", before_profile=before)
+
+    sink = chat_mod._session_finding_sink(
+        "llm-findings", str(store.root), profile_path=str(before_path)
+    )
+    sink(
+        {
+            "type": "region",
+            "label": "NCCL stall",
+            "start_ns": 10,
+            "end_ns": 20,
+            "severity": "warning",
+            "confidence": 0.8,
+            "stream": 7,
+            "provenance": {
+                "source": "llm",
+                "model": "test-model",
+                "prompt_sha256": "c" * 64,
+            },
+        }
+    )
+
+    report = store.load("llm-findings").findings
+    assert report is not None
+    assert report.findings[0].confidence == 0.8
+    assert report.findings[0].stream == "7"
+    assert report.findings[0].provenance == {
+        "source": "llm",
+        "model": "test-model",
+        "prompt_sha256": "c" * 64,
+    }
+
+
 def test_sse_event():
     """_sse_event produces valid SSE line format."""
     raw = chat_mod._sse_event("text", {"chunk": "hi"})

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -80,3 +80,40 @@ def test_query_profile_db_remains_exploratory_tool(minimal_nsys_conn):
     result = dispatcher.dispatch("query_profile_db", '{"sql_query":"SELECT 1"}')
 
     assert result.content == "exploratory:SELECT 1"
+
+
+def test_submit_finding_uses_session_sink_and_preserves_confidence():
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    persisted = []
+    dispatcher = ToolDispatcher(
+        finding_counter=lambda: 7,
+        finding_sink=persisted.append,
+        finding_provenance={
+            "source": "llm",
+            "model": "test-model",
+            "prompt_sha256": "a" * 64,
+        },
+    )
+    result = dispatcher.dispatch(
+        "submit_finding",
+        json.dumps(
+            {
+                "type": "region",
+                "label": "NCCL stall",
+                "start_ns": 10,
+                "end_ns": 20,
+                "severity": "warning",
+                "confidence": 0.75,
+            }
+        ),
+    )
+
+    assert json.loads(result.content)["index"] == 7
+    assert result.events[0]["finding"]["index"] == 7
+    assert persisted[0]["confidence"] == 0.75
+    assert persisted[0]["provenance"] == {
+        "source": "llm",
+        "model": "test-model",
+        "prompt_sha256": "a" * 64,
+    }


### PR DESCRIPTION
## Summary

- persist LLM submit_finding output through the existing SessionStore findings contract
- attach llm source, model, and prompt SHA-256 provenance while preserving optional confidence
- wire session context through Web and both Textual TUI chat paths
- force Web requests onto the active session and validate the profile binding

Closes #407

## Verification

- Full suite with tests/fixtures/h100_2gpu_1s.sqlite: 2325 passed, 140 skipped, 4 xfailed
- Focused chat, dispatcher, and TUI tests: 108 passed
- Ruff check on changed source and tests: passed
- git diff --check: passed

