### PR TITLE
loop: reconcile multiple findings in one session

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1174,9 +1174,9 @@ def _cmd_diff(args, _profile):
         )
         sys.exit(1)
 
-    # With --session the decision belongs to the session's own diff.json, recorded
-    # below through the store. Writing a second copy into the working directory
-    # would leave two records of one decision, free to disagree.
+    # With --session the decision belongs to the session store, recorded below
+    # through the writer. Accepted decisions remain on diff.json; rejected
+    # findings are appended to decisions.json and reopen the session for propose.
     if decision is not None and gate_summary is not None and session is None:
         try:
             decision_path, _, decision_warnings = write_diff_decision_json(
@@ -1250,9 +1250,8 @@ def _cmd_diff(args, _profile):
             sys.exit(2)
         print(f"Diff published to session {session_id}", file=sys.stderr)
         if decision is not None:
-            # The store permits exactly one decision, so a re-run of the same
-            # command reports why rather than silently leaving the session
-            # undecided.
+            # The store permits one decision per finding. A rejection is durable
+            # history and intentionally returns the session to propose.
             from nsys_ai.session_cli import publish_session_decision
 
             try:

--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -106,7 +106,9 @@ def _resume_command(
     )
 
 
-def _select_finding_id(report: EvidenceReport) -> str | None:
+def _select_finding_id(
+    report: EvidenceReport, *, decided_ids: set[str] | frozenset[str] = frozenset()
+) -> str | None:
     """Pick the finding to propose from: ranked order, actionable first.
 
     ``findings`` arrives already ranked by :func:`rank_findings`, so the first
@@ -116,10 +118,10 @@ def _select_finding_id(report: EvidenceReport) -> str | None:
     suggested action") rather than turning it into "no finding id".
     """
     for finding in report.findings:
-        if finding.id and finding.suggested_actions:
+        if finding.id and finding.id not in decided_ids and finding.suggested_actions:
             return finding.id
     for finding in report.findings:
-        if finding.id:
+        if finding.id and finding.id not in decided_ids:
             return finding.id
     return None
 
@@ -167,7 +169,23 @@ def _print_recorded_decision(
     reason = projected.get("decision_reason") or ""
     if reason:
         print(f"Reason: {reason}", file=stdout)
-    print(f"Diff artifact: {directory / 'diff.json'}", file=stdout)
+    artifact = projected.get("decision_path") or directory / "diff.json"
+    print(f"Decision artifact: {artifact}", file=stdout)
+
+
+def _session_quiescent(snapshot: SessionSnapshot) -> bool:
+    """Return whether every identified finding has one durable decision."""
+    if snapshot.findings is None or not snapshot.findings.findings:
+        return False
+    finding_ids = {finding.id for finding in snapshot.findings.findings if finding.id}
+    if len(finding_ids) != len(snapshot.findings.findings):
+        return False
+    decided_ids = {
+        decision.get("finding_id")
+        for decision in snapshot.decisions
+        if decision.get("finding_id")
+    }
+    return finding_ids.issubset(decided_ids)
 
 
 def _print_verification_plan(
@@ -331,6 +349,13 @@ def run_optimize(
             )
             _print_recorded_decision(resolved_id, snapshot, session_root, stdout=stdout)
             return 0
+        if _session_quiescent(snapshot):
+            print(
+                "Loop already complete; reporting the recorded decisions.",
+                file=stdout,
+            )
+            _print_recorded_decision(resolved_id, snapshot, session_root, stdout=stdout)
+            return 0
 
     # Step 1 — diagnose.
     if snapshot is None or snapshot.findings is None:
@@ -363,8 +388,22 @@ def run_optimize(
 
     # Step 2 — propose, or reuse the proposal this session already carries.
     if snapshot.proposal is None:
-        finding_id = _select_finding_id(snapshot.findings)
+        decided_ids = {
+            str(decision["finding_id"])
+            for decision in snapshot.decisions
+            if decision.get("finding_id")
+        }
+        finding_id = _select_finding_id(snapshot.findings, decided_ids=decided_ids)
         if finding_id is None:
+            if snapshot.decisions:
+                print(
+                    "Loop already complete; no undecided finding remains to propose.",
+                    file=stdout,
+                )
+                _print_recorded_decision(
+                    resolved_id, snapshot, session_root, stdout=stdout
+                )
+                return 0
             return stopped(
                 "no finding carries a stable id, so there is nothing to propose "
                 "from; re-run diagnose or open the session with "
@@ -499,8 +538,20 @@ def run_optimize(
         print(f"Warning: {warning}", file=stderr)
 
     snapshot = _load_snapshot(store, resolved_id)
-    if snapshot is None or not _decision_recorded(snapshot):
+    if snapshot is None:
         return stopped("the decision was not persisted to diff.json")
+    if not _decision_recorded(snapshot):
+        if snapshot.decisions:
+            latest = snapshot.decisions[-1]
+            status = str(latest.get("status") or "")
+            if status == "rejected":
+                print(
+                    "Decision recorded for finding "
+                    f"{latest.get('finding_id')}; session remains open for another finding.",
+                    file=stdout,
+                )
+                return 0
+        return stopped("the decision was not persisted to the session")
     _print_recorded_decision(resolved_id, snapshot, session_root, stdout=stdout)
     return 0
 

--- a/src/nsys_ai/propose_command.py
+++ b/src/nsys_ai/propose_command.py
@@ -32,7 +32,7 @@ _SESSION_TOP_LEVEL_SIGNATURE = frozenset(
 )
 _SESSION_PROFILE_SIGNATURE = frozenset({"before", "after"})
 _SESSION_ARTIFACT_SIGNATURE = frozenset(
-    {"runspec", "findings", "proposal", "diff"}
+    {"runspec", "findings", "proposal", "diff", "decisions"}
 )
 _SESSION_CONTROL_KEYS = frozenset({"session_id", "phase"})
 _SESSION_STRUCTURE_KEYS = frozenset({"profiles", "artifacts"})
@@ -488,6 +488,13 @@ def run_propose(
                 print(f"Warning: {lineage_warning}", file=stderr)
 
     finding = _select_finding(report, finding_id)
+    if session_id is not None and any(
+        decision.get("finding_id") == finding_id for decision in snapshot.decisions
+    ):
+        raise ProposeCommandError(
+            f"finding {finding_id!r} already has a recorded session decision; "
+            "choose another finding"
+        )
     proposal = generate_proposal(
         finding,
         runspec,

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -233,6 +233,10 @@ def _print_decision_path(
         print(f"Verdict: {verdict}", file=stdout)
     else:
         print(f"Diff artifact: (none yet under {directory})", file=stdout)
+        if snapshot.decisions:
+            print(
+                f"Decision history: {directory / 'decisions.json'}", file=stdout
+            )
 
     decision = projected.get("decision")
     if decision:
@@ -244,8 +248,9 @@ def _print_decision_path(
         if reason:
             print(f"Reason: {reason}", file=stdout)
     elif snapshot.diff is not None:
-        # Both paths record the same decision on the session's diff.json. The
-        # CLI one is listed first because it needs no browser and is scriptable.
+        # Both paths record the same decision contract. Accepted decisions stay
+        # on diff.json; rejected findings are appended to decisions.json before
+        # the session reopens at propose.
         before_ref = getattr(snapshot.state, "before_profile", None)
         after_ref = getattr(snapshot.state, "after_profile", None)
         before_path = getattr(before_ref, "path", None) or "<before>"

--- a/src/nsys_ai/session_cli.py
+++ b/src/nsys_ai/session_cli.py
@@ -149,10 +149,11 @@ def publish_session_decision(
 ) -> SessionState:
     """Record accept/reject on a session's published diff.
 
-    The store permits exactly one decision and requires the session to be in the
-    ``diff`` phase, so this is the terminal step of the loop. ``publish_decision``
-    raises if the diff is missing or already decided; both are surfaced to the
-    caller unchanged rather than being swallowed into a partial success.
+    The store permits one decision per finding. An accepted finding remains a
+    terminal session; a rejected finding is recorded in ``decisions.json`` and
+    returns the session to ``propose`` so another finding can be evaluated.
+    ``publish_decision`` raises if the diff is missing or the finding was already
+    decided; both are surfaced to the caller unchanged.
     """
     if not reason or not reason.strip():
         raise ValueError("a decision requires a reason")
@@ -176,7 +177,8 @@ def project_loop_state(
 
     Field dispositions follow docs/notes/session-wiring-design.md Deliverable 6.
     DERIVED fields come from artifacts at read time; DROP fields are omitted or
-    empty. ``decision_path`` is emitted only when ``diff["decision"]`` is set.
+    empty. ``decision_path`` is emitted only when a decision is recorded, either
+    in ``diff.json`` or in the session's ``decisions.json`` history.
     """
     from .loop_state import profile_display_name
 
@@ -227,6 +229,15 @@ def project_loop_state(
             # C5: path only when a decision has been recorded, not merely when
             # diff.json exists.
             decision_path = str(Path(session_dir_path) / "diff.json")
+    if decision is None and snapshot.decisions:
+        recorded = snapshot.decisions[-1]
+        status = str(recorded.get("status") or "").strip().lower()
+        if status == "accepted":
+            decision = "accept"
+        elif status == "rejected":
+            decision = "reject"
+        decision_reason = str(recorded.get("reason") or "")
+        decision_path = str(Path(session_dir_path) / "decisions.json")
 
     return {
         "session_mode": True,

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -66,6 +66,7 @@ from .runspec import (
 
 SESSION_SCHEMA_VERSION = "0.1"
 DIFF_SCHEMA_VERSION = EVIDENCE_SCHEMA_VERSION
+DECISIONS_SCHEMA_VERSION = "0.1"
 
 SessionPhase = Literal["diagnose", "propose", "reprofile", "diff", "accept"]
 _PHASES = frozenset({"diagnose", "propose", "reprofile", "diff", "accept"})
@@ -75,6 +76,7 @@ _ARTIFACT_PATHS = {
     "findings": "findings.json",
     "proposal": "proposal.json",
     "diff": "diff.json",
+    "decisions": "decisions.json",
 }
 _TRANSACTION_DIR = ".transaction"
 _TRANSACTION_STAGING_PREFIX = ".transaction.stage."
@@ -100,6 +102,8 @@ _DIFF_FIELDS = {
     "nvtx_improvements",
     "overlap",
 }
+_DECISION_FIELDS = {"finding_id", "status", "reason", "decider", "decided_at"}
+_UNSET = object()
 _DIFF_SIDE_FIELDS = {
     "path",
     "profile_id",
@@ -276,7 +280,14 @@ class SessionState:
         profiles = _require_mapping(payload.get("profiles"), "session profiles")
         _require_exact_keys(profiles, {"before", "after"}, "session profiles")
         artifacts_payload = _require_mapping(payload.get("artifacts"), "session artifacts")
-        _require_exact_keys(artifacts_payload, set(_ARTIFACT_PATHS), "session artifacts")
+        artifact_keys = set(artifacts_payload)
+        current_artifact_keys = set(_ARTIFACT_PATHS)
+        legacy_artifact_keys = current_artifact_keys - {"decisions"}
+        if artifact_keys not in {
+            frozenset(current_artifact_keys),
+            frozenset(legacy_artifact_keys),
+        }:
+            _require_exact_keys(artifacts_payload, current_artifact_keys, "session artifacts")
         artifacts: dict[str, ArtifactReference] = {}
         for name, value in artifacts_payload.items():
             if value is None:
@@ -323,6 +334,7 @@ class SessionSnapshot:
     findings: EvidenceReport | None
     proposal: Proposal | None
     diff: Mapping[str, Any] | None
+    decisions: tuple[Mapping[str, Any], ...] = ()
 
 
 class SessionStore:
@@ -392,6 +404,7 @@ class SessionStore:
         findings = None
         proposal = None
         diff = None
+        decisions: tuple[Mapping[str, Any], ...] = ()
         if "runspec" in state.artifacts:
             self._check_artifact_version(state, "runspec", RUNSPEC_SCHEMA_VERSION)
             self._verify_artifact(state, "runspec")
@@ -453,35 +466,66 @@ class SessionStore:
                 raise SessionCorruptError(f"invalid diff.json: {exc}") from exc
             diff = MappingProxyType(parsed_diff)
             _validate_diff_references(state, diff, error_type=SessionCorruptError)
-        snapshot = SessionSnapshot(state, runspec, findings, proposal, diff)
+        if "decisions" in state.artifacts:
+            self._check_artifact_version(
+                state, "decisions", DECISIONS_SCHEMA_VERSION
+            )
+            self._verify_artifact(state, "decisions")
+            decisions_payload = _read_json(
+                session_dir / "decisions.json", "decisions.json"
+            )
+            decisions = _validate_decisions_payload(
+                decisions_payload, error_type=SessionCorruptError
+            )
+        snapshot = SessionSnapshot(state, runspec, findings, proposal, diff, decisions)
         _validate_snapshot_invariants(snapshot)
         return snapshot
 
-    def _begin_transaction(self, session_id: str, artifact_name: str) -> None:
+    def _begin_transaction(
+        self, session_id: str, artifact_name: str | tuple[str, ...]
+    ) -> None:
         session_dir = self._session_dir(session_id)
         journal = session_dir / _TRANSACTION_DIR
         if journal.exists():
             raise SessionCorruptError("session has an unrecovered publication journal")
+        names = (artifact_name,) if isinstance(artifact_name, str) else artifact_name
+        if not names or any(name not in _ARTIFACT_PATHS for name in names):
+            raise SessionCorruptError("transaction references an unknown artifact")
         staging = Path(
             tempfile.mkdtemp(prefix=_TRANSACTION_STAGING_PREFIX, dir=session_dir)
         )
-        artifact_path = session_dir / _ARTIFACT_PATHS[artifact_name]
         try:
             atomic_write_bytes(
                 staging / "session.json", _read_bytes(session_dir / "session.json", "session.json")
             )
-            artifact_existed = artifact_path.is_file()
-            if artifact_existed:
-                atomic_write_bytes(
-                    staging / "artifact.json", _read_bytes(artifact_path, artifact_path.name)
-                )
-            atomic_write_json(
-                staging / "transaction.json",
-                {
-                    "artifact": artifact_name,
+            if len(names) == 1:
+                name = names[0]
+                artifact_path = session_dir / _ARTIFACT_PATHS[name]
+                artifact_existed = artifact_path.is_file()
+                if artifact_existed:
+                    atomic_write_bytes(
+                        staging / "artifact.json",
+                        _read_bytes(artifact_path, artifact_path.name),
+                    )
+                metadata: Mapping[str, Any] = {
+                    "artifact": name,
                     "artifact_existed": artifact_existed,
-                },
-            )
+                }
+            else:
+                entries = []
+                for name in names:
+                    artifact_path = session_dir / _ARTIFACT_PATHS[name]
+                    artifact_existed = artifact_path.is_file()
+                    if artifact_existed:
+                        atomic_write_bytes(
+                            staging / f"artifact-{name}.json",
+                            _read_bytes(artifact_path, artifact_path.name),
+                        )
+                    entries.append(
+                        {"name": name, "artifact_existed": artifact_existed}
+                    )
+                metadata = {"artifacts": entries}
+            atomic_write_json(staging / "transaction.json", metadata)
             fsync_directory(staging)
             os.replace(staging, journal)
             fsync_directory(session_dir)
@@ -520,26 +564,57 @@ class SessionStore:
                 _read_json(journal / "transaction.json", "transaction journal"),
                 "transaction journal",
             )
-            _require_exact_keys(
-                metadata,
-                {"artifact", "artifact_existed"},
-                "transaction journal",
-            )
-            artifact_name = metadata.get("artifact")
-            artifact_existed = metadata.get("artifact_existed")
-            if artifact_name not in _ARTIFACT_PATHS or not isinstance(
-                artifact_existed, bool
-            ):
-                raise SessionCorruptError("transaction journal metadata is invalid")
-            artifact_path = session_dir / _ARTIFACT_PATHS[artifact_name]
-            if artifact_existed:
-                atomic_write_bytes(
-                    artifact_path,
-                    _read_bytes(journal / "artifact.json", "journal artifact backup"),
+            if "artifact" in metadata:
+                _require_exact_keys(
+                    metadata,
+                    {"artifact", "artifact_existed"},
+                    "transaction journal",
                 )
+                entries = [
+                    {
+                        "name": metadata.get("artifact"),
+                        "artifact_existed": metadata.get("artifact_existed"),
+                        "backup": "artifact.json",
+                    }
+                ]
             else:
-                artifact_path.unlink(missing_ok=True)
-                fsync_directory(session_dir)
+                _require_exact_keys(metadata, {"artifacts"}, "transaction journal")
+                raw_entries = metadata.get("artifacts")
+                if not isinstance(raw_entries, list):
+                    raise SessionCorruptError("transaction journal metadata is invalid")
+                entries = [
+                    {
+                        "name": entry.get("name") if isinstance(entry, Mapping) else None,
+                        "artifact_existed": (
+                            entry.get("artifact_existed")
+                            if isinstance(entry, Mapping)
+                            else None
+                        ),
+                        "backup": (
+                            f"artifact-{entry.get('name')}.json"
+                            if isinstance(entry, Mapping)
+                            else ""
+                        ),
+                    }
+                    for entry in raw_entries
+                ]
+            for entry in entries:
+                artifact_name = entry["name"]
+                artifact_existed = entry["artifact_existed"]
+                backup = entry["backup"]
+                if artifact_name not in _ARTIFACT_PATHS or not isinstance(
+                    artifact_existed, bool
+                ):
+                    raise SessionCorruptError("transaction journal metadata is invalid")
+                artifact_path = session_dir / _ARTIFACT_PATHS[artifact_name]
+                if artifact_existed:
+                    atomic_write_bytes(
+                        artifact_path,
+                        _read_bytes(journal / backup, "journal artifact backup"),
+                    )
+                else:
+                    artifact_path.unlink(missing_ok=True)
+            fsync_directory(session_dir)
             atomic_write_bytes(
                 session_dir / "session.json",
                 _read_bytes(journal / "session.json", "journal manifest backup"),
@@ -692,7 +767,12 @@ class SessionWriter:
         def validate_snapshot(snapshot: SessionSnapshot) -> None:
             _require_phase(snapshot, {"diagnose"}, "publish findings")
             state = self._replace_state(
-                snapshot.state, before_profile=before_profile
+                snapshot.state,
+                before_profile=(
+                    before_profile
+                    if before_profile is not None
+                    else snapshot.state.before_profile
+                ),
             )
             _validate_findings_provenance(
                 state.before_profile, canonical_findings, error_type=ValueError
@@ -714,7 +794,9 @@ class SessionWriter:
             EVIDENCE_SCHEMA_VERSION,
             lambda path: atomic_write_json(path, payload),
             phase="diagnose",
-            before_profile=before_profile,
+            before_profile=(
+                before_profile if before_profile is not None else _UNSET
+            ),
             snapshot_validator=validate_snapshot,
         )
 
@@ -742,6 +824,13 @@ class SessionWriter:
                 proposal,
                 error_type=ValueError,
             )
+            if any(
+                decision.get("finding_id") == proposal.source_finding_id
+                for decision in snapshot.decisions
+            ):
+                raise ValueError(
+                    "finding already has a recorded session decision; choose another finding"
+                )
 
         return self._publish(
             "proposal",
@@ -805,28 +894,72 @@ class SessionWriter:
                 decided_at=decided_at,
             )
             _validate_diff_payload(candidate)
-            self.store._begin_transaction(self.session_id, "diff")
-            _path, payload = write_diff_json_from_diff_dict(
-                candidate,
-                path=self.store._session_dir(self.session_id) / "diff.json",
+            finding_id = snapshot.proposal.source_finding_id if snapshot.proposal else ""
+            if not finding_id:
+                raise ValueError(
+                    "the published proposal must identify a finding before recording a decision"
+                )
+            if any(
+                record.get("finding_id") == finding_id for record in snapshot.decisions
+            ):
+                raise ValueError(
+                    "finding already has a recorded session decision; choose another finding"
+                )
+            decision_record = {
+                "finding_id": finding_id,
+                "status": status,
+                "reason": candidate["decision"]["reason"],
+                "decider": candidate["decision"]["decider"],
+                "decided_at": candidate["decision"]["decided_at"],
+            }
+            decisions_payload = _decisions_payload(
+                (*snapshot.decisions, MappingProxyType(decision_record))
             )
+            session_dir = self.store._session_dir(self.session_id)
+            if status == "rejected":
+                self.store._begin_transaction(
+                    self.session_id, ("decisions", "proposal", "diff")
+                )
+                atomic_write_json(session_dir / "decisions.json", decisions_payload)
+                (session_dir / "proposal.json").unlink(missing_ok=True)
+                (session_dir / "diff.json").unlink(missing_ok=True)
+            else:
+                self.store._begin_transaction(self.session_id, ("decisions", "diff"))
+                atomic_write_json(session_dir / "decisions.json", decisions_payload)
+                write_diff_json_from_diff_dict(
+                    candidate,
+                    path=session_dir / "diff.json",
+                )
             artifacts = dict(snapshot.state.artifacts)
-            artifacts["diff"] = ArtifactReference(
-                _ARTIFACT_PATHS["diff"],
-                DIFF_SCHEMA_VERSION,
-                _sha256_file(
-                    self.store._session_dir(self.session_id) / "diff.json", "diff.json"
-                ),
+            artifacts["decisions"] = ArtifactReference(
+                _ARTIFACT_PATHS["decisions"],
+                DECISIONS_SCHEMA_VERSION,
+                _sha256_file(session_dir / "decisions.json", "decisions.json"),
             )
-            state = self._replace_state(
-                snapshot.state, phase="accept", artifacts=artifacts
-            )
+            if status == "rejected":
+                artifacts.pop("proposal", None)
+                artifacts.pop("diff", None)
+                state = self._replace_state(
+                    snapshot.state,
+                    phase="propose",
+                    after_profile=None,
+                    artifacts=artifacts,
+                )
+            else:
+                artifacts["diff"] = ArtifactReference(
+                    _ARTIFACT_PATHS["diff"],
+                    DIFF_SCHEMA_VERSION,
+                    _sha256_file(session_dir / "diff.json", "diff.json"),
+                )
+                state = self._replace_state(
+                    snapshot.state, phase="accept", artifacts=artifacts
+                )
             atomic_write_json(
-                self.store._session_dir(self.session_id) / "session.json",
+                session_dir / "session.json",
                 state.to_dict(),
             )
             self.store._finish_transaction(self.session_id)
-            return state, MappingProxyType(payload), tuple(warnings)
+            return state, MappingProxyType(candidate), tuple(warnings)
 
     def _publish(
         self,
@@ -835,7 +968,7 @@ class SessionWriter:
         publisher,
         *,
         phase: SessionPhase | None = None,
-        before_profile: LocalProfileReference | None = None,
+        before_profile: LocalProfileReference | None | object = _UNSET,
         snapshot_validator: Callable[[SessionSnapshot], None] | None = None,
     ) -> SessionState:
         self._ensure_open()
@@ -907,16 +1040,20 @@ class SessionWriter:
         state: SessionState,
         *,
         phase: SessionPhase | None = None,
-        before_profile: LocalProfileReference | None = None,
-        after_profile: LocalProfileReference | None = None,
-        artifacts: Mapping[str, ArtifactReference] | None = None,
+        before_profile: LocalProfileReference | None | object = _UNSET,
+        after_profile: LocalProfileReference | None | object = _UNSET,
+        artifacts: Mapping[str, ArtifactReference] | None | object = _UNSET,
     ) -> SessionState:
         return SessionState(
             session_id=state.session_id,
             phase=phase or state.phase,
-            before_profile=before_profile or state.before_profile,
-            after_profile=after_profile or state.after_profile,
-            artifacts=artifacts or state.artifacts,
+            before_profile=(
+                state.before_profile if before_profile is _UNSET else before_profile
+            ),
+            after_profile=(
+                state.after_profile if after_profile is _UNSET else after_profile
+            ),
+            artifacts=(state.artifacts if artifacts is _UNSET else artifacts),
         )
 
     def _ensure_open(self) -> None:
@@ -1057,6 +1194,12 @@ def _validate_snapshot_invariants(snapshot: SessionSnapshot) -> None:
         return
 
     if proposal is None:
+        if phase == "propose" and snapshot.decisions:
+            if state.after_profile is not None or diff is not None:
+                raise SessionCorruptError(
+                    "propose phase without a proposal cannot retain an after profile or diff artifact"
+                )
+            return
         raise SessionCorruptError(f"{phase} phase requires proposal.json")
     if phase == "propose":
         if state.after_profile is not None or diff is not None:
@@ -1643,6 +1786,61 @@ def _validate_diff_decision(diff: Mapping[str, Any]) -> bool:
         if not isinstance(value, str) or not value.strip():
             raise ValueError(f"diff decision {field} must be a non-empty string")
     return True
+
+
+def _decisions_payload(
+    decisions: tuple[Mapping[str, Any], ...] | list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    return {
+        "schema_version": DECISIONS_SCHEMA_VERSION,
+        "decisions": [dict(decision) for decision in decisions],
+    }
+
+
+def _validate_decisions_payload(
+    payload: Any, *, error_type: type[Exception]
+) -> tuple[Mapping[str, Any], ...]:
+    try:
+        if not isinstance(payload, Mapping):
+            raise ValueError("decisions.json must be an object")
+        _require_exact_keys(payload, {"schema_version", "decisions"}, "decisions.json")
+        if payload.get("schema_version") != DECISIONS_SCHEMA_VERSION:
+            raise UnsupportedSessionVersionError(
+                "unsupported decisions.json schema_version "
+                f"{payload.get('schema_version')!r}"
+            )
+        values = payload.get("decisions")
+        if not isinstance(values, list):
+            raise ValueError("decisions.json decisions must be an array")
+        parsed: list[Mapping[str, Any]] = []
+        finding_ids: set[str] = set()
+        for index, value in enumerate(values):
+            if not isinstance(value, Mapping):
+                raise ValueError(f"decision {index} must be an object")
+            if set(value) != _DECISION_FIELDS:
+                raise ValueError(
+                    f"decision {index} fields do not match schema"
+                )
+            finding_id = value.get("finding_id")
+            if not isinstance(finding_id, str) or not finding_id.strip():
+                raise ValueError(f"decision {index} finding_id must be non-empty")
+            if finding_id in finding_ids:
+                raise ValueError(f"finding {finding_id!r} has more than one decision")
+            finding_ids.add(finding_id)
+            if value.get("status") not in {"accepted", "rejected"}:
+                raise ValueError(f"decision {index} status is invalid")
+            for field_name in ("reason", "decider", "decided_at"):
+                field_value = value.get(field_name)
+                if not isinstance(field_value, str) or not field_value.strip():
+                    raise ValueError(
+                        f"decision {index} {field_name} must be non-empty"
+                    )
+            parsed.append(MappingProxyType(dict(value)))
+        return tuple(parsed)
+    except (SessionCorruptError, UnsupportedSessionVersionError):
+        raise
+    except (TypeError, ValueError) as exc:
+        raise error_type(str(exc)) from exc
 
 
 def _require_json_serializable(value: Any, label: str) -> None:

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -4063,7 +4063,9 @@ function loopSetBusy(busy) {
 
 function loopSuggestedPhase(state) {
     const s = state || LOOP_STATE || {};
-    if (s.decision) return 'accept';
+    // A rejected finding is persisted in decisions.json while the session
+    // returns to propose. Only the accept phase is terminal for this loop.
+    if (s.phase === 'accept' && s.decision) return 'accept';
     if (s.diff_summary) return 'accept';
     if (!s.diagnose_ran) return 'diagnose';
     if (!loopHasProposal(s)) return 'propose';
@@ -4191,7 +4193,9 @@ function loopSetStepUi(next) {
     const sectionProposal = document.getElementById('loopSectionProposal');
     const sectionDecide = document.getElementById('loopDecideSection');
     const sessionMode = loopIsSessionMode();
-    const decided = Boolean(LOOP_STATE && LOOP_STATE.decision);
+    const decided = Boolean(
+        LOOP_STATE && LOOP_STATE.decision && LOOP_STATE.phase === 'accept'
+    );
 
     // Session mode: CLI owns propose/reprofile inputs; keep them read-only.
     if (proposalEl) {
@@ -4206,7 +4210,7 @@ function loopSetStepUi(next) {
         afterEl.disabled = LOOP_BUSY || sessionMode || next !== 'reprofile';
         afterEl.readOnly = sessionMode;
     }
-    // C2: once a decision exists, disable accept/reject (store rejects a second write).
+    // C2: only a terminal accept decision disables the current action buttons.
     if (btnAccept) btnAccept.disabled = LOOP_BUSY || decided || next !== 'accept';
     if (btnReject) btnReject.disabled = LOOP_BUSY || decided || next !== 'accept';
 
@@ -4567,7 +4571,7 @@ async function loopSetDecision(decision) {
         loopSetError('Run diff before accepting or rejecting.');
         return;
     }
-    if (LOOP_STATE.decision) {
+    if (LOOP_STATE.phase === 'accept' && LOOP_STATE.decision) {
         loopSetError('A decision is already recorded for this session.');
         return;
     }

--- a/tests/test_diagnose_review.py
+++ b/tests/test_diagnose_review.py
@@ -354,5 +354,9 @@ def test_undecided_review_names_the_cli_decision_path_and_it_runs(tmp_path: Path
     assert decided.returncode == 0, decided.stderr
 
     directory = session_dir(session_id, root=tmp_path / ".nsys-ai" / "sessions")
-    payload = json.loads((directory / "diff.json").read_text(encoding="utf-8"))
-    assert payload["decision"]["status"] == "rejected"
+    payload = json.loads(
+        (directory / "decisions.json").read_text(encoding="utf-8")
+    )
+    assert payload["decisions"][-1]["status"] == "rejected"
+    assert json.loads((directory / "session.json").read_text())["phase"] == "propose"
+    assert not (directory / "diff.json").exists()

--- a/tests/test_loop_api.py
+++ b/tests/test_loop_api.py
@@ -213,8 +213,9 @@ def test_web_decision_survives_reload(tmp_path):
     assert status == 200
     assert reloaded["decision"] == "reject"
     assert reloaded["decision_reason"] == "regressed"
-    assert reloaded["decision_path"].endswith("diff.json")
-    assert (tmp_path / ".nsys-ai" / "sessions" / session_id / "diff.json").exists()
+    assert reloaded["decision_path"].endswith("decisions.json")
+    assert reloaded["phase"] == "propose"
+    assert not (tmp_path / ".nsys-ai" / "sessions" / session_id / "diff.json").exists()
 
 
 def test_web_decision_requires_reason(tmp_path):

--- a/tests/test_optimize_command.py
+++ b/tests/test_optimize_command.py
@@ -198,15 +198,24 @@ def test_optimize_reaches_a_recorded_decision_without_a_supplied_after_profile(t
     assert out.index("-- Proposal --") < out.index("Profile Diff")
 
     snapshot = _snapshot(tmp_path)
-    assert snapshot.state.phase == "accept"
-    assert snapshot.state.after_profile == after_reference
-    decision = snapshot.diff["decision"]
-    assert decision["status"] in {"accepted", "rejected"}
-    assert decision["reason"].startswith("diff verdict ")
-    payload = json.loads(
-        (_session_root(tmp_path) / SESSION_ID / "diff.json").read_text(encoding="utf-8")
-    )
-    assert payload["decision"]["reason"] == decision["reason"]
+    if snapshot.state.phase == "accept":
+        assert snapshot.state.after_profile == after_reference
+        decision = snapshot.diff["decision"]
+        assert decision["status"] == "accepted"
+        assert decision["reason"].startswith("diff verdict ")
+        payload = json.loads(
+            (_session_root(tmp_path) / SESSION_ID / "diff.json").read_text(
+                encoding="utf-8"
+            )
+        )
+        assert payload["decision"]["reason"] == decision["reason"]
+    else:
+        assert snapshot.state.phase == "propose"
+        assert snapshot.state.after_profile is None
+        assert snapshot.diff is None
+        assert snapshot.decisions[-1]["status"] == "rejected"
+        assert snapshot.decisions[-1]["reason"].startswith("diff verdict ")
+        assert "session remains open for another finding" in out
 
 
 def test_optimize_reports_an_already_decided_session_without_re_profiling(tmp_path):
@@ -274,7 +283,9 @@ def test_optimize_resumes_from_the_session_after_a_failed_capture(tmp_path):
     assert "Step 2/5 propose" not in err2
     assert len(runner.specs) == 1
     assert runner.specs[0] == interrupted.runspec
-    assert _snapshot(tmp_path).state.phase == "accept"
+    resumed = _snapshot(tmp_path)
+    assert resumed.state.phase == "propose"
+    assert resumed.decisions[-1]["status"] == "rejected"
 
 
 def test_optimize_refuses_a_session_opened_on_another_profile(tmp_path):
@@ -374,15 +385,16 @@ def test_optimize_accepts_the_same_capture_reached_by_another_path(tmp_path):
     assert "Loop already complete" in out2
 
 
-def test_optimize_reports_the_recorded_decision_for_the_same_workload(tmp_path):
-    """The guard must not break resume, which is the whole point of the session."""
+def test_optimize_resumes_after_a_rejection_for_the_same_workload(tmp_path):
+    """A rejected finding leaves the same session available for the next one."""
     after_reference = build_local_profile_reference(AFTER)
     code, _out, err = _run(tmp_path, _succeeding_runner(after_reference))
     assert code == 0, err
 
-    code, out, _err = _run(tmp_path, _exploding_runner())
+    code, out, err = _run(tmp_path, _succeeding_runner(after_reference))
     assert code == 0
-    assert "Loop already complete" in out
+    assert "Decision recorded" in out or "Loop already complete" in out
+    assert not err.startswith("Stopped:")
 
 
 def test_optimize_rejects_a_repo_that_is_not_a_directory(tmp_path):

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -386,7 +386,7 @@ def test_cli_session_accepts_relative_profile_paths(tmp_path: Path):
         )
 
 
-def test_cli_session_records_the_decision_on_the_session_diff(tmp_path: Path):
+def test_cli_session_records_a_rejected_finding_and_reopens_propose(tmp_path: Path):
     """--session and --accept/--reject compose: the loop's last step is reachable.
 
     They used to be mutually exclusive, and the error directed a CLI user to
@@ -422,15 +422,17 @@ def test_cli_session_records_the_decision_on_the_session_diff(tmp_path: Path):
     assert decided.returncode == 0, decided.stderr
 
     directory = session_dir(session_id, root=tmp_path / ".nsys-ai" / "sessions")
-    diff_payload = json.loads((directory / "diff.json").read_text(encoding="utf-8"))
-    decision = diff_payload.get("decision")
-    assert decision is not None, "session diff was left undecided"
+    history = json.loads(
+        (directory / "decisions.json").read_text(encoding="utf-8")
+    )
+    decision = history["decisions"][-1]
     assert decision["status"] == "rejected"
     assert decision["reason"] == "3x the launches for 2x the time"
 
     state = json.loads((directory / "session.json").read_text(encoding="utf-8"))
-    assert state["phase"] == "accept"
+    assert state["phase"] == "propose"
+    assert not (directory / "diff.json").exists()
 
-    # The session's diff.json is the record. A second copy in the working
+    # The session's decisions.json is the record. A second copy in the working
     # directory would be free to disagree with it.
     assert not (tmp_path / "diff.json").exists()

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -329,6 +329,7 @@ def test_complete_session_round_trip_uses_exact_layout_and_local_references(tmp_
         "findings.json",
         "proposal.json",
         "diff.json",
+        "decisions.json",
         "logs",
     }
     assert not list(session_dir.rglob("*.sqlite"))
@@ -363,6 +364,71 @@ def test_complete_session_round_trip_uses_exact_layout_and_local_references(tmp_
     assert json.loads((session_dir / "diff.json").read_text())["schema_version"] == (
         DIFF_SCHEMA_VERSION
     )
+
+
+def test_rejected_finding_reopens_session_for_a_different_finding(tmp_path):
+    before = _profile_reference(tmp_path / "before.sqlite", "before")
+    after = _profile_reference(tmp_path / "after.sqlite", "after")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("multi-finding", before_profile=before)
+    runspec = RunSpec(argv=("python3", "train.py"), cwd=str(tmp_path))
+    first = _finding(before, "f1")
+    second = _finding(before, "f2")
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=before.path,
+        profile_id=before.profile_id,
+        findings=[first, second],
+    )
+    first_proposal = generate_proposal(first, runspec)
+    second_proposal = generate_proposal(second, runspec)
+
+    with store.writer("multi-finding") as writer:
+        writer.publish_runspec(runspec)
+        writer.publish_findings(report)
+        writer.publish_proposal(first_proposal)
+        writer.publish_after_profile(after)
+        writer.publish_diff(_diff(before, after))
+        state, rejected, _warnings = writer.publish_decision(
+            "reject",
+            "first finding was not actionable",
+            decider="test@example.com",
+            decided_at="2026-08-06T00:00:00Z",
+        )
+
+    assert state.phase == "propose"
+    assert rejected["decision"]["status"] == "rejected"
+    snapshot = store.load("multi-finding")
+    assert snapshot.proposal is None
+    assert snapshot.diff is None
+    assert snapshot.state.after_profile is None
+    assert snapshot.decisions == (
+        {
+            "finding_id": "f1",
+            "status": "rejected",
+            "reason": "first finding was not actionable",
+            "decider": "test@example.com",
+            "decided_at": "2026-08-06T00:00:00Z",
+        },
+    )
+    assert (store.root / "multi-finding" / "decisions.json").is_file()
+    with store.writer("multi-finding") as writer:
+        with pytest.raises(ValueError, match="already has a recorded session decision"):
+            writer.publish_proposal(first_proposal)
+        writer.publish_proposal(second_proposal)
+        writer.publish_after_profile(after)
+        writer.publish_diff(_diff(before, after))
+        final_state, _accepted, _warnings = writer.publish_decision(
+            "accept",
+            "second finding verified",
+            decider="test@example.com",
+            decided_at="2026-08-06T00:01:00Z",
+        )
+
+    assert final_state.phase == "accept"
+    snapshot = store.load("multi-finding")
+    assert [decision["finding_id"] for decision in snapshot.decisions] == ["f1", "f2"]
+    assert snapshot.diff["decision"]["status"] == "accepted"
 
 
 def test_active_writer_conflict_is_observed_from_a_second_process(tmp_path):

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -1753,7 +1753,61 @@ def test_interrupted_decision_publication_recovers_undecided_snapshot(
     assert recovered.diff["decision"] is None
     assert (session_dir / "diff.json").read_bytes() == diff_before
     assert (session_dir / "session.json").read_bytes() == manifest_before
+    assert not (session_dir / "decisions.json").exists()
     assert not (session_dir / ".transaction").exists()
+
+
+@pytest.mark.parametrize("interruption", ["after_artifact", "after_manifest"])
+def test_interrupted_rejection_reverts_all_session_artifacts(
+    monkeypatch, tmp_path, interruption
+):
+    import nsys_ai.session_store as session_store
+
+    store, before, after, _finding_value, _spec, _proposal = _reprofiled_session(
+        tmp_path, "rejection-recovery"
+    )
+    with store.writer("rejection-recovery") as writer:
+        writer.publish_diff(_diff(before, after))
+
+    session_dir = store.root / "rejection-recovery"
+    proposal_before = (session_dir / "proposal.json").read_bytes()
+    diff_before = (session_dir / "diff.json").read_bytes()
+    manifest_before = (session_dir / "session.json").read_bytes()
+    if interruption == "after_artifact":
+        manifest_path = session_dir / "session.json"
+        real_atomic_write_json = session_store.atomic_write_json
+
+        def fail_manifest(path, payload):
+            if Path(path) == manifest_path:
+                raise OSError("simulated crash after rejection artifacts")
+            return real_atomic_write_json(path, payload)
+
+        monkeypatch.setattr(session_store, "atomic_write_json", fail_manifest)
+    else:
+
+        def interrupt_cleanup(_session_id):
+            raise OSError("simulated crash after rejection manifest")
+
+        monkeypatch.setattr(store, "_finish_transaction", interrupt_cleanup)
+
+    with store.writer("rejection-recovery") as writer:
+        with pytest.raises(OSError, match="simulated crash"):
+            writer.publish_decision(
+                "reject",
+                "rejection must be recoverable",
+                decider="test@example.com",
+                decided_at="2026-08-06T00:00:00Z",
+            )
+
+    recovered = SessionStore(store.root).load("rejection-recovery")
+    assert recovered.state.phase == "diff"
+    assert recovered.proposal is not None
+    assert recovered.diff["decision"] is None
+    assert not recovered.decisions
+    assert (session_dir / "proposal.json").read_bytes() == proposal_before
+    assert (session_dir / "diff.json").read_bytes() == diff_before
+    assert (session_dir / "session.json").read_bytes() == manifest_before
+    assert not (session_dir / "decisions.json").exists()
 
 
 def test_manifest_cannot_regress_while_retaining_downstream_artifacts(tmp_path):

--- a/tests/test_tui_session.py
+++ b/tests/test_tui_session.py
@@ -162,6 +162,8 @@ import json, sys
 from nsys_ai.session_store import SessionStore
 snapshot = SessionStore(sys.argv[1]).load(sys.argv[2])
 decision = snapshot.diff.get("decision") if snapshot.diff else None
+if decision is None and snapshot.decisions:
+    decision = snapshot.decisions[-1]
 print(json.dumps({
     "phase": snapshot.state.phase,
     "status": None if decision is None else decision.get("status"),
@@ -310,11 +312,11 @@ async def test_timeline_tui_decision_visible_to_new_cli_process(tmp_path: Path, 
     async with app.run_test(size=(120, 40)) as pilot:
         app.set_loop_decision("reject", "timeline TUI rejected regression")
         await pilot.pause()
-        assert app.analysis_phase == "accept"
+        assert app.analysis_phase == "propose"
         assert app._session_projection is not None
         assert app._session_projection["decision"] == "reject"
 
     reloaded = _reload_decision_in_new_process(tmp_path, session_id)
-    assert reloaded["phase"] == "accept"
+    assert reloaded["phase"] == "propose"
     assert reloaded["status"] == "rejected"
     assert reloaded["reason"] == "timeline TUI rejected regression"

--- a/tests/test_tui_timeline_app.py
+++ b/tests/test_tui_timeline_app.py
@@ -312,4 +312,6 @@ async def test_loop_set_decision_empty_reason_uses_fallback(tmp_path, monkeypatc
         assert app._session_projection is not None
         assert app._session_projection["decision"] == "reject"
         assert app._session_projection["decision_reason"].strip()
-        assert (tmp_path / ".nsys-ai" / "sessions" / session_id / "diff.json").exists()
+        history = tmp_path / ".nsys-ai" / "sessions" / session_id / "decisions.json"
+        assert history.exists()
+        assert app._session_projection["decision_path"] == str(history)

--- a/tests/test_tui_tree_app.py
+++ b/tests/test_tui_tree_app.py
@@ -402,4 +402,6 @@ async def test_loop_set_decision_empty_reason_uses_fallback(tmp_path, monkeypatc
         assert app._session_projection is not None
         assert app._session_projection["decision"] == "reject"
         assert app._session_projection["decision_reason"].strip()
-        assert (tmp_path / ".nsys-ai" / "sessions" / session_id / "diff.json").exists()
+        history = tmp_path / ".nsys-ai" / "sessions" / session_id / "decisions.json"
+        assert history.exists()
+        assert app._session_projection["decision_path"] == str(history)

--- a/tests/test_web_session.py
+++ b/tests/test_web_session.py
@@ -327,8 +327,8 @@ def test_cli_decision_visible_to_browser(tmp_path: Path):
         assert status == 200
         assert state["decision"] == "reject"
         assert state["decision_reason"] == "cli rejected before browser open"
-        assert state["decision_path"].endswith("diff.json")
-        assert state["phase"] == "accept"
+        assert state["decision_path"].endswith("decisions.json")
+        assert state["phase"] == "propose"
 
         status, again = _post(
             port,
@@ -336,7 +336,7 @@ def test_cli_decision_visible_to_browser(tmp_path: Path):
             {"decision": "accept", "reason": "should fail"},
         )
         assert status == 400
-        assert "decision" in again.get("error", "").lower()
+        assert "diff" in again.get("error", "").lower()
 
 
 def test_abstained_proposal_diff_session_names_cause_and_fix(tmp_path: Path):


### PR DESCRIPTION
## Summary

- persist one decision per finding in a hash-protected `decisions.json` session artifact
- reopen a session at `propose` after a rejection while removing stale proposal/diff artifacts
- skip decided findings when proposing or resuming optimize, and report quiescent sessions
- extend the publication journal to recover multi-artifact rejection transitions

Closes #406.

## Validation

- `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite PYTHONPATH=src pytest -q --disable-warnings --maxfail=1`
- `PYTHONPATH=src pytest -q tests/test_session_store.py tests/test_propose_command.py tests/test_optimize_command.py`
- `ruff check .`
- `bandit -q -r src/nsys_ai/session_store.py src/nsys_ai/session_cli.py src/nsys_ai/propose_command.py src/nsys_ai/optimize_command.py`
- `PYTHONPATH=src python3 -m nsys_ai --help`
