### PR TITLE
fix(timeline-web): keep trimmed views progressive

### DIFF
--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -603,8 +603,14 @@ async function initData() {
             // Default view starts at the profile's actual first event. Profiles
             // exported from Nsight commonly have a non-zero epoch-relative start.
             const [profileStart, profileEnd] = profileRangeNs();
-            viewStart = profileStart;
-            viewEnd = Math.min(profileEnd, profileStart + TILE_WINDOW_S * 1e9);
+            const requestedTrim = loopTrimPayload().trim;
+            if (requestedTrim) {
+                viewStart = Math.max(profileStart, requestedTrim[0]);
+                viewEnd = Math.min(profileEnd, requestedTrim[1]);
+            } else {
+                viewStart = profileStart;
+                viewEnd = Math.min(profileEnd, profileStart + TILE_WINDOW_S * 1e9);
+            }
             await ensureTilesForView(viewStart, viewEnd);
             rebuildDataFromCache();
             resetViewHistory();

--- a/src/nsys_ai/viewer.py
+++ b/src/nsys_ai/viewer.py
@@ -289,12 +289,15 @@ def generate_timeline_html(
     profile_path: str = "",
     profile_id: str | None = None,
     loop_mode: bool = False,
+    progressive_mode: bool = False,
 ) -> str:
     """Generate a standalone HTML page with the horizontal timeline viewer.
 
     *device* may be a single int or a list of ints.
     When *trim* is None, HTML is generated in progressive mode: ``$DATA``
     is ``null`` and the template fetches data via ``/api/data`` on demand.
+    Set *progressive_mode* when a server wants to keep a trim window as the
+    initial viewport without embedding its data in the HTML.
     """
     from collections.abc import Sequence
 
@@ -330,12 +333,14 @@ def generate_timeline_html(
     loop_trim_ns_json = "null"
     trim_meta = ""
     if trim is not None:
-        # Full data baked into HTML (kernel-first payload).
-        gpu_entries = build_timeline_gpu_data(prof, devices, trim)
-        data_json = json.dumps({"gpus": gpu_entries})
         trim_window = f"{trim[0] / 1e9:.1f}s – {trim[1] / 1e9:.1f}s"
         trim_meta = f" · {html.escape(trim_window)}"
         loop_trim_ns_json = json.dumps([int(trim[0]), int(trim[1])])
+
+    if trim is not None and not progressive_mode:
+        # Full data baked into HTML (kernel-first payload).
+        gpu_entries = build_timeline_gpu_data(prof, devices, trim)
+        data_json = json.dumps({"gpus": gpu_entries})
         progressive = ""
     else:
         # Progressive mode: no data baked in

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -244,6 +244,7 @@ class _ViewerHandler(BaseHTTPRequestHandler):
     _findings: list[dict] = []  # mutable findings state for evidence overlay
     _session_id: str | None = None  # SessionStore id (always set by serve_timeline)
     _session_root: str = ".nsys-ai/sessions"
+    _trim: tuple[int, int] | None = None
 
     def do_GET(self):
         path = self.path.split("?")[0]
@@ -339,7 +340,7 @@ class _ViewerHandler(BaseHTTPRequestHandler):
             info = prof.meta.gpu_info.get(dev)
             gpu_infos.append({"id": dev, "label": format_gpu_label(dev, info)})
         # Get profile time range from kernel metadata (min_start_ns, max_end_ns)
-        t_start, t_end = prof.meta.time_range
+        t_start, t_end = self.__class__._trim or prof.meta.time_range
         self._json_response(
             {
                 "time_range_ns": [t_start, t_end],
@@ -1017,6 +1018,7 @@ def serve_timeline(
     _ViewerHandler._findings = findings_data or []
     _ViewerHandler._session_id = None
     _ViewerHandler._session_root = os.fspath(session_root)
+    _ViewerHandler._trim = trim
     from .loop_state import detect_h100_replay_preset
 
     raw_path = prof.path if hasattr(prof, "path") else ""
@@ -1088,34 +1090,21 @@ def serve_timeline(
     _asset_v = _template_asset_version()
     _css_href = _versioned_asset_url("/assets/timeline.css")
     _js_src = _versioned_asset_url("/assets/timeline.js")
-    if trim is not None:
-        # Legacy: render full HTML with all data baked in
-        html = generate_timeline_html(
-            prof,
-            devices,
-            trim,
-            findings_data=findings_data,
-            profile_path=_profile_path,
-            profile_id=_ViewerHandler._profile_id,
-            loop_mode=_in_loop_mode,
-            timeline_css_href=_css_href,
-            timeline_js_src=_js_src,
-        )
-        _ViewerHandler._prebuilt_nvtx_mode = "full"
-    else:
-        # Progressive: generate shell HTML, data fetched via /api/data
-        html = generate_timeline_html(
-            prof,
-            devices,
-            None,
-            findings_data=findings_data,
-            profile_path=_profile_path,
-            profile_id=_ViewerHandler._profile_id,
-            loop_mode=_in_loop_mode,
-            timeline_css_href=_css_href,
-            timeline_js_src=_js_src,
-        )
-        _ViewerHandler._prebuilt_nvtx_mode = "background"
+    # Always serve the progressive shell. A trim window is metadata for the
+    # initial viewport and API range, not a reason to embed the selected data.
+    html = generate_timeline_html(
+        prof,
+        devices,
+        trim,
+        findings_data=findings_data,
+        profile_path=_profile_path,
+        profile_id=_ViewerHandler._profile_id,
+        loop_mode=_in_loop_mode,
+        timeline_css_href=_css_href,
+        timeline_js_src=_js_src,
+        progressive_mode=True,
+    )
+    _ViewerHandler._prebuilt_nvtx_mode = "background"
 
     _ViewerHandler.html_bytes = html.encode("utf-8")
     if _in_loop_mode:
@@ -1123,10 +1112,15 @@ def serve_timeline(
 
     nvtx_done: threading.Event | None = None
 
-    # Pre-build full kernel-first timeline payload for all GPUs (progressive mode)
-    if trim is None:
+    # Pre-build the requested range only. A trim window must not switch back
+    # to the legacy full-document path or force a full-profile scan.
+    if _ViewerHandler._prebuilt_nvtx_mode == "background":
         db_path = _profile_path
-        cache_path = db_path + ".timeline-cache-v3-kernels.json" if db_path else ""
+        cache_path = (
+            db_path + ".timeline-cache-v3-kernels.json"
+            if db_path and trim is None
+            else ""
+        )
         cache_valid = False
 
         # Try loading from disk cache
@@ -1162,7 +1156,7 @@ def serve_timeline(
 
         if not cache_valid:
             t0 = _time.monotonic()
-            full_range = prof.meta.time_range
+            full_range = trim or prof.meta.time_range
             print(
                 f"Pre-building kernels only for {len(devices)} GPU(s) "
                 f"({full_range[0] / 1e9:.1f}s–{full_range[1] / 1e9:.1f}s)...",
@@ -1200,7 +1194,7 @@ def serve_timeline(
                     print(f"Cache save failed: {e}", flush=True)
 
         _ViewerHandler._overview_bins, _ViewerHandler._overview_kernel_count = (
-            _build_timeline_overview(prebuilt, prof.meta.time_range)
+            _build_timeline_overview(prebuilt, trim or prof.meta.time_range)
         )
 
         # NVTX is much more expensive than kernel filtering.  Warm the full
@@ -1214,7 +1208,7 @@ def serve_timeline(
 
         def _warm_nvtx() -> None:
             t_nv = _time.monotonic()
-            full_range = prof.meta.time_range
+            full_range = trim or prof.meta.time_range
             try:
                 print(
                     f"Pre-building NVTX in background for {len(devices)} GPU(s) "

--- a/tests/test_cli_usage_errors.py
+++ b/tests/test_cli_usage_errors.py
@@ -370,6 +370,38 @@ def test_timeline_web_survives_a_busy_port(tmp_path: Path, monkeypatch):
     assert bound.get("port") not in (None, busy), bound
 
 
+def test_timeline_web_trim_uses_progressive_shell_and_bounded_prebuild(
+    tmp_path: Path, monkeypatch
+):
+    profile_copy = tmp_path / "profile.sqlite"
+    shutil.copyfile(PROFILE, profile_copy)
+    calls: list[tuple[int, int]] = []
+    captured: dict[str, bytes] = {}
+
+    def _fake_timeline_data(_prof, devices, window, **_kwargs):
+        calls.append(window)
+        return [{"id": dev, "kernels": [], "nvtx_spans": []} for dev in devices]
+
+    def _capture_instead_of_serving(server, _open_url, _prof):
+        captured["html"] = web._ViewerHandler.html_bytes
+        server.server_close()
+
+    monkeypatch.setattr(web, "build_timeline_gpu_data", _fake_timeline_data)
+    monkeypatch.setattr(web, "_run_server", _capture_instead_of_serving)
+    monkeypatch.chdir(tmp_path)
+
+    with _profile.open(str(profile_copy)) as prof:
+        start_ns, end_ns = prof.meta.time_range
+        trim = (start_ns, min(end_ns, start_ns + 2_000_000_000))
+        web.serve_timeline(prof, [0], trim, port=0, open_browser=False)
+
+    html = captured["html"].decode("utf-8")
+    assert "INITIAL_DATA: null" in html
+    assert "PROGRESSIVE: '1' === '1'" in html
+    assert f"LOOP_TRIM_NS: [{trim[0]}, {trim[1]}]" in html
+    assert calls and all(window == trim for window in calls)
+
+
 def test_timeline_web_bind_failure_waits_for_the_background_worker(tmp_path: Path, monkeypatch):
     """A bind that still fails must not leave the NVTX worker running.
 


### PR DESCRIPTION
## Summary

Fixes issue #456 by keeping `timeline-web --trim` on the progressive shell/data path.

- Trim metadata is passed to the shell as the initial viewport and API range.
- Only the selected trim window is pre-built for kernels and NVTX; full-range disk caches remain available for untrimmed views.
- The trim range is exposed through `/api/meta`, and the frontend starts there rather than fitting the full profile.
- Static `timeline-html` behavior remains unchanged: it still embeds its requested range.

## Validation

- Relevant timeline and server tests: `14 passed`
- Node syntax check for `timeline.js`
- Ruff and `git diff --check`
- Real fastvideo smoke on `perf.sqlite --gpu 0 --trim 35 40`: progressive shell bound successfully and pre-built only `35.0s–40.0s`; the process was then stopped by the smoke timeout.

Closes #456.
