### PR TITLE
profile: unify ingest policy and persist storage metadata

### DIFF
--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -326,6 +326,12 @@ def open_profile_readonly(path: str):
     ``kernels`` view; raw sqlite3 does not.
     """
     from nsys_ai import parquet_cache
+    from nsys_ai.profile import resolve_profile
+
+    resolution = resolve_profile(path)
+    if resolution.backend == "parquetdir":
+        return parquet_cache.open_parquetdir_db(resolution.resolved_path)
+    path = resolution.resolved_path
 
     db, _err = parquet_cache.open_with_direct_fallback(
         path, parquet_cache.open_auto_db, log=_log

--- a/src/nsys_ai/ai/backend/profile_db_tool.py
+++ b/src/nsys_ai/ai/backend/profile_db_tool.py
@@ -333,9 +333,12 @@ def open_profile_readonly(path: str):
         return parquet_cache.open_parquetdir_db(resolution.resolved_path)
     path = resolution.resolved_path
 
-    db, _err = parquet_cache.open_with_direct_fallback(
-        path, parquet_cache.open_auto_db, log=_log
+    primary = (
+        parquet_cache.open_direct_sqlite
+        if resolution.cache_mode == "direct"
+        else parquet_cache.open_auto_db
     )
+    db, _err = parquet_cache.open_with_direct_fallback(path, primary, log=_log)
     if db is not None:
         return db
 

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -1018,6 +1018,9 @@ def resolve_profile(
     nsys_executable: str = "nsys",
 ) -> ProfileResolution:
     """Resolve one profile input according to the shared ingest policy."""
+    path = os.fspath(path)
+    if not isinstance(path, str):
+        raise TypeError("profile path must be a string or path-like object")
     if not os.path.exists(path):
         raise ProfileNotFoundError(f"profile not found: {path}")
 

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -1,7 +1,7 @@
 """
-profile.py — Open and query Nsight Systems SQLite databases.
+profile.py — Ingest and query Nsight Systems profiles.
 
-Provides a thin wrapper around the SQLite export with typed accessors
+Provides a thin wrapper around profile backends with typed accessors
 for kernels, NVTX events, CUDA runtime calls, and metadata.
 """
 
@@ -15,6 +15,7 @@ import subprocess  # nosec B404
 import threading
 import typing
 from dataclasses import dataclass, field
+from typing import Literal
 
 # subprocess: nsys export (.nsys-rep→.sqlite) only; argv list, no shell.
 if typing.TYPE_CHECKING:
@@ -33,6 +34,34 @@ from nsys_ai.exceptions import (
 
 # Regex for safe SQL identifiers (table/column names).
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+IngestPolicy = Literal["auto", "parquetdir", "sqlite"]
+StorageKind = Literal["nsys-rep", "parquetdir", "sqlite"]
+
+
+@dataclass(frozen=True)
+class ProfileResolution:
+    """The single ingest decision shared by every profile entry point."""
+
+    source_path: str
+    resolved_path: str
+    storage_kind: StorageKind
+    backend: Literal["sqlite", "parquetdir"]
+    cache_mode: Literal["auto", "direct"]
+
+
+def resolve_ingest_policy(policy: str | None = None) -> IngestPolicy:
+    """Return the explicit ingest policy, honoring ``NSYS_AI_INGEST``."""
+    value = (
+        policy
+        if policy is not None
+        else os.environ.get("NSYS_AI_INGEST", "auto").strip().lower()
+    )
+    if value not in {"auto", "parquetdir", "sqlite"}:
+        raise ValueError(
+            f"Unknown ingest policy: {value!r}. Expected 'auto', 'parquetdir', or 'sqlite'."
+        )
+    return value  # type: ignore[return-value]
 
 
 def _validate_table_name(name: str) -> str:
@@ -298,7 +327,7 @@ class ProfileMeta:
 
 
 class Profile:
-    """Handle to an opened Nsight Systems SQLite database.
+    """Handle to an opened Nsight Systems profile.
 
     Exposes two database connections:
       - ``self.conn`` (sqlite3.Connection | duckdb.DuckDBPyConnection): the primary
@@ -323,42 +352,60 @@ class Profile:
         path: str,
         *,
         cache_mode: str = "auto",
-        backend: str = "sqlite",
+        backend: str = "auto",
+        ingest_policy: str | None = None,
         progress: typing.Callable[[str, int, int], None] | None = None,
     ):
         if cache_mode not in ("auto", "parquet", "direct"):
             raise ValueError(
                 f"Unknown cache_mode: {cache_mode!r}. Expected 'auto', 'parquet', or 'direct'."
             )
-        if backend not in ("sqlite", "parquetdir"):
-            raise ValueError(f"Unknown backend: {backend!r}. Expected 'sqlite' or 'parquetdir'.")
+        if backend not in ("auto", "sqlite", "parquetdir"):
+            raise ValueError(
+                f"Unknown backend: {backend!r}. Expected 'auto', 'sqlite', or 'parquetdir'."
+            )
         if backend == "parquetdir" and cache_mode != "auto":
             raise ValueError(
                 "cache_mode is not supported with backend='parquetdir'; use cache_mode='auto'."
             )
-        # Guard before sqlite3.connect, which would otherwise create an empty
-        # stub + cache for a missing path. Covers every entry path, including
-        # direct Profile(...) construction that bypasses resolve_profile_path.
-        if not os.path.exists(path):
-            raise ProfileNotFoundError(f"profile not found: {path}")
-        self.path = path
-        self.backend = backend
+        resolution = resolve_profile(
+            path,
+            backend=backend,
+            ingest_policy=ingest_policy,
+        )
+        if resolution.backend == "parquetdir" and cache_mode != "auto":
+            raise ValueError(
+                "cache_mode is not supported with backend='parquetdir'; use cache_mode='auto'."
+            )
+        if resolution.cache_mode == "direct" and cache_mode == "parquet":
+            raise ValueError(
+                "ingest policy 'sqlite' requires direct SQLite access; "
+                "cache_mode='parquet' is incompatible"
+            )
+        self.path = resolution.resolved_path
+        self.input_path = resolution.source_path
+        self.resolved_path = resolution.resolved_path
+        self.storage_kind = resolution.storage_kind
+        self.backend = resolution.backend
         self._lock = threading.Lock()
         self._owns_conn = True
-        if backend == "parquetdir":
-            self.db = parquet_cache.open_parquetdir_db(path)
+        if resolution.backend == "parquetdir":
+            self.db = parquet_cache.open_parquetdir_db(resolution.resolved_path)
             self.conn = self.db
         else:
-            self.conn = sqlite3.connect(path, check_same_thread=False)
+            self.conn = sqlite3.connect(resolution.resolved_path, check_same_thread=False)
             self.conn.row_factory = sqlite3.Row
             # Three-tier open (cache / direct attach / raw sqlite3) lives in
             # parquet_cache.open_with_direct_fallback — also used by
             # open_profile_readonly and skill run, so a failed build cannot
             # drop only some entry points onto raw sqlite3 (issue #333).
-            if cache_mode == "direct":
+            effective_cache_mode = (
+                "direct" if resolution.cache_mode == "direct" else cache_mode
+            )
+            if effective_cache_mode == "direct":
                 # Force direct SQLite via DuckDB — zero ETL, instant startup
                 primary = parquet_cache.open_direct_sqlite
-            elif cache_mode == "parquet":
+            elif effective_cache_mode == "parquet":
                 # Original behaviour: block until cache is built.
                 # env_escape=False: this branch never reads
                 # NSYS_AI_CACHE_MODE, so the build banner must not tell the
@@ -374,7 +421,7 @@ class Profile:
                 # open_profile_readonly reach it without a Profile.
                 primary = functools.partial(parquet_cache.open_auto_db, progress=progress)
             self.db, err = parquet_cache.open_with_direct_fallback(
-                path, primary, log=self._log
+                resolution.resolved_path, primary, log=self._log
             )
             if err is not None:
                 self.cache_error = err
@@ -961,15 +1008,56 @@ class Profile:
         self.close()
 
 
+def resolve_profile(
+    path: str,
+    *,
+    backend: str = "auto",
+    ingest_policy: str | None = None,
+    nsys_executable: str = "nsys",
+) -> ProfileResolution:
+    """Resolve one profile input according to the shared ingest policy."""
+    if not os.path.exists(path):
+        raise ProfileNotFoundError(f"profile not found: {path}")
+
+    policy = resolve_ingest_policy(ingest_policy)
+    if backend not in {"auto", "sqlite", "parquetdir"}:
+        raise ValueError(
+            f"Unknown backend: {backend!r}. Expected 'auto', 'sqlite', or 'parquetdir'."
+        )
+    selected = policy if backend == "auto" else backend
+    if os.path.isdir(path):
+        if not any(name.endswith(".parquet") for name in os.listdir(path)):
+            raise ExportError(f"Parquet directory '{path}' does not contain any .parquet files.")
+        if selected == "sqlite":
+            raise ExportError(
+                "SQLite ingest policy cannot open a parquetdir; use NSYS_AI_INGEST=parquetdir."
+            )
+        return ProfileResolution(path, path, "parquetdir", "parquetdir", "auto")
+
+    if path.lower().endswith(".nsys-rep"):
+        if selected in {"auto", "parquetdir"}:
+            resolved = _resolve_parquetdir_path(path, nsys_executable=nsys_executable)
+            return ProfileResolution(path, resolved, "nsys-rep", "parquetdir", "auto")
+        resolved = _resolve_sqlite_path(path, nsys_executable=nsys_executable)
+        return ProfileResolution(path, resolved, "nsys-rep", "sqlite", "direct")
+
+    if selected == "parquetdir":
+        raise ExportError(
+            "Parquetdir ingest requires a parquetdir directory or a .nsys-rep input."
+        )
+    cache_mode: Literal["auto", "direct"] = "direct" if selected == "sqlite" else "auto"
+    return ProfileResolution(path, path, "sqlite", "sqlite", cache_mode)
+
+
 def resolve_profile_path(
-    path: str, *, backend: str = "sqlite", nsys_executable: str = "nsys"
+    path: str, *, backend: str = "auto", nsys_executable: str = "nsys"
 ) -> str:
     """
     Resolve a profile path for the selected backend.
 
-    `backend='sqlite'` returns a `.sqlite` file, exporting from `.nsys-rep`
-    when needed. `backend='parquetdir'` returns a Parquet directory, exporting
-    from `.nsys-rep` when needed.
+    The default ``auto`` policy resolves `.nsys-rep` to a Parquet directory and
+    opens `.sqlite` through the cache/direct fallback. Explicit ``sqlite`` and
+    ``parquetdir`` backends remain available for compatibility and diagnostics.
 
     Exports always pass `--include-blobs=true` so NVTX payload-dependent
     analysis (for example communicator-aware NCCL diagnostics) remains available.
@@ -977,12 +1065,15 @@ def resolve_profile_path(
     Raises ProfileNotFoundError when *path* does not exist (e.g. a missing
     `.nsys-rep`, before any export is attempted).
     """
-    if not os.path.exists(path):
-        raise ProfileNotFoundError(f"profile not found: {path}")
-    if backend == "parquetdir":
-        return _resolve_parquetdir_path(path, nsys_executable=nsys_executable)
-    if not path.lower().endswith(".nsys-rep"):
-        return path
+    return resolve_profile(
+        path,
+        backend=backend,
+        nsys_executable=nsys_executable,
+    ).resolved_path
+
+
+def _resolve_sqlite_path(path: str, *, nsys_executable: str = "nsys") -> str:
+    """Resolve a ``.nsys-rep`` to its compatibility SQLite export."""
 
     # Reuse an existing up-to-date SQLite export if possible.
     out = path[:-9] + ".sqlite"  # .nsys-rep -> .sqlite
@@ -1182,19 +1273,16 @@ def get_first_gpu_name(conn) -> str:
 def open(
     path: str,
     *,
-    backend: str = "sqlite",
+    backend: str = "auto",
     cache_mode: str = "auto",
+    ingest_policy: str | None = None,
     progress: typing.Callable[[str, int, int], None] | None = None,
 ) -> Profile:
     """Open an Nsight Systems profile using the requested backend."""
-    path = resolve_profile_path(path, backend=backend)
-    # Heuristic: if the given path is an empty .sqlite stub but a sibling
-    # file without the .sqlite suffix exists and is a non-empty SQLite DB,
-    # prefer the sibling. This helps when users accidentally point nsys-ai
-    # at a placeholder file instead of the real Nsight export.
-    if backend == "sqlite" and path.endswith(".sqlite") and os.path.exists(path) and not os.path.getsize(path):
-        base = path[:-7]
-        if os.path.exists(base) and os.path.getsize(base) > 0:
-            path = base
-
-    return Profile(path, cache_mode=cache_mode, backend=backend, progress=progress)
+    return Profile(
+        path,
+        cache_mode=cache_mode,
+        backend=backend,
+        ingest_policy=ingest_policy,
+        progress=progress,
+    )

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -15,6 +15,7 @@ import subprocess  # nosec B404
 import threading
 import typing
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Literal
 
 # subprocess: nsys export (.nsys-rep→.sqlite) only; argv list, no shell.
@@ -31,6 +32,7 @@ from nsys_ai.exceptions import (
     ProfileNotFoundError,
     SchemaError,
 )
+from nsys_ai.profile_reference import inspect_local_parquetdir
 
 # Regex for safe SQL identifiers (table/column names).
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
@@ -1025,9 +1027,11 @@ def resolve_profile(
             f"Unknown backend: {backend!r}. Expected 'auto', 'sqlite', or 'parquetdir'."
         )
     selected = policy if backend == "auto" else backend
-    if os.path.isdir(path):
-        if not any(name.endswith(".parquet") for name in os.listdir(path)):
-            raise ExportError(f"Parquet directory '{path}' does not contain any .parquet files.")
+    if os.path.isdir(path) or Path(path).suffix.lower() in {".parquetdir", ".nsys-cache"}:
+        try:
+            inspect_local_parquetdir(os.path.abspath(path), allow_missing=False)
+        except ValueError as exc:
+            raise ExportError(str(exc)) from exc
         if selected == "sqlite":
             raise ExportError(
                 "SQLite ingest policy cannot open a parquetdir; use NSYS_AI_INGEST=parquetdir."
@@ -1154,10 +1158,11 @@ def _resolve_sqlite_path(path: str, *, nsys_executable: str = "nsys") -> str:
 def _resolve_parquetdir_path(path: str, *, nsys_executable: str = "nsys") -> str:
     """Return a path to an Nsight `parquetdir` export."""
     if os.path.isdir(path):
-        parquet_files = [name for name in os.listdir(path) if name.endswith(".parquet")]
-        if parquet_files:
-            return path
-        raise ExportError(f"Parquet directory '{path}' does not contain any .parquet files.")
+        try:
+            inspect_local_parquetdir(str(os.path.abspath(path)), allow_missing=False)
+        except ValueError as exc:
+            raise ExportError(str(exc)) from exc
+        return path
 
     if not path.lower().endswith(".nsys-rep"):
         return path
@@ -1166,9 +1171,12 @@ def _resolve_parquetdir_path(path: str, *, nsys_executable: str = "nsys") -> str
     if (
         os.path.exists(path)
         and os.path.isdir(out)
-        and any(name.endswith(".parquet") for name in os.listdir(out))
         and os.path.getmtime(out) >= os.path.getmtime(path)
     ):
+        try:
+            inspect_local_parquetdir(str(os.path.abspath(out)), allow_missing=False)
+        except ValueError as exc:
+            raise ExportError(str(exc)) from exc
         return out
 
     nsys_exe = shutil.which(nsys_executable)
@@ -1210,10 +1218,12 @@ def _resolve_parquetdir_path(path: str, *, nsys_executable: str = "nsys") -> str
             "-o <out.parquetdir> --force-overwrite=true <file.nsys-rep>"
         ) from e
 
-    if not (os.path.isdir(out) and any(name.endswith(".parquet") for name in os.listdir(out))):
+    try:
+        inspect_local_parquetdir(str(os.path.abspath(out)), allow_missing=False)
+    except ValueError as exc:
         raise ExportError(
-            f"nsys export completed without error but did not produce a usable parquetdir at '{out}'."
-        )
+            f"nsys export completed without error: {exc}"
+        ) from exc
     return out
 
 

--- a/src/nsys_ai/profile_reference.py
+++ b/src/nsys_ai/profile_reference.py
@@ -249,7 +249,12 @@ def _inspect_parquetdir(path: str, *, allow_missing: bool) -> Path | None:
         resolved = parquet_path.resolve(strict=True)
         if resolved != parquet_path or not parquet_path.is_dir():
             raise ValueError("local profile parquetdir must be a canonical directory")
-        if not any(item.suffix.lower() == ".parquet" for item in parquet_path.iterdir()):
+        parquet_files = [
+            item for item in parquet_path.iterdir() if item.suffix.lower() == ".parquet"
+        ]
+        if any(item.is_symlink() for item in parquet_files):
+            raise ValueError("local profile parquetdir cannot contain symlink parquet files")
+        if not parquet_files:
             raise ValueError("local profile parquetdir contains no parquet files")
         return resolved
     except (OSError, RuntimeError):

--- a/src/nsys_ai/profile_reference.py
+++ b/src/nsys_ai/profile_reference.py
@@ -7,23 +7,31 @@ import re
 import stat
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from .fingerprint import PROFILE_ID_VERSION
 
 LOCAL_PROFILE_ID_PATTERN = re.compile(
     rf"{re.escape(PROFILE_ID_VERSION)}:sha256:[0-9a-f]{{64}}"
 )
+StorageKind = Literal["nsys-rep", "parquetdir", "sqlite"]
 
 
 @dataclass(frozen=True)
 class LocalProfileReference:
-    """Validated identity and schema metadata for a local SQLite export."""
+    """Validated identity and schema metadata for one local profile input."""
 
     path: str
     profile_id: str
     schema_version: str | None
     product_version: str | None
     kernel_count: int
+    storage_kind: StorageKind = "sqlite"
+    resolved_path: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.resolved_path is None:
+            object.__setattr__(self, "resolved_path", self.path)
 
 
 def profile_stat_signature(metadata: os.stat_result) -> tuple[int, ...]:
@@ -178,9 +186,34 @@ def validate_local_profile_reference(
         or not Path(path).is_absolute()
     ):
         raise ValueError("local profile reference path must be an absolute path string")
-    if Path(path).suffix.lower() != ".sqlite":
-        raise ValueError("local profile reference path must name a .sqlite file")
-    inspect_local_profile_file(path, allow_missing=not require_file)
+    storage_kind = reference.storage_kind
+    if storage_kind not in {"nsys-rep", "parquetdir", "sqlite"}:
+        raise ValueError("local profile reference storage kind is invalid")
+    if storage_kind == "sqlite" and Path(path).suffix.lower() != ".sqlite":
+        raise ValueError("sqlite profile reference path must name a .sqlite file")
+    if storage_kind == "nsys-rep" and Path(path).suffix.lower() != ".nsys-rep":
+        raise ValueError("nsys-rep profile reference path must name a .nsys-rep file")
+    if storage_kind == "parquetdir" and not Path(path).is_dir():
+        raise ValueError("parquetdir profile reference path must name a directory")
+
+    if storage_kind == "parquetdir":
+        _inspect_parquetdir(path, allow_missing=not require_file)
+    else:
+        inspect_local_profile_file(path, allow_missing=not require_file)
+
+    resolved_path = reference.resolved_path or path
+    if (
+        not isinstance(resolved_path, str)
+        or not resolved_path
+        or "\x00" in resolved_path
+        or not Path(resolved_path).is_absolute()
+        or os.path.normpath(resolved_path) != resolved_path
+    ):
+        raise ValueError("local profile resolved_path must be a canonical absolute path")
+    if storage_kind == "parquetdir" or resolved_path.lower().endswith(".parquetdir"):
+        _inspect_parquetdir(resolved_path, allow_missing=not require_file)
+    else:
+        inspect_local_profile_file(resolved_path, allow_missing=not require_file)
 
     if not isinstance(reference.profile_id, str) or not LOCAL_PROFILE_ID_PATTERN.fullmatch(
         reference.profile_id
@@ -201,3 +234,23 @@ def validate_local_profile_reference(
     if reference.kernel_count <= 0:
         raise ValueError("local profile contains no GPU kernel activity")
     return reference
+
+
+def _inspect_parquetdir(path: str, *, allow_missing: bool) -> Path | None:
+    """Validate a canonical parquet directory without following symlinks."""
+    parquet_path = Path(path)
+    if not parquet_path.is_absolute() or os.path.normpath(path) != path:
+        raise ValueError("local profile parquetdir path must be canonical")
+    try:
+        if not parquet_path.exists():
+            if allow_missing:
+                return None
+            raise ValueError("local profile parquetdir does not exist")
+        resolved = parquet_path.resolve(strict=True)
+        if resolved != parquet_path or not parquet_path.is_dir():
+            raise ValueError("local profile parquetdir must be a canonical directory")
+        if not any(item.suffix.lower() == ".parquet" for item in parquet_path.iterdir()):
+            raise ValueError("local profile parquetdir contains no parquet files")
+        return resolved
+    except (OSError, RuntimeError):
+        raise ValueError("local profile parquetdir cannot be inspected") from None

--- a/src/nsys_ai/profile_reference.py
+++ b/src/nsys_ai/profile_reference.py
@@ -197,7 +197,7 @@ def validate_local_profile_reference(
         raise ValueError("parquetdir profile reference path must name a directory")
 
     if storage_kind == "parquetdir":
-        _inspect_parquetdir(path, allow_missing=not require_file)
+        inspect_local_parquetdir(path, allow_missing=not require_file)
     else:
         inspect_local_profile_file(path, allow_missing=not require_file)
 
@@ -211,7 +211,7 @@ def validate_local_profile_reference(
     ):
         raise ValueError("local profile resolved_path must be a canonical absolute path")
     if storage_kind == "parquetdir" or resolved_path.lower().endswith(".parquetdir"):
-        _inspect_parquetdir(resolved_path, allow_missing=not require_file)
+        inspect_local_parquetdir(resolved_path, allow_missing=not require_file)
     else:
         inspect_local_profile_file(resolved_path, allow_missing=not require_file)
 
@@ -236,7 +236,7 @@ def validate_local_profile_reference(
     return reference
 
 
-def _inspect_parquetdir(path: str, *, allow_missing: bool) -> Path | None:
+def inspect_local_parquetdir(path: str, *, allow_missing: bool) -> Path | None:
     """Validate a canonical parquet directory without following symlinks."""
     parquet_path = Path(path)
     if not parquet_path.is_absolute() or os.path.normpath(path) != path:

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -27,6 +27,7 @@ from .fingerprint import get_profile_id
 from .profile import Profile, resolve_profile_path
 from .profile_reference import (
     LocalProfileReference,
+    inspect_local_parquetdir,
     inspect_local_profile_file,
     profile_stat_signature,
     validate_local_profile_reference,
@@ -195,6 +196,21 @@ def read_local_profile_under_guard(
         raise ProfileError(
             f"local profile path contains a resolved secret{secret_error_detail}"
         )
+
+    # Validate the source before Profile can export, attach, or repair anything.
+    # The resolved output is checked again by the shared profile resolver.
+    if profile_path.suffix.lower() == ".nsys-rep":
+        try:
+            inspect_local_profile_file(profile_path)
+        except ValueError as exc:
+            raise ProfileError(str(exc)) from None
+    elif profile_path.suffix.lower() in {".parquetdir", ".nsys-cache"} or (
+        profile_path.is_dir() and profile_path.suffix.lower() != ".sqlite"
+    ):
+        try:
+            inspect_local_parquetdir(str(profile_path), allow_missing=False)
+        except ValueError as exc:
+            raise ProfileError(str(exc)) from None
 
     if profile_path.suffix.lower() != ".sqlite":
         raise ProfileError("local profile path must name a .sqlite file")

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -165,8 +165,6 @@ def read_local_profile_under_guard(
         profile_path = Path(raw_path).expanduser().absolute()
     except (OSError, RuntimeError):
         raise ProfileError("local profile path cannot be normalized") from None
-    if profile_path.suffix.lower() != ".sqlite":
-        raise ProfileError("local profile path must name a .sqlite file")
     secret_error_detail: str | None = None
     try:
         validate_persisted_secret_strings(
@@ -198,6 +196,8 @@ def read_local_profile_under_guard(
             f"local profile path contains a resolved secret{secret_error_detail}"
         )
 
+    if profile_path.suffix.lower() != ".sqlite":
+        raise ProfileError("local profile path must name a .sqlite file")
     descriptor, before = _open_profile_descriptor(profile_path)
     connection: sqlite3.Connection | None = None
     validation_succeeded = False
@@ -257,6 +257,8 @@ def read_local_profile_under_guard(
         schema_version=schema_version,
         product_version=product_version,
         kernel_count=kernel_count,
+        storage_kind="sqlite",
+        resolved_path=str(profile_path),
     )
     try:
         validated = validate_local_profile_reference(reference, require_file=True)
@@ -269,8 +271,52 @@ def build_local_profile_reference(
     path: str | os.PathLike[str],
     *,
     resolved_secrets: Mapping[str, str] | None = None,
+    ingest_policy: str | None = None,
 ) -> LocalProfileReference:
-    """The reference alone, for the callers that do not need the GPU count."""
+    """Build a reference through the shared ingest policy."""
+    path_conversion_failed = False
+    try:
+        raw_path = os.fspath(path)
+    except Exception:
+        path_conversion_failed = True
+        raw_path = None
+    if path_conversion_failed:
+        raise ProfileError("local profile path must be a path string")
+    if not isinstance(raw_path, str):
+        raise ProfileError("local profile path must be a path string")
+    if not raw_path:
+        raise ProfileError("local profile path must not be empty")
+    if "\x00" in raw_path:
+        raise ProfileError("local profile path must not contain NUL bytes")
+    profile_path = Path(raw_path).expanduser().absolute()
+    if profile_path.suffix.lower() != ".sqlite":
+        try:
+            validate_persisted_secret_strings(
+                {"path": str(profile_path)},
+                resolved_secrets if resolved_secrets is not None else {},
+            )
+        except Exception:
+            raise ProfileError("local profile path contains a resolved secret") from None
+        try:
+            with Profile(str(profile_path), ingest_policy=ingest_policy) as profile:
+                reference = LocalProfileReference(
+                    path=str(profile.input_path),
+                    profile_id=get_profile_id(
+                        profile.conn,
+                        fallback_path=str(profile.input_path),
+                    ),
+                    schema_version=profile.schema.schema_version,
+                    product_version=profile.schema.version,
+                    kernel_count=profile.meta.kernel_count,
+                    storage_kind=profile.storage_kind,
+                    resolved_path=profile.resolved_path,
+                )
+        except (NsysAiError, OSError, *DB_ERRORS) as exc:
+            raise ProfileError(str(exc)) from None
+        try:
+            return validate_local_profile_reference(reference, require_file=True)
+        except (TypeError, ValueError) as exc:
+            raise ProfileError(str(exc)) from None
     reference, _ = read_local_profile_under_guard(
         path, resolved_secrets=resolved_secrets
     )

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -416,7 +416,9 @@ class LocalProfileRunner:
     classified as ``application_failed`` by inference; it is not a separately
     observed application exit code.
 
-    Export uses the existing blocking :func:`resolve_profile_path` API.  The
+    Export explicitly uses the SQLite compatibility backend because
+    ``RunResult.sqlite_path`` is an established result contract. The default
+    profile ingest policy remains parquetdir for user-supplied inputs. The
     cancellation token is consequently observed during capture, not while that
     shared export call is in progress. Progress callbacks are observers:
     ordinary callback exceptions are isolated from the run, while
@@ -609,8 +611,14 @@ class LocalProfileRunner:
         progress(RunStage.EXPORTING)
         export_started = time.monotonic()
         try:
+            # Keep the runner's established ``sqlite_path`` result meaningful;
+            # user-facing profile opens still use the shared auto policy.
             sqlite_path = Path(
-                resolve_profile_path(str(report_path), nsys_executable=executable)
+                resolve_profile_path(
+                    str(report_path),
+                    backend="sqlite",
+                    nsys_executable=executable,
+                )
             ).absolute()
             created_files.add(sqlite_path)
         except (NsysAiError, OSError, subprocess.SubprocessError) as exc:

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -313,6 +313,16 @@ def build_local_profile_reference(
             )
         except Exception:
             raise ProfileError("local profile path contains a resolved secret") from None
+        if profile_path.suffix.lower() == ".nsys-rep":
+            try:
+                inspect_local_profile_file(profile_path)
+            except ValueError as exc:
+                raise ProfileError(str(exc)) from None
+        elif profile_path.suffix.lower() in {".parquetdir", ".nsys-cache"} or profile_path.is_dir():
+            try:
+                inspect_local_parquetdir(str(profile_path), allow_missing=False)
+            except ValueError as exc:
+                raise ProfileError(str(exc)) from None
         try:
             with Profile(str(profile_path), ingest_policy=ingest_policy) as profile:
                 reference = LocalProfileReference(

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -1264,6 +1264,8 @@ def _profile_reference_to_dict(
     return {
         "kind": "local",
         "path": reference.path,
+        "storage_kind": reference.storage_kind,
+        "resolved_path": reference.resolved_path or reference.path,
         "profile_id": reference.profile_id,
         "export_schema_version": reference.schema_version,
         "product_version": reference.product_version,
@@ -1275,23 +1277,31 @@ def _profile_reference_from_dict(value: Any) -> LocalProfileReference | None:
     if value is None:
         return None
     payload = _require_mapping(value, "profile reference")
-    _require_exact_keys(
-        payload,
-        {
-            "kind",
-            "path",
-            "profile_id",
-            "export_schema_version",
-            "product_version",
-            "kernel_count",
-        },
-        "profile reference",
-    )
+    legacy_keys = {
+        "kind",
+        "path",
+        "profile_id",
+        "export_schema_version",
+        "product_version",
+        "kernel_count",
+    }
+    current_keys = legacy_keys | {"storage_kind", "resolved_path"}
+    actual_keys = set(payload)
+    if actual_keys == legacy_keys:
+        storage_kind = "sqlite"
+        resolved_path = payload.get("path")
+    elif actual_keys == current_keys:
+        storage_kind = payload.get("storage_kind")
+        resolved_path = payload.get("resolved_path")
+    else:
+        _require_exact_keys(payload, current_keys, "profile reference")
     if payload.get("kind") != "local":
         raise SessionCorruptError("profile reference kind must be 'local'")
     try:
         reference = LocalProfileReference(
             path=payload["path"],
+            storage_kind=storage_kind,
+            resolved_path=resolved_path,
             profile_id=payload["profile_id"],
             schema_version=payload["export_schema_version"],
             product_version=payload["product_version"],

--- a/tests/test_profile_modes.py
+++ b/tests/test_profile_modes.py
@@ -370,6 +370,25 @@ def test_open_profile_readonly_honours_the_cache_mode_override(
     )
 
 
+def test_open_profile_readonly_honours_sqlite_ingest_policy(
+    minimal_nsys_db_path, tmp_path, monkeypatch
+):
+    from nsys_ai.ai.backend.profile_db_tool import open_profile_readonly
+
+    db_path = _copy_fixture(minimal_nsys_db_path, tmp_path / "readonly_ingest.sqlite")
+    monkeypatch.setenv("NSYS_AI_INGEST", "sqlite")
+    with mock.patch(
+        "nsys_ai.parquet_cache.open_auto_db",
+        side_effect=AssertionError("sqlite ingest policy must not build a cache"),
+    ):
+        conn = open_profile_readonly(str(db_path))
+    try:
+        assert conn.execute("SELECT COUNT(*) FROM CUPTI_ACTIVITY_KIND_RUNTIME").fetchone()[0] >= 0
+    finally:
+        conn.close()
+    assert not _cache_dir_for(str(db_path)).exists()
+
+
 def test_a_declined_cache_says_so_at_warning(minimal_nsys_db_path, tmp_path, caplog):
     """A cache declined for disk reasons must be announced at WARNING, not INFO.
 

--- a/tests/test_profile_reference.py
+++ b/tests/test_profile_reference.py
@@ -93,6 +93,26 @@ def test_nsys_rep_reference_validation_accepts_parquetdir_resolution(tmp_path):
     assert validate_local_profile_reference(reference, require_file=True) is reference
 
 
+def test_parquetdir_reference_rejects_symlink_parquet_file(tmp_path):
+    parquetdir = tmp_path / "profile.parquetdir"
+    parquetdir.mkdir()
+    target = tmp_path / "outside.parquet"
+    target.write_bytes(b"parquet")
+    (parquetdir / "kernels.parquet").symlink_to(target)
+    reference = LocalProfileReference(
+        path=str(parquetdir),
+        profile_id=VALID_PROFILE_ID,
+        schema_version=None,
+        product_version=None,
+        kernel_count=1,
+        storage_kind="parquetdir",
+        resolved_path=str(parquetdir),
+    )
+
+    with pytest.raises(ValueError, match="symlink parquet files"):
+        validate_local_profile_reference(reference, require_file=True)
+
+
 def test_existing_profile_reference_has_no_local_artifact_or_cache_side_effects(
     minimal_nsys_db_path, tmp_path
 ):

--- a/tests/test_profile_reference.py
+++ b/tests/test_profile_reference.py
@@ -113,6 +113,43 @@ def test_parquetdir_reference_rejects_symlink_parquet_file(tmp_path):
         validate_local_profile_reference(reference, require_file=True)
 
 
+@pytest.mark.parametrize("source_kind", ["rep", "parquetdir", "parquet_file"])
+def test_profile_reference_rejects_symlinked_ingest_source_before_profile(
+    tmp_path, monkeypatch, source_kind
+):
+    import nsys_ai.profile_runner as profile_runner
+
+    real_source = tmp_path / "real.nsys-rep"
+    real_source.write_bytes(b"capture")
+    source = tmp_path / "input.nsys-rep"
+    source.symlink_to(real_source)
+    if source_kind == "parquetdir":
+        real_source = tmp_path / "real.parquetdir"
+        real_source.mkdir()
+        (real_source / "kernels.parquet").write_bytes(b"parquet")
+        source = tmp_path / "input.parquetdir"
+        source.symlink_to(real_source, target_is_directory=True)
+    elif source_kind == "parquet_file":
+        source = tmp_path / "input.parquetdir"
+        source.mkdir()
+        parquet_target = tmp_path / "kernels.parquet"
+        parquet_target.write_bytes(b"parquet")
+        (source / "kernels.parquet").symlink_to(parquet_target)
+
+    called = False
+    real_profile = profile_runner.Profile
+
+    def unexpected_profile(*args, **kwargs):
+        nonlocal called
+        called = True
+        return real_profile(*args, **kwargs)
+
+    monkeypatch.setattr(profile_runner, "Profile", unexpected_profile)
+    with pytest.raises(ProfileError):
+        build_local_profile_reference(source)
+    assert not called
+
+
 def test_existing_profile_reference_has_no_local_artifact_or_cache_side_effects(
     minimal_nsys_db_path, tmp_path
 ):

--- a/tests/test_profile_reference.py
+++ b/tests/test_profile_reference.py
@@ -60,6 +60,39 @@ def test_existing_profile_reference_matches_profile_and_evidence_identity(
     assert reference.kernel_count == 5
 
 
+def test_parquetdir_reference_records_source_and_resolved_storage(tmp_path):
+    from test_parquetdir_backend import _create_parquetdir_profile
+
+    cache = Path(_create_parquetdir_profile(tmp_path / "mock.parquetdir"))
+
+    reference = build_local_profile_reference(cache)
+
+    assert reference.storage_kind == "parquetdir"
+    assert reference.path == str(cache.absolute())
+    assert reference.resolved_path == str(cache.absolute())
+    assert reference.profile_id.startswith("nsys2:")
+    assert reference.kernel_count > 0
+
+
+def test_nsys_rep_reference_validation_accepts_parquetdir_resolution(tmp_path):
+    source = tmp_path / "profile.nsys-rep"
+    resolved = tmp_path / "profile.parquetdir"
+    source.write_bytes(b"capture")
+    resolved.mkdir()
+    (resolved / "kernels.parquet").write_bytes(b"parquet")
+    reference = LocalProfileReference(
+        path=str(source),
+        profile_id=VALID_PROFILE_ID,
+        schema_version=None,
+        product_version=None,
+        kernel_count=1,
+        storage_kind="nsys-rep",
+        resolved_path=str(resolved),
+    )
+
+    assert validate_local_profile_reference(reference, require_file=True) is reference
+
+
 def test_existing_profile_reference_has_no_local_artifact_or_cache_side_effects(
     minimal_nsys_db_path, tmp_path
 ):
@@ -93,7 +126,6 @@ def test_relative_profile_path_is_normalized_without_copying(
     [
         ("", "must not be empty"),
         (b"profile.sqlite", "must be a path string"),
-        ("profile.nsys-rep", "must name a .sqlite file"),
         ("bad\x00.sqlite", "must not contain NUL bytes"),
     ],
 )

--- a/tests/test_profile_resolve.py
+++ b/tests/test_profile_resolve.py
@@ -97,7 +97,7 @@ def test_resolve_nsys_rep_missing_nsys_reuses_blobless_sqlite(
         conn.commit()
 
     with caplog.at_level(logging.WARNING, logger="nsys_ai.profile"):
-        out = profile_mod.resolve_profile_path(str(rep))
+        out = profile_mod.resolve_profile_path(str(rep), backend="sqlite")
     assert out == str(sqlite_path)
     assert any("without NVTX payload blobs" in r.message for r in caplog.records)
 
@@ -126,7 +126,7 @@ def test_resolve_nsys_rep_success(monkeypatch, tmp_path: Path):
 
     rep = tmp_path / "foo.nsys-rep"
     rep.write_bytes(b"0")
-    out = profile_mod.resolve_profile_path(str(rep))
+    out = profile_mod.resolve_profile_path(str(rep), backend="sqlite")
     assert out.endswith(".sqlite")
     args = calls["args"]
     assert args[0] == "/opt/nsys"
@@ -155,7 +155,9 @@ def test_resolve_nsys_rep_uses_selected_executable(monkeypatch, tmp_path: Path):
     rep = tmp_path / "selected.nsys-rep"
     rep.write_bytes(b"report")
 
-    profile_mod.resolve_profile_path(str(rep), nsys_executable=selected)
+    profile_mod.resolve_profile_path(
+        str(rep), backend="sqlite", nsys_executable=selected
+    )
 
     assert which_calls == [selected]
 
@@ -190,6 +192,47 @@ def test_resolve_nsys_rep_parquetdir_success(monkeypatch, tmp_path: Path):
     assert "--include-blobs=true" in args
 
 
+def test_resolve_nsys_rep_defaults_to_parquetdir(monkeypatch, tmp_path: Path):
+    monkeypatch.setattr(profile_mod.shutil, "which", lambda name: "/opt/nsys")
+
+    def fake_run(args, **kwargs):
+        out_dir = Path(args[args.index("-o") + 1])
+        out_dir.mkdir()
+        (out_dir / "kernels.parquet").write_bytes(b"parquet")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(profile_mod.subprocess, "run", fake_run)
+    rep = tmp_path / "foo.nsys-rep"
+    rep.write_bytes(b"report")
+
+    resolution = profile_mod.resolve_profile(str(rep))
+    assert resolution.storage_kind == "nsys-rep"
+    assert resolution.backend == "parquetdir"
+    assert resolution.resolved_path.endswith(".parquetdir")
+
+
+def test_sqlite_ingest_policy_skips_cache_and_exports_sqlite(
+    monkeypatch, tmp_path: Path
+):
+    monkeypatch.setenv("NSYS_AI_INGEST", "sqlite")
+    monkeypatch.setattr(profile_mod.shutil, "which", lambda name: "/opt/nsys")
+
+    def fake_run(args, **kwargs):
+        out = Path(args[args.index("-o") + 1])
+        out.write_bytes(b"sqlite")
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(profile_mod.subprocess, "run", fake_run)
+    rep = tmp_path / "foo.nsys-rep"
+    rep.write_bytes(b"report")
+
+    resolution = profile_mod.resolve_profile(str(rep))
+    assert resolution.storage_kind == "nsys-rep"
+    assert resolution.backend == "sqlite"
+    assert resolution.cache_mode == "direct"
+    assert resolution.resolved_path.endswith(".sqlite")
+
+
 def test_resolve_nsys_rep_failure(monkeypatch, tmp_path: Path):
     """If nsys export fails, the stderr/stdout should be surfaced in a RuntimeError."""
     monkeypatch.setattr(profile_mod.shutil, "which", lambda name: "/opt/nsys")
@@ -202,7 +245,7 @@ def test_resolve_nsys_rep_failure(monkeypatch, tmp_path: Path):
     rep = tmp_path / "foo.nsys-rep"
     rep.write_bytes(b"0")
     with pytest.raises(ExportError) as exc:
-        profile_mod.resolve_profile_path(str(rep))
+        profile_mod.resolve_profile_path(str(rep), backend="sqlite")
     assert "nsys export failed" in str(exc.value)
     assert "nsys error" in str(exc.value)
 

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -234,6 +234,22 @@ def test_runner_reuses_public_profile_reference_factory(
     assert calls == [(Path(result.sqlite_path), {})]
 
 
+def test_runner_keeps_sqlite_result_contract_under_auto_ingest(
+    tmp_path, fake_nsys, monkeypatch
+):
+    monkeypatch.setenv("NSYS_AI_INGEST", "auto")
+
+    result = _run(tmp_path, fake_nsys)
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert result.sqlite_path is not None
+    assert result.sqlite_path.endswith(".sqlite")
+    assert result.profile is not None
+    assert result.profile.storage_kind == "sqlite"
+    assert result.profile.resolved_path == result.sqlite_path
+    assert not Path(result.sqlite_path).with_suffix(".parquetdir").exists()
+
+
 @pytest.mark.parametrize(
     ("mode", "expected"),
     [

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -161,6 +161,12 @@ def _spec(mode="valid", **overrides):
     return RunSpec(**values)
 
 
+@pytest.fixture(autouse=True)
+def sqlite_compat_ingest_policy(monkeypatch):
+    """Keep runner artifact tests on the explicit SQLite compatibility path."""
+    monkeypatch.setenv("NSYS_AI_INGEST", "sqlite")
+
+
 def _run(tmp_path, fake_nsys, mode="valid", **spec_overrides):
     runner = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys))
     return runner.run(_spec(mode, **spec_overrides))

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -352,6 +352,8 @@ def test_complete_session_round_trip_uses_exact_layout_and_local_references(tmp_
     assert manifest["profiles"]["before"] == {
         "kind": "local",
         "path": before.path,
+        "storage_kind": before.storage_kind,
+        "resolved_path": before.resolved_path,
         "profile_id": before.profile_id,
         "export_schema_version": before.schema_version,
         "product_version": before.product_version,
@@ -429,6 +431,19 @@ def test_rejected_finding_reopens_session_for_a_different_finding(tmp_path):
     snapshot = store.load("multi-finding")
     assert [decision["finding_id"] for decision in snapshot.decisions] == ["f1", "f2"]
     assert snapshot.diff["decision"]["status"] == "accepted"
+
+
+def test_legacy_session_profile_reference_defaults_to_sqlite_path(tmp_path):
+    profile = _profile_reference(tmp_path / "legacy.sqlite", "legacy")
+    payload = SessionState(session_id="legacy", before_profile=profile).to_dict()
+    payload["profiles"]["before"].pop("storage_kind")
+    payload["profiles"]["before"].pop("resolved_path")
+
+    restored = SessionState.from_dict(payload)
+
+    assert restored.before_profile is not None
+    assert restored.before_profile.storage_kind == "sqlite"
+    assert restored.before_profile.resolved_path == restored.before_profile.path
 
 
 def test_active_writer_conflict_is_observed_from_a_second_process(tmp_path):


### PR DESCRIPTION
## Summary

- make profile ingest resolution explicit and shared across profile, runner, and read-only chat paths
- prefer `.nsys-rep` → parquetdir while preserving explicit sqlite compatibility and direct/cache behavior
- persist additive `storage_kind` and `resolved_path` metadata in `LocalProfileReference`
- keep legacy session profile references loadable and validate parquetdir/source paths
- honor the explicit sqlite compatibility policy in read-only consumers and runner outputs
- reject parquet-file symlinks inside parquetdir inputs
- reject unsafe source/directory paths before any ingest/export side effect

## Issue

Closes #431

## Validation

- `PYTHONPATH=src pytest -q tests/test_profile_resolve.py tests/test_profile_reference.py tests/test_profile_runner.py tests/test_session_store.py tests/test_profile_modes.py tests/test_parquetdir_backend.py tests/test_profile_query_conn.py tests/test_chat_connection_threading.py`
- `ruff check src tests`
- `git diff --check`

Focused suite: `298 passed` after review fixes.
