### PR TITLE
fix(diff): guard session pair memo before reconcile

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1035,6 +1035,8 @@ def _cmd_diff(args, _profile):
     # (no symlink dereference), matching SessionStore / build_local_profile_reference.
     session_before_path = None
     session_after_path = None
+    before_ref = None
+    after_ref = None
     # Defaulted here rather than in the parser so the default stays visible next
     # to the only code that writes it. A CI job runs in a checkout, so a record
     # it cannot redirect is a record it cannot keep out of the repo under test.
@@ -1116,15 +1118,36 @@ def _cmd_diff(args, _profile):
             # Opened Profile.path is the resolved .sqlite (including .nsys-rep sidecars).
             session_before_path = before.path
             session_after_path = after.path
-            if session == "":
-                from nsys_ai.profile_runner import build_local_profile_reference
-                from nsys_ai.session_cli import resolve_session_id
+            from nsys_ai.exceptions import ProfileError
+            from nsys_ai.profile_runner import build_local_profile_reference
+            from nsys_ai.session_cli import (
+                resolve_session_id,
+                validate_session_diff_after_profile,
+            )
 
+            try:
                 before_ref = build_local_profile_reference(
-                    os.path.abspath(os.path.expanduser(before.path))
+                    os.path.abspath(os.path.expanduser(before.path)),
+                    trim_ns=trim_before or trim,
                 )
-                session = resolve_session_id(None, before=before_ref)
-                diff_index = _diff_index_for_session(session)
+                after_ref = build_local_profile_reference(
+                    os.path.abspath(os.path.expanduser(after.path)),
+                    trim_ns=trim_after or trim,
+                )
+                if session == "":
+                    session = resolve_session_id(None, before=before_ref)
+                    diff_index = _diff_index_for_session(session, root=session_root)
+                # Do this before DiffIndex.reconcile. The writer repeats the
+                # guard later, but waiting until then can rebuild and persist a
+                # memo for an after profile the session will reject.
+                validate_session_diff_after_profile(
+                    session_id=session,
+                    after_profile=after_ref,
+                    root=session_root,
+                )
+            except (TypeError, ValueError, ProfileError) as exc:
+                print(f"Error: {exc}", file=sys.stderr)
+                sys.exit(2)
         if trim_before is not None and trim_after is not None:
             summary = diff_profiles(
                 before,
@@ -1315,7 +1338,6 @@ def _cmd_diff(args, _profile):
             print("Error: --session requires a computed profile diff", file=sys.stderr)
             sys.exit(2)
         from nsys_ai.exceptions import ProfileError
-        from nsys_ai.profile_runner import build_local_profile_reference
         from nsys_ai.session_cli import publish_session_diff, resolve_session_id
 
         # Absolute either way. ``session_before_path`` is the opened profile's
@@ -1334,12 +1356,13 @@ def _cmd_diff(args, _profile):
             os.path.expanduser(session_after_path or args.after)
         )
         try:
-            before_ref = build_local_profile_reference(
-                before_path, trim_ns=trim_before or trim
-            )
-            after_ref = build_local_profile_reference(
-                after_path, trim_ns=trim_after or trim
-            )
+            if before_ref is None or after_ref is None:
+                before_ref = build_local_profile_reference(
+                    before_path, trim_ns=trim_before or trim
+                )
+                after_ref = build_local_profile_reference(
+                    after_path, trim_ns=trim_after or trim
+                )
             session_id = resolve_session_id(session or None, before=before_ref)
             # to_diff_dict carries each profile's ``path`` straight from
             # Profile.path, which is the caller's spelling -- "before.sqlite"

--- a/src/nsys_ai/session_cli.py
+++ b/src/nsys_ai/session_cli.py
@@ -235,6 +235,32 @@ def publish_session_diff(
         return writer.publish_diff(diff)
 
 
+def validate_session_diff_after_profile(
+    *,
+    session_id: str,
+    after_profile: LocalProfileReference,
+    root: str | os.PathLike[str] = DEFAULT_SESSION_ROOT,
+) -> SessionSnapshot:
+    """Validate a diff candidate before any expensive or persistent work.
+
+    ``publish_session_diff`` remains the authoritative writer-side guard. CLI
+    callers also need the same check before running ``DiffIndex.reconcile``:
+    a rejected after profile must not spend analysis time or overwrite a warm
+    pair memo. Proposal/reprofile and diagnose phases intentionally retain the
+    existing publish semantics; only an already-established after profile is
+    immutable here.
+    """
+    session_id, root = _normalize_target(session_id, root)
+    if not isinstance(after_profile, LocalProfileReference):
+        raise TypeError("after_profile must be a LocalProfileReference")
+    snapshot = SessionStore(root).load(session_id)
+    if snapshot.state.phase not in {"propose", "reprofile", "diagnose"} and (
+        snapshot.state.after_profile != after_profile
+    ):
+        raise ValueError("session after profile does not match the after profile being diffed")
+    return snapshot
+
+
 def publish_session_decision(
     *,
     session_id: str,

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -175,6 +175,27 @@ def test_cli_session_artifacts_survive_a_second_process(tmp_path: Path):
         "logs",
     }
 
+    # A rejected after profile must fail before DiffIndex.reconcile can
+    # replace the warm pair memo with the wrong pair.
+    pair_path = directory / "indices" / "pair_summary.json"
+    pair_before = pair_path.read_bytes()
+    mismatched_diff = _run_cli(
+        tmp_path,
+        "diff",
+        str(before),
+        str(before),
+        "--gpu",
+        "0",
+        "--format",
+        "json",
+        "--no-ai",
+        "--session",
+        session_id,
+    )
+    assert mismatched_diff.returncode == 2
+    assert "session after profile does not match" in mismatched_diff.stderr
+    assert pair_path.read_bytes() == pair_before
+
     script = """
 import json, sys
 from nsys_ai.session_store import SessionStore


### PR DESCRIPTION
## Summary

- validate the session's immutable after profile before running `DiffIndex.reconcile`
- preserve the existing writer-side validation as the final guard
- add an integration regression test proving a rejected pair cannot overwrite `pair_summary.json`

## Validation

- `ruff check src/nsys_ai/cli/handlers.py src/nsys_ai/session_cli.py tests/test_session_cli.py tests/test_diff_index.py`
- `PYTHONPATH=src python3 -m pytest -q tests/test_session_cli.py tests/test_diff_index.py --tb=short` (13 passed)

Closes #466
