### PR TITLE
fix(runspec): record dirty worktree identity

### DIFF
--- a/src/nsys_ai/optimize_command.py
+++ b/src/nsys_ai/optimize_command.py
@@ -224,7 +224,9 @@ def _build_runspec(
     *, repo: Path, workload: Sequence[str], nsys_executable: str, stderr: TextIO
 ) -> RunSpec:
     """Build the verification RunSpec from ``--repo`` and the workload argv."""
-    repository, commit, runspec_cwd = discover_git_provenance(repo)
+    repository, commit, runspec_cwd, dirty, worktree_diff_sha256 = (
+        discover_git_provenance(repo)
+    )
     if repository is None:
         # Not a Git checkout: still bind the run to the directory the user
         # named, so the recorded RunSpec is reproducible without a commit.
@@ -238,6 +240,8 @@ def _build_runspec(
         cwd=runspec_cwd,
         repository=repository,
         commit=commit,
+        dirty=dirty,
+        worktree_diff_sha256=worktree_diff_sha256,
         environment=EnvironmentSpec(policy="inherit"),
         trace_options=NsysTraceOptions(trace=trace),
     )

--- a/src/nsys_ai/profile_command.py
+++ b/src/nsys_ai/profile_command.py
@@ -7,6 +7,7 @@ does not own runner internals or durable session layout.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
 import shutil
@@ -180,12 +181,19 @@ def parse_environment(
     return EnvironmentSpec(public=public, secrets=tuple(secret_names))
 
 
-def discover_git_provenance(cwd: Path) -> tuple[str | None, str | None, str]:
-    """Return repository, commit, and RunSpec cwd with clean non-Git fallback."""
+def discover_git_provenance(
+    cwd: Path,
+) -> tuple[str | None, str | None, str, bool, str | None]:
+    """Return repository identity, worktree identity, and RunSpec cwd.
+
+    The diff itself is never persisted. Only its SHA-256 digest is recorded,
+    so a dirty checkout is distinguishable without creating a secret-bearing
+    patch artifact.
+    """
     absolute_cwd = cwd.resolve()
     git_executable = shutil.which("git")
     if git_executable is None:
-        return None, None, str(absolute_cwd)
+        return None, None, str(absolute_cwd), False, None
     git_executable = str(Path(git_executable).resolve())
 
     def git(*args: str, working_directory: Path) -> str | None:
@@ -207,16 +215,24 @@ def discover_git_provenance(cwd: Path) -> tuple[str | None, str | None, str]:
 
     root_text = git("rev-parse", "--show-toplevel", working_directory=absolute_cwd)
     if root_text is None:
-        return None, None, str(absolute_cwd)
+        return None, None, str(absolute_cwd), False, None
     root = Path(root_text).resolve()
     try:
         relative = absolute_cwd.relative_to(root).as_posix() or "."
     except ValueError:
-        return None, None, str(absolute_cwd)
+        return None, None, str(absolute_cwd), False, None
     commit = git("rev-parse", "--verify", "HEAD", working_directory=root)
     if commit is None or not re.fullmatch(r"[0-9a-fA-F]{40}", commit):
-        return None, None, str(absolute_cwd)
-    return str(root), commit.lower(), relative
+        return None, None, str(absolute_cwd), False, None
+
+    status = git("status", "--porcelain", working_directory=root)
+    dirty = bool(status)
+    if not dirty:
+        return str(root), commit.lower(), relative, False, None
+
+    diff = git("diff", "HEAD", "--binary", working_directory=root) or ""
+    diff_sha256 = hashlib.sha256(diff.encode("utf-8")).hexdigest()
+    return str(root), commit.lower(), relative, True, diff_sha256
 
 
 def default_output_leaf(cwd: Path) -> Path:
@@ -299,12 +315,16 @@ def run_profile_command(
         )
         return 0
 
-    repository, commit, runspec_cwd = discover_git_provenance(working_directory)
+    repository, commit, runspec_cwd, dirty, worktree_diff_sha256 = (
+        discover_git_provenance(working_directory)
+    )
     spec = RunSpec(
         argv=workload,
         cwd=runspec_cwd,
         repository=repository,
         commit=commit,
+        dirty=dirty,
+        worktree_diff_sha256=worktree_diff_sha256,
         environment=environment,
         warmup_steps=args.warmup_steps,
         profile_steps=args.profile_steps,

--- a/src/nsys_ai/profile_command.py
+++ b/src/nsys_ai/profile_command.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import re
 import shutil
+import stat
 import subprocess  # nosec B404
 import sys
 from collections.abc import Callable, Sequence
@@ -213,6 +215,21 @@ def discover_git_provenance(
         value = completed.stdout.strip()
         return value or None
 
+    def git_bytes(*args: str, working_directory: Path) -> bytes | None:
+        try:
+            completed = subprocess.run(  # nosec B603
+                [git_executable, *args],
+                cwd=working_directory,
+                capture_output=True,
+                timeout=_GIT_TIMEOUT_SECONDS,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return None
+        if completed.returncode != 0:
+            return None
+        return completed.stdout
+
     root_text = git("rev-parse", "--show-toplevel", working_directory=absolute_cwd)
     if root_text is None:
         return None, None, str(absolute_cwd), False, None
@@ -230,8 +247,50 @@ def discover_git_provenance(
     if not dirty:
         return str(root), commit.lower(), relative, False, None
 
-    diff = git("diff", "HEAD", "--binary", working_directory=root) or ""
-    diff_sha256 = hashlib.sha256(diff.encode("utf-8")).hexdigest()
+    diff = git_bytes("diff", "HEAD", "--binary", working_directory=root)
+    untracked = git_bytes(
+        "ls-files",
+        "--others",
+        "--exclude-standard",
+        "-z",
+        working_directory=root,
+    )
+    if diff is None or untracked is None:
+        return str(root), commit.lower(), relative, True, hashlib.sha256(
+            b"worktree identity unavailable"
+        ).hexdigest()
+
+    digest = hashlib.sha256()
+
+    def add_record(label: bytes, payload: bytes) -> None:
+        digest.update(label)
+        digest.update(len(payload).to_bytes(8, "big"))
+        digest.update(payload)
+
+    add_record(b"git-diff-head\0", diff)
+    for encoded_path in untracked.split(b"\0"):
+        if not encoded_path:
+            continue
+        path = root / os.fsdecode(encoded_path)
+        try:
+            metadata = path.lstat()
+            if stat.S_ISREG(metadata.st_mode):
+                payload = (
+                    b"regular\0"
+                    + stat.S_IMODE(metadata.st_mode).to_bytes(4, "big")
+                    + path.read_bytes()
+                )
+            elif stat.S_ISLNK(metadata.st_mode):
+                payload = b"symlink\0" + os.fsencode(os.readlink(path))
+            else:
+                payload = b"special\0" + stat.S_IMODE(metadata.st_mode).to_bytes(
+                    4, "big"
+                )
+        except OSError as exc:
+            payload = b"unreadable\0" + type(exc).__name__.encode("ascii")
+        add_record(b"untracked\0" + encoded_path + b"\0", payload)
+
+    diff_sha256 = digest.hexdigest()
     return str(root), commit.lower(), relative, True, diff_sha256
 
 

--- a/src/nsys_ai/profile_command.py
+++ b/src/nsys_ai/profile_command.py
@@ -275,10 +275,14 @@ def discover_git_provenance(
         try:
             metadata = path.lstat()
             if stat.S_ISREG(metadata.st_mode):
+                content_digest = hashlib.sha256()
+                with path.open("rb") as file_handle:
+                    while chunk := file_handle.read(1 << 20):
+                        content_digest.update(chunk)
                 payload = (
                     b"regular\0"
                     + stat.S_IMODE(metadata.st_mode).to_bytes(4, "big")
-                    + path.read_bytes()
+                    + content_digest.digest()
                 )
             elif stat.S_ISLNK(metadata.st_mode):
                 payload = b"symlink\0" + os.fsencode(os.readlink(path))

--- a/src/nsys_ai/runspec.py
+++ b/src/nsys_ai/runspec.py
@@ -21,7 +21,8 @@ from typing import Any
 
 from .exceptions import NsysAiError
 
-RUNSPEC_SCHEMA_VERSION = "0.1"
+RUNSPEC_SCHEMA_VERSION = "0.2"
+RUNSPEC_SCHEMA_VERSIONS = frozenset({"0.1", RUNSPEC_SCHEMA_VERSION})
 RUNSPEC_COMPATIBILITY_VERSION = "1"
 _ENV_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _TRACE_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -230,6 +231,8 @@ class RunSpec:
     cwd: str = "."
     repository: str | None = None
     commit: str | None = None
+    dirty: bool = False
+    worktree_diff_sha256: str | None = None
     environment: EnvironmentSpec = field(default_factory=EnvironmentSpec)
     warmup_steps: int = 0
     profile_steps: int = 1
@@ -261,6 +264,21 @@ class RunSpec:
             object.__setattr__(self, "cwd", str(posix_cwd))
         if self.commit is not None:
             _validate_string(self.commit, "commit")
+        if not isinstance(self.dirty, bool):
+            raise RunSpecError("dirty must be a boolean")
+        if self.dirty and (self.repository is None or self.commit is None):
+            raise RunSpecError("dirty requires repository and commit provenance")
+        if self.worktree_diff_sha256 is not None:
+            if not isinstance(self.worktree_diff_sha256, str) or not re.fullmatch(
+                r"[0-9a-f]{64}", self.worktree_diff_sha256
+            ):
+                raise RunSpecError(
+                    "worktree_diff_sha256 must be a SHA-256 hex string or null"
+                )
+        if self.dirty != (self.worktree_diff_sha256 is not None):
+            raise RunSpecError(
+                "dirty and worktree_diff_sha256 must either describe a dirty worktree or a clean one"
+            )
         if not isinstance(self.environment, EnvironmentSpec):
             raise RunSpecError("environment must be an EnvironmentSpec")
         if isinstance(self.warmup_steps, bool) or not isinstance(self.warmup_steps, int):
@@ -295,6 +313,8 @@ class RunSpec:
             "cwd": self.cwd,
             "repository": self.repository,
             "commit": self.commit,
+            "dirty": self.dirty,
+            "worktree_diff_sha256": self.worktree_diff_sha256,
             "environment": self.environment.to_dict(),
             "warmup_steps": self.warmup_steps,
             "profile_steps": self.profile_steps,
@@ -310,7 +330,7 @@ class RunSpec:
     def from_dict(cls, payload: Mapping[str, Any]) -> RunSpec:
         data = _require_mapping(payload, "RunSpec")
         version = data.get("schema_version")
-        if version != RUNSPEC_SCHEMA_VERSION:
+        if version not in RUNSPEC_SCHEMA_VERSIONS:
             raise UnsupportedRunSpecVersionError(
                 f"unsupported RunSpec schema_version {version!r}; "
                 f"expected {RUNSPEC_SCHEMA_VERSION!r}"
@@ -321,6 +341,8 @@ class RunSpec:
             "cwd",
             "repository",
             "commit",
+            "dirty",
+            "worktree_diff_sha256",
             "environment",
             "warmup_steps",
             "profile_steps",
@@ -332,6 +354,12 @@ class RunSpec:
             "runner",
         }
         _reject_unknown_keys(data, allowed, "RunSpec")
+        if version == "0.1" and (
+            "dirty" in data or "worktree_diff_sha256" in data
+        ):
+            raise UnsupportedRunSpecVersionError(
+                "RunSpec dirty worktree identity requires schema_version '0.2'"
+            )
         if "argv" not in data:
             raise RunSpecError("RunSpec.argv is required")
         return cls(
@@ -339,6 +367,8 @@ class RunSpec:
             cwd=data.get("cwd", "."),
             repository=data.get("repository"),
             commit=data.get("commit"),
+            dirty=data.get("dirty", False),
+            worktree_diff_sha256=data.get("worktree_diff_sha256"),
             environment=EnvironmentSpec.from_dict(data.get("environment", {})),
             warmup_steps=data.get("warmup_steps", 0),
             profile_steps=data.get("profile_steps", 1),
@@ -386,6 +416,8 @@ class RunSpec:
     def compatibility_limitations(self) -> tuple[str, ...]:
         """Name inputs whose equality the persisted artifact cannot prove."""
         limitations: list[str] = []
+        if self.dirty:
+            limitations.append("uncommitted_worktree")
         if self.environment.policy == "inherit":
             limitations.append("inherited_environment_unresolved")
         if self.environment.secrets:

--- a/src/nsys_ai/runspec.py
+++ b/src/nsys_ai/runspec.py
@@ -333,7 +333,7 @@ class RunSpec:
         if version not in RUNSPEC_SCHEMA_VERSIONS:
             raise UnsupportedRunSpecVersionError(
                 f"unsupported RunSpec schema_version {version!r}; "
-                f"expected {RUNSPEC_SCHEMA_VERSION!r}"
+                f"expected one of {', '.join(sorted(RUNSPEC_SCHEMA_VERSIONS))!r}"
             )
         allowed = {
             "schema_version",

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -59,6 +59,7 @@ from .proposal import (
 )
 from .runspec import (
     RUNSPEC_SCHEMA_VERSION,
+    RUNSPEC_SCHEMA_VERSIONS,
     RunSpec,
     RunSpecError,
     validate_secret_boundaries,
@@ -406,7 +407,9 @@ class SessionStore:
         diff = None
         decisions: tuple[Mapping[str, Any], ...] = ()
         if "runspec" in state.artifacts:
-            self._check_artifact_version(state, "runspec", RUNSPEC_SCHEMA_VERSION)
+            self._check_artifact_version(
+                state, "runspec", RUNSPEC_SCHEMA_VERSIONS
+            )
             self._verify_artifact(state, "runspec")
             try:
                 runspec = RunSpec.from_dict(
@@ -640,12 +643,14 @@ class SessionStore:
 
     @staticmethod
     def _check_artifact_version(
-        state: SessionState, name: str, expected: str
+        state: SessionState, name: str, expected: str | frozenset[str]
     ) -> None:
         actual = state.artifacts[name].schema_version
-        if actual != expected:
+        expected_versions = {expected} if isinstance(expected, str) else expected
+        if actual not in expected_versions:
             raise UnsupportedSessionVersionError(
-                f"unsupported {name} artifact schema_version {actual!r}; expected {expected!r}"
+                f"unsupported {name} artifact schema_version {actual!r}; "
+                f"expected {sorted(expected_versions)!r}"
             )
 
     def _require_session(self, session_id: str) -> None:

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -223,18 +223,33 @@ def test_git_provenance_records_absolute_root_full_commit_and_relative_cwd(tmp_p
     subprocess.run(["git", "-C", str(repo), "add", "tracked.txt"], check=True)
     subprocess.run(["git", "-C", str(repo), "commit", "-qm", "fixture"], check=True)
 
-    repository, commit, cwd = discover_git_provenance(nested)
+    repository, commit, cwd, dirty, worktree_diff_sha256 = discover_git_provenance(nested)
 
     assert repository == str(repo.resolve())
     assert commit is not None and len(commit) == 40
     assert cwd == "training/jobs"
+    assert dirty is False
+    assert worktree_diff_sha256 is None
+
+    (repo / "tracked.txt").write_text("changed")
+    _, dirty_commit, _, dirty, dirty_hash = discover_git_provenance(nested)
+    assert dirty_commit == commit
+    assert dirty is True
+    assert dirty_hash is not None and len(dirty_hash) == 64
+
+    (repo / "tracked.txt").write_text("changed again")
+    _, _, _, changed_dirty, changed_hash = discover_git_provenance(nested)
+    assert changed_dirty is True
+    assert changed_hash != dirty_hash
 
 
 def test_non_git_provenance_degrades_to_absolute_cwd(tmp_path):
-    repository, commit, cwd = discover_git_provenance(tmp_path)
+    repository, commit, cwd, dirty, worktree_diff_sha256 = discover_git_provenance(tmp_path)
     assert repository is None
     assert commit is None
     assert cwd == str(tmp_path.resolve())
+    assert dirty is False
+    assert worktree_diff_sha256 is None
 
 
 def test_dry_run_is_structurally_redacted_and_does_not_create_output(

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -273,6 +273,29 @@ def test_non_git_provenance_degrades_to_absolute_cwd(tmp_path):
     assert worktree_diff_sha256 is None
 
 
+def test_git_provenance_hashes_untracked_files_in_chunks(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "test@example.com"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "Test"], check=True)
+    (repo / "tracked.txt").write_text("tracked")
+    subprocess.run(["git", "-C", str(repo), "add", "tracked.txt"], check=True)
+    subprocess.run(["git", "-C", str(repo), "commit", "-qm", "fixture"], check=True)
+    (repo / "capture.nsys-rep").write_bytes(b"capture" * 1024)
+
+    def forbidden_read_bytes(_path):
+        raise AssertionError("untracked provenance must hash files incrementally")
+
+    monkeypatch.setattr(Path, "read_bytes", forbidden_read_bytes)
+    repository, commit, _cwd, dirty, digest = discover_git_provenance(repo)
+
+    assert repository == str(repo.resolve())
+    assert commit is not None
+    assert dirty is True
+    assert digest is not None and len(digest) == 64
+
+
 def test_dry_run_is_structurally_redacted_and_does_not_create_output(
     tmp_path, fake_nsys, monkeypatch
 ):

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -242,6 +242,27 @@ def test_git_provenance_records_absolute_root_full_commit_and_relative_cwd(tmp_p
     assert changed_dirty is True
     assert changed_hash != dirty_hash
 
+    (repo / "tracked.txt").write_text("changed")
+    (repo / "untracked-one.txt").write_text("one")
+    _, _, _, untracked_dirty, untracked_hash = discover_git_provenance(nested)
+    assert untracked_dirty is True
+    assert untracked_hash != dirty_hash
+
+    (repo / "untracked-one.txt").write_text("two")
+    _, _, _, changed_untracked, changed_untracked_hash = discover_git_provenance(
+        nested
+    )
+    assert changed_untracked is True
+    assert changed_untracked_hash != untracked_hash
+
+    (repo / "untracked-one.txt").unlink()
+    (repo / "untracked-two.txt").write_text("one")
+    _, _, _, renamed_untracked, renamed_untracked_hash = discover_git_provenance(
+        nested
+    )
+    assert renamed_untracked is True
+    assert renamed_untracked_hash != untracked_hash
+
 
 def test_non_git_provenance_degrades_to_absolute_cwd(tmp_path):
     repository, commit, cwd, dirty, worktree_diff_sha256 = discover_git_provenance(tmp_path)

--- a/tests/test_runspec.py
+++ b/tests/test_runspec.py
@@ -120,8 +120,57 @@ def test_unknown_schema_version_has_stated_reason():
     payload = _full_spec().to_dict()
     payload["schema_version"] = "9.0"
 
-    with pytest.raises(UnsupportedRunSpecVersionError, match="9.0.*expected '0.1'"):
+    with pytest.raises(UnsupportedRunSpecVersionError, match="9.0.*expected '0.2'"):
         RunSpec.from_dict(payload)
+
+
+def test_schema_v01_remains_readable_without_new_identity_fields():
+    payload = _full_spec().to_dict()
+    payload["schema_version"] = "0.1"
+    payload.pop("dirty")
+    payload.pop("worktree_diff_sha256")
+
+    parsed = RunSpec.from_dict(payload)
+
+    assert parsed.dirty is False
+    assert parsed.worktree_diff_sha256 is None
+
+
+def test_schema_v01_rejects_v02_identity_fields():
+    payload = _full_spec(dirty=True, worktree_diff_sha256="a" * 64).to_dict()
+    payload["schema_version"] = "0.1"
+
+    with pytest.raises(UnsupportedRunSpecVersionError, match="requires schema_version '0.2'"):
+        RunSpec.from_dict(payload)
+
+
+def test_dirty_worktree_identity_round_trips_and_is_distinct():
+    first = _full_spec(
+        dirty=True,
+        worktree_diff_sha256="a" * 64,
+    )
+    second = _full_spec(
+        dirty=True,
+        worktree_diff_sha256="b" * 64,
+    )
+
+    assert RunSpec.from_dict(first.to_dict()) == first
+    assert first.canonical_json_bytes() != second.canonical_json_bytes()
+    assert first.compatibility_key() == second.compatibility_key()
+    assert "uncommitted_worktree" in first.compatibility_limitations()
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"dirty": True},
+        {"worktree_diff_sha256": "not-a-sha"},
+        {"dirty": False, "worktree_diff_sha256": "a" * 64},
+    ],
+)
+def test_dirty_worktree_identity_requires_a_complete_provenance_pair(overrides):
+    with pytest.raises(RunSpecError, match="dirty|worktree_diff_sha256"):
+        _full_spec(**overrides)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runspec.py
+++ b/tests/test_runspec.py
@@ -120,7 +120,10 @@ def test_unknown_schema_version_has_stated_reason():
     payload = _full_spec().to_dict()
     payload["schema_version"] = "9.0"
 
-    with pytest.raises(UnsupportedRunSpecVersionError, match="9.0.*expected '0.2'"):
+    with pytest.raises(
+        UnsupportedRunSpecVersionError,
+        match=r"9\.0.*expected one of.*0\.1.*0\.2",
+    ):
         RunSpec.from_dict(payload)
 
 


### PR DESCRIPTION
## Summary

- record `dirty` and `worktree_diff_sha256` in RunSpec v0.2
- capture the worktree identity from both `profile` and `optimize`
- persist only the SHA-256 digest; never write the worktree patch into a session artifact
- keep clean and non-Git fallbacks, and allow legacy RunSpec v0.1 artifacts without the new fields
- surface dirty-worktree provenance as a proposal compatibility limitation

## Verification

- `PYTHONPATH=src python3 -m pytest tests/test_runspec.py tests/test_profile_command.py tests/test_optimize_command.py tests/test_proposal.py tests/test_session_store.py -q --tb=short` — 274 passed
- `ruff check` on changed source and test files — passed
- full suite — 2403 passed, 146 skipped, 4 xfailed; 8 failures are pre-existing environment/surface failures involving fixed Web ports, Web/TUI session signatures, and the CI profile skip guard

Closes #409
