### PR TITLE
fix(cli): select an available GPU by default

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -50,7 +50,7 @@ def _cmd_diagnose(args, _profile):
             profile_path=profile_path,
             session_id=getattr(args, "session", None),
             session_root=DEFAULT_SESSION_ROOT,
-            gpu=getattr(args, "gpu", 0) or 0,
+            gpu=getattr(args, "gpu", None),
             trim=trim,
             web=bool(getattr(args, "web", False)),
             port=getattr(args, "port", 8144),
@@ -128,7 +128,7 @@ def _cmd_optimize(args, _profile):
             session_id=getattr(args, "session", None),
             session_root=DEFAULT_SESSION_ROOT,
             nsys=getattr(args, "nsys", "nsys"),
-            gpu=getattr(args, "gpu", 0) or 0,
+            gpu=getattr(args, "gpu", None),
             trim=trim,
         )
     except KeyboardInterrupt:
@@ -754,12 +754,14 @@ def _cmd_analyze(args, _profile):
         )
         sys.exit(1)
 
+    from nsys_ai.profile import select_gpu_device
     from nsys_ai.report import format_report_markdown, format_report_terminal, run_analyze
 
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
         _check_trim_window(trim, prof)
-        data = run_analyze(prof, args.gpu, trim)
+        device = select_gpu_device(prof, getattr(args, "gpu", None))
+        data = run_analyze(prof, device, trim)
         print(format_report_terminal(data))
         if getattr(args, "output", None):
             md = format_report_markdown(data, args.profile, trim)
@@ -842,7 +844,9 @@ def _cmd_analyze_json(args, _profile):
     with _profile.open(args.profile) as prof:
         trim = _parse_trim(args)
         _check_trim_window(trim, prof)
-        device = getattr(args, "gpu", 0) or 0
+        from nsys_ai.profile import select_gpu_device
+
+        device = select_gpu_device(prof, getattr(args, "gpu", None))
         builder = EvidenceBuilder(prof, device=device, trim=trim)
         report = builder.build()
 
@@ -1962,7 +1966,9 @@ def _cmd_evidence(args, _profile):
     with _profile.open(profile_path) as prof:
         trim = _parse_trim(args)
         _check_trim_window(trim, prof)
-        device = getattr(args, "gpu", 0) or 0
+        from nsys_ai.profile import select_gpu_device
+
+        device = select_gpu_device(prof, getattr(args, "gpu", None))
         builder = EvidenceBuilder(prof, device=device, trim=trim)
 
         analyzers_raw = getattr(args, "analyzers", None)

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -206,8 +206,8 @@ def _register_optimize_parser(sub):
     p.add_argument(
         "--gpu",
         type=int,
-        default=0,
-        help="GPU device id for diagnose (default: 0, as evidence build); the diff stays all-GPU",
+        default=None,
+        help="GPU device id for diagnose (default: first GPU in profile); the diff stays all-GPU",
     )
     p.add_argument(
         "--trim",
@@ -408,7 +408,9 @@ def _register_evidence_parser(sub):
         default=None,
         help="Time window in seconds",
     )
-    sp_build.add_argument("--gpu", type=int, default=0, help="GPU device ID (default: 0)")
+    sp_build.add_argument(
+        "--gpu", type=int, default=None, help="GPU device ID (default: first GPU in profile)"
+    )
     sp_build.add_argument("-o", "--output", default=None, help="Write findings JSON to file")
     sp_build.add_argument(
         "--session",
@@ -618,8 +620,8 @@ def _build_parser():
     p.add_argument(
         "--gpu",
         type=int,
-        default=0,
-        help="GPU device ID (default: 0; same as evidence build)",
+        default=None,
+        help="GPU device ID (default: first GPU in profile; same as evidence build)",
     )
     p.add_argument(
         "--trim",
@@ -1310,7 +1312,7 @@ def _register_legacy_commands(sub):
     # --trim is optional at the parser level so `--format json` can run on
     # the full profile span; the text path enforces a clear error when
     # --trim is missing (see _cmd_analyze).
-    _add_gpu_trim(p, trim_required=False)
+    _add_gpu_trim(p, gpu_required=False, trim_required=False)
     p.add_argument(
         "-o",
         "--output",

--- a/src/nsys_ai/diagnose_command.py
+++ b/src/nsys_ai/diagnose_command.py
@@ -12,7 +12,7 @@ import sys
 from typing import TextIO
 
 from .exceptions import NsysAiError, ProfileError
-from .profile import Profile, resolve_profile_path
+from .profile import Profile, resolve_profile_path, select_gpu_device
 from .profile_runner import build_local_profile_reference
 from .session_cli import (
     publish_session_findings,
@@ -34,7 +34,7 @@ def run_diagnose(
     *,
     profile_path: str | os.PathLike[str] | None = None,
     session_id: str | os.PathLike[str] | None = None,
-    gpu: int = 0,
+    gpu: int | None = None,
     trim: tuple[int, int] | None = None,
     web: bool = False,
     port: int = 8144,
@@ -49,7 +49,7 @@ def run_diagnose(
     callers can reuse this path without fabricating an argparse Namespace.
 
     Defaults match ``evidence build`` for the parameters this verb forwards
-    (``gpu`` defaults to 0). It does not forward ``--analyzers``, ``--format``,
+    (``gpu`` defaults to the first device in the profile). It does not forward ``--analyzers``, ``--format``,
     or ``--output``: the default pack always runs, evidence prints to stdout,
     and findings land in the session.
 
@@ -82,7 +82,8 @@ def run_diagnose(
 
     try:
         with Profile(sqlite_path) as prof:
-            builder = EvidenceBuilder(prof, device=gpu, trim=trim)
+            selected_gpu = select_gpu_device(prof, gpu)
+            builder = EvidenceBuilder(prof, device=selected_gpu, trim=trim)
             # Analysis completes before any session writer lease is taken.
             report = builder.build()
             before = build_local_profile_reference(prof.path, trim_ns=trim)
@@ -158,7 +159,7 @@ def run_diagnose(
         return _open_session_web(
             before_path=before.path,
             session_id=resolved_id,
-            gpu=gpu,
+            gpu=selected_gpu,
             trim=trim,
             port=port,
             open_browser=open_browser,

--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -273,7 +273,7 @@ def run_optimize(
     workload: Sequence[str],
     session_id: str | os.PathLike[str] | None = None,
     nsys: str = "nsys",
-    gpu: int = 0,
+    gpu: int | None = None,
     trim: tuple[int, int] | None = None,
     session_root: str | os.PathLike[str] = ".nsys-ai/sessions",
     cwd: str | os.PathLike[str] | None = None,

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -31,6 +31,7 @@ from nsys_ai.exceptions import (
     ExportToolMissingError,
     ProfileNotFoundError,
     SchemaError,
+    UsageError,
 )
 from nsys_ai.profile_reference import inspect_local_parquetdir
 
@@ -50,6 +51,20 @@ class ProfileResolution:
     storage_kind: StorageKind
     backend: Literal["sqlite", "parquetdir"]
     cache_mode: Literal["auto", "direct"]
+
+
+def select_gpu_device(profile: "Profile", requested: int | None) -> int:
+    """Choose a real profile device, preserving an explicit GPU 0."""
+    devices = list(profile.meta.devices)
+    if requested is None:
+        return devices[0] if devices else 0
+    if requested not in devices:
+        rendered = ", ".join(str(device) for device in devices)
+        raise UsageError(
+            f"GPU device {requested} is not present in the profile; available devices: "
+            f"{rendered or '(none)'}"
+        )
+    return requested
 
 
 def resolve_ingest_policy(policy: str | None = None) -> IngestPolicy:

--- a/tests/test_gpu_selection.py
+++ b/tests/test_gpu_selection.py
@@ -1,0 +1,42 @@
+from types import SimpleNamespace
+
+import pytest
+
+from nsys_ai.cli.parsers import _build_legacy_parser, _build_parser
+from nsys_ai.exceptions import UsageError
+from nsys_ai.profile import select_gpu_device
+
+
+@pytest.mark.parametrize(
+    ("devices", "requested", "expected"),
+    [([1, 2, 3], None, 1), ([0, 1], 0, 0), ([7], 7, 7), ([], None, 0)],
+)
+def test_select_gpu_device_preserves_explicit_zero_and_uses_first_present(
+    devices, requested, expected
+):
+    profile = SimpleNamespace(meta=SimpleNamespace(devices=devices))
+
+    assert select_gpu_device(profile, requested) == expected
+
+
+def test_select_gpu_device_rejects_absent_explicit_device():
+    profile = SimpleNamespace(meta=SimpleNamespace(devices=[1, 2, 3]))
+
+    with pytest.raises(UsageError, match=r"GPU device 0.*available devices: 1, 2, 3"):
+        select_gpu_device(profile, 0)
+
+
+def test_cli_defaults_for_profile_aware_commands_are_unset():
+    parser = _build_parser()
+    profile = "profile.sqlite"
+
+    diagnose = parser.parse_args(["diagnose", profile])
+    evidence = parser.parse_args(["evidence", "build", profile])
+    optimize = parser.parse_args(["optimize", "--repo", ".", profile, "--", "true"])
+    legacy_parser = _build_legacy_parser()
+    analyze = legacy_parser.parse_args(["analyze", profile, "--format", "json"])
+
+    assert diagnose.gpu is None
+    assert evidence.gpu is None
+    assert analyze.gpu is None
+    assert optimize.gpu is None


### PR DESCRIPTION
## Summary

- select the first device present in the profile when `--gpu` is omitted
- preserve explicit `--gpu 0` semantics
- reject an explicit device that is absent and list available devices
- apply the same selection to `diagnose`, `optimize`, `analyze`, and `evidence build`
- add parser and selection coverage for non-zero device ids

Closes #460

## Validation

- `ruff check src/nsys_ai/profile.py src/nsys_ai/cli/handlers.py src/nsys_ai/cli/parsers.py src/nsys_ai/diagnose_command.py src/nsys_ai/optimize_command.py tests/test_gpu_selection.py`
- `PYTHONPATH=src pytest -q tests/test_gpu_selection.py tests/test_profile_resolve.py tests/test_profile_modes.py` — 43 passed
- real `perf.sqlite` metadata check reports devices `[0, 1, 2, 3]`
