### PR TITLE
test(schema): verify committed export fixture matrix

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ Always check `nsys --version` on the target system and cross-reference with the 
 | [user-guide.md](./user-guide.md) | nsys-ai end to end: capture, diagnose, propose, diff, decide | Project Guide |
 | [guided-loop-setup.md](./guided-loop-setup.md) | The same loop driven from the timeline web UI | Project Guide |
 | [doctor.md](./doctor.md) | Environment and profile health checks | Project Guide |
+| [support-matrix.md](./support-matrix.md) | Committed export schemas verified by CI | Project Guide |
 | [01-cli-reference.md](./01-cli-reference.md) | CLI commands, flags, and example command lines | User Guide |
 | [02-sqlite-schema.md](./02-sqlite-schema.md) | SQLite export schema and common queries | Exporter Docs (v2022.4) |
 | [03-nvtx-annotations.md](./03-nvtx-annotations.md) | NVTX API for instrumenting applications | User Guide |

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,23 @@
+# Verified Nsight export schemas
+
+This table is the support boundary for the committed real SQLite exports. CI
+reads every row, opens the capture, checks the required schema contract, and
+runs the canonical diagnose skill pack. A schema is listed here only when the
+capture parses and the pack produces at least one usable evidence row.
+
+The matrix guards schemas we actually hold an export for; it does not claim
+that an unobserved future Nsight Systems schema is supported. Product versions
+are recorded as provenance, while the export schema version is the compatibility
+axis.
+
+| Fixture | Export schema | Nsight Systems product | CI coverage |
+|---|---|---|---|
+| `tests/fixtures/mock.sqlite` | `3.24.14` | `2026.1.1.204` | schema contract + default diagnose pack |
+| `tests/fixtures/healthy_1pct.sqlite` | `3.24.14` | `2026.1.1.204` | schema contract + default diagnose pack |
+| `tests/fixtures/healthy_judged_1pct.sqlite` | `3.24.14` | `2026.1.1.204` | schema contract + default diagnose pack |
+| `tests/fixtures/h100_2gpu_1s.sqlite` | `3.25.0` | `2026.2.1.210` | schema contract + default diagnose pack |
+| `tests/fixtures/mfu_2gpu_before.sqlite` | `3.25.0` | `2026.2.1.210` | schema contract + default diagnose pack |
+| `tests/fixtures/mfu_2gpu_after.sqlite` | `3.25.0` | `2026.2.1.210` | schema contract + default diagnose pack |
+
+To add a supported schema, commit a real export, add its row here, and let the
+matrix test fail until the capture's metadata and analysis output are verified.

--- a/tests/test_schema_fixture_matrix.py
+++ b/tests/test_schema_fixture_matrix.py
@@ -1,0 +1,97 @@
+"""Verify every published Nsight export schema against a real capture.
+
+The support table is deliberately documentation-owned: keeping the fixture
+paths and observed metadata in one visible table makes the support claim easy
+to review. This test makes that table load-bearing by checking that it neither
+omits a committed SQLite export nor names an uncommitted one.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+from nsys_ai.agent.runner import run_diagnose_pack
+from nsys_ai.profile import Profile
+from nsys_ai.skills.base import is_abstention_row
+
+REPO = Path(__file__).resolve().parents[1]
+FIXTURES = REPO / "tests" / "fixtures"
+SUPPORT_TABLE = REPO / "docs" / "support-matrix.md"
+ROW_RE = re.compile(
+    r"^\| `(?P<path>tests/fixtures/[^`]+\.sqlite)` \| `(?P<schema>[^`]+)` "
+    r"\| `(?P<product>[^`]+)` \| (?P<coverage>[^|]+) \|$"
+)
+
+
+def _support_rows() -> list[dict[str, str]]:
+    rows = []
+    in_table = False
+    for line in SUPPORT_TABLE.read_text(encoding="utf-8").splitlines():
+        if line.startswith("| Fixture |"):
+            in_table = True
+            continue
+        if not in_table or not line.startswith("|") or line.startswith("|---"):
+            continue
+        match = ROW_RE.match(line)
+        assert match, f"malformed support-matrix row: {line}"
+        rows.append(match.groupdict())
+    return rows
+
+
+def _is_git_tracked(relative_path: str) -> bool:
+    result = subprocess.run(
+        ["git", "ls-files", "--error-unmatch", "--", relative_path],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def test_support_table_covers_exactly_the_committed_sqlite_exports():
+    rows = _support_rows()
+    listed = {row["path"] for row in rows}
+    committed = {
+        str(path.relative_to(REPO))
+        for path in FIXTURES.glob("*.sqlite")
+    }
+
+    assert len(rows) == len(listed), "support table contains duplicate fixture rows"
+    assert listed == committed, (
+        "support table drifted from committed exports: "
+        f"missing={sorted(committed - listed)}, extra={sorted(listed - committed)}"
+    )
+    assert all(_is_git_tracked(path) for path in listed), (
+        "support table names an export that is not tracked by git"
+    )
+
+
+def test_each_published_schema_parses_and_produces_diagnose_evidence(tmp_path):
+    """A fixture that parses but produces no evidence cannot be supported."""
+    for row in _support_rows():
+        source = REPO / row["path"]
+        profile_copy = tmp_path / source.name
+        shutil.copy2(source, profile_copy)
+
+        with Profile(profile_copy) as profile:
+            assert profile.schema.schema_version == row["schema"], row["path"]
+            assert profile.schema.version == row["product"], row["path"]
+            assert profile.schema.missing_required_columns() == [], row["path"]
+
+            evidence = run_diagnose_pack(profile.query_conn())
+            usable_rows = [
+                item
+                for rows in evidence.values()
+                for item in rows
+                if isinstance(item, dict)
+                and item
+                and not item.get("error")
+                and not is_abstention_row(item)
+            ]
+            assert usable_rows, (
+                f"default diagnose pack produced no usable evidence for {row['path']}"
+            )


### PR DESCRIPTION
## Summary

- publish the committed real-export schema support matrix with observed export and product versions
- add a CI-backed matrix test that fails on fixture drift, untracked exports, malformed table rows, schema contract failures, or an empty canonical diagnose pack
- run the smoke through `Profile.query_conn()` so the check exercises the production SQLite/Parquet runtime path
- link the support table from the docs index

## Verification

- `pytest tests/ -q --tb=short`: 2333 passed, 140 skipped, 4 xfailed
- focused matrix/schema/skill/coverage gate: 28 passed with `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`
- `ruff check src/ tests/`
- Bandit changed-file scan
- CLI help smoke test

Closes #263