### PR TITLE
mcp: expose read-only skills and diff tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,15 +30,17 @@ classifiers = [
 
 [project.scripts]
 nsys-ai = "nsys_ai.__main__:main"
+nsys-ai-mcp = "nsys_ai.mcp_server:main"
 
 [project.optional-dependencies]
 agent = ["anthropic>=0.20.0", "litellm>=1.0.0"]
+mcp = ["mcp>=1.0.0,<2"]
 ai = ["anthropic>=0.20.0", "litellm>=1.0.0"]  # backward compat alias
 tui = ["textual>=8.0.0"]                        # backward compat; textual is now core (tree + timeline)
 chat = ["litellm>=1.0.0", "nsys-ai[tui]"]       # AI chat TUI (tui extra kept for compat)
 cutracer = ["cutracer>=0.2.0"]                  # CUTracer CLI + instruction-level analysis
 dev = ["pytest>=8.2,<9", "ruff>=0.4.0", "pytest-textual-snapshot>=1.1.0", "pytest-asyncio>=0.25,<1"]
-all = ["nsys-ai[agent,tui,chat,cutracer]"]
+all = ["nsys-ai[agent,tui,chat,cutracer,mcp]"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/src/nsys_ai/mcp_server.py
+++ b/src/nsys_ai/mcp_server.py
@@ -8,6 +8,7 @@ not acquire a new runtime dependency.
 from __future__ import annotations
 
 import json
+import math
 import sqlite3
 from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
@@ -15,19 +16,31 @@ from pathlib import Path
 from typing import Any
 
 from .annotation import PRODUCER, SCHEMA_VERSION
+from .connection import DB_ERRORS
 from .diff import diff_profiles, diff_profiles_all_gpus
 from .diff_render import to_diff_dict
-from .exceptions import SkillExecutionError, SkillNotFoundError, SkillParameterError
+from .exceptions import (
+    ExportToolMissingError,
+    NsysAiError,
+    ProfileNotFoundError,
+    SkillNotFoundError,
+    SkillParameterError,
+)
 from .fingerprint import get_profile_id
-from .profile import Profile, resolve_profile_path
+from .profile import Profile
 
 MAX_ROWS = 50
 MAX_DIFF_LIMIT = 50
+MAX_SKILL_PARAMS = 32
+MAX_PARAM_INT = 10**15
+MAX_PARAM_FLOAT = 10**18
+MAX_PARAM_STRING_CHARS = 4096
 # The SQL tool's 8,000-character cap is tuned for an LLM prompt. MCP returns
 # the canonical structured diff envelope, so it needs a larger bounded budget
 # while retaining an explicit payload guardrail.
 MCP_MAX_PAYLOAD_CHARS = 100_000
 _TRIM_KEYS = frozenset({"trim_start_ns", "trim_end_ns"})
+_READ_ERRORS = DB_ERRORS + (OSError, ValueError)
 
 
 def _error(code: str, message: str, **detail: Any) -> dict[str, Any]:
@@ -77,25 +90,47 @@ def _coerce_param(value: Any, param_type: Any) -> Any:
     if param_type is int or type_name in {"int", "integer"}:
         if isinstance(value, bool):
             raise ValueError("boolean is not a valid integer parameter")
-        return int(value)
+        parsed = int(value)
+        if abs(parsed) > MAX_PARAM_INT:
+            raise ValueError(f"integer parameter exceeds the {MAX_PARAM_INT} bound")
+        return parsed
     if param_type is float or type_name in {"float", "double"}:
         if isinstance(value, bool):
             raise ValueError("boolean is not a valid float parameter")
-        return float(value)
+        parsed = float(value)
+        if not math.isfinite(parsed) or abs(parsed) > MAX_PARAM_FLOAT:
+            raise ValueError(f"float parameter must be finite and within ±{MAX_PARAM_FLOAT}")
+        return parsed
     if param_type is bool or type_name in {"bool", "boolean"}:
         if not isinstance(value, bool):
             raise ValueError("parameter must be a boolean")
         return value
     if not isinstance(value, str):
         raise ValueError("parameter must be a string")
+    if len(value) > MAX_PARAM_STRING_CHARS:
+        raise ValueError(
+            f"string parameter exceeds the {MAX_PARAM_STRING_CHARS}-character bound"
+        )
     return value
+
+
+def _validate_param_bound(name: str, value: Any, param_type: Any) -> Any:
+    """Apply the same safety limits to declared defaults and user parameters."""
+    parsed = _coerce_param(value, param_type)
+    if name == "limit" and parsed > MAX_ROWS:
+        raise ValueError(f"limit must not exceed {MAX_ROWS}")
+    return parsed
 
 
 def _resolve_skill_params(skill, params: Mapping[str, Any] | None) -> dict[str, Any]:
     if params is None:
-        return {}
+        params = {}
     if not isinstance(params, Mapping):
         raise ValueError("params must be an object")
+    if len(params) > MAX_SKILL_PARAMS:
+        raise ValueError(f"params must contain at most {MAX_SKILL_PARAMS} entries")
+    if any(not isinstance(name, str) for name in params):
+        raise ValueError("all parameter names must be strings")
 
     declared = {param.name: param for param in skill.params}
     allowed = set(declared) | _TRIM_KEYS
@@ -110,13 +145,24 @@ def _resolve_skill_params(skill, params: Mapping[str, Any] | None) -> dict[str, 
         if name in _TRIM_KEYS:
             if isinstance(value, bool):
                 raise ValueError(f"{name} must be an integer")
-            resolved[name] = int(value)
+            resolved[name] = _validate_param_bound(name, value, int)
         else:
-            resolved[name] = _coerce_param(value, declared[name].type)
+            resolved[name] = _validate_param_bound(name, value, declared[name].type)
+
+    # Skill.execute applies defaults internally. Copying safe defaults into the
+    # call makes the bound apply before SQL/Python execution as well, including
+    # a builtin whose declared default limit is larger than MAX_ROWS.
+    for param in skill.params:
+        if param.name not in resolved and param.default is not None:
+            resolved[param.name] = _validate_param_bound(
+                param.name, param.default, param.type
+            )
     return resolved
 
 
 def _cap_rows(rows: list[dict], max_rows: int) -> tuple[list[dict], bool]:
+    if isinstance(max_rows, bool) or not isinstance(max_rows, int):
+        raise ValueError("max_rows must be an integer")
     if max_rows < 0 or max_rows > MAX_ROWS:
         raise ValueError(f"max_rows must be between 0 and {MAX_ROWS}")
     if len(rows) <= max_rows:
@@ -134,10 +180,27 @@ def _cap_rows(rows: list[dict], max_rows: int) -> tuple[list[dict], bool]:
 
 @contextmanager
 def _open_readonly(path: str) -> Iterator[tuple[Any, str]]:
-    """Yield a direct-attach or SQLite ``mode=ro`` connection without a cache build."""
+    """Yield a read-only connection without exporting or building a sidecar."""
     from .parquet_cache import open_direct_sqlite, open_with_direct_fallback
 
-    resolved = resolve_profile_path(path)
+    source = Path(path)
+    if not source.exists():
+        raise ProfileNotFoundError(f"profile not found: {path}")
+    if source.suffix.lower() == ".nsys-rep":
+        sidecar = source.with_suffix(".sqlite")
+        if not sidecar.is_file() or sidecar.stat().st_size == 0:
+            raise ExportToolMissingError(
+                "MCP access to .nsys-rep is read-only and will not export a sidecar; "
+                "provide an up-to-date .sqlite export next to the capture"
+            )
+        if sidecar.stat().st_mtime < source.stat().st_mtime:
+            raise ExportToolMissingError(
+                "MCP access to .nsys-rep will not refresh a stale sidecar; "
+                "export an up-to-date .sqlite file before calling the server"
+            )
+        resolved = str(sidecar)
+    else:
+        resolved = str(source)
     conn, _error_detail = open_with_direct_fallback(resolved, open_direct_sqlite)
     if conn is None:
         uri = Path(resolved).resolve().as_uri() + "?mode=ro"
@@ -160,6 +223,11 @@ def _run_skill(
     from .skills.base import is_abstention
     from .skills.registry import all_skills, get_skill
 
+    try:
+        _cap_rows([], max_rows)
+    except ValueError as exc:
+        return _error("INVALID_PARAMETER", str(exc))
+
     skill = get_skill(skill_name)
     if skill is None:
         return SkillNotFoundError(
@@ -169,7 +237,7 @@ def _run_skill(
 
     try:
         skill_params = _resolve_skill_params(skill, params)
-    except (TypeError, ValueError) as exc:
+    except (TypeError, ValueError, OverflowError) as exc:
         return _error("INVALID_PARAMETER", str(exc), skill=skill.name)
 
     try:
@@ -209,7 +277,11 @@ def _run_skill(
             return _json_safe(payload)
     except SkillParameterError as exc:
         return exc.to_dict()
-    except (SkillExecutionError, sqlite3.Error, OSError, ValueError) as exc:
+    except NsysAiError as exc:
+        return exc.to_dict()
+    except _READ_ERRORS as exc:
+        return _error("SKILL_EXECUTION_ERROR", str(exc), skill=skill.name)
+    except Exception as exc:
         return _error("SKILL_EXECUTION_ERROR", str(exc), skill=skill.name)
 
 
@@ -264,7 +336,11 @@ def _diff_payload(
                         max_payload_chars=MCP_MAX_PAYLOAD_CHARS,
                     )
                 return _json_safe(payload)
-    except (OSError, sqlite3.Error, ValueError) as exc:
+    except NsysAiError as exc:
+        return exc.to_dict()
+    except _READ_ERRORS as exc:
+        return _error("DIFF_EXECUTION_ERROR", str(exc))
+    except Exception as exc:
         return _error("DIFF_EXECUTION_ERROR", str(exc))
 
 

--- a/src/nsys_ai/mcp_server.py
+++ b/src/nsys_ai/mcp_server.py
@@ -1,0 +1,318 @@
+"""Optional read-only MCP transport for the canonical analysis contracts.
+
+The module itself has no MCP import at import time.  Installing the ``mcp``
+extra enables the ``nsys-ai-mcp`` entry point; importing the core package does
+not acquire a new runtime dependency.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any
+
+from .annotation import PRODUCER, SCHEMA_VERSION
+from .diff import diff_profiles, diff_profiles_all_gpus
+from .diff_render import to_diff_dict
+from .exceptions import SkillExecutionError, SkillNotFoundError, SkillParameterError
+from .fingerprint import get_profile_id
+from .profile import Profile, resolve_profile_path
+
+MAX_ROWS = 50
+MAX_DIFF_LIMIT = 50
+# The SQL tool's 8,000-character cap is tuned for an LLM prompt. MCP returns
+# the canonical structured diff envelope, so it needs a larger bounded budget
+# while retaining an explicit payload guardrail.
+MCP_MAX_PAYLOAD_CHARS = 100_000
+_TRIM_KEYS = frozenset({"trim_start_ns", "trim_end_ns"})
+
+
+def _error(code: str, message: str, **detail: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"error": {"code": code, "message": message}}
+    payload["error"].update(detail)
+    return payload
+
+
+def _json_safe(value: Any) -> Any:
+    """Normalize database values to the JSON values MCP clients receive."""
+    return json.loads(json.dumps(value, ensure_ascii=False, default=str))
+
+
+def _catalog_entry(skill) -> dict[str, Any]:
+    return {
+        "name": skill.name,
+        "title": skill.title,
+        "description": skill.description,
+        "category": skill.category,
+        "params": [
+            {
+                "name": param.name,
+                "type": param.type,
+                "description": getattr(param, "description", ""),
+                "required": param.required,
+                "default": param.default,
+            }
+            for param in skill.params
+        ],
+    }
+
+
+def _list_skills() -> dict[str, Any]:
+    """Return the same skill metadata exposed by ``skill list --format json``."""
+    from .skills.registry import all_skills
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "producer": PRODUCER,
+        "skills": [_catalog_entry(skill) for skill in all_skills()],
+    }
+
+
+def _coerce_param(value: Any, param_type: Any) -> Any:
+    """Validate the JSON value against the type declared by a SkillParam."""
+    type_name = str(param_type).lower()
+    if param_type is int or type_name in {"int", "integer"}:
+        if isinstance(value, bool):
+            raise ValueError("boolean is not a valid integer parameter")
+        return int(value)
+    if param_type is float or type_name in {"float", "double"}:
+        if isinstance(value, bool):
+            raise ValueError("boolean is not a valid float parameter")
+        return float(value)
+    if param_type is bool or type_name in {"bool", "boolean"}:
+        if not isinstance(value, bool):
+            raise ValueError("parameter must be a boolean")
+        return value
+    if not isinstance(value, str):
+        raise ValueError("parameter must be a string")
+    return value
+
+
+def _resolve_skill_params(skill, params: Mapping[str, Any] | None) -> dict[str, Any]:
+    if params is None:
+        return {}
+    if not isinstance(params, Mapping):
+        raise ValueError("params must be an object")
+
+    declared = {param.name: param for param in skill.params}
+    allowed = set(declared) | _TRIM_KEYS
+    unknown = sorted(set(params) - allowed)
+    if unknown:
+        raise ValueError(
+            f"unknown parameter(s) for skill '{skill.name}': {', '.join(unknown)}"
+        )
+
+    resolved: dict[str, Any] = {}
+    for name, value in params.items():
+        if name in _TRIM_KEYS:
+            if isinstance(value, bool):
+                raise ValueError(f"{name} must be an integer")
+            resolved[name] = int(value)
+        else:
+            resolved[name] = _coerce_param(value, declared[name].type)
+    return resolved
+
+
+def _cap_rows(rows: list[dict], max_rows: int) -> tuple[list[dict], bool]:
+    if max_rows < 0 or max_rows > MAX_ROWS:
+        raise ValueError(f"max_rows must be between 0 and {MAX_ROWS}")
+    if len(rows) <= max_rows:
+        return rows, False
+    capped = list(rows[:max_rows])
+    capped.append(
+        {
+            "_truncated": True,
+            "_total_rows": len(rows),
+            "_shown_rows": max_rows,
+        }
+    )
+    return capped, True
+
+
+@contextmanager
+def _open_readonly(path: str) -> Iterator[tuple[Any, str]]:
+    """Yield a direct-attach or SQLite ``mode=ro`` connection without a cache build."""
+    from .parquet_cache import open_direct_sqlite, open_with_direct_fallback
+
+    resolved = resolve_profile_path(path)
+    conn, _error_detail = open_with_direct_fallback(resolved, open_direct_sqlite)
+    if conn is None:
+        uri = Path(resolved).resolve().as_uri() + "?mode=ro"
+        conn = sqlite3.connect(uri, uri=True)
+        conn.row_factory = sqlite3.Row
+    try:
+        yield conn, resolved
+    finally:
+        conn.close()
+
+
+def _run_skill(
+    profile: str,
+    skill_name: str,
+    params: Mapping[str, Any] | None = None,
+    max_rows: int = MAX_ROWS,
+) -> dict[str, Any]:
+    """Run one registered skill and return rows plus canonical Finding evidence."""
+    from .evidence_builder import _invoke_to_findings
+    from .skills.base import is_abstention
+    from .skills.registry import all_skills, get_skill
+
+    skill = get_skill(skill_name)
+    if skill is None:
+        return SkillNotFoundError(
+            f"Unknown skill '{skill_name}'",
+            available=[item.name for item in all_skills()],
+        ).to_dict()
+
+    try:
+        skill_params = _resolve_skill_params(skill, params)
+    except (TypeError, ValueError) as exc:
+        return _error("INVALID_PARAMETER", str(exc), skill=skill.name)
+
+    try:
+        with _open_readonly(profile) as (conn, resolved):
+            rows = skill.execute(conn, **skill_params)
+            profile_id = get_profile_id(conn, fallback_path=resolved)
+            findings = (
+                _invoke_to_findings(
+                    skill.to_findings_fn,
+                    rows,
+                    {"profile_id": profile_id},
+                )
+                if skill.to_findings_fn
+                else []
+            )
+            capped_rows, truncated = _cap_rows(rows, max_rows)
+            capped_findings, findings_truncated = _cap_rows(
+                [finding.to_dict() for finding in findings], max_rows
+            )
+            payload = {
+                "schema_version": SCHEMA_VERSION,
+                "producer": PRODUCER,
+                "skill": _catalog_entry(skill),
+                "profile": {"path": resolved, "profile_id": profile_id},
+                "rows": capped_rows,
+                "findings": capped_findings,
+                "abstained": is_abstention(rows),
+                "truncated": truncated or findings_truncated,
+            }
+            encoded = json.dumps(payload, ensure_ascii=False, default=str)
+            if len(encoded) > MCP_MAX_PAYLOAD_CHARS:
+                return _error(
+                    "PAYLOAD_TOO_LARGE",
+                    "skill result exceeds the MCP payload cap; lower max_rows or narrow the skill parameters",
+                    max_payload_chars=MCP_MAX_PAYLOAD_CHARS,
+                )
+            return _json_safe(payload)
+    except SkillParameterError as exc:
+        return exc.to_dict()
+    except (SkillExecutionError, sqlite3.Error, OSError, ValueError) as exc:
+        return _error("SKILL_EXECUTION_ERROR", str(exc), skill=skill.name)
+
+
+def _diff_payload(
+    before: str,
+    after: str,
+    gpu: int | None = None,
+    trim_start_ns: int | None = None,
+    trim_end_ns: int | None = None,
+    limit: int = 15,
+    sort: str = "delta",
+) -> dict[str, Any]:
+    """Return the canonical ``diff.json`` payload without persisting it."""
+    if (trim_start_ns is None) != (trim_end_ns is None):
+        return _error("INVALID_PARAMETER", "trim_start_ns and trim_end_ns must be provided together")
+    if limit < 1 or limit > MAX_DIFF_LIMIT:
+        return _error("INVALID_PARAMETER", f"limit must be between 1 and {MAX_DIFF_LIMIT}")
+    if sort not in {"delta", "percent", "total"}:
+        return _error("INVALID_PARAMETER", "sort must be one of: delta, percent, total")
+
+    trim = None if trim_start_ns is None else (int(trim_start_ns), int(trim_end_ns))
+    try:
+        with _open_readonly(before) as (before_conn, before_path):
+            with _open_readonly(after) as (after_conn, after_path):
+                before_prof = Profile._from_conn(before_conn)
+                after_prof = Profile._from_conn(after_conn)
+                before_prof.path = before_path
+                after_prof.path = after_path
+                if gpu is None:
+                    summary, _per_gpu = diff_profiles_all_gpus(
+                        before_prof,
+                        after_prof,
+                        trim=trim,
+                        limit=limit,
+                        sort=sort,
+                    )
+                else:
+                    summary = diff_profiles(
+                        before_prof,
+                        after_prof,
+                        gpu=int(gpu),
+                        trim=trim,
+                        limit=limit,
+                        sort=sort,
+                    )
+                payload = to_diff_dict(summary)
+                encoded = json.dumps(payload, ensure_ascii=False, default=str)
+                if len(encoded) > MCP_MAX_PAYLOAD_CHARS:
+                    return _error(
+                        "PAYLOAD_TOO_LARGE",
+                        "diff result exceeds the MCP payload cap; lower limit or select one GPU",
+                        max_payload_chars=MCP_MAX_PAYLOAD_CHARS,
+                    )
+                return _json_safe(payload)
+    except (OSError, sqlite3.Error, ValueError) as exc:
+        return _error("DIFF_EXECUTION_ERROR", str(exc))
+
+
+def create_server():
+    """Build the optional FastMCP server; importing this module stays dependency-free."""
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except ImportError as exc:
+        raise RuntimeError(
+            "MCP support is optional; install it with `pip install 'nsys-ai[mcp]'`."
+        ) from exc
+
+    server = FastMCP("nsys-ai")
+
+    @server.tool(name="list_skills")
+    def list_skills() -> dict[str, Any]:
+        """List registered analysis skills and their parameter schemas."""
+        return _list_skills()
+
+    @server.tool(name="run_skill")
+    def run_skill(
+        profile: str,
+        skill_name: str,
+        params: dict[str, Any] | None = None,
+        max_rows: int = MAX_ROWS,
+    ) -> dict[str, Any]:
+        """Run one named skill read-only and return rows plus Finding evidence."""
+        return _run_skill(profile, skill_name, params, max_rows)
+
+    @server.tool(name="diff_profiles")
+    def diff_profiles_tool(
+        before: str,
+        after: str,
+        gpu: int | None = None,
+        trim_start_ns: int | None = None,
+        trim_end_ns: int | None = None,
+        limit: int = 15,
+        sort: str = "delta",
+    ) -> dict[str, Any]:
+        """Compare two profiles read-only and return the canonical diff contract."""
+        return _diff_payload(before, after, gpu, trim_start_ns, trim_end_ns, limit, sort)
+
+    return server
+
+
+def main() -> None:
+    """Run the MCP server over stdio."""
+    create_server().run(transport="stdio")
+
+
+__all__ = ["create_server", "main"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -2,6 +2,10 @@
 
 import hashlib
 import json
+import shutil
+import sqlite3
+import sys
+import types
 from pathlib import Path
 
 
@@ -43,6 +47,28 @@ def test_run_skill_rejects_undeclared_parameters_before_opening_profile():
     assert "kernel_table" in result["error"]["message"]
 
 
+def test_run_skill_rejects_unsafe_parameter_bounds_before_opening_profile():
+    from nsys_ai.mcp_server import MAX_ROWS, _run_skill
+
+    result = _run_skill(
+        "does-not-exist.sqlite",
+        "top_kernels",
+        {"limit": MAX_ROWS + 1},
+    )
+
+    assert result["error"]["code"] == "INVALID_PARAMETER"
+    assert "limit" in result["error"]["message"]
+
+
+def test_run_skill_rejects_unsafe_max_rows_before_opening_profile():
+    from nsys_ai.mcp_server import MAX_ROWS, _run_skill
+
+    result = _run_skill("does-not-exist.sqlite", "top_kernels", max_rows=MAX_ROWS + 1)
+
+    assert result["error"]["code"] == "INVALID_PARAMETER"
+    assert "max_rows" in result["error"]["message"]
+
+
 def test_run_skill_preserves_read_only_profile_bytes(profile_copy):
     from nsys_ai.mcp_server import _run_skill
 
@@ -53,6 +79,64 @@ def test_run_skill_preserves_read_only_profile_bytes(profile_copy):
 
     assert "error" not in result
     assert hashlib.sha256(Path(profile).read_bytes()).digest() == before
+
+
+def test_nsys_rep_uses_existing_sidecar_without_writing(profile_copy, tmp_path):
+    from nsys_ai.mcp_server import _run_skill
+
+    sidecar = tmp_path / "capture.sqlite"
+    shutil.copyfile(profile_copy("h100_2gpu_1s.sqlite"), sidecar)
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"capture placeholder")
+    sidecar.touch()
+    before_rep = hashlib.sha256(rep.read_bytes()).digest()
+    before_sidecar = hashlib.sha256(sidecar.read_bytes()).digest()
+
+    result = _run_skill(str(rep), "top_kernels", {"limit": 1}, max_rows=1)
+
+    assert "error" not in result
+    assert result["profile"]["path"] == str(sidecar)
+    assert hashlib.sha256(rep.read_bytes()).digest() == before_rep
+    assert hashlib.sha256(sidecar.read_bytes()).digest() == before_sidecar
+    assert not (tmp_path / "capture.parquetdir").exists()
+
+
+def test_nsys_rep_without_current_sidecar_returns_export_error_without_writing(tmp_path):
+    from nsys_ai.mcp_server import _run_skill
+
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"capture placeholder")
+
+    result = _run_skill(str(rep), "top_kernels", {"limit": 1})
+
+    assert result["error"]["code"] == "EXPORT_TOOL_MISSING"
+    assert not (tmp_path / "capture.sqlite").exists()
+    assert not (tmp_path / "capture.parquetdir").exists()
+
+
+def test_profile_open_errors_are_standard_mcp_payloads(tmp_path):
+    from nsys_ai.mcp_server import _diff_payload, _run_skill
+
+    missing = tmp_path / "missing.sqlite"
+    skill_result = _run_skill(str(missing), "top_kernels")
+    diff_result = _diff_payload(str(missing), str(missing), gpu=0, limit=1)
+
+    assert skill_result["error"]["code"] == "PROFILE_NOT_FOUND"
+    assert diff_result["error"]["code"] == "PROFILE_NOT_FOUND"
+
+
+def test_schema_errors_are_standard_mcp_payloads(tmp_path):
+    from nsys_ai.mcp_server import _diff_payload
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    for path in (before, after):
+        with sqlite3.connect(path) as conn:
+            conn.execute("CREATE TABLE unrelated (value INTEGER)")
+
+    result = _diff_payload(str(before), str(after), gpu=0, limit=1)
+
+    assert result["error"]["code"] == "SCHEMA_ERROR"
 
 
 def test_diff_returns_the_persisted_diff_contract(profile_copy):
@@ -98,3 +182,39 @@ def test_mcp_extra_is_lazy_and_has_a_clear_install_message(monkeypatch):
         assert "nsys-ai[mcp]" in str(exc)
     else:
         raise AssertionError("create_server unexpectedly imported the MCP extra")
+
+
+def test_mcp_registration_exposes_the_three_read_only_tools(monkeypatch):
+    from nsys_ai.mcp_server import create_server
+
+    class FakeServer:
+        def __init__(self, name):
+            self.name = name
+            self.tools = {}
+
+        def tool(self, *, name):
+            def register(function):
+                self.tools[name] = function
+                return function
+
+            return register
+
+    servers = []
+
+    def make_server(name):
+        server = FakeServer(name)
+        servers.append(server)
+        return server
+
+    fake_mcp = types.ModuleType("mcp")
+    fake_server = types.ModuleType("mcp.server")
+    fake_fastmcp = types.ModuleType("mcp.server.fastmcp")
+    fake_fastmcp.FastMCP = make_server
+    monkeypatch.setitem(sys.modules, "mcp", fake_mcp)
+    monkeypatch.setitem(sys.modules, "mcp.server", fake_server)
+    monkeypatch.setitem(sys.modules, "mcp.server.fastmcp", fake_fastmcp)
+
+    server = create_server()
+
+    assert server is servers[0]
+    assert set(server.tools) == {"list_skills", "run_skill", "diff_profiles"}

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,0 +1,100 @@
+"""Contracts for the optional read-only MCP transport."""
+
+import hashlib
+import json
+from pathlib import Path
+
+
+def test_skill_catalog_matches_registry():
+    from nsys_ai.mcp_server import _list_skills
+    from nsys_ai.skills.registry import all_skills
+
+    payload = _list_skills()
+
+    assert payload["producer"] == "nsys-ai"
+    assert [skill["name"] for skill in payload["skills"]] == [
+        skill.name for skill in all_skills()
+    ]
+    assert {"name", "title", "description", "category", "params"} <= set(
+        payload["skills"][0]
+    )
+
+
+def test_run_skill_returns_rows_and_canonical_findings(profile_copy):
+    from nsys_ai.mcp_server import _run_skill
+
+    profile = profile_copy("h100_2gpu_1s.sqlite")
+    result = _run_skill(str(profile), "top_kernels", {"limit": 1}, max_rows=1)
+
+    assert result["producer"] == "nsys-ai"
+    assert result["profile"]["path"] == str(profile)
+    assert result["rows"]
+    assert isinstance(result["findings"], list)
+    assert result["abstained"] is False
+    json.dumps(result)
+
+
+def test_run_skill_rejects_undeclared_parameters_before_opening_profile():
+    from nsys_ai.mcp_server import _run_skill
+
+    result = _run_skill("does-not-exist.sqlite", "top_kernels", {"kernel_table": "x"})
+
+    assert result["error"]["code"] == "INVALID_PARAMETER"
+    assert "kernel_table" in result["error"]["message"]
+
+
+def test_run_skill_preserves_read_only_profile_bytes(profile_copy):
+    from nsys_ai.mcp_server import _run_skill
+
+    profile = profile_copy("h100_2gpu_1s.sqlite")
+    before = hashlib.sha256(Path(profile).read_bytes()).digest()
+
+    result = _run_skill(str(profile), "top_kernels", {"limit": 1}, max_rows=1)
+
+    assert "error" not in result
+    assert hashlib.sha256(Path(profile).read_bytes()).digest() == before
+
+
+def test_diff_returns_the_persisted_diff_contract(profile_copy):
+    from nsys_ai.mcp_server import _diff_payload
+
+    before = profile_copy("mfu_2gpu_before.sqlite")
+    after = profile_copy("mfu_2gpu_after.sqlite")
+    result = _diff_payload(str(before), str(after), gpu=0, limit=1)
+
+    assert result["schema_version"] == "0.1"
+    assert result["producer"] == "nsys-ai"
+    assert result["decision"] is None
+    assert {"before", "after", "verdict", "comparability_confidence"} <= set(result)
+    assert result["before"]["path"] == str(before)
+    json.dumps(result)
+
+
+def test_diff_rejects_an_unbounded_request():
+    from nsys_ai.mcp_server import _diff_payload
+
+    result = _diff_payload("before.sqlite", "after.sqlite", limit=51)
+
+    assert result["error"]["code"] == "INVALID_PARAMETER"
+
+
+def test_mcp_extra_is_lazy_and_has_a_clear_install_message(monkeypatch):
+    import builtins
+
+    from nsys_ai.mcp_server import create_server
+
+    original_import = builtins.__import__
+
+    def reject_mcp(name, *args, **kwargs):
+        if name == "mcp" or name.startswith("mcp."):
+            raise ImportError("test: mcp extra is absent")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", reject_mcp)
+
+    try:
+        create_server()
+    except RuntimeError as exc:
+        assert "nsys-ai[mcp]" in str(exc)
+    else:
+        raise AssertionError("create_server unexpectedly imported the MCP extra")


### PR DESCRIPTION
## Summary

- add an optional, read-only MCP transport for the canonical skill and diff contracts
- expose `list_skills`, `run_skill`, and `diff_profiles` through `nsys-ai-mcp`
- keep the MCP dependency lazy and bounded by row, parameter, and payload caps

## Issue

Closes #273

## Validation

- `PYTHONPATH=src pytest -q tests/test_mcp_server.py tests/test_tool_dispatch.py tests/test_skill_packs.py tests/test_diff_json_shape.py`
- `ruff check src tests`
- `bandit -q -r src/nsys_ai/mcp_server.py`
- `PYTHONPATH=src python3 -m nsys_ai --help`

All focused tests passed (`25 passed`).
