### PR TITLE
refactor(web): unify GPU labels and 404 responses

### DIFF
--- a/src/nsys_ai/diff_web.py
+++ b/src/nsys_ai/diff_web.py
@@ -15,6 +15,7 @@ from urllib.parse import parse_qs, urlparse
 
 from .diff import ProfileDiffSummary, diff_profiles
 from .diff_render import to_diff_json
+from .gpu_label import format_gpu_label
 from .profile import Profile
 from .viewer import build_timeline_gpu_data, generate_timeline_html
 from .web import _TEMPLATE_DIR, _bind_local_server, _run_server
@@ -39,7 +40,7 @@ class _DiffHandler(BaseHTTPRequestHandler):
             return
 
         # Iframe timelines
-        if path.startswith("/timeline"):
+        if path == "/timeline":
             qs = parse_qs(urlparse(self.path).query)
             side = str(qs.get("side", ["before"])[0]).lower()
             self._serve_timeline_iframe(side)
@@ -81,7 +82,14 @@ class _DiffHandler(BaseHTTPRequestHandler):
             self._serve_asset("timeline.js", "application/javascript; charset=utf-8")
             return
 
-        # Fallback: serve HTML shell.
+        if path.startswith("/api/"):
+            self._json_response({"error": "not found", "path": path}, 404)
+            return
+        if path != "/":
+            self.send_error(404)
+            return
+
+        # Root: serve HTML shell.
         self._serve_html()
 
     def _serve_asset(self, filename: str, content_type: str):
@@ -155,10 +163,7 @@ class _DiffHandler(BaseHTTPRequestHandler):
         gpu_infos = []
         for dev in devices:
             info = prof.meta.gpu_info.get(dev)
-            label = f"GPU {dev}"
-            if info:
-                label += f" - {info.name} ({info.pci_bus}), {info.sm_count} SMs, {info.memory_bytes / 1e9:.0f}GB"
-            gpu_infos.append({"id": dev, "label": label})
+            gpu_infos.append({"id": dev, "label": format_gpu_label(dev, info)})
 
         trim = self.__class__.trim
         t_start, t_end = prof.meta.time_range

--- a/src/nsys_ai/gpu_label.py
+++ b/src/nsys_ai/gpu_label.py
@@ -1,0 +1,39 @@
+"""Consistent human-readable labels for GPU metadata."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+def format_gpu_label(device: int, info: Any = None) -> str:
+    """Format a GPU label without inventing values for missing metadata."""
+    label = f"GPU {device}"
+    if info is None:
+        return label
+
+    if isinstance(info, Mapping):
+        get = info.get
+        name = str(get("name", "") or "").strip()
+        pci_bus = str(get("pci_bus", "") or "").strip()
+        sm_count = get("sm_count", 0) or 0
+        memory_gb = get("memory_gb", 0) or 0
+    else:
+        def get(key, default=None):
+            return getattr(info, key, default)
+
+        name = str(get("name", "") or "").strip()
+        pci_bus = str(get("pci_bus", "") or "").strip()
+        sm_count = get("sm_count", 0) or 0
+        memory_gb = (get("memory_bytes", 0) or 0) / 1e9
+
+    if name or pci_bus:
+        detail = name
+        if pci_bus:
+            detail = f"{detail} ({pci_bus})" if detail else f"({pci_bus})"
+        label += f" - {detail}"
+    if sm_count:
+        label += f", {sm_count} SMs"
+    if memory_gb:
+        label += f", {memory_gb:.0f}GB"
+    return label

--- a/src/nsys_ai/gpu_label.py
+++ b/src/nsys_ai/gpu_label.py
@@ -35,5 +35,16 @@ def format_gpu_label(device: int, info: Any = None) -> str:
     if sm_count:
         label += f", {sm_count} SMs"
     if memory_gb:
-        label += f", {memory_gb:.0f}GB"
+        memory_text = f"{memory_gb:.1f}".rstrip("0").rstrip(".")
+        label += f", {memory_text}GB"
     return label
+
+
+def format_gpu_narrative_label(device: int, info: Any = None) -> str:
+    """Format the short GPU identity used at the start of prose sentences."""
+    label = f"GPU {device}"
+    if isinstance(info, Mapping):
+        name = str(info.get("name", "") or "").strip()
+    else:
+        name = str(getattr(info, "name", "") or "").strip() if info is not None else ""
+    return f"{label} ({name})" if name else label

--- a/src/nsys_ai/report.py
+++ b/src/nsys_ai/report.py
@@ -9,6 +9,7 @@ profiling (trim window) and post-processing SQLite results into a report.
 
 import statistics
 
+from .gpu_label import format_gpu_label
 from .overlap import (
     detect_iterations,
     format_iterations,
@@ -149,7 +150,7 @@ def format_report_markdown(data: dict, profile_path: str, trim: tuple[int, int])
         hw = s["hardware"]
         t = s["timing"]
         lines.append(
-            f"**GPU {s['device']}:** {hw['name']} ({hw['pci_bus']}) — {hw['sm_count']} SMs, {hw['memory_gb']}GB"
+            f"**{format_gpu_label(s['device'], hw)}:**"
         )
         lines.append("")
         lines.append(

--- a/src/nsys_ai/summary.py
+++ b/src/nsys_ai/summary.py
@@ -6,7 +6,7 @@ NVTX breakdown, stream utilization, and NCCL timing. Designed for both
 agent consumption and human reading.
 """
 
-from .gpu_label import format_gpu_label
+from .gpu_label import format_gpu_label, format_gpu_narrative_label
 from .profile import Profile
 
 
@@ -143,7 +143,7 @@ def auto_commentary(summary: dict) -> str:
 
     sentences = []
     sentences.append(
-        f"GPU {summary['device']} ({hw['name']}) ran {summary['kernel_count']} kernels "
+        f"{format_gpu_narrative_label(summary['device'], hw)} ran {summary['kernel_count']} kernels "
         f"over {t['span_ms']:.0f}ms with {t['utilization_pct']}% utilization."
     )
 

--- a/src/nsys_ai/summary.py
+++ b/src/nsys_ai/summary.py
@@ -6,6 +6,7 @@ NVTX breakdown, stream utilization, and NCCL timing. Designed for both
 agent consumption and human reading.
 """
 
+from .gpu_label import format_gpu_label
 from .profile import Profile
 
 
@@ -105,7 +106,7 @@ def format_text(summary: dict) -> str:
     hw = summary["hardware"]
     t = summary["timing"]
     lines = [
-        f"GPU {summary['device']}: {hw['name']} ({hw['pci_bus']}) — {hw['sm_count']} SMs, {hw['memory_gb']}GB",
+        f"{format_gpu_label(summary['device'], hw)}:",
         f"  Span: {t['span_ms']:.1f}ms | Compute: {t['compute_ms']:.1f}ms | Idle: {t['idle_ms']:.1f}ms | Util: {t['utilization_pct']}%",
         f"  Kernels: {summary['kernel_count']}",
         "",

--- a/src/nsys_ai/viewer.py
+++ b/src/nsys_ai/viewer.py
@@ -11,6 +11,7 @@ import logging
 import os
 from string import Template
 
+from .gpu_label import format_gpu_label
 from .tree import build_nvtx_tree, to_json
 
 _log = logging.getLogger(__name__)
@@ -70,12 +71,7 @@ def generate_html(prof, device: int, trim: tuple[int, int]) -> str:
     tree_json = to_json(roots)
 
     gpu_info = prof.meta.gpu_info.get(device)
-    gpu_label = f"GPU {device}"
-    if gpu_info:
-        gpu_label += (
-            f" - {gpu_info.name} ({gpu_info.pci_bus}), "
-            f"{gpu_info.sm_count} SMs, {gpu_info.memory_bytes / 1e9:.0f}GB"
-        )
+    gpu_label = format_gpu_label(device, gpu_info)
 
     # Stable id for this profile view (device + time window) for profile-bound chat history
     trim_sec = (trim[0] / 1e9, trim[1] / 1e9)

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -790,6 +790,9 @@ class _ViewerHandler(BaseHTTPRequestHandler):
                 self._json_response({"error": str(e)}, 400)
             return
         if path != "/api/chat":
+            if path.startswith("/api/"):
+                self._json_response({"error": "not found", "path": path}, 404)
+                return
             self.send_error(404)
             return
         content_length = int(self.headers.get("Content-Length", 0))

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -21,6 +21,8 @@ import time as _time
 import webbrowser
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
+from .gpu_label import format_gpu_label
+
 _log = logging.getLogger(__name__)
 
 _FINDINGS_LOCK = threading.Lock()
@@ -286,6 +288,12 @@ class _ViewerHandler(BaseHTTPRequestHandler):
         if path == "/api/loop/state":
             self._handle_loop_get()
             return
+        if path.startswith("/api/"):
+            self._json_response({"error": "not found", "path": path}, 404)
+            return
+        if path not in {"/", "/index.html"}:
+            self.send_error(404)
+            return
         _send_body(
             self,
             self.html_bytes,
@@ -329,10 +337,7 @@ class _ViewerHandler(BaseHTTPRequestHandler):
         gpu_infos = []
         for dev in devices:
             info = prof.meta.gpu_info.get(dev)
-            label = f"GPU {dev}"
-            if info:
-                label += f" - {info.name} ({info.pci_bus}), {info.sm_count} SMs, {info.memory_bytes / 1e9:.0f}GB"
-            gpu_infos.append({"id": dev, "label": label})
+            gpu_infos.append({"id": dev, "label": format_gpu_label(dev, info)})
         # Get profile time range from kernel metadata (min_start_ns, max_end_ns)
         t_start, t_end = prof.meta.time_range
         self._json_response(
@@ -1279,6 +1284,12 @@ class _EvidenceHandler(BaseHTTPRequestHandler):
             return
         if path == "/api/data":
             self._handle_data()
+            return
+        if path.startswith("/api/"):
+            self._json_response({"error": "not found", "path": path}, 404)
+            return
+        if path not in {"/", "/index.html"}:
+            self.send_error(404)
             return
         # Default: serve evidence HTML
         _send_body(self, self.html_bytes, "text/html; charset=utf-8")

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -45,6 +45,20 @@ def _get(handler, path: str, *, html: bytes = b"<html>"):
     return result
 
 
+def _post(handler, path: str):
+    server = web._ThreadedHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.handle_request, daemon=True)
+    thread.start()
+    conn = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+    conn.request("POST", path, body=b"{}", headers={"Content-Type": "application/json"})
+    response = conn.getresponse()
+    result = response.status, response.read(), response.getheader("Content-Type")
+    conn.close()
+    thread.join(timeout=5)
+    server.server_close()
+    return result
+
+
 @pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])
 def test_web_surfaces_return_404_for_unknown_paths(handler):
     status, body, content_type = _get(handler, "/api/definitely-not-real")
@@ -59,3 +73,11 @@ def test_web_surfaces_keep_root_page(handler):
     status, _body, _content_type = _get(handler, "/")
 
     assert status == 200
+
+
+def test_viewer_returns_json_404_for_unknown_post_api():
+    status, body, content_type = _post(web._ViewerHandler, "/api/definitely-not-real")
+
+    assert status == 404
+    assert content_type.startswith("application/json")
+    assert b"not found" in body

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import http.client
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from nsys_ai import web
+from nsys_ai.diff_web import _DiffHandler
+from nsys_ai.gpu_label import format_gpu_label
+
+
+def test_gpu_label_omits_missing_metadata():
+    assert format_gpu_label(0) == "GPU 0"
+    assert format_gpu_label(0, SimpleNamespace(name="", pci_bus="", sm_count=0, memory_bytes=0)) == "GPU 0"
+    assert format_gpu_label(1, SimpleNamespace(name="H100", pci_bus="", sm_count=132, memory_bytes=0)) == "GPU 1 - H100, 132 SMs"
+
+
+def test_gpu_label_supports_summary_data():
+    assert format_gpu_label(
+        2,
+        {"name": "H100", "pci_bus": "0000:01:00.0", "sm_count": 132, "memory_gb": 80},
+    ) == "GPU 2 - H100 (0000:01:00.0), 132 SMs, 80GB"
+
+
+def _get(handler, path: str, *, html: bytes = b"<html>"):
+    if handler is web._ViewerHandler:
+        old_html = handler.html_bytes
+        handler.html_bytes = html
+    else:
+        old_html = None
+    server = web._ThreadedHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.handle_request, daemon=True)
+    thread.start()
+    conn = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+    conn.request("GET", path)
+    response = conn.getresponse()
+    result = response.status, response.read(), response.getheader("Content-Type")
+    conn.close()
+    thread.join(timeout=5)
+    server.server_close()
+    if handler is web._ViewerHandler:
+        handler.html_bytes = old_html
+    return result
+
+
+@pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])
+def test_web_surfaces_return_404_for_unknown_paths(handler):
+    status, body, content_type = _get(handler, "/api/definitely-not-real")
+
+    assert status == 404
+    assert content_type.startswith("application/json")
+    assert b"not found" in body
+
+
+@pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])
+def test_web_surfaces_keep_root_page(handler):
+    status, _body, _content_type = _get(handler, "/")
+
+    assert status == 200

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -8,13 +8,16 @@ import pytest
 
 from nsys_ai import web
 from nsys_ai.diff_web import _DiffHandler
-from nsys_ai.gpu_label import format_gpu_label
+from nsys_ai.gpu_label import format_gpu_label, format_gpu_narrative_label
+from nsys_ai.summary import auto_commentary
 
 
 def test_gpu_label_omits_missing_metadata():
     assert format_gpu_label(0) == "GPU 0"
     assert format_gpu_label(0, SimpleNamespace(name="", pci_bus="", sm_count=0, memory_bytes=0)) == "GPU 0"
     assert format_gpu_label(1, SimpleNamespace(name="H100", pci_bus="", sm_count=132, memory_bytes=0)) == "GPU 1 - H100, 132 SMs"
+    assert format_gpu_narrative_label(0, {"name": ""}) == "GPU 0"
+    assert format_gpu_narrative_label(1, {"name": "H100"}) == "GPU 1 (H100)"
 
 
 def test_gpu_label_supports_summary_data():
@@ -22,6 +25,28 @@ def test_gpu_label_supports_summary_data():
         2,
         {"name": "H100", "pci_bus": "0000:01:00.0", "sm_count": 132, "memory_gb": 80},
     ) == "GPU 2 - H100 (0000:01:00.0), 132 SMs, 80GB"
+
+
+def test_gpu_label_preserves_fractional_memory_precision():
+    assert format_gpu_label(
+        0,
+        SimpleNamespace(name="H200", pci_bus="", sm_count=0, memory_bytes=150_100_000_000),
+    ) == "GPU 0 - H200, 150.1GB"
+
+
+def test_summary_commentary_omits_empty_gpu_name():
+    summary = {
+        "device": 0,
+        "hardware": {"name": ""},
+        "timing": {"span_ms": 10.0, "utilization_pct": 25.0, "idle_ms": 0.0},
+        "kernel_count": 3,
+        "top_kernels": [],
+    }
+
+    commentary = auto_commentary(summary)
+
+    assert commentary.startswith("GPU 0 ran 3 kernels")
+    assert "()" not in commentary
 
 
 def _get(handler, path: str, *, html: bytes = b"<html>"):


### PR DESCRIPTION
## Summary

This is the first independently mergeable foundation slice for #458:

- return JSON 404 responses for unknown `/api/*` paths on the viewer, evidence, and diff web surfaces
- return 404 instead of the page shell for unknown non-API paths
- centralize GPU label formatting across web, diff-web, summary, report, and standalone viewer output
- omit absent GPU metadata instead of rendering empty parentheses and zero-valued measurements

The remaining #458 work (shared CSS tokens, canvas palette bridge, route-table consolidation, and palette validation) stays separate for follow-up commits/PRs.

## Validation

- `ruff check src/nsys_ai/gpu_label.py src/nsys_ai/web.py src/nsys_ai/diff_web.py src/nsys_ai/summary.py src/nsys_ai/report.py src/nsys_ai/viewer.py tests/test_web_foundation.py`
- `PYTHONPATH=src pytest -q tests/test_web_foundation.py tests/test_timeline_web_data.py tests/test_web_compression.py` — 26 passed
