### PR TITLE
feat(diff): add session-scoped pair index memo

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1138,14 +1138,19 @@ def _cmd_diff(args, _profile):
                 # The persisted pair memo owns the node-wide summary. Keep the
                 # per-GPU view on the existing canonical path; those rows are
                 # presentation detail, while diff.json is built from global_summary.
-                _, per_gpu = diff_profiles_all_gpus(
-                    before,
-                    after,
-                    trim=trim,
-                    limit=args.limit,
-                    sort=args.sort,
-                    regression_pct=regression_pct,
-                )
+                devices = sorted(set(before.meta.devices) | set(after.meta.devices))
+                per_gpu = {
+                    device: diff_profiles(
+                        before,
+                        after,
+                        gpu=device,
+                        trim=trim,
+                        limit=min(args.limit, 3),
+                        sort=args.sort,
+                        regression_pct=regression_pct,
+                    )
+                    for device in devices
+                }
             else:
                 global_summary, per_gpu = diff_profiles_all_gpus(
                     before,

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -968,9 +968,32 @@ def _cmd_diff(args, _profile):
     location = resolve_session_location(raw_session, root=DEFAULT_SESSION_ROOT)
     session = location.session_id if location is not None else raw_session
     session_root = location.root if location is not None else DEFAULT_SESSION_ROOT
-    diff_index = None
-    if location is not None:
-        diff_index = DiffIndex(location.directory)
+
+    def _session_directory_for_diff(raw_session, *, root=DEFAULT_SESSION_ROOT):
+        if raw_session in (None, ""):
+            return None
+        location = resolve_session_location(raw_session, root=root)
+        return location.directory if location is not None else None
+
+    def _diff_index_for_session(raw_session, *, root=DEFAULT_SESSION_ROOT):
+        """Validate the handoff before allowing DiffIndex to create artifacts."""
+        session_directory = _session_directory_for_diff(raw_session, root=root)
+        if session_directory is None:
+            return None
+        from nsys_ai.session_store import SessionError, SessionStore
+
+        session_directory = session_directory.resolve(strict=False)
+        try:
+            SessionStore(session_directory.parent).load(session_directory.name)
+        except (OSError, SessionError, TypeError, ValueError) as exc:
+            print(
+                f"Error: --session must reference an existing valid session: {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(2)
+        return DiffIndex(session_directory)
+
+    diff_index = _diff_index_for_session(session, root=session_root)
     if session is not None and getattr(args, "chat", False):
         print("Error: --session cannot be combined with --chat", file=sys.stderr)
         sys.exit(2)
@@ -1070,6 +1093,15 @@ def _cmd_diff(args, _profile):
             # Opened Profile.path is the resolved .sqlite (including .nsys-rep sidecars).
             session_before_path = before.path
             session_after_path = after.path
+            if session == "":
+                from nsys_ai.profile_runner import build_local_profile_reference
+                from nsys_ai.session_cli import resolve_session_id
+
+                before_ref = build_local_profile_reference(
+                    os.path.abspath(os.path.expanduser(before.path))
+                )
+                session = resolve_session_id(None, before=before_ref)
+                diff_index = _diff_index_for_session(session)
         if trim_before is not None and trim_after is not None:
             summary = diff_profiles(
                 before,

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -969,6 +969,8 @@ def _cmd_diff(args, _profile):
     session = location.session_id if location is not None else raw_session
     session_root = location.root if location is not None else DEFAULT_SESSION_ROOT
     diff_index = None
+    if location is not None:
+        diff_index = DiffIndex(location.directory)
     if session is not None and getattr(args, "chat", False):
         print("Error: --session cannot be combined with --chat", file=sys.stderr)
         sys.exit(2)

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -932,6 +932,7 @@ def _cmd_diff(args, _profile):
         diff_profiles_all_gpus,
     )
     from nsys_ai.diff_decision import write_diff_decision_json
+    from nsys_ai.diff_index import DiffIndex
     from nsys_ai.diff_render import (
         _fmt_confidence,
         format_diff_markdown,
@@ -967,6 +968,7 @@ def _cmd_diff(args, _profile):
     location = resolve_session_location(raw_session, root=DEFAULT_SESSION_ROOT)
     session = location.session_id if location is not None else raw_session
     session_root = location.root if location is not None else DEFAULT_SESSION_ROOT
+    diff_index = None
     if session is not None and getattr(args, "chat", False):
         print("Error: --session cannot be combined with --chat", file=sys.stderr)
         sys.exit(2)
@@ -1088,15 +1090,26 @@ def _cmd_diff(args, _profile):
             else:
                 raise RuntimeError(f"Unknown format: {args.format}")
         elif args.gpu is not None:
-            summary = diff_profiles(
-                before,
-                after,
-                gpu=args.gpu,
-                trim=trim,
-                limit=args.limit,
-                sort=args.sort,
-                regression_pct=regression_pct,
-            )
+            if diff_index is not None:
+                summary = diff_index.reconcile(
+                    before,
+                    after,
+                    gpu=args.gpu,
+                    trim=trim,
+                    limit=args.limit,
+                    sort=args.sort,
+                    regression_pct=regression_pct,
+                )
+            else:
+                summary = diff_profiles(
+                    before,
+                    after,
+                    gpu=args.gpu,
+                    trim=trim,
+                    limit=args.limit,
+                    sort=args.sort,
+                    regression_pct=regression_pct,
+                )
             gate_summary = summary
             narrative = _narrative_for(summary)
             if args.format == "terminal":
@@ -1110,14 +1123,36 @@ def _cmd_diff(args, _profile):
         else:
             # Global (all GPUs) + per-GPU breakdown. Shared with `review` so the
             # two front doors cannot drift on devices or per-GPU top-k.
-            global_summary, per_gpu = diff_profiles_all_gpus(
-                before,
-                after,
-                trim=trim,
-                limit=args.limit,
-                sort=args.sort,
-                regression_pct=regression_pct,
-            )
+            if diff_index is not None:
+                global_summary = diff_index.reconcile(
+                    before,
+                    after,
+                    gpu=None,
+                    trim=trim,
+                    limit=args.limit,
+                    sort=args.sort,
+                    regression_pct=regression_pct,
+                )
+                # The persisted pair memo owns the node-wide summary. Keep the
+                # per-GPU view on the existing canonical path; those rows are
+                # presentation detail, while diff.json is built from global_summary.
+                _, per_gpu = diff_profiles_all_gpus(
+                    before,
+                    after,
+                    trim=trim,
+                    limit=args.limit,
+                    sort=args.sort,
+                    regression_pct=regression_pct,
+                )
+            else:
+                global_summary, per_gpu = diff_profiles_all_gpus(
+                    before,
+                    after,
+                    trim=trim,
+                    limit=args.limit,
+                    sort=args.sort,
+                    regression_pct=regression_pct,
+                )
             gate_summary = global_summary
 
             narrative = _narrative_for(global_summary)

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -1150,12 +1150,18 @@ def diff_profiles(
     sort: str = "delta",
     nvtx_limit: int | None = 200,
     regression_pct: float = STEP_TIME_REGRESSION_PCT,
+    before_summary: ProfileSummary | None = None,
+    after_summary: ProfileSummary | None = None,
 ) -> ProfileDiffSummary:
     """Compare two profiles. Use trim for same window, or trim_before/trim_after for iteration diff."""
     t_before = trim_before if trim_before is not None else trim
     t_after = trim_after if trim_after is not None else trim
-    before = build_profile_summary(before_prof, gpu, t_before, nvtx_limit=nvtx_limit)
-    after = build_profile_summary(after_prof, gpu, t_after, nvtx_limit=nvtx_limit)
+    before = before_summary or build_profile_summary(
+        before_prof, gpu, t_before, nvtx_limit=nvtx_limit
+    )
+    after = after_summary or build_profile_summary(
+        after_prof, gpu, t_after, nvtx_limit=nvtx_limit
+    )
     warnings, comparability_confidence = collect_sanity_warnings(before, after)
     # Same capture on both sides, read through the same window. The trim check
     # is what keeps an iteration diff — window A of a capture against window B

--- a/src/nsys_ai/diff.py
+++ b/src/nsys_ai/diff.py
@@ -1257,8 +1257,8 @@ def diff_profiles(
     improvements.sort(key=sort_key)  # most negative first
     diff_id_params = {
         "gpu": gpu,
-        "trim_before": trim_before,
-        "trim_after": trim_after,
+        "trim_before": t_before,
+        "trim_after": t_after,
         "limit": limit,
         "sort": sort,
         "nvtx_limit": nvtx_limit,

--- a/src/nsys_ai/diff_index.py
+++ b/src/nsys_ai/diff_index.py
@@ -1,0 +1,297 @@
+"""Session-scoped memoization for before/after diff work.
+
+The index is deliberately a derived cache, not a SessionStore artifact.  A
+broken or stale file under ``indices/`` is treated as a cache miss and rebuilt;
+``diff.json`` remains the auditable source of truth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict, replace
+from pathlib import Path
+from typing import Any
+
+from .annotation import TraceSelection
+from .artifact_io import atomic_write_json
+from .diff import (
+    CategoryDelta,
+    DiffAxisEntry,
+    DiffAxisSummary,
+    KernelAgg,
+    KernelDiff,
+    NvtxAgg,
+    NvtxDiff,
+    ProfileDiffSummary,
+    ProfileSummary,
+    build_profile_summary,
+    diff_profiles,
+)
+from .fingerprint import get_profile_id, profile_id_is_capture_derived
+from .profile import Profile
+
+INDEX_SCHEMA_VERSION = "diff-index-v1"
+PAIR_SCHEMA_VERSION = "diff-pair-v1"
+
+
+def _json_read(path: Path) -> dict[str, Any] | None:
+    """Read one optional memo, returning a miss for every corruption shape."""
+    try:
+        with path.open(encoding="utf-8") as stream:
+            payload = json.load(stream)
+    except (OSError, TypeError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _path_signature(path: str) -> list[int | str]:
+    """Add a cheap source guard for identities that are not capture-derived."""
+    try:
+        stat = os.stat(path, follow_symlinks=False)
+    except OSError:
+        return [os.path.abspath(path), "missing"]
+    return [
+        os.path.abspath(path),
+        int(stat.st_dev),
+        int(stat.st_ino),
+        int(stat.st_size),
+        int(stat.st_mtime_ns),
+        int(stat.st_ctime_ns),
+    ]
+
+
+def _profile_identity(profile: Profile) -> dict[str, Any]:
+    connection = profile.conn
+    profile_id = get_profile_id(connection, fallback_path=profile.path)
+    capture_derived = profile_id_is_capture_derived(connection)
+    identity: dict[str, Any] = {
+        "profile_id": profile_id,
+        "capture_derived": capture_derived,
+    }
+    if not capture_derived:
+        identity["source_signature"] = _path_signature(profile.path)
+    return identity
+
+
+def _parameters(
+    *, gpu: int | None, trim: tuple[int, int] | None, nvtx_limit: int | None
+) -> dict[str, Any]:
+    return {
+        "gpu": gpu,
+        "trim": list(trim) if trim is not None else None,
+        "nvtx_limit": nvtx_limit,
+    }
+
+
+def _key(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _profile_summary_to_dict(summary: ProfileSummary) -> dict[str, Any]:
+    return asdict(summary)
+
+
+def _profile_summary_from_dict(payload: dict[str, Any]) -> ProfileSummary:
+    kernels = [KernelAgg(**row) for row in payload["kernels"]]
+    nvtx = [NvtxAgg(**row) for row in payload["nvtx"]]
+    return ProfileSummary(
+        path=str(payload["path"]),
+        gpu=payload.get("gpu"),
+        schema_version=payload.get("schema_version"),
+        total_gpu_ns=int(payload["total_gpu_ns"]),
+        kernel_rows=int(payload["kernel_rows"]),
+        kernels=kernels,
+        nvtx=nvtx,
+        overlap=dict(payload["overlap"]),
+        profile_id=str(payload.get("profile_id") or ""),
+        product_version=payload.get("product_version"),
+        devices=tuple(int(device) for device in payload.get("devices") or ()),
+        profile_id_is_capture_derived=bool(
+            payload.get("profile_id_is_capture_derived", False)
+        ),
+        device_kernel_ns={
+            int(device): int(total)
+            for device, total in (payload.get("device_kernel_ns") or {}).items()
+        },
+    )
+
+
+def _selection(payload: dict[str, Any] | None) -> TraceSelection | None:
+    return TraceSelection.from_dict(payload) if payload is not None else None
+
+
+def _kernel_diff(payload: dict[str, Any]) -> KernelDiff:
+    value = dict(payload)
+    value["selection"] = _selection(value.get("selection"))
+    return KernelDiff(**value)
+
+
+def _axis_summary(payload: dict[str, Any] | None) -> DiffAxisSummary | None:
+    if payload is None:
+        return None
+    entries = []
+    for raw in payload.get("entries") or []:
+        value = dict(raw)
+        value["selection"] = _selection(value.get("selection"))
+        entries.append(DiffAxisEntry(**value))
+    value = dict(payload)
+    value["entries"] = entries
+    return DiffAxisSummary(**value)
+
+
+def _diff_summary_to_dict(summary: ProfileDiffSummary) -> dict[str, Any]:
+    return asdict(summary)
+
+
+def _diff_summary_from_dict(payload: dict[str, Any]) -> ProfileDiffSummary:
+    categories = [CategoryDelta(**row) for row in payload.get("category_attribution") or []]
+    return ProfileDiffSummary(
+        before=_profile_summary_from_dict(payload["before"]),
+        after=_profile_summary_from_dict(payload["after"]),
+        warnings=[str(warning) for warning in payload.get("warnings") or []],
+        kernel_diffs=[_kernel_diff(row) for row in payload.get("kernel_diffs") or []],
+        nvtx_diffs=[NvtxDiff(**row) for row in payload.get("nvtx_diffs") or []],
+        overlap_before=dict(payload.get("overlap_before") or {}),
+        overlap_after=dict(payload.get("overlap_after") or {}),
+        overlap_delta=dict(payload.get("overlap_delta") or {}),
+        top_regressions=[_kernel_diff(row) for row in payload.get("top_regressions") or []],
+        top_improvements=[_kernel_diff(row) for row in payload.get("top_improvements") or []],
+        verdict=str(payload.get("verdict") or "neutral"),
+        comparability_confidence=float(payload.get("comparability_confidence", 1.0)),
+        category_attribution=categories,
+        communication_summary=_axis_summary(payload.get("communication_summary")),
+        idle_summary=_axis_summary(payload.get("idle_summary")),
+        step_time_delta_ms=payload.get("step_time_delta_ms"),
+        step_time_delta_pct=payload.get("step_time_delta_pct"),
+        diff_id=str(payload.get("diff_id") or ""),
+    )
+
+
+class DiffIndex:
+    """Persist side summaries and one reconciled pair summary for a session."""
+
+    def __init__(self, session_directory: str | os.PathLike[str]):
+        self.session_directory = Path(session_directory).expanduser().resolve(strict=False)
+        self.indices_directory = self.session_directory / "indices"
+
+    def _side_path(self, role: str) -> Path:
+        if role not in {"before", "after"}:
+            raise ValueError("diff index role must be before or after")
+        return self.indices_directory / f"{role}.json"
+
+    def _side_summary(
+        self,
+        role: str,
+        profile: Profile,
+        *,
+        gpu: int | None,
+        trim: tuple[int, int] | None,
+        nvtx_limit: int | None,
+    ) -> tuple[ProfileSummary, str]:
+        identity = _profile_identity(profile)
+        parameters = _parameters(gpu=gpu, trim=trim, nvtx_limit=nvtx_limit)
+        key_payload = {
+            "schema_version": INDEX_SCHEMA_VERSION,
+            "role": role,
+            "identity": identity,
+            "parameters": parameters,
+        }
+        key = _key(key_payload)
+        cached = _json_read(self._side_path(role))
+        if cached is not None and cached.get("key") == key:
+            try:
+                summary = _profile_summary_from_dict(cached["summary"])
+                return replace(summary, path=profile.path), key
+            except (KeyError, TypeError, ValueError):
+                pass
+
+        summary = build_profile_summary(
+            profile, gpu, trim, nvtx_limit=nvtx_limit
+        )
+        atomic_write_json(
+            self._side_path(role),
+            {
+                "schema_version": INDEX_SCHEMA_VERSION,
+                "key": key,
+                "role": role,
+                "identity": identity,
+                "parameters": parameters,
+                "summary": _profile_summary_to_dict(summary),
+            },
+        )
+        return summary, key
+
+    def reconcile(
+        self,
+        before: Profile,
+        after: Profile,
+        *,
+        gpu: int | None,
+        trim: tuple[int, int] | None = None,
+        limit: int = 15,
+        sort: str = "delta",
+        nvtx_limit: int | None = 200,
+        regression_pct: float = 5.0,
+    ) -> ProfileDiffSummary:
+        """Load/rebuild side indexes and reconcile a pair summary.
+
+        The pair memo is optional derived state. Any read/validation failure
+        falls through to the canonical ``diff_profiles`` computation.
+        """
+        before_summary, before_key = self._side_summary(
+            "before", before, gpu=gpu, trim=trim, nvtx_limit=nvtx_limit
+        )
+        after_summary, after_key = self._side_summary(
+            "after", after, gpu=gpu, trim=trim, nvtx_limit=nvtx_limit
+        )
+        pair_payload = {
+            "schema_version": PAIR_SCHEMA_VERSION,
+            "before_key": before_key,
+            "after_key": after_key,
+            "parameters": {
+                **_parameters(gpu=gpu, trim=trim, nvtx_limit=nvtx_limit),
+                "limit": limit,
+                "sort": sort,
+                "regression_pct": regression_pct,
+            },
+        }
+        pair_key = _key(pair_payload)
+        cached = _json_read(self.indices_directory / "pair_summary.json")
+        if cached is not None and cached.get("key") == pair_key:
+            try:
+                summary = _diff_summary_from_dict(cached["summary"])
+                return replace(
+                    summary,
+                    before=replace(summary.before, path=before.path),
+                    after=replace(summary.after, path=after.path),
+                )
+            except (KeyError, TypeError, ValueError):
+                pass
+
+        summary = diff_profiles(
+            before,
+            after,
+            gpu=gpu,
+            trim=trim,
+            limit=limit,
+            sort=sort,
+            nvtx_limit=nvtx_limit,
+            regression_pct=regression_pct,
+            before_summary=before_summary,
+            after_summary=after_summary,
+        )
+        atomic_write_json(
+            self.indices_directory / "pair_summary.json",
+            {
+                **pair_payload,
+                "key": pair_key,
+                "summary": _diff_summary_to_dict(summary),
+            },
+        )
+        return summary
+
+
+__all__ = ["DiffIndex", "INDEX_SCHEMA_VERSION", "PAIR_SCHEMA_VERSION"]

--- a/src/nsys_ai/diff_index.py
+++ b/src/nsys_ai/diff_index.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from collections.abc import Mapping
 from dataclasses import asdict, replace
 from pathlib import Path
 from typing import Any
@@ -47,12 +48,44 @@ def _json_read(path: Path) -> dict[str, Any] | None:
     return payload if isinstance(payload, dict) else None
 
 
-def _path_signature(path: str) -> list[int | str]:
-    """Add a cheap source guard for identities that are not capture-derived."""
+def _path_signature(path: str) -> list[Any]:
+    """Add a cheap source guard for identities that are not capture-derived.
+
+    A parquetdir's directory mtime is not a reliable identity: replacing one
+    parquet file can leave the directory metadata unchanged.  Record the
+    deterministic parquet manifest (metadata only, never file contents) so a
+    reused cache notices file replacement while remaining much cheaper than a
+    full content hash.
+    """
     try:
         stat = os.stat(path, follow_symlinks=False)
     except OSError:
         return [os.path.abspath(path), "missing"]
+    if os.path.isdir(path):
+        manifest: list[list[int | str]] = []
+        try:
+            children = sorted(
+                child for child in Path(path).rglob("*.parquet") if child.is_file()
+            )
+            for child in children:
+                child_stat = child.stat(follow_symlinks=False)
+                manifest.append(
+                    [
+                        child.relative_to(path).as_posix(),
+                        int(child_stat.st_size),
+                        int(child_stat.st_mtime_ns),
+                        int(child_stat.st_ctime_ns),
+                    ]
+                )
+        except OSError:
+            return [os.path.abspath(path), "unreadable", int(stat.st_mtime_ns)]
+        return [
+            os.path.abspath(path),
+            "directory",
+            int(stat.st_dev),
+            int(stat.st_ino),
+            manifest,
+        ]
     return [
         os.path.abspath(path),
         int(stat.st_dev),
@@ -120,8 +153,12 @@ def _profile_summary_from_dict(payload: dict[str, Any]) -> ProfileSummary:
     )
 
 
-def _selection(payload: dict[str, Any] | None) -> TraceSelection | None:
-    return TraceSelection.from_dict(payload) if payload is not None else None
+def _selection(payload: Mapping[str, Any] | None) -> TraceSelection | None:
+    if payload is None:
+        return None
+    if not isinstance(payload, Mapping):
+        raise ValueError("selection memo must be an object")
+    return TraceSelection.from_dict(dict(payload))
 
 
 def _kernel_diff(payload: dict[str, Any]) -> KernelDiff:
@@ -133,8 +170,12 @@ def _kernel_diff(payload: dict[str, Any]) -> KernelDiff:
 def _axis_summary(payload: dict[str, Any] | None) -> DiffAxisSummary | None:
     if payload is None:
         return None
+    if not isinstance(payload, Mapping):
+        raise ValueError("axis summary memo must be an object")
     entries = []
     for raw in payload.get("entries") or []:
+        if not isinstance(raw, Mapping):
+            raise ValueError("axis entry memo must be an object")
         value = dict(raw)
         value["selection"] = _selection(value.get("selection"))
         entries.append(DiffAxisEntry(**value))
@@ -206,7 +247,7 @@ class DiffIndex:
             try:
                 summary = _profile_summary_from_dict(cached["summary"])
                 return replace(summary, path=profile.path), key
-            except (KeyError, TypeError, ValueError):
+            except (AttributeError, KeyError, TypeError, ValueError):
                 pass
 
         summary = build_profile_summary(
@@ -284,7 +325,7 @@ class DiffIndex:
                     before=replace(summary.before, path=before.path),
                     after=replace(summary.after, path=after.path),
                 )
-            except (KeyError, TypeError, ValueError):
+            except (AttributeError, KeyError, TypeError, ValueError):
                 pass
 
         summary = diff_profiles(

--- a/src/nsys_ai/diff_index.py
+++ b/src/nsys_ai/diff_index.py
@@ -17,6 +17,7 @@ from typing import Any
 from .annotation import TraceSelection
 from .artifact_io import atomic_write_json
 from .diff import (
+    STEP_TIME_REGRESSION_PCT,
     CategoryDelta,
     DiffAxisEntry,
     DiffAxisSummary,
@@ -231,28 +232,43 @@ class DiffIndex:
         *,
         gpu: int | None,
         trim: tuple[int, int] | None = None,
+        trim_before: tuple[int, int] | None = None,
+        trim_after: tuple[int, int] | None = None,
         limit: int = 15,
         sort: str = "delta",
         nvtx_limit: int | None = 200,
-        regression_pct: float = 5.0,
+        regression_pct: float = STEP_TIME_REGRESSION_PCT,
     ) -> ProfileDiffSummary:
         """Load/rebuild side indexes and reconcile a pair summary.
 
         The pair memo is optional derived state. Any read/validation failure
         falls through to the canonical ``diff_profiles`` computation.
         """
+        effective_trim_before = trim_before if trim_before is not None else trim
+        effective_trim_after = trim_after if trim_after is not None else trim
         before_summary, before_key = self._side_summary(
-            "before", before, gpu=gpu, trim=trim, nvtx_limit=nvtx_limit
+            "before", before, gpu=gpu, trim=effective_trim_before, nvtx_limit=nvtx_limit
         )
         after_summary, after_key = self._side_summary(
-            "after", after, gpu=gpu, trim=trim, nvtx_limit=nvtx_limit
+            "after", after, gpu=gpu, trim=effective_trim_after, nvtx_limit=nvtx_limit
         )
         pair_payload = {
             "schema_version": PAIR_SCHEMA_VERSION,
             "before_key": before_key,
             "after_key": after_key,
             "parameters": {
-                **_parameters(gpu=gpu, trim=trim, nvtx_limit=nvtx_limit),
+                "gpu": gpu,
+                "trim_before": (
+                    list(effective_trim_before)
+                    if effective_trim_before is not None
+                    else None
+                ),
+                "trim_after": (
+                    list(effective_trim_after)
+                    if effective_trim_after is not None
+                    else None
+                ),
+                "nvtx_limit": nvtx_limit,
                 "limit": limit,
                 "sort": sort,
                 "regression_pct": regression_pct,
@@ -276,6 +292,8 @@ class DiffIndex:
             after,
             gpu=gpu,
             trim=trim,
+            trim_before=effective_trim_before,
+            trim_after=effective_trim_after,
             limit=limit,
             sort=sort,
             nvtx_limit=nvtx_limit,

--- a/src/nsys_ai/diff_tools.py
+++ b/src/nsys_ai/diff_tools.py
@@ -23,12 +23,16 @@ import json
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .ai.backend.chat_tools import TOOL_COMPUTE_MFU, TOOL_GET_GPU_PEAK_TFLOPS
 from .diff import ProfileDiffSummary, diff_profiles
 from .nvtx_tree import build_nvtx_tree
 from .overlap import detect_iterations, overlap_analysis
 from .profile import Profile
+
+if TYPE_CHECKING:
+    from .diff_index import DiffIndex
 
 
 def _top_k_payload(summary: ProfileDiffSummary, top_n: int = 5) -> tuple[list, list, float]:
@@ -86,19 +90,33 @@ class DiffContext:
     after: Profile
     trim: tuple[int, int] | None
     marker: str
+    index: DiffIndex | None = None
     _cached_summary: ProfileDiffSummary | None = field(default=None, repr=False)
+    _cached_gpu: int | None = field(default=None, repr=False)
 
     def ensure_summary(self, gpu: int | None) -> ProfileDiffSummary:
-        if self._cached_summary is None:
-            self._cached_summary = diff_profiles(
-                self.before,
-                self.after,
-                gpu=gpu,
-                trim=self.trim,
-                limit=500,
-                sort="delta",
-                nvtx_limit=500,
-            )
+        if self._cached_summary is None or self._cached_gpu != gpu:
+            if self.index is not None:
+                self._cached_summary = self.index.reconcile(
+                    self.before,
+                    self.after,
+                    gpu=gpu,
+                    trim=self.trim,
+                    limit=500,
+                    sort="delta",
+                    nvtx_limit=500,
+                )
+            else:
+                self._cached_summary = diff_profiles(
+                    self.before,
+                    self.after,
+                    gpu=gpu,
+                    trim=self.trim,
+                    limit=500,
+                    sort="delta",
+                    nvtx_limit=500,
+                )
+            self._cached_gpu = gpu
         return self._cached_summary
 
     @property

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1085,11 +1085,11 @@ def test_diff_cli_derived_session_does_not_pollute_session_root(tmp_path):
         env=_decision_cli_env(tmp_path),
     )
 
-    # No session exists yet, so publishing is expected to fail after the
-    # deterministic diff has been memoized. The regression is the location of
-    # that memo, not the later SessionStore precondition.
+    # No session exists yet, so the command must fail before profile analysis or
+    # memo publication. In particular, it must not leave an orphan handoff that
+    # blocks a later evidence build using the same derived session id.
     assert result.returncode != 0
-    assert not (tmp_path / ".nsys-ai" / "sessions" / "indices").exists()
+    assert not (tmp_path / ".nsys-ai").exists()
 
 
 def test_diff_cli_gate_tightens_threshold_and_implies_exit(tmp_path):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -701,6 +701,35 @@ def test_diff_with_trim_before_trim_after(tmp_path):
     assert kB.delta_ns == -20  # 10 - 30
 
 
+def test_diff_id_keys_effective_asymmetric_trim_windows(tmp_path):
+    """The id must distinguish the actual before/after windows used."""
+    from nsys_ai import profile as profile_mod
+    from nsys_ai.diff import diff_profiles
+
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(100, 110, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(200, 220, 0, 7, 1, 1, 2)])
+
+    with profile_mod.open(str(before)) as b, profile_mod.open(str(after)) as a:
+        first = diff_profiles(
+            b,
+            a,
+            gpu=0,
+            trim_before=(0, 150),
+            trim_after=(150, 250),
+        )
+        second = diff_profiles(
+            b,
+            a,
+            gpu=0,
+            trim_before=(0, 150),
+            trim_after=(250, 350),
+        )
+
+    assert first.diff_id != second.diff_id
+
+
 def test_diff_tools_search_nvtx_regions(tmp_path):
     """Phase C: search_nvtx_regions returns merged before/after NVTX names."""
     from nsys_ai import profile as profile_mod
@@ -1036,6 +1065,31 @@ def test_diff_cli_gate_help_and_validation(tmp_path):
         bad = _run_diff_cli(before, after, f"--gate={invalid}")
         assert bad.returncode == 2, f"--gate {invalid} should be rejected"
         assert "positive percentage" in bad.stderr
+
+
+def test_diff_cli_derived_session_does_not_pollute_session_root(tmp_path):
+    """Bare ``--session`` derives its index directory after opening the profile."""
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--format",
+        "json",
+        "--no-ai",
+        "--session",
+        cwd=tmp_path,
+        env=_decision_cli_env(tmp_path),
+    )
+
+    # No session exists yet, so publishing is expected to fail after the
+    # deterministic diff has been memoized. The regression is the location of
+    # that memo, not the later SessionStore precondition.
+    assert result.returncode != 0
+    assert not (tmp_path / ".nsys-ai" / "sessions" / "indices").exists()
 
 
 def test_diff_cli_gate_tightens_threshold_and_implies_exit(tmp_path):

--- a/tests/test_diff_index.py
+++ b/tests/test_diff_index.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 from nsys_ai.diff import ProfileDiffSummary, ProfileSummary
-from nsys_ai.diff_index import DiffIndex
+from nsys_ai.diff_index import DiffIndex, _path_signature, _selection
 
 
 class _FakeProfile:
@@ -140,3 +140,24 @@ def test_diff_parameters_are_part_of_side_and_pair_keys(tmp_path, monkeypatch):
     index.reconcile(before, after, gpu=1, trim=(100, 200), nvtx_limit=20)
 
     assert builds == [(0, (0, 100), 10), (0, (0, 100), 10), (1, (100, 200), 20), (1, (100, 200), 20)]
+
+
+def test_parquetdir_signature_changes_when_a_file_is_replaced(tmp_path):
+    parquetdir = tmp_path / "profile.parquetdir"
+    parquetdir.mkdir()
+    parquet = parquetdir / "kernels.parquet"
+    parquet.write_bytes(b"before")
+    before = _path_signature(str(parquetdir))
+
+    parquet.write_bytes(b"after-content")
+    parquet.touch()
+    after = _path_signature(str(parquetdir))
+
+    assert before != after
+
+
+def test_malformed_nested_selection_is_a_recoverable_memo_error():
+    import pytest
+
+    with pytest.raises(ValueError, match="selection memo"):
+        _selection([])  # type: ignore[arg-type]

--- a/tests/test_diff_index.py
+++ b/tests/test_diff_index.py
@@ -1,0 +1,142 @@
+"""Persistent side-summary and pair reconciliation tests for #433."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from nsys_ai.diff import ProfileDiffSummary, ProfileSummary
+from nsys_ai.diff_index import DiffIndex
+
+
+class _FakeProfile:
+    def __init__(self, path: Path):
+        self.path = str(path)
+        self.conn = object()
+
+
+def _summary(profile: _FakeProfile, profile_id: str, gpu: int | None, trim):
+    return ProfileSummary(
+        path=profile.path,
+        gpu=gpu,
+        schema_version="3.25.0",
+        product_version="2026.2.1",
+        total_gpu_ns=10,
+        kernel_rows=1,
+        kernels=[],
+        nvtx=[],
+        overlap={},
+        profile_id=profile_id,
+        profile_id_is_capture_derived=True,
+    )
+
+
+def _pair(before: ProfileSummary, after: ProfileSummary) -> ProfileDiffSummary:
+    return ProfileDiffSummary(
+        before=before,
+        after=after,
+        warnings=[],
+        kernel_diffs=[],
+        nvtx_diffs=[],
+        overlap_before={},
+        overlap_after={},
+        overlap_delta={},
+        top_regressions=[],
+        top_improvements=[],
+        diff_id=f"{before.profile_id}:{after.profile_id}",
+    )
+
+
+def test_reconcile_reuses_before_and_rebuilds_only_changed_after(tmp_path, monkeypatch):
+    before = _FakeProfile(tmp_path / "before.sqlite")
+    after = _FakeProfile(tmp_path / "after.sqlite")
+    ids = {before.path: "before-v1", after.path: "after-v1"}
+    builds: list[str] = []
+    diffs: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        "nsys_ai.diff_index._profile_identity",
+        lambda profile: {"profile_id": ids[profile.path], "capture_derived": True},
+    )
+
+    def build(profile, gpu, trim, *, nvtx_limit):
+        builds.append(profile.path)
+        return _summary(profile, ids[profile.path], gpu, trim)
+
+    def diff(before_profile, after_profile, **kwargs):
+        diffs.append((kwargs["before_summary"].profile_id, kwargs["after_summary"].profile_id))
+        return _pair(kwargs["before_summary"], kwargs["after_summary"])
+
+    monkeypatch.setattr("nsys_ai.diff_index.build_profile_summary", build)
+    monkeypatch.setattr("nsys_ai.diff_index.diff_profiles", diff)
+    index = DiffIndex(tmp_path / "session")
+
+    index.reconcile(before, after, gpu=0, trim=(0, 100), limit=5, nvtx_limit=10)
+    index.reconcile(before, after, gpu=0, trim=(0, 100), limit=5, nvtx_limit=10)
+
+    assert builds == [before.path, after.path]
+    assert diffs == [("before-v1", "after-v1")]
+    assert (tmp_path / "session" / "indices" / "pair_summary.json").is_file()
+
+    ids[after.path] = "after-v2"
+    index.reconcile(before, after, gpu=0, trim=(0, 100), limit=5, nvtx_limit=10)
+    assert builds == [before.path, after.path, after.path]
+    assert diffs[-1] == ("before-v1", "after-v2")
+
+
+def test_corrupt_pair_memo_is_a_cache_miss(tmp_path, monkeypatch):
+    before = _FakeProfile(tmp_path / "before.sqlite")
+    after = _FakeProfile(tmp_path / "after.sqlite")
+    monkeypatch.setattr(
+        "nsys_ai.diff_index._profile_identity",
+        lambda profile: {"profile_id": Path(profile.path).stem, "capture_derived": True},
+    )
+    monkeypatch.setattr(
+        "nsys_ai.diff_index.build_profile_summary",
+        lambda profile, gpu, trim, *, nvtx_limit: _summary(
+            profile, Path(profile.path).stem, gpu, trim
+        ),
+    )
+    calls = {"diff": 0}
+
+    def diff(before_profile, after_profile, **kwargs):
+        calls["diff"] += 1
+        return _pair(kwargs["before_summary"], kwargs["after_summary"])
+
+    monkeypatch.setattr("nsys_ai.diff_index.diff_profiles", diff)
+    index = DiffIndex(tmp_path / "session")
+    index.reconcile(before, after, gpu=None)
+    pair_path = tmp_path / "session" / "indices" / "pair_summary.json"
+    pair_path.write_text("{not-json", encoding="utf-8")
+
+    index.reconcile(before, after, gpu=None)
+
+    assert calls["diff"] == 2
+    assert json.loads(pair_path.read_text(encoding="utf-8"))["schema_version"] == "diff-pair-v1"
+
+
+def test_diff_parameters_are_part_of_side_and_pair_keys(tmp_path, monkeypatch):
+    before = _FakeProfile(tmp_path / "before.sqlite")
+    after = _FakeProfile(tmp_path / "after.sqlite")
+    monkeypatch.setattr(
+        "nsys_ai.diff_index._profile_identity",
+        lambda profile: {"profile_id": Path(profile.path).stem, "capture_derived": True},
+    )
+    builds: list[tuple[int | None, tuple[int, int] | None, int | None]] = []
+
+    def build(profile, gpu, trim, *, nvtx_limit):
+        builds.append((gpu, trim, nvtx_limit))
+        return _summary(profile, Path(profile.path).stem, gpu, trim)
+
+    monkeypatch.setattr("nsys_ai.diff_index.build_profile_summary", build)
+    monkeypatch.setattr(
+        "nsys_ai.diff_index.diff_profiles",
+        lambda before_profile, after_profile, **kwargs: _pair(
+            kwargs["before_summary"], kwargs["after_summary"]
+        ),
+    )
+    index = DiffIndex(tmp_path / "session")
+    index.reconcile(before, after, gpu=0, trim=(0, 100), nvtx_limit=10)
+    index.reconcile(before, after, gpu=1, trim=(100, 200), nvtx_limit=20)
+
+    assert builds == [(0, (0, 100), 10), (0, (0, 100), 10), (1, (100, 200), 20), (1, (100, 200), 20)]

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -171,6 +171,7 @@ def test_cli_session_artifacts_survive_a_second_process(tmp_path: Path):
         "findings.json",
         "proposal.json",
         "diff.json",
+        "indices",
         "logs",
     }
 
@@ -339,6 +340,7 @@ def test_derived_session_id_round_trip_without_explicit_id(tmp_path: Path):
         "findings.json",
         "proposal.json",
         "diff.json",
+        "indices",
         "logs",
     }
 


### PR DESCRIPTION
## Summary

- add a session-scoped `DiffIndex` for reusable before/after profile summaries
- persist rebuildable `indices/before.json`, `indices/after.json`, and `indices/pair_summary.json`
- include profile identity, GPU, trim, limit, sort, NVTX limit, regression threshold, and index schema in cache keys
- treat missing, stale, or corrupt memo files as cache misses; `diff.json` remains the source of truth
- wire session-backed `diff` and `DiffContext` through the canonical diff path
- keep compatibility with main before the transport handoff contract in PR #449 lands

Closes #433

## Tests

- `359 passed` — DiffIndex, diff, determinism, CLI, and SessionStore suites
- `ruff check` passed
- real `/home/rich-wsl/fastvideo/profile_results/perf.nsys-rep` checkpoint:
  - `doctor --format json` passed
  - `diagnose` published findings into a session
  - `review --session` reopened the same session
  - `ask` returned grounded evidence-first output
  - full `diff` completed with non-zero GPU totals
  - session-backed `diff` wrote `diff.json` plus all three `indices/` artifacts
  - second diff preserved the `diff.json` SHA-256
  - corrupt `pair_summary.json` rebuilt successfully

The sandbox cannot bind localhost ports, so web-serving tests remain environment-only and are not part of this change's pass claim.
