### PR TITLE
ci: package the canonical diff gate

### DIFF
--- a/.github/actions/diff-gate/README.md
+++ b/.github/actions/diff-gate/README.md
@@ -1,0 +1,72 @@
+# nsys-ai diff gate
+
+This composite action is a thin CI wrapper around the canonical
+`nsys-ai diff --gate` command. It always writes a machine-readable JSON report,
+disables optional AI narration, and enables the existing non-zero exit contract
+for regressions and inconclusive comparisons. Threshold evaluation is not
+implemented by the action.
+
+## GitHub Actions
+
+The caller must make a baseline and candidate profile available first. A
+baseline can be a direct path or a named local baseline store reference:
+
+```yaml
+- uses: GindaChen/nsys-ai/.github/actions/diff-gate@main
+  id: perf-gate
+  with:
+    before: artifacts/baseline.sqlite
+    after: artifacts/current.sqlite
+    gate: "3"
+    output: artifacts/diff.json
+
+- uses: actions/upload-artifact@v4
+  if: always()
+  with:
+    name: nsys-ai-diff
+    path: artifacts/diff.json
+```
+
+For a named baseline, tag it before the action and replace `before` with
+`against`:
+
+```yaml
+- run: python -m pip install nsys-ai
+- run: nsys-ai baseline tag main artifacts/baseline.sqlite --reason "CI baseline"
+- uses: GindaChen/nsys-ai/.github/actions/diff-gate@main
+  with:
+    against: baseline:main
+    after: artifacts/current.sqlite
+    gate: "3"
+    output: artifacts/diff.json
+```
+
+Pin the action and package to a release tag when adopting it in a project. The
+`verdict` and `diff-json` step outputs are read from the same JSON file that
+the CLI writes; they do not introduce a second verdict format.
+
+`extra-args` accepts additional `diff` arguments one per line, for example:
+
+```yaml
+    extra-args: |
+      --gpu
+      0
+```
+
+Do not put `--format`, `--output`, `--no-ai`, or
+`--exit-on-regression` in `extra-args`; the action owns those CI contract
+flags.
+
+## Ordinary CI
+
+After installing the package, use the repository wrapper when a shell-level
+entry point is more convenient:
+
+```bash
+scripts/nsys-ai-diff-gate \
+  artifacts/baseline.sqlite artifacts/current.sqlite \
+  --gate 3 --output artifacts/diff.json
+```
+
+The wrapper only forwards arguments to `nsys-ai diff`; `--gate` remains the
+single source of threshold and exit-code semantics.

--- a/.github/actions/diff-gate/action.yml
+++ b/.github/actions/diff-gate/action.yml
@@ -1,0 +1,126 @@
+name: nsys-ai diff gate
+description: Run the canonical nsys-ai diff --gate command and publish its JSON verdict
+
+inputs:
+  after:
+    description: Candidate profile path (.sqlite or .nsys-rep)
+    required: true
+  before:
+    description: Baseline profile path; omit when against is supplied
+    required: false
+    default: ""
+  against:
+    description: Baseline reference, for example baseline:main
+    required: false
+    default: ""
+  gate:
+    description: Step-time regression threshold passed to diff --gate (percent)
+    required: false
+    default: ""
+  output:
+    description: JSON report path, relative to working-directory
+    required: false
+    default: diff.json
+  working-directory:
+    description: Directory containing the profiles and baseline store
+    required: false
+    default: .
+  package:
+    description: Package specifier to install when install is true
+    required: false
+    default: nsys-ai
+  install:
+    description: Install package before running the gate
+    required: false
+    default: "true"
+  extra-args:
+    description: Additional diff arguments, one argument per line
+    required: false
+    default: ""
+
+outputs:
+  verdict:
+    description: Verdict read from the canonical diff JSON
+    value: ${{ steps.diff.outputs.verdict }}
+  diff-json:
+    description: Path to the generated canonical diff JSON
+    value: ${{ steps.diff.outputs.diff-json }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install nsys-ai
+      if: inputs.install == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        NSYS_AI_PACKAGE: ${{ inputs.package }}
+      run: python -m pip install --disable-pip-version-check "$NSYS_AI_PACKAGE"
+
+    - name: Run diff gate
+      id: diff
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        NSYS_AI_AFTER: ${{ inputs.after }}
+        NSYS_AI_BEFORE: ${{ inputs.before }}
+        NSYS_AI_AGAINST: ${{ inputs.against }}
+        NSYS_AI_GATE: ${{ inputs.gate }}
+        NSYS_AI_OUTPUT: ${{ inputs.output }}
+        NSYS_AI_EXTRA_ARGS: ${{ inputs.extra-args }}
+      run: |
+        set -uo pipefail
+
+        if [[ -n "$NSYS_AI_BEFORE" && -n "$NSYS_AI_AGAINST" ]]; then
+          echo "before and against are mutually exclusive" >&2
+          exit 2
+        fi
+        if [[ -z "$NSYS_AI_AFTER" ]]; then
+          echo "after is required" >&2
+          exit 2
+        fi
+        if [[ -z "$NSYS_AI_OUTPUT" ]]; then
+          echo "output must not be empty" >&2
+          exit 2
+        fi
+
+        args=(diff)
+        if [[ -n "$NSYS_AI_AGAINST" ]]; then
+          args+=(--against "$NSYS_AI_AGAINST")
+        elif [[ -n "$NSYS_AI_BEFORE" ]]; then
+          args+=("$NSYS_AI_BEFORE")
+        else
+          echo "one of before or against is required" >&2
+          exit 2
+        fi
+        args+=("$NSYS_AI_AFTER" --format json --no-ai --exit-on-regression --output "$NSYS_AI_OUTPUT")
+        if [[ -n "$NSYS_AI_GATE" ]]; then
+          args+=(--gate "$NSYS_AI_GATE")
+        fi
+        while IFS= read -r extra; do
+          [[ -n "$extra" ]] && args+=("$extra")
+        done <<< "$NSYS_AI_EXTRA_ARGS"
+
+        mkdir -p "$(dirname -- "$NSYS_AI_OUTPUT")"
+        set +e
+        python -m nsys_ai "${args[@]}"
+        status=$?
+        set -e
+
+        if [[ -f "$NSYS_AI_OUTPUT" ]]; then
+          verdict="$(python - "$NSYS_AI_OUTPUT" <<'PY'
+        import json
+        import sys
+
+        with open(sys.argv[1], encoding="utf-8") as stream:
+            payload = json.load(stream)
+        print(payload.get("verdict", ""))
+        PY
+          )"
+          printf 'diff-json=%s\n' "$NSYS_AI_OUTPUT" >> "$GITHUB_OUTPUT"
+          printf 'verdict=%s\n' "$verdict" >> "$GITHUB_OUTPUT"
+        elif [[ "$status" -eq 0 ]]; then
+          echo "diff did not produce the requested JSON report" >&2
+          status=2
+        fi
+        exit "$status"

--- a/scripts/nsys-ai-diff-gate
+++ b/scripts/nsys-ai-diff-gate
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Thin ordinary-CI wrapper. All comparison and threshold semantics remain in
+# `nsys-ai diff`; this only fixes the machine-readable CI contract.
+set -euo pipefail
+
+python_bin="${PYTHON:-python3}"
+exec "$python_bin" -m nsys_ai diff "$@" --format json --no-ai --exit-on-regression

--- a/tests/test_ci_diff_gate.py
+++ b/tests/test_ci_diff_gate.py
@@ -1,0 +1,42 @@
+"""Contract tests for the thin CI wrappers around the canonical diff gate."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+ACTION = ROOT / ".github" / "actions" / "diff-gate" / "action.yml"
+WRAPPER = ROOT / "scripts" / "nsys-ai-diff-gate"
+
+
+def test_github_action_forwards_the_canonical_gate_contract():
+    text = ACTION.read_text(encoding="utf-8")
+
+    assert "using: composite" in text
+    assert "python -m nsys_ai" in text
+    assert "args+=(\"$NSYS_AI_AFTER\" --format json --no-ai --exit-on-regression" in text
+    assert "args+=(--gate \"$NSYS_AI_GATE\")" in text
+    assert "payload.get(\"verdict\", \"\")" in text
+
+
+def test_ordinary_ci_wrapper_emits_the_canonical_json_report(tmp_path):
+    output = tmp_path / "artifacts" / "diff.json"
+    profile = ROOT / "tests" / "fixtures" / "mock.sqlite"
+    env = os.environ.copy()
+    env["PYTHON"] = sys.executable
+    env["PYTHONPATH"] = str(ROOT / "src")
+
+    result = subprocess.run(
+        [str(WRAPPER), str(profile), str(profile), "--output", str(output)],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert isinstance(payload["verdict"], str)
+    assert "--format" not in result.stderr


### PR DESCRIPTION
## Summary

- Add a reusable GitHub composite action for the canonical `nsys-ai diff --gate` CI contract.
- Add a thin ordinary-CI wrapper and copy-pasteable action documentation without duplicating gate logic.
- Preserve the CLI-produced `diff.json` verdict and regression/inconclusive exit codes.

## Changes

- `.github/actions/diff-gate/action.yml`
  - accepts direct `before` or named `against` baselines;
  - always requests JSON, disables AI narration, and enables the existing gate exit contract;
  - exposes the generated JSON path and verdict as action outputs;
  - supports additional `diff` arguments one per line.
- `.github/actions/diff-gate/README.md`
  - documents direct and named-baseline GitHub Actions usage;
  - documents ordinary CI usage and artifact retention.
- `scripts/nsys-ai-diff-gate`
  - forwards ordinary CI invocations directly to `nsys-ai diff`.
- `tests/test_ci_diff_gate.py`
  - verifies action contract and wrapper JSON output.

## Backward compatibility

Yes. The action and script are wrappers only; `nsys-ai diff --gate` remains the sole threshold/verdict engine.

## Test plan

- `207 passed` for `tests/test_ci_diff_gate.py`, `tests/test_diff.py`, and `tests/test_cli.py` in an isolated venv with `NSYS_TEST_PROFILE`.
- `ruff check src/ tests/`
- `git diff --check`
- `bandit -q -ll tests/test_ci_diff_gate.py`
- `bash -n` for the wrapper and extracted composite-action shell.
- YAML parse and wrapper smoke test producing valid JSON.
- `python -m nsys_ai --help`
- Full suite was attempted in the isolated venv but was interrupted after an existing slow section stopped producing progress; GitHub CI is the final full-matrix gate.

## Out of scope

- No new `check` command or second threshold implementation.
- Companion end-to-end CI guide remains in #184.

## Linked issues

Closes #13
