### PR TITLE
fix(mcp): reuse existing parquetdir ingest

### DIFF
--- a/src/nsys_ai/mcp_server.py
+++ b/src/nsys_ai/mcp_server.py
@@ -208,12 +208,23 @@ def _open_readonly(path: str) -> Iterator[tuple[Any, str]]:
         )
     resolved = resolution.resolved_path
     if resolution.backend == "parquetdir":
-        conn = open_parquetdir_db(resolved)
         try:
-            yield conn, resolved
-        finally:
-            conn.close()
-        return
+            conn = open_parquetdir_db(resolved)
+        except Exception:
+            # A directory can pass the cheap file-presence inspection while a
+            # parquet file is unreadable. A read-only MCP call must still use
+            # a current SQLite sidecar when one is available.
+            fallback = find_ingested_profile(path, backend="sqlite")
+            if fallback is None:
+                raise
+            resolution = fallback
+            resolved = resolution.resolved_path
+        else:
+            try:
+                yield conn, resolved
+            finally:
+                conn.close()
+            return
 
     conn, _error_detail = open_with_direct_fallback(resolved, open_direct_sqlite)
     if conn is None:

--- a/src/nsys_ai/mcp_server.py
+++ b/src/nsys_ai/mcp_server.py
@@ -22,7 +22,6 @@ from .diff_render import to_diff_dict
 from .exceptions import (
     ExportToolMissingError,
     NsysAiError,
-    ProfileNotFoundError,
     SkillNotFoundError,
     SkillParameterError,
 )
@@ -193,26 +192,29 @@ def _cap_rows(rows: list[dict], max_rows: int) -> tuple[list[dict], bool]:
 @contextmanager
 def _open_readonly(path: str) -> Iterator[tuple[Any, str]]:
     """Yield a read-only connection without exporting or building a sidecar."""
-    from .parquet_cache import open_direct_sqlite, open_with_direct_fallback
+    from .parquet_cache import (
+        open_direct_sqlite,
+        open_parquetdir_db,
+        open_with_direct_fallback,
+    )
+    from .profile import find_ingested_profile
 
-    source = Path(path)
-    if not source.exists():
-        raise ProfileNotFoundError(f"profile not found: {path}")
-    if source.suffix.lower() == ".nsys-rep":
-        sidecar = source.with_suffix(".sqlite")
-        if not sidecar.is_file() or sidecar.stat().st_size == 0:
-            raise ExportToolMissingError(
-                "MCP access to .nsys-rep is read-only and will not export a sidecar; "
-                "provide an up-to-date .sqlite export next to the capture"
-            )
-        if sidecar.stat().st_mtime < source.stat().st_mtime:
-            raise ExportToolMissingError(
-                "MCP access to .nsys-rep will not refresh a stale sidecar; "
-                "export an up-to-date .sqlite file before calling the server"
-            )
-        resolved = str(sidecar)
-    else:
-        resolved = str(source)
+    resolution = find_ingested_profile(path)
+    if resolution is None:
+        raise ExportToolMissingError(
+            "MCP access is read-only and will not export a profile; run "
+            f"`nsys-ai diagnose {path}` first to create a parquetdir or provide "
+            "an up-to-date SQLite export"
+        )
+    resolved = resolution.resolved_path
+    if resolution.backend == "parquetdir":
+        conn = open_parquetdir_db(resolved)
+        try:
+            yield conn, resolved
+        finally:
+            conn.close()
+        return
+
     conn, _error_detail = open_with_direct_fallback(resolved, open_direct_sqlite)
     if conn is None:
         uri = Path(resolved).resolve().as_uri() + "?mode=ro"

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -1056,6 +1056,91 @@ def resolve_profile(
     return ProfileResolution(path, path, "sqlite", "sqlite", cache_mode)
 
 
+def _existing_parquetdir_path(path: str) -> str | None:
+    """Return a current, valid parquetdir beside a capture, if one exists."""
+    output = path[:-9] + ".parquetdir"
+    try:
+        if (
+            not os.path.isdir(output)
+            or os.path.getmtime(output) < os.path.getmtime(path)
+        ):
+            return None
+        canonical = os.path.abspath(output)
+        inspect_local_parquetdir(canonical, allow_missing=False)
+    except (OSError, ValueError):
+        return None
+    return canonical
+
+
+def _existing_sqlite_sidecar(path: str) -> str | None:
+    """Return a current, non-empty SQLite sidecar beside a capture, if any."""
+    output = path[:-9] + ".sqlite"
+    try:
+        if (
+            not os.path.isfile(output)
+            or os.path.getsize(output) <= 0
+            or os.path.getmtime(output) < os.path.getmtime(path)
+        ):
+            return None
+    except OSError:
+        return None
+    return output
+
+
+def find_ingested_profile(
+    path: str,
+    *,
+    backend: str = "auto",
+    ingest_policy: str | None = None,
+) -> ProfileResolution | None:
+    """Find an already-ingested profile without exporting or writing files.
+
+    This is the non-exporting counterpart to :func:`resolve_profile`.  It uses
+    the same backend/policy precedence, but returns ``None`` when a ``.nsys-rep``
+    has no usable existing store instead of invoking ``nsys export``.  The
+    fallback from parquetdir to a current SQLite sidecar is intentional: it
+    lets read-only callers use whichever representation has already been
+    ingested while keeping parquetdir first when both are present.
+    """
+    path = os.fspath(path)
+    if not isinstance(path, str):
+        raise TypeError("profile path must be a string or path-like object")
+    if not os.path.exists(path):
+        raise ProfileNotFoundError(f"profile not found: {path}")
+
+    policy = resolve_ingest_policy(ingest_policy)
+    if backend not in {"auto", "sqlite", "parquetdir"}:
+        raise ValueError(
+            f"Unknown backend: {backend!r}. Expected 'auto', 'sqlite', or 'parquetdir'."
+        )
+    selected = policy if backend == "auto" else backend
+
+    if os.path.isdir(path) or Path(path).suffix.lower() in {".parquetdir", ".nsys-cache"}:
+        if selected == "sqlite":
+            return None
+        try:
+            inspect_local_parquetdir(os.path.abspath(path), allow_missing=False)
+        except ValueError:
+            return None
+        return ProfileResolution(path, path, "parquetdir", "parquetdir", "auto")
+
+    if path.lower().endswith(".nsys-rep"):
+        if selected in {"auto", "parquetdir"}:
+            parquetdir = _existing_parquetdir_path(path)
+            if parquetdir is not None:
+                return ProfileResolution(path, parquetdir, "nsys-rep", "parquetdir", "auto")
+        if selected in {"auto", "sqlite"}:
+            sqlite_path = _existing_sqlite_sidecar(path)
+            if sqlite_path is not None:
+                return ProfileResolution(path, sqlite_path, "nsys-rep", "sqlite", "direct")
+        return None
+
+    if selected == "parquetdir":
+        return None
+    cache_mode: Literal["auto", "direct"] = "direct" if selected == "sqlite" else "auto"
+    return ProfileResolution(path, path, "sqlite", "sqlite", cache_mode)
+
+
 def resolve_profile_path(
     path: str, *, backend: str = "auto", nsys_executable: str = "nsys"
 ) -> str:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -129,6 +129,64 @@ def test_nsys_rep_without_current_sidecar_returns_export_error_without_writing(t
     assert not (tmp_path / "capture.parquetdir").exists()
 
 
+def test_nsys_rep_uses_existing_parquetdir_without_writing(monkeypatch, tmp_path):
+    from nsys_ai import parquet_cache
+    from nsys_ai.mcp_server import _open_readonly
+
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"capture placeholder")
+    parquetdir = tmp_path / "capture.parquetdir"
+    parquetdir.mkdir()
+    (parquetdir / "kernels.parquet").write_bytes(b"parquet placeholder")
+    opened: list[str] = []
+
+    def fake_open(path):
+        opened.append(path)
+        return sqlite3.connect(":memory:")
+
+    monkeypatch.setattr(parquet_cache, "open_parquetdir_db", fake_open)
+
+    with _open_readonly(str(rep)) as (_conn, resolved):
+        assert resolved == str(parquetdir.resolve())
+
+    assert opened == [str(parquetdir.resolve())]
+
+
+def test_run_skill_reads_parquetdir_only_capture(tmp_path):
+    from test_parquetdir_backend import _create_parquetdir_profile
+
+    from nsys_ai.mcp_server import _run_skill
+
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"capture placeholder")
+    parquetdir = Path(_create_parquetdir_profile(tmp_path / "capture.parquetdir"))
+
+    result = _run_skill(str(rep), "top_kernels", {"limit": 1}, max_rows=1)
+
+    assert "error" not in result
+    assert result["profile"]["path"] == str(parquetdir.resolve())
+    assert result["rows"]
+
+
+def test_diff_reads_parquetdir_on_both_sides(tmp_path):
+    from test_parquetdir_backend import _create_parquetdir_profile
+
+    from nsys_ai.mcp_server import _diff_payload
+
+    before = tmp_path / "before.nsys-rep"
+    after = tmp_path / "after.nsys-rep"
+    before.write_bytes(b"before")
+    after.write_bytes(b"after")
+    before_dir = Path(_create_parquetdir_profile(tmp_path / "before.parquetdir"))
+    after_dir = Path(_create_parquetdir_profile(tmp_path / "after.parquetdir"))
+
+    result = _diff_payload(str(before), str(after), gpu=0, limit=1)
+
+    assert "error" not in result
+    assert result["before"]["path"] == str(before_dir.resolve())
+    assert result["after"]["path"] == str(after_dir.resolve())
+
+
 def test_profile_open_errors_are_standard_mcp_payloads(tmp_path):
     from nsys_ai.mcp_server import _diff_payload, _run_skill
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -152,6 +152,30 @@ def test_nsys_rep_uses_existing_parquetdir_without_writing(monkeypatch, tmp_path
     assert opened == [str(parquetdir.resolve())]
 
 
+def test_nsys_rep_falls_back_to_current_sqlite_when_parquetdir_open_fails(
+    monkeypatch, profile_copy, tmp_path
+):
+    from nsys_ai import parquet_cache
+    from nsys_ai.mcp_server import _open_readonly
+
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"capture placeholder")
+    parquetdir = tmp_path / "capture.parquetdir"
+    parquetdir.mkdir()
+    (parquetdir / "kernels.parquet").write_bytes(b"parquet placeholder")
+    sidecar = tmp_path / "capture.sqlite"
+    shutil.copyfile(profile_copy("h100_2gpu_1s.sqlite"), sidecar)
+    sidecar.touch()
+
+    def fail_open(_path):
+        raise RuntimeError("corrupt parquet")
+
+    monkeypatch.setattr(parquet_cache, "open_parquetdir_db", fail_open)
+
+    with _open_readonly(str(rep)) as (_conn, resolved):
+        assert resolved == str(sidecar)
+
+
 def test_run_skill_reads_parquetdir_only_capture(tmp_path):
     from test_parquetdir_backend import _create_parquetdir_profile
 

--- a/tests/test_profile_resolve.py
+++ b/tests/test_profile_resolve.py
@@ -211,6 +211,42 @@ def test_resolve_nsys_rep_defaults_to_parquetdir(monkeypatch, tmp_path: Path):
     assert resolution.resolved_path.endswith(".parquetdir")
 
 
+def test_find_ingested_profile_prefers_parquetdir_without_export(tmp_path: Path):
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"report")
+    parquetdir = tmp_path / "capture.parquetdir"
+    parquetdir.mkdir()
+    (parquetdir / "kernels.parquet").write_bytes(b"parquet")
+    sqlite_path = tmp_path / "capture.sqlite"
+    sqlite_path.write_bytes(b"sqlite")
+
+    resolution = profile_mod.find_ingested_profile(str(rep))
+
+    assert resolution is not None
+    assert resolution.backend == "parquetdir"
+    assert resolution.resolved_path == str(parquetdir.resolve())
+
+
+def test_find_ingested_profile_uses_sqlite_only_without_export(tmp_path: Path):
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"report")
+    sqlite_path = tmp_path / "capture.sqlite"
+    sqlite_path.write_bytes(b"sqlite")
+
+    resolution = profile_mod.find_ingested_profile(str(rep))
+
+    assert resolution is not None
+    assert resolution.backend == "sqlite"
+    assert resolution.resolved_path == str(sqlite_path)
+
+
+def test_find_ingested_profile_returns_none_when_no_store_exists(tmp_path: Path):
+    rep = tmp_path / "capture.nsys-rep"
+    rep.write_bytes(b"report")
+
+    assert profile_mod.find_ingested_profile(str(rep)) is None
+
+
 def test_sqlite_ingest_policy_skips_cache_and_exports_sqlite(
     monkeypatch, tmp_path: Path
 ):


### PR DESCRIPTION
## Summary

- add a shared non-exporting profile resolver for already-ingested stores
- make read-only MCP open parquetdir first and fall back to a current SQLite sidecar
- keep missing-store failures actionable without exporting or writing beside `.nsys-rep`
- cover parquetdir-only MCP skill/diff paths and backend precedence

Closes #453

## Validation

- `ruff check src/nsys_ai/profile.py src/nsys_ai/mcp_server.py tests/test_profile_resolve.py tests/test_mcp_server.py`
- `PYTHONPATH=src pytest -q tests/test_profile_resolve.py tests/test_mcp_server.py tests/test_parquetdir_backend.py` — 42 passed
- full `PYTHONPATH=src pytest -q` is running locally
