### PR TITLE
fix(parquetdir): expose enriched kernel analysis view

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -1289,6 +1289,7 @@ def _table_has_column(db: duckdb.DuckDBPyConnection, table: str, column: str) ->
 def _create_existing_alias_views(db: duckdb.DuckDBPyConnection) -> None:
     """Create stable aliases for whatever canonical tables already exist."""
     existing_views = {r[0] for r in db.execute("SHOW TABLES").fetchall()}
+    _create_enriched_kernel_view(db, existing_views)
     for short_name, aliases in _ALIASES.items():
         actual = None
         if short_name in existing_views:
@@ -1310,6 +1311,56 @@ def _create_existing_alias_views(db: duckdb.DuckDBPyConnection) -> None:
                 existing_views.add(alias)
             except duckdb.Error:
                 pass
+
+
+def _create_enriched_kernel_view(
+    db: duckdb.DuckDBPyConnection,
+    existing_views: set[str],
+) -> None:
+    """Expose the cache-compatible ``kernels`` view for raw parquetdir data.
+
+    The SQLite-to-Parquet cache builder writes an enriched ``kernels.parquet``
+    containing resolved names and Tensor Core classification. A raw Nsight
+    parquetdir export only contains the source activity table and string-id
+    references. Keep that raw table untouched, but make the stable ``kernels``
+    alias provide the same columns so skills can use either backend.
+    """
+    if "kernels" in existing_views or "StringIds" not in existing_views:
+        return
+    kernel_table = _find_table(
+        existing_views,
+        "CUPTI_ACTIVITY_KIND_KERNEL",
+    )
+    if kernel_table is None:
+        return
+
+    try:
+        db.execute(
+            f'''
+            CREATE VIEW "kernels" AS
+            SELECT k.*,
+                   COALESCE(d.value, s.value, 'kernel_' || CAST(k.shortName AS VARCHAR)) AS name,
+                   d.value AS demangled,
+                   CAST(CASE
+                       WHEN regexp_matches(lower(COALESCE(d.value, s.value, '')), {_TC_ELIGIBLE_PATTERN})
+                         OR regexp_matches(lower(COALESCE(d.value, s.value, '')), {_TC_ACTIVE_PATTERN})
+                       THEN 1 ELSE 0
+                   END AS INTEGER) AS is_tc_eligible,
+                   CAST(CASE
+                       WHEN regexp_matches(lower(COALESCE(d.value, s.value, '')), {_TC_ACTIVE_PATTERN})
+                       THEN 1 ELSE 0
+                   END AS INTEGER) AS uses_tc
+            FROM "{kernel_table}" k
+            LEFT JOIN "StringIds" s ON k.shortName = s.id
+            LEFT JOIN "StringIds" d ON k.demangledName = d.id
+            '''
+        )
+        existing_views.add("kernels")
+    except duckdb.Error:
+        # A raw export with an incomplete kernel/string-id schema should still
+        # open; the normal schema/skill diagnostics will report the missing
+        # capability instead of making parquetdir opening fail here.
+        pass
 
 
 def _register_parquetdir_tables(

--- a/tests/test_parquetdir_backend.py
+++ b/tests/test_parquetdir_backend.py
@@ -289,6 +289,25 @@ def test_profile_parquetdir_backend_opens_and_aliases(tmp_path):
         assert prof.db.execute("SELECT COUNT(*) FROM cuda_device").fetchone()[0] == 2
 
 
+def test_top_kernels_runs_against_raw_parquetdir(tmp_path):
+    parquetdir = _create_parquetdir_profile(tmp_path / "synthetic.parquetdir")
+    skill = get_skill("top_kernels")
+    assert skill is not None
+    with Profile(parquetdir, backend="parquetdir") as prof:
+        rows = skill.execute(prof.db, limit=2)
+        enriched_columns = {
+            row[0] for row in prof.db.execute("DESCRIBE kernels").fetchall()
+        }
+        raw_columns = {
+            row[0]
+            for row in prof.db.execute("DESCRIBE CUPTI_ACTIVITY_KIND_KERNEL").fetchall()
+        }
+
+    assert rows[0]["kernel_name"] == "ncclDevKernel_AllReduce"
+    assert {"name", "demangled", "is_tc_eligible", "uses_tc"} <= enriched_columns
+    assert "name" not in raw_columns
+
+
 def test_schema_inspect_runs_on_parquetdir_backend(tmp_path):
     parquetdir = _create_parquetdir_profile(tmp_path / "synthetic.parquetdir")
     skill = get_skill("schema_inspect")


### PR DESCRIPTION
## Summary

- fix the raw parquetdir `kernels` alias to expose the same enriched analysis columns as the SQLite-to-Parquet cache
- resolve `StringIds` into `name` and `demangled`, and expose Tensor Core flags without changing the raw kernel activity view
- add a regression test that runs `top_kernels` against a raw parquetdir

## Validation

- `70 passed` — parquetdir backend, parquet cache, top-kernels, and profile query tests
- `ruff check` passed
- `compileall` passed
- real `perf.nsys-rep` `EvidenceBuilder(... only=['top_kernel_aggregates'])` produced findings without a DuckDB binder error

Closes #450
