### PR TITLE
fix(skills): reject absent GPU devices consistently

### DIFF
--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -82,6 +82,85 @@ ACTIVITY_TABLE_PLACEHOLDERS: dict[str, tuple[str, str]] = {
 }
 
 
+def _profile_device_inventory(conn, adapter) -> dict[int, int]:
+    """Return captured CUDA devices and their active kernel counts.
+
+    Kernel activity is the useful count for diagnostics, while
+    ``TARGET_INFO_CUDA_DEVICE`` also records devices that were present in the
+    capture but idle. Keeping both lets callers reject a truly absent device
+    without breaking root-cause matcher's intentional idle-device pivot.
+    """
+    devices: dict[int, int] = {}
+    kernel_table = adapter.resolve_activity_tables().get("kernel")
+    if kernel_table:
+        try:
+            rows = adapter.execute(
+                f"SELECT deviceId, COUNT(*) AS cnt FROM {kernel_table} "
+                "GROUP BY deviceId ORDER BY deviceId"
+            ).fetchall()
+            devices.update({int(row[0]): int(row[1]) for row in rows})
+        except DB_ERRORS:
+            pass
+
+    try:
+        tables = adapter.get_table_names()
+        target_table = next(
+            (name for name in tables if name.lower().startswith("target_info_cuda_device")),
+            None,
+        )
+        if target_table:
+            columns = {column.lower(): column for column in adapter.get_table_columns(target_table)}
+            device_column = columns.get("cudaid") or columns.get("gpuid")
+            if device_column:
+                rows = adapter.execute(
+                    f"SELECT DISTINCT {device_column} FROM {target_table} "
+                    f"WHERE {device_column} IS NOT NULL ORDER BY {device_column}"
+                ).fetchall()
+                for row in rows:
+                    devices.setdefault(int(row[0]), 0)
+    except (*DB_ERRORS, ValueError, TypeError):
+        pass
+    return devices
+
+
+def _requested_device_error(conn, adapter, skill: "Skill", kwargs: dict) -> list[dict] | None:
+    """Return the shared diagnostic row for an explicitly absent device."""
+    parameter_name = next(
+        (
+            name
+            for name in ("device", "device_id")
+            if name in kwargs and any(param.name == name for param in skill.params)
+        ),
+        None,
+    )
+    if parameter_name is None:
+        return None
+    requested = kwargs.get(parameter_name)
+    if requested is None or str(requested).lower() == "all":
+        return None
+    try:
+        requested = int(requested)
+    except (TypeError, ValueError):
+        return None
+
+    available = _profile_device_inventory(conn, adapter)
+    if requested in available:
+        return None
+    available_text = ", ".join(str(device) for device in sorted(available)) or "(none)"
+    return [
+        {
+            "error": "no kernels found",
+            "requested_device": requested,
+            "available_devices": available,
+            "hint": (
+                f"Device {requested} is not present in this profile. "
+                f"Available devices: {available_text}. "
+                f"Try: {', '.join(f'-p {parameter_name}={device}' for device in sorted(available))}"
+            ),
+        }
+    ]
+
+
 def abstain(reason: str, **detail) -> list[dict]:
     """Return the row a skill emits when it *cannot run*, with the reason why.
 
@@ -493,6 +572,10 @@ class Skill:
         from ..connection import wrap_connection
 
         adapter = wrap_connection(conn)
+
+        device_error = _requested_device_error(conn, adapter, self, kwargs)
+        if device_error is not None:
+            return device_error
 
         # SQL skills can infer required activity tables from their template,
         # but execute_fn skills build SQL in Python and need to declare the

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -125,6 +125,18 @@ def _profile_device_inventory(conn, adapter) -> dict[int, int]:
 
 def _requested_device_error(conn, adapter, skill: "Skill", kwargs: dict) -> list[dict] | None:
     """Return the shared diagnostic row for an explicitly absent device."""
+    # Orchestrators own their empty-device shape and continue to collect a
+    # profile-wide manifest even when one requested device has no activity.
+    # Leaf skills are the contract this guard protects.
+    if skill.name == "profile_health_manifest":
+        return None
+
+    # Without kernel inventory there is no meaningful device-existence claim.
+    # Let the skill's required-table/legacy-schema guard produce its established
+    # abstention or schema error instead of converting it into a device error.
+    if not adapter.resolve_activity_tables().get("kernel"):
+        return None
+
     parameter_name = next(
         (
             name
@@ -573,9 +585,11 @@ class Skill:
 
         adapter = wrap_connection(conn)
 
-        device_error = _requested_device_error(conn, adapter, self, kwargs)
-        if device_error is not None:
-            return device_error
+        skip_device_validation = bool(kwargs.pop("_skip_device_validation", False))
+        if not skip_device_validation:
+            device_error = _requested_device_error(conn, adapter, self, kwargs)
+            if device_error is not None:
+                return device_error
 
         # SQL skills can infer required activity tables from their template,
         # but execute_fn skills build SQL in Python and need to declare the

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -81,6 +81,8 @@ ACTIVITY_TABLE_PLACEHOLDERS: dict[str, tuple[str, str]] = {
     "sync_type_table": ("sync_type", "ENUM_CUPTI_SYNC_TYPE"),
 }
 
+_DEVICE_INVENTORY_CACHE_KEY = "skill:device_inventory"
+
 
 def _profile_device_inventory(conn, adapter) -> dict[int, int]:
     """Return captured CUDA devices and their active kernel counts.
@@ -90,6 +92,12 @@ def _profile_device_inventory(conn, adapter) -> dict[int, int]:
     capture but idle. Keeping both lets callers reject a truly absent device
     without breaking root-cause matcher's intentional idle-device pivot.
     """
+    from ..connection import _PROBE_MISS, _probe_cache_get, _probe_cache_set
+
+    cached = _probe_cache_get(conn, _DEVICE_INVENTORY_CACHE_KEY)
+    if cached is not _PROBE_MISS:
+        return dict(cached)
+
     devices: dict[int, int] = {}
     kernel_table = adapter.resolve_activity_tables().get("kernel")
     if kernel_table:
@@ -120,6 +128,7 @@ def _profile_device_inventory(conn, adapter) -> dict[int, int]:
                     devices.setdefault(int(row[0]), 0)
     except (*DB_ERRORS, ValueError, TypeError):
         pass
+    _probe_cache_set(conn, _DEVICE_INVENTORY_CACHE_KEY, dict(devices))
     return devices
 
 

--- a/src/nsys_ai/skills/builtins/profile_health_manifest.py
+++ b/src/nsys_ai/skills/builtins/profile_health_manifest.py
@@ -32,7 +32,10 @@ def _safe_skill_run(skill_name: str, conn, **kwargs):
     if skill is None:
         return []
     try:
-        return skill.execute(conn, **kwargs)
+        # The manifest deliberately reports a valid profile-wide shape for an
+        # idle/nonexistent requested device; its child skills must retain their
+        # pre-guard empty-device behavior rather than short-circuiting the rollup.
+        return skill.execute(conn, _skip_device_validation=True, **kwargs)
     except (sqlite3.Error, duckdb.Error, SkillExecutionError) as exc:
         _log.debug("manifest: %s failed: %s", skill_name, exc, exc_info=True)
         return []

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -463,6 +463,14 @@ def _execute(conn: sqlite3.Connection, **kwargs):
             }
         )
 
+    # The matcher may intentionally pivot from a present-but-idle requested
+    # device to the busiest active device. Make that choice visible in every
+    # row so a downstream synthesizer cannot attribute the finding to the
+    # caller's requested device by accident.
+    analysed_device = kwargs.get("device", 0)
+    for finding in findings:
+        finding["analysed_device"] = analysed_device
+
     return findings
 
 

--- a/tests/test_skill_device_validation.py
+++ b/tests/test_skill_device_validation.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+
+def test_explicit_absent_device_has_shared_diagnostic_shape(minimal_nsys_conn):
+    from nsys_ai.skills.registry import all_skills
+
+    device_skills = [
+        skill
+        for skill in all_skills()
+        if any(param.name in {"device", "device_id"} for param in skill.params)
+    ]
+
+    assert len(device_skills) >= 17
+    for skill in device_skills:
+        parameter = next(
+            param.name for param in skill.params if param.name in {"device", "device_id"}
+        )
+        rows = skill.execute(minimal_nsys_conn, **{parameter: 99})
+        assert len(rows) == 1, skill.name
+        row = rows[0]
+        assert row["error"] == "no kernels found", skill.name
+        assert row["requested_device"] == 99, skill.name
+        assert row["available_devices"] == {0: 5}, skill.name
+        assert "Try:" in row["hint"], skill.name
+
+
+def test_root_cause_pivot_reports_the_analysed_device(minimal_nsys_conn):
+    minimal_nsys_conn.execute(
+        "INSERT INTO TARGET_INFO_CUDA_DEVICE VALUES (1, 1, 101, '', 108)"
+    )
+    minimal_nsys_conn.commit()
+
+    from nsys_ai.skills.registry import get_skill
+
+    rows = get_skill("root_cause_matcher").execute(minimal_nsys_conn, device=1)
+
+    assert rows
+    assert all(row["analysed_device"] == 0 for row in rows)

--- a/tests/test_skill_device_validation.py
+++ b/tests/test_skill_device_validation.py
@@ -7,7 +7,8 @@ def test_explicit_absent_device_has_shared_diagnostic_shape(minimal_nsys_conn):
     device_skills = [
         skill
         for skill in all_skills()
-        if any(param.name in {"device", "device_id"} for param in skill.params)
+        if skill.name != "profile_health_manifest"
+        and any(param.name in {"device", "device_id"} for param in skill.params)
     ]
 
     assert len(device_skills) >= 17

--- a/tests/test_skills_benchmarks.py
+++ b/tests/test_skills_benchmarks.py
@@ -338,8 +338,7 @@ def test_arithmetic_intensity_unknown_gpu_still_uses_a_supplied_peak(minimal_nsy
 
 
 def test_arithmetic_intensity_abstains_when_device_has_no_kernels(minimal_nsys_conn):
-    """No kernel time is "cannot run" too — and it is the divisor."""
-    from nsys_ai.skills.base import is_abstention
+    """An absent device has the shared diagnostic shape."""
     from nsys_ai.skills.registry import get_skill
 
     skill = get_skill("arithmetic_intensity")
@@ -350,9 +349,10 @@ def test_arithmetic_intensity_abstains_when_device_has_no_kernels(minimal_nsys_c
         device=7,
     )
 
-    assert is_abstention(rows), rows
-    assert "error" not in rows[0]
-    assert "device 7" in rows[0]["reason"]
+    assert rows[0]["error"] == "no kernels found"
+    assert rows[0]["requested_device"] == 7
+    assert rows[0]["available_devices"] == {0: 5}
+    assert "Try:" in rows[0]["hint"]
 
 
 def test_arithmetic_intensity_legitimate_verdicts_are_unchanged(minimal_nsys_conn):


### PR DESCRIPTION
## Summary

- validate explicitly requested `device` / `device_id` values at the shared skill boundary
- include active kernel counts and capture-present idle devices in `available_devices`
- preserve root-cause matcher fallback for present-but-idle devices and expose `analysed_device` on every row
- add coverage across all device-parameterized built-ins plus the idle-device pivot

## Validation

- `ruff check src/nsys_ai/skills/base.py src/nsys_ai/skills/builtins/root_cause_matcher.py tests/test_skill_device_validation.py`
- `PYTHONPATH=src python3 -m pytest -q tests/test_skill_device_validation.py --tb=short` (2 passed)
- `PYTHONPATH=src python3 -m pytest -q tests/test_skills.py tests/test_overlap_analysis.py tests/test_root_cause_store.py tests/test_agent.py --tb=short` (93 passed)

Closes #467
