### PR TITLE
fix(skill): route captures through ingest policy

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1945,10 +1945,52 @@ def _apply_max_rows_truncation(rows: list, max_rows: int) -> list:
     return rows
 
 
+def _open_skill_connection(profile_path: str, *, no_cache: bool):
+    """Open a skill profile through the canonical ingest policy.
+
+    ``skill run`` does not construct a :class:`Profile`, so it must still
+    resolve the input itself. Keep the resolution and backend dispatch here:
+    a ``.nsys-rep`` normally resolves to parquetdir, while explicit
+    ``--no-cache`` or ``NSYS_AI_CACHE_MODE=direct`` resolves to SQLite and
+    uses the same fallback as the other non-Profile callers.
+    """
+    import sqlite3
+
+    from nsys_ai.parquet_cache import (
+        open_auto_db,
+        open_direct_sqlite,
+        open_parquetdir_db,
+        open_with_direct_fallback,
+    )
+    from nsys_ai.profile import resolve_profile
+
+    cache_mode = os.environ.get("NSYS_AI_CACHE_MODE", "").strip().lower()
+    direct = no_cache or cache_mode == "direct"
+    resolution = resolve_profile(profile_path, backend="sqlite" if direct else "auto")
+    if resolution.backend == "parquetdir":
+        return open_parquetdir_db(resolution.resolved_path)
+
+    sqlite_path = resolution.resolved_path
+    primary = (
+        open_direct_sqlite
+        if direct or resolution.cache_mode == "direct"
+        else open_auto_db
+    )
+    conn, _err = open_with_direct_fallback(sqlite_path, primary)
+    if conn is not None:
+        return conn
+    return sqlite3.connect(sqlite_path)
+
+
 def _cmd_skill(args, _profile):
     import json as _json
 
-    from nsys_ai.exceptions import SkillExecutionError, SkillNotFoundError, SkillParameterError
+    from nsys_ai.exceptions import (
+        NsysAiError,
+        SkillExecutionError,
+        SkillNotFoundError,
+        SkillParameterError,
+    )
     from nsys_ai.skills.registry import all_skills, get_skill, load_custom_skills_dir
     from nsys_ai.skills.registry import run_skill as _run_skill
 
@@ -2026,24 +2068,20 @@ def _cmd_skill(args, _profile):
 
         import duckdb
 
-        from nsys_ai.parquet_cache import (
-            open_auto_db,
-            open_direct_sqlite,
-            open_with_direct_fallback,
-        )
-
         fmt = getattr(args, "format", "text")
         no_cache = getattr(args, "no_cache", False)
-        # Same three-tier chain as Profile and open_profile_readonly: cache
-        # (or --no-cache direct), then open_direct_sqlite, then raw sqlite3.
-        # open_auto_db, not open_cached_db: this handler builds no Profile, and
-        # calling the builder directly made it the one subcommand where
-        # NSYS_AI_CACHE_MODE=direct did nothing — while the build banner
-        # printed that very instruction at the user.
-        primary = open_direct_sqlite if no_cache else open_auto_db
-        conn, _err = open_with_direct_fallback(args.profile, primary)
-        if conn is None:
-            conn = sqlite3.connect(args.profile)
+        # Same ingest policy and three-tier SQLite fallback as Profile and
+        # open_profile_readonly. This also makes .nsys-rep inputs use their
+        # existing parquetdir instead of treating the capture as SQLite.
+        try:
+            conn = _open_skill_connection(args.profile, no_cache=no_cache)
+        except (NsysAiError, OSError, RuntimeError, sqlite3.Error, duckdb.Error) as exc:
+            payload = {"error": {"code": "SKILL_EXECUTION_ERROR", "message": str(exc)}}
+            if fmt == "json":
+                print(_json.dumps(payload))
+            else:
+                print(f"Error: {exc}", file=sys.stderr)
+            sys.exit(1)
 
         # Build trim kwargs if --trim was provided
         trim_kwargs = {}

--- a/tests/test_profile_modes.py
+++ b/tests/test_profile_modes.py
@@ -1,3 +1,4 @@
+import json
 import os
 import stat
 import subprocess
@@ -8,8 +9,9 @@ from unittest import mock
 import pytest
 
 from nsys_ai import parquet_cache
+from nsys_ai.cli import handlers
 from nsys_ai.parquet_cache import _cache_dir_for
-from nsys_ai.profile import Profile
+from nsys_ai.profile import Profile, ProfileResolution
 
 
 def test_invalid_cache_mode(minimal_nsys_db_path):
@@ -339,6 +341,150 @@ def test_skill_run_honours_the_cache_mode_override(minimal_nsys_db_path, tmp_pat
     )
 
 
+def test_skill_run_resolves_nsys_rep_to_existing_parquetdir(tmp_path):
+    """The skill entry point must dispatch resolved captures to parquetdir."""
+    rep = tmp_path / "capture.nsys-rep"
+    parquetdir = tmp_path / "capture.parquetdir"
+    rep.write_bytes(b"capture")
+    parquetdir.mkdir()
+    connection = mock.Mock()
+    resolution = ProfileResolution(
+        str(rep), str(parquetdir), "nsys-rep", "parquetdir", "auto"
+    )
+
+    with mock.patch("nsys_ai.profile.resolve_profile", return_value=resolution) as resolve:
+        with mock.patch(
+            "nsys_ai.parquet_cache.open_parquetdir_db", return_value=connection
+        ) as open_parquet:
+            result = handlers._open_skill_connection(str(rep), no_cache=False)
+
+    assert result is connection
+    resolve.assert_called_once_with(str(rep), backend="auto")
+    open_parquet.assert_called_once_with(str(parquetdir))
+
+
+def test_skill_run_no_cache_resolves_nsys_rep_to_direct_sqlite(tmp_path):
+    """``--no-cache`` keeps its direct SQLite meaning for captures."""
+    rep = tmp_path / "capture.nsys-rep"
+    sqlite_path = tmp_path / "capture.sqlite"
+    rep.write_bytes(b"capture")
+    sqlite_path.write_bytes(b"sqlite")
+    connection = mock.Mock()
+    resolution = ProfileResolution(
+        str(rep), str(sqlite_path), "nsys-rep", "sqlite", "direct"
+    )
+
+    with mock.patch("nsys_ai.profile.resolve_profile", return_value=resolution) as resolve:
+        with mock.patch(
+            "nsys_ai.parquet_cache.open_direct_sqlite", return_value=connection
+        ) as open_direct:
+            result = handlers._open_skill_connection(str(rep), no_cache=True)
+
+    assert result is connection
+    resolve.assert_called_once_with(str(rep), backend="sqlite")
+    open_direct.assert_called_once_with(str(sqlite_path))
+
+
+def test_skill_run_cache_mode_direct_resolves_nsys_rep_to_direct_sqlite(
+    tmp_path, monkeypatch
+):
+    """The direct cache escape hatch also applies to capture inputs."""
+    rep = tmp_path / "capture.nsys-rep"
+    sqlite_path = tmp_path / "capture.sqlite"
+    rep.write_bytes(b"capture")
+    sqlite_path.write_bytes(b"sqlite")
+    connection = mock.Mock()
+    resolution = ProfileResolution(
+        str(rep), str(sqlite_path), "nsys-rep", "sqlite", "direct"
+    )
+    monkeypatch.setenv("NSYS_AI_CACHE_MODE", "direct")
+
+    with mock.patch("nsys_ai.profile.resolve_profile", return_value=resolution) as resolve:
+        with mock.patch(
+            "nsys_ai.parquet_cache.open_direct_sqlite", return_value=connection
+        ) as open_direct:
+            result = handlers._open_skill_connection(str(rep), no_cache=False)
+
+    assert result is connection
+    resolve.assert_called_once_with(str(rep), backend="sqlite")
+    open_direct.assert_called_once_with(str(sqlite_path))
+
+
+def test_skill_run_uses_real_existing_parquetdir_resolution(tmp_path):
+    """The capture-to-parquetdir path is covered without mocking the resolver."""
+    import duckdb
+
+    rep = tmp_path / "capture.nsys-rep"
+    parquetdir = tmp_path / "capture.parquetdir"
+    rep.write_bytes(b"capture")
+    parquetdir.mkdir()
+    db = duckdb.connect()
+    try:
+        db.execute(
+            "COPY (SELECT 1 AS value) TO ? (FORMAT PARQUET)",
+            [str(parquetdir / "sample.parquet")],
+        )
+    finally:
+        db.close()
+
+    connection = handlers._open_skill_connection(str(rep), no_cache=False)
+    try:
+        assert connection is not None
+    finally:
+        connection.close()
+
+
+def test_skill_run_parquetdir_open_failure_is_structured_json(monkeypatch, capsys):
+    """A backend-open failure must not escape as a traceback."""
+    from argparse import Namespace
+
+    monkeypatch.setattr(
+        handlers,
+        "_open_skill_connection",
+        mock.Mock(side_effect=RuntimeError("parquet backend unavailable")),
+    )
+    args = Namespace(
+        skill_action="run",
+        skill_name="top_kernels",
+        profile="capture.nsys-rep",
+        format="json",
+        no_cache=False,
+        trim=None,
+        iteration=None,
+        marker="sample_0",
+        param=[],
+        max_rows=None,
+        skills_dir=None,
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        handlers._cmd_skill(args, None)
+
+    assert exc.value.code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload == {
+        "error": {
+            "code": "SKILL_EXECUTION_ERROR",
+            "message": "parquet backend unavailable",
+        }
+    }
+
+
+def test_skill_run_failed_rep_resolution_leaves_no_cache(tmp_path, monkeypatch):
+    """A failed capture resolution must not create an empty cache directory."""
+    from nsys_ai import profile as profile_module
+    from nsys_ai.exceptions import ExportToolMissingError
+
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"capture")
+    monkeypatch.setattr(profile_module.shutil, "which", lambda _name: None)
+
+    with pytest.raises(ExportToolMissingError):
+        handlers._open_skill_connection(str(rep), no_cache=False)
+
+    assert sorted(path.name for path in tmp_path.iterdir()) == [rep.name]
+
+
 def test_open_profile_readonly_honours_the_cache_mode_override(
     minimal_nsys_db_path, tmp_path, monkeypatch
 ):
@@ -441,11 +587,13 @@ def test_the_batch_audit_script_opens_the_same_way_skill_run_does():
 
     # What `skill run` actually calls, read from the handler rather than
     # assumed, so this test tracks the CLI instead of restating it.
-    assert "open_with_direct_fallback(args.profile, primary)" in handlers, (
-        "`skill run` no longer uses open_with_direct_fallback — update this "
-        "test and the batch audit script together, they are supposed to agree"
+    assert "_open_skill_connection(args.profile, no_cache=no_cache)" in handlers, (
+        "`skill run` no longer uses the canonical profile opener — update this "
+        "test and the batch audit script together"
     )
-    assert "open_auto_db" in handlers and "open_direct_sqlite if no_cache else open_auto_db" in handlers
+    assert "open_auto_db" in handlers
+    assert "open_direct_sqlite" in handlers
+    assert 'backend="sqlite" if direct else "auto"' in handlers
 
     assert "open_with_direct_fallback(profile_path, open_auto_db)" in script, (
         "batch_audit_skills.py does not open the way `skill run` does; its "


### PR DESCRIPTION
## Summary

- route `skill run` through `resolve_profile` and the canonical ingest policy
- open `.nsys-rep` inputs from an existing parquetdir instead of treating capture bytes as SQLite
- preserve `--no-cache`, `NSYS_AI_CACHE_MODE=direct`, and the SQLite DuckDB/raw fallback paths
- fail before creating an empty cache when capture resolution cannot succeed

Closes #452

## Verification

- `ruff check src/nsys_ai/cli/handlers.py tests/test_profile_modes.py`
- `pytest tests/test_profile_modes.py tests/test_profile_resolve.py tests/test_parquet_cache.py -q` — 86 passed
- CLI skill smoke — 3 passed
- real `.nsys-rep` checkpoints against `/home/rich-wsl/fastvideo/profile_results/perf.nsys-rep`: default parquetdir and `NSYS_AI_CACHE_MODE=direct` both returned the same top-kernel rows

## Scope

MCP profile opening remains separate in #453. This change keeps `skill run`'s existing SQLite output and cache controls intact.
