### PR TITLE
feat(session): add portable transport handoff contract

### DIFF
--- a/docs/notes/session-wiring-design.md
+++ b/docs/notes/session-wiring-design.md
@@ -196,7 +196,7 @@ Concrete split:
 
 14. **Fingerprint cost on naive `str` → `LocalProfileReference` conversion** (Deliverable 5b). Calling `build_local_profile_reference` on every path touch re-opens SQLite and re-runs identity SQL including a full kernel `COUNT(*)`.
 
-15. **CWD-relative default session root (C1).** `SessionStore.__init__` defaults to `.nsys-ai/sessions` resolved from process CWD (`session_store.py:331-332`). A browser server started in a different directory than the CLI that created the session will not see it. C1 explicitly forbids a root flag; processes must share CWD (or an equivalent agreed working directory).
+15. **Portable session handoff (C1).** `SessionStore.__init__` still defaults to `.nsys-ai/sessions` resolved from process CWD (`session_store.py:331-332`), preserving the legacy id form. The transport contract also accepts the session directory itself; its parent becomes the store root, so a browser, TUI, plugin, or MCP process started in another directory can open the same artifacts without a root flag.
 
 ---
 
@@ -208,8 +208,8 @@ Under **C1** (decided; not re-opened):
 
 | piece | rule | how a web or TUI process gets it |
 |---|---|---|
-| `root` | Always `.nsys-ai/sessions` relative to the working directory. **No flag.** | Construct `SessionStore()` / `SessionStore(".nsys-ai/sessions")` (`session_store.py:331`). Same convention as `.git`. Web `serve_timeline` and both TUIs use process CWD. A CLI that created the session must have been run from that same working directory. |
-| `session_id` when `--session <id>` is given | Caller-supplied; validated by `_SESSION_ID` (`session_store.py:72`, `:927-930`) | Open contract must accept `--session <id>` (or an equivalent open argument) and pass it to `SessionStore.load` / `writer`. **Today:** `cli/parsers.py` has zero `session` strings — the flag does not exist yet; C1 says it must. |
+| `root` | Defaults to `.nsys-ai/sessions` relative to the working directory for legacy ids; an explicit session directory uses its parent. | Construct through `session_cli.resolve_session_location`, then pass the resulting root to `SessionStore` and Web/TUI. The directory form is the portable handoff. |
+| `session` when `--session <dir>` is given | The basename is the caller-supplied id, validated by `_SESSION_ID`; the directory parent is the root. A bare value remains a legacy id. | Open contract passes the normalized id/root to `SessionStore.load` / `writer`; MCP `get_session` returns the same projection without mutation. |
 | `session_id` when no id is given | **Derived** from the before profile's content id that `LocalProfileReference` already carries (`profile_reference.py:23`) | Open with a before profile path → `build_local_profile_reference(before_path)` once (`profile_runner.py:130`) → use `reference.profile_id` as `session_id`. Two processes pointed at the same profile land in the same session without passing anything between them. One session per before-profile is the intended model. |
 
 Measured absence today (not a design choice):

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -160,6 +160,21 @@ Three things to notice, because they are deliberate:
 
 Add `--web` to open the same session in the browser without recomputing anything.
 
+For a cross-process handoff, pass the session directory itself instead of an id:
+
+```console
+$ nsys-ai diagnose run-before/profile.sqlite --session /tmp/nsys-run-001
+$ nsys-ai review --session /tmp/nsys-run-001
+$ nsys-ai ask --session /tmp/nsys-run-001 "what is the bottleneck?"
+```
+
+The directory is the contract: its `session.json` and artifacts are opened by the CLI, Web, and
+TUI from any working directory. A bare value such as `--session run-001` remains supported and
+continues to mean `.nsys-ai/sessions/run-001` relative to the current directory.
+
+The optional MCP transport exposes the same read-only handoff as `get_session`; it returns the
+SessionStore projection rather than a second MCP-specific session schema.
+
 Two lower-level entry points remain available when you want them: `nsys-ai evidence build <profile>`
 runs the same analyzers and writes findings JSON to stdout or `-o` (add `--session` to publish, and
 `--analyzers` to pick a subset), and `nsys-ai skill list` / `nsys-ai skill run <name> <profile>` run a
@@ -268,6 +283,11 @@ Using `--session` throughout leaves a single directory describing the whole inve
 
 `session.json` records a hash of each artifact, so a file edited by hand is detectable rather than
 silently trusted.
+
+Only the short publication step takes the session writer lock. Analysis runs before that lock is
+acquired; concurrent writers receive a conflict instead of overwriting another transport's
+publication. Artifact files are written atomically and the store's recovery journal restores a
+coherent snapshot after an interrupted publication.
 
 ## Things worth knowing
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -30,6 +30,14 @@ def _cmd_profile(args, _profile):
 def _cmd_propose(args, _profile):
     """Generate a deterministic proposal artifact from one finding."""
     from nsys_ai.propose_command import run_propose_command
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+
+    location = resolve_session_location(
+        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
+    )
+    if location is not None:
+        args.session = location.session_id
+        args.session_root = location.root
 
     exit_code = run_propose_command(args)
     if exit_code:
@@ -39,11 +47,17 @@ def _cmd_propose(args, _profile):
 def _cmd_diagnose(args, _profile):
     """Thin front door: default evidence pack → session findings."""
     from nsys_ai.diagnose_command import DiagnoseCommandError, run_diagnose
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+
+    location = resolve_session_location(
+        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
+    )
 
     try:
         exit_code = run_diagnose(
             profile_path=getattr(args, "profile", None),
-            session_id=getattr(args, "session", None),
+            session_id=location.session_id if location is not None else None,
+            session_root=location.root if location is not None else DEFAULT_SESSION_ROOT,
             gpu=getattr(args, "gpu", 0) or 0,
             trim=_parse_trim(args),
             web=bool(getattr(args, "web", False)),
@@ -60,12 +74,18 @@ def _cmd_diagnose(args, _profile):
 def _cmd_review(args, _profile):
     """Thin front door: canonical before/after diff, or resume a session."""
     from nsys_ai.review_command import ReviewCommandError, run_review
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+
+    location = resolve_session_location(
+        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
+    )
 
     try:
         exit_code = run_review(
             before_path=getattr(args, "before", None),
             after_path=getattr(args, "after", None),
-            session_id=getattr(args, "session", None),
+            session_id=location.session_id if location is not None else None,
+            session_root=location.root if location is not None else DEFAULT_SESSION_ROOT,
             gpu=getattr(args, "gpu", None),
             trim=_parse_trim(args),
             web=bool(getattr(args, "web", False)),
@@ -82,6 +102,11 @@ def _cmd_review(args, _profile):
 def _cmd_optimize(args, _profile):
     """Front door over the loop: diagnose -> propose -> capture -> diff -> decision."""
     from nsys_ai.optimize_command import OptimizeCommandError, run_optimize
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+
+    location = resolve_session_location(
+        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
+    )
 
     workload = list(getattr(args, "workload", None) or [])
     if not workload:
@@ -108,7 +133,8 @@ def _cmd_optimize(args, _profile):
             before_path=args.profile,
             repo=args.repo,
             workload=workload,
-            session_id=getattr(args, "session", None),
+            session_id=location.session_id if location is not None else None,
+            session_root=location.root if location is not None else DEFAULT_SESSION_ROOT,
             nsys=getattr(args, "nsys", "nsys"),
             gpu=getattr(args, "gpu", 0) or 0,
             trim=_parse_trim(args),
@@ -955,7 +981,12 @@ def _cmd_diff(args, _profile):
     elif getattr(args, "reject", False):
         decision = "rejected"
     reason = getattr(args, "reason", None)
-    session = getattr(args, "session", None)
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+
+    raw_session = getattr(args, "session", None)
+    location = resolve_session_location(raw_session, root=DEFAULT_SESSION_ROOT)
+    session = location.session_id if location is not None else raw_session
+    session_root = location.root if location is not None else DEFAULT_SESSION_ROOT
     if session is not None and getattr(args, "chat", False):
         print("Error: --session cannot be combined with --chat", file=sys.stderr)
         sys.exit(2)
@@ -1244,6 +1275,7 @@ def _cmd_diff(args, _profile):
                 session_id=session_id,
                 diff=diff_payload,
                 after_profile=after_ref,
+                root=session_root,
             )
         except (TypeError, ValueError, ProfileError) as exc:
             print(f"Error: {exc}", file=sys.stderr)
@@ -1259,6 +1291,7 @@ def _cmd_diff(args, _profile):
                     session_id=session_id,
                     decision=decision,
                     reason=reason,
+                    root=session_root,
                 )
             except (TypeError, ValueError) as exc:
                 print(f"Error: {exc}", file=sys.stderr)
@@ -1602,7 +1635,15 @@ def _cmd_open(args, _profile):
 
 
 def _cmd_timeline_web(args, _profile):
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
     from nsys_ai.web import serve_timeline
+
+    raw_session = getattr(args, "session", None)
+    location = resolve_session_location(raw_session, root=DEFAULT_SESSION_ROOT)
+    session_value = (
+        location.session_id if location is not None else raw_session
+    )
+    session_root = location.root if location is not None else DEFAULT_SESSION_ROOT
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
@@ -1633,7 +1674,8 @@ def _cmd_timeline_web(args, _profile):
             auto_findings=auto_findings,
             loop_before=getattr(args, "loop_before", None),
             loop_h100_preset=getattr(args, "h100_preset", False),
-            session=getattr(args, "session", None),
+            session=session_value,
+            session_root=session_root,
         )
 
 
@@ -1642,6 +1684,12 @@ def _cmd_loop(args, _profile):
     from pathlib import Path
 
     trim = _parse_trim(args)
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+
+    raw_session = getattr(args, "session", None)
+    location = resolve_session_location(raw_session, root=DEFAULT_SESSION_ROOT)
+    session = location.session_id if location is not None else raw_session
+    session_root = location.root if location is not None else DEFAULT_SESSION_ROOT
     before_path = getattr(args, "before", None)
     if getattr(args, "h100_preset", False):
         from nsys_ai.loop_state import detect_h100_replay_preset
@@ -1691,11 +1739,10 @@ def _cmd_loop(args, _profile):
                 open_browser=not args.no_browser,
                 loop_before=before_path,
                 loop_h100_preset=bool(getattr(args, "h100_preset", False)),
-                session=getattr(args, "session", None),
+                session=session,
+                session_root=session_root,
             )
         return
-
-    session = getattr(args, "session", None)
 
     # Resolve the window before the surface starts, the way `open` does. These
     # surfaces cannot represent "no trim", and the profile is closed first so
@@ -1731,6 +1778,7 @@ def _cmd_loop(args, _profile):
             trim,
             min_ms=0,
             session=session,
+            session_root=session_root,
         )
         return
 
@@ -1743,6 +1791,7 @@ def _cmd_loop(args, _profile):
         max_depth=-1,
         min_ms=0,
         session=session,
+        session_root=session_root,
     )
 
 
@@ -1815,7 +1864,12 @@ def _cmd_evidence(args, _profile):
         flush=True,
     )
 
-    session = getattr(args, "session", None)
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+
+    raw_session = getattr(args, "session", None)
+    location = resolve_session_location(raw_session, root=DEFAULT_SESSION_ROOT)
+    session = location.session_id if location is not None else raw_session
+    session_root = location.root if location is not None else DEFAULT_SESSION_ROOT
     profile_path = args.profile
     if session is not None:
         # Absolute path keeps EvidenceReport.profile_id aligned with
@@ -1877,6 +1931,7 @@ def _cmd_evidence(args, _profile):
                     session_id=session_id,
                     report=report,
                     before_profile=before,
+                    root=session_root,
                 )
             except (TypeError, ValueError, ProfileError) as exc:
                 print(f"Error: {exc}", file=sys.stderr, flush=True)
@@ -2295,7 +2350,8 @@ def _cmd_agent(args, _profile):
         finally:
             agent.close()
     elif args.agent_action == "ask":
-        agent = Agent(args.profile)
+        profile_path = _resolve_ask_profile(args)
+        agent = Agent(profile_path)
         try:
             print(agent.ask(args.question))
         finally:
@@ -2309,11 +2365,40 @@ def _cmd_ask(args, _profile):
     """Simplified alias for `agent ask`."""
     from nsys_ai.agent.loop import Agent
 
-    agent = Agent(args.profile)
+    profile_path = _resolve_ask_profile(args)
+    agent = Agent(profile_path)
     try:
         print(agent.ask(args.question))
     finally:
         agent.close()
+
+
+def _resolve_ask_profile(args) -> str:
+    """Resolve Ask's profile from an explicit path or a session handoff."""
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+    from nsys_ai.session_store import SessionStore
+
+    profile_path = getattr(args, "profile", None)
+    location = resolve_session_location(
+        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
+    )
+    if profile_path:
+        return profile_path
+    if location is None:
+        print(
+            "Error: ask requires a profile, or --session <dir> with a recorded before profile",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    snapshot = SessionStore(location.root).load(location.session_id)
+    before = snapshot.state.before_profile
+    if before is None:
+        print(
+            f"Error: session {location.session_id} has no before profile",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return before.path
 
 
 def _cmd_agent_guide(args, _profile):

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -30,14 +30,6 @@ def _cmd_profile(args, _profile):
 def _cmd_propose(args, _profile):
     """Generate a deterministic proposal artifact from one finding."""
     from nsys_ai.propose_command import run_propose_command
-    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
-
-    location = resolve_session_location(
-        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
-    )
-    if location is not None:
-        args.session = location.session_id
-        args.session_root = location.root
 
     exit_code = run_propose_command(args)
     if exit_code:
@@ -47,17 +39,13 @@ def _cmd_propose(args, _profile):
 def _cmd_diagnose(args, _profile):
     """Thin front door: default evidence pack → session findings."""
     from nsys_ai.diagnose_command import DiagnoseCommandError, run_diagnose
-    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
-
-    location = resolve_session_location(
-        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
-    )
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT
 
     try:
         exit_code = run_diagnose(
             profile_path=getattr(args, "profile", None),
-            session_id=location.session_id if location is not None else None,
-            session_root=location.root if location is not None else DEFAULT_SESSION_ROOT,
+            session_id=getattr(args, "session", None),
+            session_root=DEFAULT_SESSION_ROOT,
             gpu=getattr(args, "gpu", 0) or 0,
             trim=_parse_trim(args),
             web=bool(getattr(args, "web", False)),
@@ -74,18 +62,14 @@ def _cmd_diagnose(args, _profile):
 def _cmd_review(args, _profile):
     """Thin front door: canonical before/after diff, or resume a session."""
     from nsys_ai.review_command import ReviewCommandError, run_review
-    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
-
-    location = resolve_session_location(
-        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
-    )
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT
 
     try:
         exit_code = run_review(
             before_path=getattr(args, "before", None),
             after_path=getattr(args, "after", None),
-            session_id=location.session_id if location is not None else None,
-            session_root=location.root if location is not None else DEFAULT_SESSION_ROOT,
+            session_id=getattr(args, "session", None),
+            session_root=DEFAULT_SESSION_ROOT,
             gpu=getattr(args, "gpu", None),
             trim=_parse_trim(args),
             web=bool(getattr(args, "web", False)),
@@ -102,11 +86,7 @@ def _cmd_review(args, _profile):
 def _cmd_optimize(args, _profile):
     """Front door over the loop: diagnose -> propose -> capture -> diff -> decision."""
     from nsys_ai.optimize_command import OptimizeCommandError, run_optimize
-    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
-
-    location = resolve_session_location(
-        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
-    )
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT
 
     workload = list(getattr(args, "workload", None) or [])
     if not workload:
@@ -133,8 +113,8 @@ def _cmd_optimize(args, _profile):
             before_path=args.profile,
             repo=args.repo,
             workload=workload,
-            session_id=location.session_id if location is not None else None,
-            session_root=location.root if location is not None else DEFAULT_SESSION_ROOT,
+            session_id=getattr(args, "session", None),
+            session_root=DEFAULT_SESSION_ROOT,
             nsys=getattr(args, "nsys", "nsys"),
             gpu=getattr(args, "gpu", 0) or 0,
             trim=_parse_trim(args),

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -196,7 +196,7 @@ def _register_optimize_parser(sub):
     p.add_argument(
         "--session",
         default=None,
-        metavar="ID",
+        metavar="DIR",
         help=(
             "Session to create or resume (default: derived from the before "
             "profile content id, so re-running resumes the same session)"
@@ -472,8 +472,24 @@ def _register_agent_parser(sub):
         help="Output path for findings JSON (default: findings.json)",
     )
     sp_ask = agent_sub.add_parser("ask", help="Ask a question about a profile")
-    sp_ask.add_argument("profile", help="Path to .sqlite file")
+    sp_ask.add_argument(
+        "profile",
+        nargs="?",
+        default=None,
+        help="Path to profile (.sqlite or .nsys-rep); omit when using --session",
+    )
     sp_ask.add_argument("question", help="Natural language question")
+    sp_ask.add_argument(
+        "--session",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Use the before profile from a SessionStore directory. A bare "
+            "value remains a legacy session id."
+        ),
+    )
     p.set_defaults(handler=_cmd_agent)
     return p
 
@@ -579,10 +595,11 @@ def _build_parser():
         nargs="?",
         const="",
         default=None,
-        metavar="ID",
+        metavar="DIR",
         help=(
             "Read findings from SessionStore and publish the proposal back. "
-            "Omit ID and pass --profile to derive the id from the before "
+            "Pass a session directory, or omit DIR and pass --profile to "
+            "derive the id from the before "
             "profile content id."
         ),
     )
@@ -617,10 +634,11 @@ def _build_parser():
         nargs="?",
         const="",
         default=None,
-        metavar="ID",
+        metavar="DIR",
         help=(
-            "Session id to publish into (or reopen with --web). Omit ID to "
-            "derive it from the profile content id."
+            "Session directory to publish into (or reopen with --web). A bare "
+            "value is treated as a legacy id; omit DIR to derive it from the "
+            "profile content id."
         ),
     )
     p.add_argument(
@@ -686,10 +704,11 @@ def _build_parser():
         nargs="?",
         const="",
         default=None,
-        metavar="ID",
+        metavar="DIR",
         help=(
-            "Resume an existing session and present its decision path. "
-            "Does not create a session; pair form is a comparison only."
+            "Resume an existing session directory and present its decision "
+            "path. A bare value remains a legacy id. Does not create a "
+            "session; pair form is a comparison only."
         ),
     )
     p.add_argument(
@@ -758,11 +777,11 @@ def _build_parser():
         nargs="?",
         const="",
         default=None,
-        metavar="ID",
+        metavar="DIR",
         help=(
-            "Open a SessionStore session for read/render/decide. Omit ID to "
-            "derive it from the before profile content id. Root is always "
-            ".nsys-ai/sessions under the working directory."
+            "Open a SessionStore session for read/render/decide. Pass the "
+            "session directory, or omit DIR to derive a legacy id from the "
+            "before profile content id."
         ),
     )
     p.set_defaults(handler=_cmd_timeline_web)
@@ -800,12 +819,11 @@ def _build_parser():
         nargs="?",
         const="",
         default=None,
-        metavar="ID",
+        metavar="DIR",
         help=(
             "Open a SessionStore session for read/render/decide on any surface "
-            "(timeline-web, timeline, tree). Omit ID to derive it from the "
-            "before profile content id. Root is always .nsys-ai/sessions under "
-            "the working directory."
+            "(timeline-web, timeline, tree). Pass the session directory, or "
+            "omit DIR to derive a legacy id from the before profile content id."
         ),
     )
     p.set_defaults(handler=_cmd_loop)
@@ -815,8 +833,24 @@ def _build_parser():
     p.set_defaults(handler=_cmd_chat)
 
     p = sub.add_parser("ask", help="Ask AI a backend analysis question")
-    p.add_argument("profile", help="Path to .sqlite file")
+    p.add_argument(
+        "profile",
+        nargs="?",
+        default=None,
+        help="Path to profile (.sqlite or .nsys-rep); omit when using --session",
+    )
     p.add_argument("question", help="Natural language question")
+    p.add_argument(
+        "--session",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Use the before profile from a SessionStore directory. A bare "
+            "value remains a legacy session id."
+        ),
+    )
     p.set_defaults(handler=_cmd_ask)
 
     p = sub.add_parser("agent-guide", help="Print machine-readable guide for AI agents")

--- a/src/nsys_ai/diagnose_command.py
+++ b/src/nsys_ai/diagnose_command.py
@@ -176,6 +176,11 @@ def _open_existing_session_web(
     session_root: str | os.PathLike[str],
     stderr: TextIO,
 ) -> int:
+    location = resolve_session_location(session_id, root=session_root)
+    if location is None:
+        raise DiagnoseCommandError("session is required")
+    session_id = location.session_id
+    session_root = location.root
     store = SessionStore(session_root)
     try:
         snapshot = store.load(session_id)

--- a/src/nsys_ai/diagnose_command.py
+++ b/src/nsys_ai/diagnose_command.py
@@ -14,7 +14,13 @@ from typing import TextIO
 from .exceptions import NsysAiError, ProfileError
 from .profile import Profile, resolve_profile_path
 from .profile_runner import build_local_profile_reference
-from .session_cli import publish_session_findings, resolve_session_id, session_dir
+from .session_cli import (
+    publish_session_findings,
+    resolve_session_id,
+    resolve_session_location,
+    session_argument,
+    session_dir,
+)
 from .session_store import SessionStore
 
 
@@ -83,10 +89,15 @@ def run_diagnose(
     except (OSError, ProfileError, TypeError, ValueError) as exc:
         raise DiagnoseCommandError(f"diagnose failed: {exc}") from exc
 
-    resolved_id = resolve_session_id(
+    location = resolve_session_location(
         None if session_id == "" else session_id,
-        before=before,
+        root=session_root,
     )
+    if location is None:
+        resolved_id = resolve_session_id(None, before=before)
+    else:
+        resolved_id = location.session_id
+        session_root = location.root
     try:
         publish_session_findings(
             session_id=resolved_id,
@@ -98,6 +109,7 @@ def run_diagnose(
         raise DiagnoseCommandError(str(exc)) from exc
 
     directory = session_dir(resolved_id, root=session_root)
+    session_ref = session_argument(resolved_id, root=session_root)
     print(f"Session: {resolved_id}", file=stdout)
     print(f"Findings artifact: {directory / 'findings.json'}", file=stdout)
     print(f"── Evidence Findings ({len(report.findings)}) ──", file=stdout)
@@ -124,17 +136,17 @@ def run_diagnose(
     if top_id:
         print(
             "Next: nsys-ai propose --session "
-            f"{resolved_id} --finding-id {top_id} --runspec <runspec.json>",
+            f"{session_ref} --finding-id {top_id} --runspec <runspec.json>",
             file=stdout,
         )
     else:
         print(
             "Next: no actionable finding id to propose from; "
-            f"re-open with nsys-ai diagnose --session {resolved_id} --web",
+            f"re-open with nsys-ai diagnose --session {session_ref} --web",
             file=stdout,
         )
     print(
-        f"Or open the same session: nsys-ai diagnose --session {resolved_id} --web",
+        f"Or open the same session: nsys-ai diagnose --session {session_ref} --web",
         file=stdout,
     )
 

--- a/src/nsys_ai/diagnose_command.py
+++ b/src/nsys_ai/diagnose_command.py
@@ -33,7 +33,7 @@ class DiagnoseCommandError(NsysAiError):
 def run_diagnose(
     *,
     profile_path: str | os.PathLike[str] | None = None,
-    session_id: str | None = None,
+    session_id: str | os.PathLike[str] | None = None,
     gpu: int = 0,
     trim: tuple[int, int] | None = None,
     web: bool = False,
@@ -89,6 +89,7 @@ def run_diagnose(
     except (OSError, ProfileError, TypeError, ValueError) as exc:
         raise DiagnoseCommandError(f"diagnose failed: {exc}") from exc
 
+    requested_session = session_id
     location = resolve_session_location(
         None if session_id == "" else session_id,
         root=session_root,
@@ -109,7 +110,10 @@ def run_diagnose(
         raise DiagnoseCommandError(str(exc)) from exc
 
     directory = session_dir(resolved_id, root=session_root)
-    session_ref = session_argument(resolved_id, root=session_root)
+    session_ref = session_argument(
+        requested_session if requested_session else resolved_id,
+        root=session_root,
+    )
     print(f"Session: {resolved_id}", file=stdout)
     print(f"Findings artifact: {directory / 'findings.json'}", file=stdout)
     print(f"── Evidence Findings ({len(report.findings)}) ──", file=stdout)

--- a/src/nsys_ai/mcp_server.py
+++ b/src/nsys_ai/mcp_server.py
@@ -84,6 +84,18 @@ def _list_skills() -> dict[str, Any]:
     }
 
 
+def _get_session(session: str) -> dict[str, Any]:
+    """Read the canonical SessionStore handoff without mutating it."""
+    from .session_cli import session_payload
+
+    try:
+        return _json_safe(session_payload(session))
+    except NsysAiError as exc:
+        return exc.to_dict()
+    except (OSError, TypeError, ValueError) as exc:
+        return _error("SESSION_READ_ERROR", str(exc))
+
+
 def _coerce_param(value: Any, param_type: Any) -> Any:
     """Validate the JSON value against the type declared by a SkillParam."""
     type_name = str(param_type).lower()
@@ -359,6 +371,11 @@ def create_server():
     def list_skills() -> dict[str, Any]:
         """List registered analysis skills and their parameter schemas."""
         return _list_skills()
+
+    @server.tool(name="get_session")
+    def get_session(session: str) -> dict[str, Any]:
+        """Read a CLI/Web/TUI session's canonical artifacts read-only."""
+        return _get_session(session)
 
     @server.tool(name="run_skill")
     def run_skill(

--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -68,6 +68,8 @@ from .session_cli import (
     project_loop_state,
     publish_session_diff,
     resolve_session_id,
+    resolve_session_location,
+    session_argument,
     session_dir,
 )
 from .session_store import SessionNotFoundError, SessionSnapshot, SessionStore
@@ -97,12 +99,18 @@ class OptimizeCommandError(NsysAiError):
 
 
 def _resume_command(
-    *, before_path: str, repo: str, session_id: str, workload: Sequence[str]
+    *,
+    before_path: str,
+    repo: str,
+    session_id: str,
+    session_root: str | os.PathLike[str],
+    workload: Sequence[str],
 ) -> str:
     """The single command that picks the loop up where it stopped."""
     return (
         f"nsys-ai optimize {before_path} --repo {repo} "
-        f"--session {session_id} -- {' '.join(workload)}"
+        f"--session {session_argument(session_id, root=session_root)} -- "
+        f"{' '.join(workload)}"
     )
 
 
@@ -295,11 +303,16 @@ def run_optimize(
     except ProfileCommandError as exc:
         raise OptimizeCommandError(str(exc)) from exc
 
+    location = resolve_session_location(session_id or None, root=session_root)
+    if location is not None:
+        session_id = location.session_id
+        session_root = location.root
     resolved_id = resolve_session_id(session_id or None, before=before_ref)
     resume = _resume_command(
         before_path=raw_before,
         repo=str(repo_path),
         session_id=resolved_id,
+        session_root=session_root,
         workload=normalized,
     )
     store = SessionStore(session_root)

--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -105,11 +105,12 @@ def _resume_command(
     session_id: str,
     session_root: str | os.PathLike[str],
     workload: Sequence[str],
+    session_argument_value: str | os.PathLike[str] | None = None,
 ) -> str:
     """The single command that picks the loop up where it stopped."""
     return (
         f"nsys-ai optimize {before_path} --repo {repo} "
-        f"--session {session_argument(session_id, root=session_root)} -- "
+        f"--session {session_argument(session_argument_value or session_id, root=session_root)} -- "
         f"{' '.join(workload)}"
     )
 
@@ -269,7 +270,7 @@ def run_optimize(
     before_path: str | os.PathLike[str],
     repo: str | os.PathLike[str],
     workload: Sequence[str],
-    session_id: str | None = None,
+    session_id: str | os.PathLike[str] | None = None,
     nsys: str = "nsys",
     gpu: int = 0,
     trim: tuple[int, int] | None = None,
@@ -303,6 +304,7 @@ def run_optimize(
     except ProfileCommandError as exc:
         raise OptimizeCommandError(str(exc)) from exc
 
+    requested_session = session_id
     location = resolve_session_location(session_id or None, root=session_root)
     if location is not None:
         session_id = location.session_id
@@ -314,6 +316,7 @@ def run_optimize(
         session_id=resolved_id,
         session_root=session_root,
         workload=normalized,
+        session_argument_value=requested_session,
     )
     store = SessionStore(session_root)
 

--- a/src/nsys_ai/propose_command.py
+++ b/src/nsys_ai/propose_command.py
@@ -420,6 +420,13 @@ def run_propose(
         raise ProposeCommandError("findings path is required unless --session is given")
     if findings_path is not None and session_id is not None:
         raise ProposeCommandError("pass a findings path or --session, not both")
+    if session_id:
+        from .session_cli import resolve_session_location
+
+        location = resolve_session_location(session_id, root=session_root)
+        if location is not None:
+            session_id = location.session_id
+            session_root = location.root
     if session_id is not None and not session_id:
         if profile_path is None:
             raise ProposeCommandError(
@@ -570,4 +577,5 @@ def run_propose_command(
         stdout=stdout,
         stderr=stderr,
         environment=environment,
+        session_root=getattr(args, "session_root", ".nsys-ai/sessions"),
     )

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -21,7 +21,12 @@ from typing import TextIO
 from .exceptions import NsysAiError, ProfileError
 from .profile import Profile
 from .profile import open as open_profile
-from .session_cli import project_loop_state, session_dir
+from .session_cli import (
+    project_loop_state,
+    resolve_session_location,
+    session_argument,
+    session_dir,
+)
 from .session_store import SessionSnapshot, SessionStore
 
 
@@ -68,6 +73,11 @@ def run_review(
     when ``gpu`` is ``None``. Next-step hints are written to ``stderr`` so a
     redirected stdout is exactly that report.
     """
+    if session_id is not None:
+        location = resolve_session_location(session_id, root=session_root)
+        if location is not None:
+            session_id = location.session_id
+            session_root = location.root
     has_pair = before_path is not None or after_path is not None
     if session_id is not None and not has_pair:
         return _resume_review(
@@ -224,6 +234,7 @@ def _print_decision_path(
     stdout: TextIO,
 ) -> None:
     directory = session_dir(session_id, root=session_root)
+    session_ref = session_argument(session_id, root=session_root)
     projected = project_loop_state(snapshot, session_dir_path=directory)
     print(f"Session: {session_id}", file=stdout)
     print(f"Phase: {projected.get('phase')}", file=stdout)
@@ -257,12 +268,12 @@ def _print_decision_path(
         after_path = getattr(after_ref, "path", None) or "<after>"
         print(
             "Decision path: undecided. Record it with: "
-            f"nsys-ai diff {before_path} {after_path} --session {session_id} "
+            f"nsys-ai diff {before_path} {after_path} --session {session_ref} "
             "--accept|--reject --reason TEXT",
             file=stdout,
         )
         print(
-            f"Or in the browser: nsys-ai review --session {session_id} --web",
+            f"Or in the browser: nsys-ai review --session {session_ref} --web",
             file=stdout,
         )
     else:
@@ -272,14 +283,14 @@ def _print_decision_path(
         if top_id:
             print(
                 "Decision path: no diff yet. Continue the loop with: "
-                f"nsys-ai propose --session {session_id} --finding-id {top_id} "
+                f"nsys-ai propose --session {session_ref} --finding-id {top_id} "
                 "--runspec <runspec.json>",
                 file=stdout,
             )
         else:
             print(
                 "Decision path: no diff yet. Finish propose → reprofile → "
-                f"diff --session {session_id} before a decision can be recorded.",
+                f"diff --session {session_ref} before a decision can be recorded.",
                 file=stdout,
             )
 

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -40,7 +40,7 @@ def run_review(
     *,
     before_path: str | os.PathLike[str] | None = None,
     after_path: str | os.PathLike[str] | None = None,
-    session_id: str | None = None,
+    session_id: str | os.PathLike[str] | None = None,
     gpu: int | None = None,
     trim: tuple[int, int] | None = None,
     web: bool = False,
@@ -73,6 +73,7 @@ def run_review(
     when ``gpu`` is ``None``. Next-step hints are written to ``stderr`` so a
     redirected stdout is exactly that report.
     """
+    requested_session = session_id
     if session_id is not None:
         location = resolve_session_location(session_id, root=session_root)
         if location is not None:
@@ -86,6 +87,7 @@ def run_review(
             port=port,
             open_browser=open_browser,
             session_root=session_root,
+            session_argument_value=requested_session,
             stdout=stdout,
             stderr=stderr,
         )
@@ -191,6 +193,7 @@ def _resume_review(
     port: int,
     open_browser: bool,
     session_root: str | os.PathLike[str],
+    session_argument_value: str | os.PathLike[str] | None = None,
     stdout: TextIO,
     stderr: TextIO,
 ) -> int:
@@ -205,7 +208,13 @@ def _resume_review(
     except (OSError, ProfileError, TypeError, ValueError) as exc:
         raise ReviewCommandError(str(exc)) from exc
 
-    _print_decision_path(session_id, snapshot, session_root, stdout=stdout)
+    _print_decision_path(
+        session_id,
+        snapshot,
+        session_root,
+        session_argument_value=session_argument_value,
+        stdout=stdout,
+    )
 
     if web:
         before = snapshot.state.before_profile
@@ -231,10 +240,14 @@ def _print_decision_path(
     snapshot: SessionSnapshot,
     session_root: str | os.PathLike[str],
     *,
+    session_argument_value: str | os.PathLike[str] | None = None,
     stdout: TextIO,
 ) -> None:
     directory = session_dir(session_id, root=session_root)
-    session_ref = session_argument(session_id, root=session_root)
+    session_ref = session_argument(
+        session_argument_value if session_argument_value is not None else session_id,
+        root=session_root,
+    )
     projected = project_loop_state(snapshot, session_dir_path=directory)
     print(f"Session: {session_id}", file=stdout)
     print(f"Phase: {projected.get('phase')}", file=stdout)

--- a/src/nsys_ai/session_cli.py
+++ b/src/nsys_ai/session_cli.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Mapping
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,96 @@ from .session_store import (
     SessionState,
     SessionStore,
 )
+
+DEFAULT_SESSION_ROOT = ".nsys-ai/sessions"
+
+
+@dataclass(frozen=True)
+class SessionLocation:
+    """The canonical handoff location shared by every transport.
+
+    Older callers pass a session id and use ``.nsys-ai/sessions`` relative to
+    their working directory.  New callers can pass the session directory
+    itself (for example ``/tmp/run-001``), which makes the artifact directory
+    portable across CLI, TUI, Web, and plugin processes.
+    """
+
+    session_id: str
+    root: Path
+
+    @property
+    def directory(self) -> Path:
+        return self.root / self.session_id
+
+    def store(self) -> SessionStore:
+        return SessionStore(self.root)
+
+
+def resolve_session_location(
+    value: str | os.PathLike[str] | None,
+    *,
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
+) -> SessionLocation | None:
+    """Resolve an id or an explicit session directory into one location.
+
+    A bare value remains a backwards-compatible id.  Absolute paths, paths
+    containing a directory component, and existing directories are treated as
+    the handoff directory itself; its basename is the SessionStore id and its
+    parent is the store root.  The directory need not exist yet, which lets
+    ``diagnose --session /path/to/new-session`` create it atomically.
+    """
+    if value is None or value == "":
+        return None
+    raw = os.fspath(value)
+    if not isinstance(raw, str) or not raw:
+        raise ValueError("session must be a non-empty id or directory path")
+
+    candidate = Path(raw).expanduser()
+    explicit_directory = (
+        candidate.is_absolute()
+        or candidate.parent != Path(".")
+        or raw.startswith(".")
+    )
+    if explicit_directory:
+        directory = candidate.resolve(strict=False)
+        if directory.name in {"", ".", ".."}:
+            raise ValueError("session directory must have a session id basename")
+        return SessionLocation(directory.name, directory.parent)
+
+    return SessionLocation(raw, Path(root).expanduser().resolve(strict=False))
+
+
+def session_location(
+    value: str | os.PathLike[str],
+    *,
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
+) -> SessionLocation:
+    """Resolve a required session id/path, raising a friendly ValueError."""
+    location = resolve_session_location(value, root=root)
+    if location is None:
+        raise ValueError("session is required")
+    return location
+
+
+def session_argument(
+    session_id: str | os.PathLike[str],
+    *,
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
+) -> str:
+    """Return a re-runnable session argument for a user-facing hint."""
+    location = session_location(session_id, root=root)
+    default_root = Path(DEFAULT_SESSION_ROOT).expanduser().resolve(strict=False)
+    if location.root == default_root:
+        return location.session_id
+    return str(location.directory)
+
+
+def _normalize_target(
+    session_id: str | os.PathLike[str],
+    root: str | os.PathLike[str],
+) -> tuple[str, Path]:
+    location = session_location(session_id, root=root)
+    return location.session_id, location.root
 
 
 def session_id_from_profile_id(profile_id: str) -> str:
@@ -59,9 +150,10 @@ def publish_session_findings(
     session_id: str,
     report: EvidenceReport,
     before_profile: LocalProfileReference,
-    root: str | os.PathLike[str] = ".nsys-ai/sessions",
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
 ) -> SessionState:
     """Create the session if needed, then publish findings under a short writer lease."""
+    session_id, root = _normalize_target(session_id, root)
     if not isinstance(report, EvidenceReport):
         raise TypeError("report must be an EvidenceReport")
     store = SessionStore(root)
@@ -79,9 +171,10 @@ def publish_session_proposal(
     proposal: Proposal,
     runspec: RunSpec | None = None,
     resolved_secrets: Mapping[str, str] | None = None,
-    root: str | os.PathLike[str] = ".nsys-ai/sessions",
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
 ) -> SessionState:
     """Publish an optional RunSpec then the Proposal under one writer lease."""
+    session_id, root = _normalize_target(session_id, root)
     if not isinstance(proposal, Proposal):
         raise TypeError("proposal must be a Proposal")
     store = SessionStore(root)
@@ -96,7 +189,7 @@ def publish_session_diff(
     session_id: str,
     diff: Mapping[str, Any],
     after_profile: LocalProfileReference,
-    root: str | os.PathLike[str] = ".nsys-ai/sessions",
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
 ) -> SessionState:
     """Publish undecided diff.json via SessionWriter.
 
@@ -107,6 +200,7 @@ def publish_session_diff(
     must already match ``after_profile``; ``publish_diff`` re-validates the
     references.
     """
+    session_id, root = _normalize_target(session_id, root)
     if not isinstance(diff, Mapping):
         raise TypeError("diff must be a mapping")
     store = SessionStore(root)
@@ -145,7 +239,7 @@ def publish_session_decision(
     decision: str,
     reason: str,
     decider: str | None = None,
-    root: str | os.PathLike[str] = ".nsys-ai/sessions",
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
 ) -> SessionState:
     """Record accept/reject on a session's published diff.
 
@@ -155,6 +249,7 @@ def publish_session_decision(
     ``publish_decision`` raises if the diff is missing or the finding was already
     decided; both are surfaced to the caller unchanged.
     """
+    session_id, root = _normalize_target(session_id, root)
     if not reason or not reason.strip():
         raise ValueError("a decision requires a reason")
     store = SessionStore(root)
@@ -163,9 +258,46 @@ def publish_session_decision(
     return state
 
 
-def session_dir(session_id: str, root: str | os.PathLike[str] = ".nsys-ai/sessions") -> Path:
+def session_dir(
+    session_id: str,
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
+) -> Path:
     """Return the on-disk directory for ``session_id`` under ``root``."""
-    return SessionStore(root).root / session_id
+    location = session_location(session_id, root=root)
+    return location.directory
+
+
+def load_session(
+    session: str | os.PathLike[str],
+    *,
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
+) -> SessionSnapshot:
+    """Load a session through the transport-neutral handoff facade."""
+    location = session_location(session, root=root)
+    return location.store().load(location.session_id)
+
+
+def session_payload(
+    session: str | os.PathLike[str],
+    *,
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
+) -> dict[str, Any]:
+    """Return the JSON-shaped handoff contract for plugin/MCP adapters.
+
+    This is a projection only: SessionStore remains the source of truth and
+    callers cannot mutate a session by changing the returned dictionaries.
+    """
+    location = session_location(session, root=root)
+    snapshot = location.store().load(location.session_id)
+    return {
+        "schema_version": "0.1",
+        "session": snapshot.state.to_dict(),
+        "findings": snapshot.findings.to_dict() if snapshot.findings else None,
+        "proposal": snapshot.proposal.to_dict() if snapshot.proposal else None,
+        "runspec": snapshot.runspec.to_dict() if snapshot.runspec else None,
+        "diff": dict(snapshot.diff) if snapshot.diff is not None else None,
+        "decisions": [dict(decision) for decision in snapshot.decisions],
+    }
 
 
 def project_loop_state(

--- a/src/nsys_ai/session_cli.py
+++ b/src/nsys_ai/session_cli.py
@@ -7,6 +7,7 @@ finish diagnose / propose / diff analysis before acquiring a writer lease.
 from __future__ import annotations
 
 import os
+import shlex
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,6 +39,7 @@ class SessionLocation:
 
     session_id: str
     root: Path
+    explicit: bool = False
 
     @property
     def directory(self) -> Path:
@@ -76,9 +78,9 @@ def resolve_session_location(
         directory = candidate.resolve(strict=False)
         if directory.name in {"", ".", ".."}:
             raise ValueError("session directory must have a session id basename")
-        return SessionLocation(directory.name, directory.parent)
+        return SessionLocation(directory.name, directory.parent, explicit=True)
 
-    return SessionLocation(raw, Path(root).expanduser().resolve(strict=False))
+    return SessionLocation(raw, Path(root).expanduser().resolve(strict=False), explicit=False)
 
 
 def session_location(
@@ -101,9 +103,9 @@ def session_argument(
     """Return a re-runnable session argument for a user-facing hint."""
     location = session_location(session_id, root=root)
     default_root = Path(DEFAULT_SESSION_ROOT).expanduser().resolve(strict=False)
-    if location.root == default_root:
+    if location.root == default_root and not location.explicit:
         return location.session_id
-    return str(location.directory)
+    return shlex.quote(str(location.directory))
 
 
 def _normalize_target(

--- a/src/nsys_ai/timeline/__init__.py
+++ b/src/nsys_ai/timeline/__init__.py
@@ -21,6 +21,7 @@ def run_timeline(
     trim: tuple[int, int] | None,
     min_ms: float = 0,
     session: str | None = None,
+    session_root: str = ".nsys-ai/sessions",
 ) -> None:
     """Launch the Textual horizontal timeline browser.
 
@@ -42,7 +43,14 @@ def run_timeline(
         return
     from .app import run_timeline as _run
 
-    _run(db_path, device, trim, min_ms=min_ms, session=session)
+    _run(
+        db_path,
+        device,
+        trim,
+        min_ms=min_ms,
+        session=session,
+        session_root=session_root,
+    )
 
 
 def _print_static_summary(

--- a/src/nsys_ai/timeline/app.py
+++ b/src/nsys_ai/timeline/app.py
@@ -166,6 +166,7 @@ class NsysTimelineApp(App):
         min_ms: float = 0,
         json_roots: list[dict] | None = None,
         session: str | None = None,
+        session_root: str = ".nsys-ai/sessions",
     ) -> None:
         super().__init__()
         self._db_path = db_path
@@ -177,7 +178,7 @@ class NsysTimelineApp(App):
         self._device = self._devices[0]  # backward compat for ChatPanel etc.
         self._trim = trim or (0, 0)
         self._session_id: str | None = None
-        self._session_root = ".nsys-ai/sessions"
+        self._session_root = session_root
         self._session_projection: dict | None = None
         # Always open a SessionStore session when a before profile path is
         # available (C1). from_json tests may omit db_path and skip open.
@@ -877,7 +878,12 @@ class NsysTimelineApp(App):
 
     def _open_session(self, session: str) -> None:
         from ..profile_runner import build_local_profile_reference
-        from ..session_cli import project_loop_state, resolve_session_id, session_dir
+        from ..session_cli import (
+            project_loop_state,
+            resolve_session_id,
+            resolve_session_location,
+            session_dir,
+        )
         from ..session_store import SessionExistsError, SessionStore
 
         if not self._db_path:
@@ -886,7 +892,12 @@ class NsysTimelineApp(App):
                 "the session id"
             )
         before_ref = build_local_profile_reference(self._db_path)
-        session_id = resolve_session_id(session or None, before=before_ref)
+        location = resolve_session_location(session, root=self._session_root)
+        if location is not None:
+            session_id = location.session_id
+            self._session_root = str(location.root)
+        else:
+            session_id = resolve_session_id(None, before=before_ref)
         store = SessionStore(self._session_root)
         try:
             store.create(session_id, before_profile=before_ref)
@@ -1041,9 +1052,15 @@ def run_timeline(
     trim: tuple[int, int] | None,
     min_ms: float = 0,
     session: str | None = None,
+    session_root: str = ".nsys-ai/sessions",
 ) -> None:
     """Launch the Textual horizontal timeline browser."""
     app = NsysTimelineApp(
-        db_path, device, trim, min_ms=min_ms, session=session
+        db_path,
+        device,
+        trim,
+        min_ms=min_ms,
+        session=session,
+        session_root=session_root,
     )
     app.run()

--- a/src/nsys_ai/tree/__init__.py
+++ b/src/nsys_ai/tree/__init__.py
@@ -50,6 +50,7 @@ def run_tui(
     max_depth: int = -1,
     min_ms: float = 0,
     session: str | None = None,
+    session_root: str = ".nsys-ai/sessions",
 ) -> None:
     """Launch the Textual NVTX tree browser.
 
@@ -73,7 +74,15 @@ def run_tui(
         return
     from .app import run_tui as _run
 
-    _run(db_path, device, trim, max_depth=max_depth, min_ms=min_ms, session=session)
+    _run(
+        db_path,
+        device,
+        trim,
+        max_depth=max_depth,
+        min_ms=min_ms,
+        session=session,
+        session_root=session_root,
+    )
 
 
 def _print_static_tree(

--- a/src/nsys_ai/tree/app.py
+++ b/src/nsys_ai/tree/app.py
@@ -145,13 +145,14 @@ class NsysTreeApp(App):
         min_ms: float = 0,
         json_roots: list[dict] | None = None,
         session: str | None = None,
+        session_root: str = ".nsys-ai/sessions",
     ) -> None:
         super().__init__()
         self._db_path = db_path
         self._device = device
         self._trim = trim or (0, 0)
         self._session_id: str | None = None
-        self._session_root = ".nsys-ai/sessions"
+        self._session_root = session_root
         self._session_projection: dict | None = None
         # Always open a SessionStore session when a before profile path is
         # available (C1). from_json tests may omit db_path and skip open.
@@ -729,7 +730,12 @@ class NsysTreeApp(App):
 
     def _open_session(self, session: str) -> None:
         from ..profile_runner import build_local_profile_reference
-        from ..session_cli import project_loop_state, resolve_session_id, session_dir
+        from ..session_cli import (
+            project_loop_state,
+            resolve_session_id,
+            resolve_session_location,
+            session_dir,
+        )
         from ..session_store import SessionExistsError, SessionStore
 
         if not self._db_path:
@@ -738,7 +744,12 @@ class NsysTreeApp(App):
                 "the session id"
             )
         before_ref = build_local_profile_reference(self._db_path)
-        session_id = resolve_session_id(session or None, before=before_ref)
+        location = resolve_session_location(session, root=self._session_root)
+        if location is not None:
+            session_id = location.session_id
+            self._session_root = str(location.root)
+        else:
+            session_id = resolve_session_id(None, before=before_ref)
         store = SessionStore(self._session_root)
         try:
             store.create(session_id, before_profile=before_ref)
@@ -894,6 +905,7 @@ def run_tui(
     max_depth: int = -1,
     min_ms: float = 0,
     session: str | None = None,
+    session_root: str = ".nsys-ai/sessions",
 ) -> None:
     """Launch the Textual NVTX tree browser."""
     app = NsysTreeApp(
@@ -903,5 +915,6 @@ def run_tui(
         max_depth=max_depth,
         min_ms=min_ms,
         session=session,
+        session_root=session_root,
     )
     app.run()

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -1029,7 +1029,12 @@ def serve_timeline(
         loop_before_path = loop_before or _profile_path
 
     from .profile_runner import build_local_profile_reference
-    from .session_cli import project_loop_state, resolve_session_id, session_dir
+    from .session_cli import (
+        project_loop_state,
+        resolve_session_id,
+        resolve_session_location,
+        session_dir,
+    )
     from .session_store import SessionExistsError, SessionStore
 
     before_for_id = loop_before_path or _profile_path
@@ -1039,7 +1044,13 @@ def serve_timeline(
             "the session id"
         )
     before_ref = build_local_profile_reference(before_for_id)
-    session_id = resolve_session_id(session or None, before=before_ref)
+    location = resolve_session_location(session or None, root=session_root)
+    if location is not None:
+        session_id = location.session_id
+        session_root = location.root
+        _ViewerHandler._session_root = os.fspath(session_root)
+    else:
+        session_id = resolve_session_id(None, before=before_ref)
     store = SessionStore(_ViewerHandler._session_root)
     try:
         store.create(session_id, before_profile=before_ref)

--- a/tests/test_diagnose_review.py
+++ b/tests/test_diagnose_review.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from nsys_ai import web
 from nsys_ai.diagnose_command import run_diagnose
+from nsys_ai.profile_runner import build_local_profile_reference
 from nsys_ai.session_cli import session_dir
 from nsys_ai.session_store import SessionStore
 
@@ -79,6 +80,32 @@ def test_diagnose_then_review_pair_both_succeed(tmp_path: Path):
     assert session_payload["phase"] == "diagnose"
     assert "mode" not in session_payload
     assert not (sessions_root / session_id / "diff.json").exists()
+
+
+def test_diagnose_web_reopens_explicit_handoff_directory(tmp_path: Path, monkeypatch):
+    """The resume form must resolve the same explicit directory as creation."""
+    handoff = tmp_path / "portable-session"
+    reference = build_local_profile_reference(BEFORE.resolve())
+    SessionStore(tmp_path).create(handoff.name, before_profile=reference)
+    captured: dict[str, object] = {}
+
+    def fake_open_session_web(**kwargs):
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("nsys_ai.diagnose_command._open_session_web", fake_open_session_web)
+
+    result = run_diagnose(
+        profile_path=None,
+        session_id=handoff,
+        web=True,
+        open_browser=False,
+        session_root=tmp_path / ".nsys-ai" / "sessions",
+    )
+
+    assert result == 0
+    assert captured["session_id"] == "portable-session"
+    assert captured["session_root"] == tmp_path
 
 
 def test_review_pair_without_session_does_not_create_nsys_ai(tmp_path: Path):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -24,6 +24,21 @@ def test_skill_catalog_matches_registry():
     )
 
 
+def test_get_session_returns_the_shared_handoff_contract(tmp_path):
+    from nsys_ai.mcp_server import _get_session
+    from nsys_ai.session_store import SessionStore
+
+    session_dir = tmp_path / "mcp-handoff"
+    SessionStore(tmp_path).create("mcp-handoff")
+
+    payload = _get_session(str(session_dir))
+
+    assert payload["schema_version"] == "0.1"
+    assert payload["session"]["session_id"] == "mcp-handoff"
+    assert payload["findings"] is None
+    assert payload["diff"] is None
+
+
 def test_run_skill_returns_rows_and_canonical_findings(profile_copy):
     from nsys_ai.mcp_server import _run_skill
 
@@ -217,4 +232,4 @@ def test_mcp_registration_exposes_the_three_read_only_tools(monkeypatch):
     server = create_server()
 
     assert server is servers[0]
-    assert set(server.tools) == {"list_skills", "run_skill", "diff_profiles"}
+    assert set(server.tools) == {"list_skills", "get_session", "run_skill", "diff_profiles"}

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -40,6 +41,14 @@ def test_session_location_supports_directory_handoff_and_legacy_ids(tmp_path: Pa
     assert resolve_session_location("tests").session_id == "tests"
     assert session_argument("tests") == "tests"
     assert session_argument(handoff) == str(handoff)
+
+    # An explicit directory must remain explicit even when it happens to sit
+    # below the default root; otherwise a copied handoff loses its location.
+    default_handoff = tmp_path / ".nsys-ai" / "sessions" / "run-001"
+    assert session_argument(default_handoff) == str(default_handoff.resolve())
+
+    spaced_handoff = tmp_path / "handoff dir" / "run-002"
+    assert session_argument(spaced_handoff) == shlex.quote(str(spaced_handoff.resolve()))
 
 
 def test_session_directory_can_be_used_by_publish_facade(tmp_path: Path):

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -10,12 +10,62 @@ import sys
 from pathlib import Path
 
 from nsys_ai.runspec import EnvironmentSpec, RunSpec
-from nsys_ai.session_cli import session_dir, session_id_from_profile_id
+from nsys_ai.session_cli import (
+    resolve_session_location,
+    session_argument,
+    session_dir,
+    session_id_from_profile_id,
+)
 from nsys_ai.session_store import SessionStore
 
 ROOT = Path(__file__).resolve().parents[1]
 BEFORE = ROOT / "tests" / "fixtures" / "mfu_2gpu_before.sqlite"
 AFTER = ROOT / "tests" / "fixtures" / "mfu_2gpu_after.sqlite"
+
+
+def test_session_location_supports_directory_handoff_and_legacy_ids(tmp_path: Path):
+    handoff = tmp_path / "portable-session"
+
+    location = resolve_session_location(handoff)
+
+    assert location is not None
+    assert location.session_id == "portable-session"
+    assert location.root == tmp_path
+    assert location.directory == handoff
+
+    legacy = resolve_session_location("legacy-session")
+    assert legacy is not None
+    assert legacy.session_id == "legacy-session"
+    assert legacy.root == Path(".nsys-ai/sessions").resolve()
+    assert resolve_session_location("tests").session_id == "tests"
+    assert session_argument("tests") == "tests"
+    assert session_argument(handoff) == str(handoff)
+
+
+def test_session_directory_can_be_used_by_publish_facade(tmp_path: Path):
+    from nsys_ai.annotation import EvidenceReport
+    from nsys_ai.profile_runner import build_local_profile_reference
+    from nsys_ai.session_cli import publish_session_findings
+
+    profile = BEFORE.resolve()
+    reference = build_local_profile_reference(profile)
+    report = EvidenceReport(
+        "diagnosis",
+        profile_path=reference.path,
+        profile_id=reference.profile_id,
+        findings=[],
+    )
+    handoff = tmp_path / "portable-session"
+
+    state = publish_session_findings(
+        session_id=handoff,
+        report=report,
+        before_profile=reference,
+    )
+
+    assert state.session_id == handoff.name
+    assert (handoff / "session.json").is_file()
+    assert (handoff / "findings.json").is_file()
 
 
 def _subprocess_environment(**extra: str) -> dict[str, str]:


### PR DESCRIPTION
## Summary

Closes #437.

- add one transport-neutral `SessionLocation` contract for legacy ids and explicit session directories
- thread the normalized session root through Diagnose, Ask, Review, Diff, Propose, Optimize, Web, and both Textual TUIs
- add the read-only MCP `get_session` projection over the same `SessionStore` artifacts
- document ownership, atomic publication, writer conflicts, and portable cross-working-directory handoff

The existing SessionStore remains the source of truth. No parallel orchestrator, SQL analysis path, or streaming/indexing framework is introduced; `stream_agent_loop` remains unchanged.

## Validation

- focused session/Web/Diagnose/Review tests: 21 passed
- CLI/TUI regression tests: 99 passed
- MCP + session contract tests: 23 passed
- ruff, compileall, CLI help smoke: passed
- full local suite: 2360 passed, 146 skipped, 4 xfailed; the repository's skip-policy test reports the pre-existing local absence of the optional integration profile (`No test profile`)

The `release/0.3.0` label is retained on the issue.
