### PR TITLE
fix(cli): reject empty trim windows before analysis

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -41,13 +41,17 @@ def _cmd_diagnose(args, _profile):
     from nsys_ai.diagnose_command import DiagnoseCommandError, run_diagnose
     from nsys_ai.session_cli import DEFAULT_SESSION_ROOT
 
+    trim = _parse_trim(args)
+    profile_path = getattr(args, "profile", None)
+    if trim is not None and profile_path:
+        _check_trim_window_for_path(trim, profile_path, _profile)
     try:
         exit_code = run_diagnose(
-            profile_path=getattr(args, "profile", None),
+            profile_path=profile_path,
             session_id=getattr(args, "session", None),
             session_root=DEFAULT_SESSION_ROOT,
             gpu=getattr(args, "gpu", 0) or 0,
-            trim=_parse_trim(args),
+            trim=trim,
             web=bool(getattr(args, "web", False)),
             port=getattr(args, "port", 8144),
             open_browser=not bool(getattr(args, "no_browser", False)),
@@ -64,14 +68,20 @@ def _cmd_review(args, _profile):
     from nsys_ai.review_command import ReviewCommandError, run_review
     from nsys_ai.session_cli import DEFAULT_SESSION_ROOT
 
+    trim = _parse_trim(args)
+    before_path = getattr(args, "before", None)
+    after_path = getattr(args, "after", None)
+    if trim is not None and before_path is not None and after_path is not None:
+        _check_trim_window_for_path(trim, before_path, _profile, label="before")
+        _check_trim_window_for_path(trim, after_path, _profile, label="after")
     try:
         exit_code = run_review(
-            before_path=getattr(args, "before", None),
-            after_path=getattr(args, "after", None),
+            before_path=before_path,
+            after_path=after_path,
             session_id=getattr(args, "session", None),
             session_root=DEFAULT_SESSION_ROOT,
             gpu=getattr(args, "gpu", None),
-            trim=_parse_trim(args),
+            trim=trim,
             web=bool(getattr(args, "web", False)),
             port=getattr(args, "port", 8144),
             open_browser=not bool(getattr(args, "no_browser", False)),
@@ -108,6 +118,8 @@ def _cmd_optimize(args, _profile):
         )
         raise SystemExit(2)
 
+    trim = _parse_trim(args)
+    _check_trim_window_for_path(trim, args.profile, _profile)
     try:
         exit_code = run_optimize(
             before_path=args.profile,
@@ -117,7 +129,7 @@ def _cmd_optimize(args, _profile):
             session_root=DEFAULT_SESSION_ROOT,
             nsys=getattr(args, "nsys", "nsys"),
             gpu=getattr(args, "gpu", 0) or 0,
-            trim=_parse_trim(args),
+            trim=trim,
         )
     except KeyboardInterrupt:
         print("Verification capture cancelled.", file=sys.stderr)
@@ -501,12 +513,19 @@ def _resolve_trim_window(trim, prof) -> tuple[int, int]:
     return (int(lo_ns), int(hi_ns))
 
 
-def _check_trim_window_for_path(trim, path, _profile):
+def _check_trim_window_for_path(trim, path, _profile, *, label=None):
     """``_check_trim_window`` for handlers that have not opened the profile yet."""
     if trim is None:
         return
-    with _profile.open(path) as prof:
-        _check_trim_window(trim, prof)
+    from nsys_ai.exceptions import TrimOutOfRangeError
+
+    try:
+        with _profile.open(path) as prof:
+            _check_trim_window(trim, prof)
+    except TrimOutOfRangeError as exc:
+        if label is None:
+            raise
+        raise TrimOutOfRangeError(f"{label} profile: {exc}") from exc
 
 
 def _required_param_names(skill):
@@ -952,6 +971,11 @@ def _cmd_diff(args, _profile):
 
     _resolve_diff_before(args)
 
+    trim = _parse_trim(args)
+    if trim is not None:
+        _check_trim_window_for_path(trim, args.before, _profile, label="before")
+        _check_trim_window_for_path(trim, args.after, _profile, label="after")
+
     no_ai = getattr(args, "no_ai", False)
     gate_summary = None
     gate_pct = getattr(args, "gate", None)
@@ -1060,7 +1084,6 @@ def _cmd_diff(args, _profile):
         _run_diff_chat(args, _profile)
         return
 
-    trim = _parse_trim(args)
     trim_before = None
     trim_after = None
     if getattr(args, "iteration", None) is not None:
@@ -1311,8 +1334,12 @@ def _cmd_diff(args, _profile):
             os.path.expanduser(session_after_path or args.after)
         )
         try:
-            before_ref = build_local_profile_reference(before_path)
-            after_ref = build_local_profile_reference(after_path)
+            before_ref = build_local_profile_reference(
+                before_path, trim_ns=trim_before or trim
+            )
+            after_ref = build_local_profile_reference(
+                after_path, trim_ns=trim_after or trim
+            )
             session_id = resolve_session_id(session or None, before=before_ref)
             # to_diff_dict carries each profile's ``path`` straight from
             # Profile.path, which is the caller's spelling -- "before.sqlite"
@@ -1979,7 +2006,7 @@ def _cmd_evidence(args, _profile):
 
             # Use the opened Profile's resolved .sqlite path so .nsys-rep inputs work.
             try:
-                before = build_local_profile_reference(prof.path)
+                before = build_local_profile_reference(prof.path, trim_ns=trim)
                 session_id = resolve_session_id(session or None, before=before)
                 publish_session_findings(
                     session_id=session_id,

--- a/src/nsys_ai/diagnose_command.py
+++ b/src/nsys_ai/diagnose_command.py
@@ -85,7 +85,7 @@ def run_diagnose(
             builder = EvidenceBuilder(prof, device=gpu, trim=trim)
             # Analysis completes before any session writer lease is taken.
             report = builder.build()
-            before = build_local_profile_reference(prof.path)
+            before = build_local_profile_reference(prof.path, trim_ns=trim)
     except (OSError, ProfileError, TypeError, ValueError) as exc:
         raise DiagnoseCommandError(f"diagnose failed: {exc}") from exc
 
@@ -201,7 +201,7 @@ def _open_existing_session_web(
         before_path=before.path,
         session_id=session_id,
         gpu=0,
-        trim=None,
+        trim=before.trim_ns,
         port=port,
         open_browser=open_browser,
         session_root=session_root,

--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -39,6 +39,7 @@ import os
 import sys
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
+from dataclasses import replace
 from pathlib import Path
 from typing import TextIO
 
@@ -295,7 +296,7 @@ def run_optimize(
         from .profile import resolve_profile_path
 
         before_sqlite = resolve_profile_path(raw_before)
-        before_ref = build_local_profile_reference(before_sqlite)
+        before_ref = build_local_profile_reference(before_sqlite, trim_ns=trim)
     except (OSError, ProfileError, TypeError, ValueError) as exc:
         raise OptimizeCommandError(f"could not resolve before profile: {exc}") from exc
 
@@ -493,6 +494,8 @@ def run_optimize(
                 print(f"Resume: {resume}", file=stderr)
                 return outcome
             return stopped("the verification capture did not produce a profile", code=outcome)
+        if trim is not None:
+            outcome = replace(outcome, trim_ns=trim)
         try:
             with store.writer(resolved_id) as writer:
                 writer.publish_after_profile(outcome)

--- a/src/nsys_ai/profile_reference.py
+++ b/src/nsys_ai/profile_reference.py
@@ -28,6 +28,7 @@ class LocalProfileReference:
     kernel_count: int
     storage_kind: StorageKind = "sqlite"
     resolved_path: str | None = None
+    trim_ns: tuple[int, int] | None = None
 
     def __post_init__(self) -> None:
         if self.resolved_path is None:
@@ -233,6 +234,15 @@ def validate_local_profile_reference(
         raise ValueError("local profile kernel count is invalid")
     if reference.kernel_count <= 0:
         raise ValueError("local profile contains no GPU kernel activity")
+    trim_ns = reference.trim_ns
+    if trim_ns is not None:
+        if (
+            not isinstance(trim_ns, tuple)
+            or len(trim_ns) != 2
+            or any(isinstance(item, bool) or not isinstance(item, int) for item in trim_ns)
+            or trim_ns[1] <= trim_ns[0]
+        ):
+            raise ValueError("local profile reference trim_ns must be an increasing integer pair")
     return reference
 
 

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -15,7 +15,7 @@ import stat
 import subprocess  # nosec B404
 import time
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
@@ -288,6 +288,7 @@ def build_local_profile_reference(
     *,
     resolved_secrets: Mapping[str, str] | None = None,
     ingest_policy: str | None = None,
+    trim_ns: tuple[int, int] | None = None,
 ) -> LocalProfileReference:
     """Build a reference through the shared ingest policy."""
     path_conversion_failed = False
@@ -336,6 +337,7 @@ def build_local_profile_reference(
                     kernel_count=profile.meta.kernel_count,
                     storage_kind=profile.storage_kind,
                     resolved_path=profile.resolved_path,
+                    trim_ns=trim_ns,
                 )
         except (NsysAiError, OSError, *DB_ERRORS) as exc:
             raise ProfileError(str(exc)) from None
@@ -346,7 +348,13 @@ def build_local_profile_reference(
     reference, _ = read_local_profile_under_guard(
         path, resolved_secrets=resolved_secrets
     )
-    return reference
+    if trim_ns is None:
+        return reference
+    reference = replace(reference, trim_ns=trim_ns)
+    try:
+        return validate_local_profile_reference(reference, require_file=True)
+    except (TypeError, ValueError) as exc:
+        raise ProfileError(str(exc)) from None
 
 
 def check_expected_gpu_count(spec: RunSpec, observed: int) -> str | None:

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -226,7 +226,7 @@ def _resume_review(
             before_path=before.path,
             session_id=session_id,
             gpu=None,
-            trim=None,
+            trim=before.trim_ns,
             port=port,
             open_browser=open_browser,
             session_root=session_root,

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -1261,7 +1261,7 @@ def _profile_reference_to_dict(
     if reference is None:
         return None
     validate_local_profile_reference(reference, require_file=False)
-    return {
+    payload = {
         "kind": "local",
         "path": reference.path,
         "storage_kind": reference.storage_kind,
@@ -1271,6 +1271,9 @@ def _profile_reference_to_dict(
         "product_version": reference.product_version,
         "kernel_count": reference.kernel_count,
     }
+    if reference.trim_ns is not None:
+        payload["trim_ns"] = list(reference.trim_ns)
+    return payload
 
 
 def _profile_reference_from_dict(value: Any) -> LocalProfileReference | None:
@@ -1286,11 +1289,13 @@ def _profile_reference_from_dict(value: Any) -> LocalProfileReference | None:
         "kernel_count",
     }
     current_keys = legacy_keys | {"storage_kind", "resolved_path"}
+    legacy_keys_with_trim = legacy_keys | {"trim_ns"}
+    current_keys_with_trim = current_keys | {"trim_ns"}
     actual_keys = set(payload)
-    if actual_keys == legacy_keys:
+    if actual_keys in (legacy_keys, legacy_keys_with_trim):
         storage_kind = "sqlite"
         resolved_path = payload.get("path")
-    elif actual_keys == current_keys:
+    elif actual_keys in (current_keys, current_keys_with_trim):
         storage_kind = payload.get("storage_kind")
         resolved_path = payload.get("resolved_path")
     else:
@@ -1306,6 +1311,11 @@ def _profile_reference_from_dict(value: Any) -> LocalProfileReference | None:
             schema_version=payload["export_schema_version"],
             product_version=payload["product_version"],
             kernel_count=payload["kernel_count"],
+            trim_ns=(
+                tuple(payload["trim_ns"])
+                if payload.get("trim_ns") is not None
+                else None
+            ),
         )
         validate_local_profile_reference(reference, require_file=False)
     except (KeyError, TypeError, ValueError) as exc:

--- a/tests/test_cli_usage_errors.py
+++ b/tests/test_cli_usage_errors.py
@@ -211,6 +211,61 @@ def test_trim_overlapping_only_partly_is_accepted():
         _check_trim_window(trim, prof)  # must not raise
 
 
+@pytest.mark.parametrize(
+    ("command", "extra"),
+    [
+        ("diagnose", ["--no-browser"]),
+        ("diff", ["--gpu", "0", "--no-ai"]),
+        ("review", ["--gpu", "0"]),
+    ],
+)
+def test_session_verbs_reject_trim_outside_the_profile_window(command, extra):
+    """The session-era front doors must share the established trim guard."""
+    args = [str(PROFILE), "--trim", "0", "1"]
+    if command in {"diff", "review"}:
+        args = [str(PROFILE), str(PROFILE), *args[1:]]
+    result = _run_cli(command, *args, *extra)
+
+    assert result.returncode == 2, (command, result.returncode, result.stderr)
+    assert "Error [TRIM_OUT_OF_RANGE]:" in result.stderr, result.stderr
+    if command == "diff":
+        assert "before profile:" in result.stderr, result.stderr
+
+
+def test_optimize_checks_trim_before_starting_the_loop(monkeypatch):
+    """An invalid optimize window must stop before the runner can capture."""
+    from argparse import Namespace
+
+    from nsys_ai.cli import handlers
+    from nsys_ai.exceptions import TrimOutOfRangeError
+
+    checked = []
+
+    def record_check(trim, path, profile, **kwargs):
+        checked.append((trim, path, profile, kwargs))
+        raise TrimOutOfRangeError("invalid trim")
+
+    monkeypatch.setattr(handlers, "_check_trim_window_for_path", record_check)
+    monkeypatch.setattr(
+        "nsys_ai.optimize_command.run_optimize",
+        lambda **_kwargs: pytest.fail("optimize loop started before trim validation"),
+    )
+    args = Namespace(
+        profile=str(PROFILE),
+        repo=".",
+        workload=["true"],
+        trim=[0.0, 1.0],
+        nsys="nsys",
+        gpu=0,
+        session=None,
+    )
+
+    with pytest.raises(TrimOutOfRangeError, match="invalid trim"):
+        handlers._cmd_optimize(args, _profile)
+
+    assert checked and checked[0][0] == (0, 1_000_000_000)
+
+
 # ── chat without a terminal ────────────────────────────────────────────
 
 

--- a/tests/test_diagnose_review.py
+++ b/tests/test_diagnose_review.py
@@ -85,7 +85,7 @@ def test_diagnose_then_review_pair_both_succeed(tmp_path: Path):
 def test_diagnose_web_reopens_explicit_handoff_directory(tmp_path: Path, monkeypatch):
     """The resume form must resolve the same explicit directory as creation."""
     handoff = tmp_path / "portable-session"
-    reference = build_local_profile_reference(BEFORE.resolve())
+    reference = build_local_profile_reference(BEFORE.resolve(), trim_ns=(10, 20))
     SessionStore(tmp_path).create(handoff.name, before_profile=reference)
     captured: dict[str, object] = {}
 
@@ -106,6 +106,7 @@ def test_diagnose_web_reopens_explicit_handoff_directory(tmp_path: Path, monkeyp
     assert result == 0
     assert captured["session_id"] == "portable-session"
     assert captured["session_root"] == tmp_path
+    assert captured["trim"] == (10, 20)
 
 
 def test_review_pair_without_session_does_not_create_nsys_ai(tmp_path: Path):

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -446,6 +446,17 @@ def test_legacy_session_profile_reference_defaults_to_sqlite_path(tmp_path):
     assert restored.before_profile.resolved_path == restored.before_profile.path
 
 
+def test_trimmed_profile_reference_round_trips_its_capture_window(tmp_path):
+    profile = replace(_profile_reference(tmp_path / "trimmed.sqlite", "trimmed"), trim_ns=(10, 20))
+    payload = SessionState(session_id="trimmed", before_profile=profile).to_dict()
+
+    assert payload["profiles"]["before"]["trim_ns"] == [10, 20]
+    restored = SessionState.from_dict(payload)
+
+    assert restored.before_profile is not None
+    assert restored.before_profile.trim_ns == (10, 20)
+
+
 def test_active_writer_conflict_is_observed_from_a_second_process(tmp_path):
     store = SessionStore(tmp_path / "sessions")
     store.create("conflict")


### PR DESCRIPTION
## Summary

- reject empty/out-of-range `--trim` windows in `diagnose`, `diff`, `review`, and `optimize`
- identify which side rejected a trim window in pair diffs
- stop `optimize` before any verification capture when the baseline window is invalid
- persist a valid trim window in session profile references and reuse it when reopening Web
- keep legacy session profile references readable

Closes #459

## Verification

- `ruff check` passed for all changed source/tests
- session/profile/diff/review suites — 217 passed
- trim guard tests — 4 passed
- real `diagnose --trim` checkpoint wrote `session.json` with `trim_ns: [155360295935, 156320780944]`

## Scope

The existing trim semantics and error code remain unchanged. The adjacent comparability-confidence inconsistency remains separate as described in the issue.
