### PR TITLE
fix(runspec): guard produced captures from environment leaks

### DIFF
--- a/docs/real-profile-testing.md
+++ b/docs/real-profile-testing.md
@@ -1,0 +1,15 @@
+# Real profile security checks
+
+The default test suite uses committed SQLite exports and therefore cannot prove
+properties of a report produced by the local Nsight runner. On a CUDA-capable
+machine with `nsys` and `nvcc`, run the load-bearing capture check explicitly:
+
+```bash
+NSYS_REAL_CAPTURE=1 pytest tests/test_real_capture_security.py -v
+```
+
+The test compiles a tiny CUDA workload, runs it through `LocalProfileRunner`,
+and verifies that the resulting capture does not persist the runner's declared
+environment. CI records this test as an opt-in skip because hosted runners do
+not provide Nsight Systems or a CUDA device; the fast argv assertion remains in
+the ordinary suite.

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -76,6 +76,67 @@ class RunProgress:
 _ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
+def _quote_sql_identifier(value: str) -> str:
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _assert_capture_does_not_persist_environment(
+    sqlite_path: Path, environment: Mapping[str, str]
+) -> None:
+    """Reject a produced capture containing a serialized runner environment.
+
+    Nsight stores process environments as newline-delimited ``NAME=value``
+    strings in text columns (commonly ``StringIds``).  ``TARGET_INFO_SYSTEM_ENV``
+    also contains legitimate machine metadata, so its row count is not a valid
+    security assertion.  Compare complete name/value entries instead and fail
+    closed before publishing the profile as a successful run.
+    """
+    if not environment:
+        return
+    expected = {f"{name}={value}" for name, value in environment.items() if value}
+    if not expected:
+        return
+
+    uri = f"file:{sqlite_path}?mode=ro"
+    try:
+        connection = sqlite3.connect(uri, uri=True)
+    except sqlite3.Error as exc:
+        raise ProfileError("produced profile cannot be checked for environment data") from exc
+    try:
+        tables = connection.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' "
+            "AND name NOT LIKE 'sqlite_%'"
+        ).fetchall()
+        for (table,) in tables:
+            columns = connection.execute(
+                f"PRAGMA table_info({_quote_sql_identifier(table)})"
+            ).fetchall()
+            text_columns = [
+                column[1]
+                for column in columns
+                if any(
+                    token in str(column[2]).upper()
+                    for token in ("CHAR", "CLOB", "TEXT", "VARCHAR")
+                )
+            ]
+            for column in text_columns:
+                predicates = " OR ".join(
+                    f"instr({_quote_sql_identifier(column)}, ?) > 0"
+                    for _ in expected
+                )
+                query = (
+                    "SELECT 1 "
+                    f"FROM {_quote_sql_identifier(table)} "
+                    f"WHERE ({predicates}) LIMIT 1"
+                )
+                if connection.execute(query, tuple(sorted(expected))).fetchone():
+                    raise ProfileError("produced profile contains runner environment data")
+    except sqlite3.Error as exc:
+        raise ProfileError("produced profile cannot be checked for environment data") from exc
+    finally:
+        connection.close()
+
+
 def _open_profile_descriptor(profile_path: Path) -> tuple[int, os.stat_result]:
     try:
         resolved_path, path_metadata = inspect_local_profile_file(profile_path)
@@ -671,8 +732,18 @@ class LocalProfileRunner:
         progress(RunStage.VALIDATING)
         validation_started = time.monotonic()
         try:
+            _assert_capture_does_not_persist_environment(sqlite_path, environment)
             reference, observed_gpus = read_local_profile_under_guard(
                 sqlite_path, resolved_secrets=resolved_secrets
+            )
+        except ProfileError as exc:
+            validation_seconds = time.monotonic() - validation_started
+            return result(
+                RunStatus.INVALID_PROFILE,
+                return_code=return_code,
+                report=report_path,
+                sqlite=sqlite_path,
+                detail=f"profile validation failed: {exc}",
             )
         except (NsysAiError, OSError, *DB_ERRORS) as exc:
             validation_seconds = time.monotonic() - validation_started

--- a/tests/test_ci_coverage.py
+++ b/tests/test_ci_coverage.py
@@ -40,6 +40,8 @@ ACCEPTED_SKIP_REASONS = (
     "Profile not found: data/nsys-hero",
     "requires duckdb",
     "parquet cache unavailable",
+    "real Nsight capture opt-in",
+    "requires nsys and nvcc",
     # Environment-shaped, not fixture-shaped: the read-only-directory test in
     # test_profile_modes.py cannot mean anything on Windows (no POSIX mode bits)
     # or as root (which ignores the write bit). It runs on every CI job we have;

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -9,11 +9,13 @@ from pathlib import Path
 
 import pytest
 
+from nsys_ai.exceptions import ProfileError
 from nsys_ai.profile_runner import (
     LocalProfileRunner,
     RunProgress,
     RunStage,
     RunStatus,
+    _assert_capture_does_not_persist_environment,
 )
 from nsys_ai.runspec import EnvironmentSpec, NsysTraceOptions, RunSpec, RunSpecError
 
@@ -170,6 +172,42 @@ def sqlite_compat_ingest_policy(monkeypatch):
 def _run(tmp_path, fake_nsys, mode="valid", **spec_overrides):
     runner = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys))
     return runner.run(_spec(mode, **spec_overrides))
+
+
+def test_capture_environment_guard_checks_serialized_text_not_metadata_row_count(tmp_path):
+    profile = tmp_path / "capture.sqlite"
+    with sqlite3.connect(profile) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE TARGET_INFO_SYSTEM_ENV (name TEXT, value TEXT);
+            INSERT INTO TARGET_INFO_SYSTEM_ENV VALUES ('CpuCores', '12');
+            CREATE TABLE StringIds (id INTEGER, value TEXT);
+            INSERT INTO StringIds VALUES (1, 'NSYS_AI_TEST_SECRET=private-value');
+            """
+        )
+
+    with pytest.raises(ProfileError, match="environment data"):
+        _assert_capture_does_not_persist_environment(
+            profile, {"NSYS_AI_TEST_SECRET": "private-value"}
+        )
+
+
+def test_capture_environment_guard_allows_machine_metadata(tmp_path):
+    profile = tmp_path / "capture.sqlite"
+    with sqlite3.connect(profile) as conn:
+        conn.executescript(
+            """
+            CREATE TABLE TARGET_INFO_SYSTEM_ENV (name TEXT, value TEXT);
+            INSERT INTO TARGET_INFO_SYSTEM_ENV VALUES
+                ('CpuCores', '12'), ('GpuInfo', '{"Gpus": []}');
+            CREATE TABLE StringIds (id INTEGER, value TEXT);
+            INSERT INTO StringIds VALUES (1, 'fake_kernel');
+            """
+        )
+
+    _assert_capture_does_not_persist_environment(
+        profile, {"NSYS_AI_TEST_SECRET": "private-value"}
+    )
 
 
 def test_success_returns_validated_reference_and_artifacts(tmp_path, fake_nsys):

--- a/tests/test_real_capture_security.py
+++ b/tests/test_real_capture_security.py
@@ -1,0 +1,69 @@
+"""Opt-in real Nsight capture checks for RunSpec security invariants.
+
+The normal CI runners do not ship Nsight Systems or a CUDA compiler. Set
+``NSYS_REAL_CAPTURE=1`` on a CUDA-capable machine to compile a tiny workload,
+run it through ``LocalProfileRunner``, and make the produced report load-bearing
+for the no-persisted-environment contract.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+
+import pytest
+
+from nsys_ai.profile_runner import LocalProfileRunner, RunStatus
+from nsys_ai.runspec import EnvironmentSpec, NsysTraceOptions, RunSpec
+
+_NSYS = shutil.which("nsys")
+_NVCC = shutil.which("nvcc")
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("NSYS_REAL_CAPTURE") != "1",
+    reason="real Nsight capture opt-in (set NSYS_REAL_CAPTURE=1)",
+)
+
+
+def test_real_cuda_capture_does_not_persist_runner_environment(tmp_path, monkeypatch):
+    if _NSYS is None or _NVCC is None:
+        pytest.skip("requires nsys and nvcc")
+
+    source = tmp_path / "env_guard.cu"
+    binary = tmp_path / "env_guard"
+    source.write_text(
+        """
+#include <cuda_runtime.h>
+
+__global__ void touch(float *value) { *value += 1.0f; }
+
+int main() {
+    float *device_value = nullptr;
+    cudaMalloc(&device_value, sizeof(float));
+    touch<<<1, 1>>>(device_value);
+    cudaDeviceSynchronize();
+    cudaFree(device_value);
+    return 0;
+}
+"""
+    )
+    subprocess.run(
+        [_NVCC, str(source), "-O0", "-o", str(binary)],
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    sentinel = "nsys-ai-runspec-secret-sentinel"
+    monkeypatch.setenv("NSYS_AI_TEST_SECRET", sentinel)
+    spec = RunSpec(
+        argv=(str(binary),),
+        environment=EnvironmentSpec(secrets=("NSYS_AI_TEST_SECRET",)),
+        trace_options=NsysTraceOptions(trace=("cuda",)),
+    )
+    result = LocalProfileRunner(tmp_path / "artifacts", _NSYS).run(spec)
+
+    assert result.status is RunStatus.SUCCEEDED, result.detail
+    assert result.sqlite_path is not None


### PR DESCRIPTION
## Summary

- add a load-bearing post-export guard for serialized `NAME=value` environment data
- avoid treating legitimate `TARGET_INFO_SYSTEM_ENV` machine metadata rows as a security failure
- fail the local run as `INVALID_PROFILE` before publishing a capture that contains the runner environment
- add an opt-in real CUDA capture test and document the non-GPU CI limitation

The original issue proposed asserting that `TARGET_INFO_SYSTEM_ENV` has zero rows. A real Nsight 2026.2.1 capture showed that table also contains legitimate CPU/GPU metadata, so the guard checks complete environment entries in persisted text columns instead. The opt-in test compiles a CUDA kernel, runs the actual `LocalProfileRunner`, and validates the produced SQLite report.

## Verification

- `PYTHONPATH=src python3 -m pytest tests/test_profile_runner.py tests/test_real_capture_security.py -q --tb=short` — 49 passed, 1 skipped without opt-in
- `PYTHONPATH=src NSYS_REAL_CAPTURE=1 NSYS_AI_INGEST=sqlite python3 -m pytest tests/test_real_capture_security.py -q --tb=short` — 1 passed on local CUDA/nsys
- `ruff check` on changed source/test files — passed

Closes #366
