### PR TITLE
fix(diff-web): respect overlap metric polarity

### DIFF
--- a/src/nsys_ai/diff_web.py
+++ b/src/nsys_ai/diff_web.py
@@ -399,14 +399,24 @@ _DIFF_HTML = """<!doctype html>
           total_ms: 'Wall-clock span',
           overlap_pct: 'Overlap %',
         };
+        // Positive means an improvement for the metric; negative means a regression.
+        const improvementDirection = {
+          compute_only_ms: -1,
+          nccl_only_ms: -1,
+          overlap_ms: 1,
+          idle_ms: -1,
+          total_ms: -1,
+          overlap_pct: 1,
+        };
         html += '<div class=\"overlap-grid\" style=\"margin-top:0.75rem;\">';
         for (const k of keys) {
           if (!d.overlap || !(k in d.overlap.before) || !(k in d.overlap.after)) continue;
           const b = d.overlap.before[k];
           const a = d.overlap.after[k];
           const delta = d.overlap.delta[k] ?? (a - b);
-          const kindClass = delta > 0 ? (k === 'idle_ms' ? 'delta-bad' : 'delta-bad') :
-                            delta < 0 ? (k === 'idle_ms' ? 'delta-good' : 'delta-good') : '';
+          const signedDelta = delta * improvementDirection[k];
+          const kindClass = signedDelta > 0 ? 'delta-good' :
+                            signedDelta < 0 ? 'delta-bad' : '';
           html += '<div><span class=\"overlap-label\">' + labels[k] +
                   '</span><span class=\"overlap-value\">' + b + ' → ' + a +
                   '</span><span class=\"' + kindClass + '\">(' + (delta >= 0 ? '+' : '') +

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from nsys_ai import web
-from nsys_ai.diff_web import _DiffHandler
+from nsys_ai.diff_web import _DIFF_HTML, _DiffHandler
 from nsys_ai.gpu_label import format_gpu_label, format_gpu_narrative_label
 from nsys_ai.summary import auto_commentary
 
@@ -47,6 +47,15 @@ def test_summary_commentary_omits_empty_gpu_name():
 
     assert commentary.startswith("GPU 0 ran 3 kernels")
     assert "()" not in commentary
+
+
+def test_diff_web_declares_metric_polarity_for_overlap_summary():
+    assert "const improvementDirection =" in _DIFF_HTML
+    assert "overlap_ms: 1" in _DIFF_HTML
+    assert "overlap_pct: 1" in _DIFF_HTML
+    assert "const signedDelta = delta * improvementDirection[k];" in _DIFF_HTML
+    assert "signedDelta > 0 ? 'delta-good'" in _DIFF_HTML
+    assert "signedDelta < 0 ? 'delta-bad'" in _DIFF_HTML
 
 
 def _get(handler, path: str, *, html: bytes = b"<html>"):


### PR DESCRIPTION
## Summary

Fixes the diff-web overlap summary polarity from issue #454.

The summary now declares the direction of each metric in one map and derives the CSS class from the signed improvement delta. Lower-is-better metrics remain unchanged; increases in `overlap_ms` and `overlap_pct` are now rendered as improvements.

## Validation

- `PYTHONPATH=src pytest tests/test_web_foundation.py tests/test_diff_json_shape.py tests/test_overlap_analysis.py -q` — 34 passed
- `node --check` on the generated diff-web script
- Ruff and `git diff --check`

Closes #454.
