### PR TITLE
fix(web): support bodyless HEAD responses

### DIFF
--- a/src/nsys_ai/diff_web.py
+++ b/src/nsys_ai/diff_web.py
@@ -18,10 +18,10 @@ from .diff_render import to_diff_json
 from .gpu_label import format_gpu_label
 from .profile import Profile
 from .viewer import build_timeline_gpu_data, generate_timeline_html
-from .web import _TEMPLATE_DIR, _bind_local_server, _run_server
+from .web import _TEMPLATE_DIR, _bind_local_server, _HeadRequestMixin, _run_server
 
 
-class _DiffHandler(BaseHTTPRequestHandler):
+class _DiffHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
     """Serve a minimal web diff viewer and JSON APIs."""
 
     before: Profile | None = None

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -102,6 +102,39 @@ def _send_body(
     handler.wfile.write(body)
 
 
+class _HeadBodySuppressor:
+    """Preserve response headers while discarding a HEAD response body."""
+
+    def __init__(self, wfile):
+        self._wfile = wfile
+
+    def write(self, body):
+        return len(body)
+
+    def __getattr__(self, name):
+        return getattr(self._wfile, name)
+
+
+class _HeadRequestMixin:
+    """Route HEAD through GET while keeping its response body empty."""
+
+    _head_only = False
+
+    def do_HEAD(self):
+        original_wfile = self.wfile
+        self._head_only = True
+        try:
+            self.do_GET()
+        finally:
+            self.wfile = original_wfile
+            self._head_only = False
+
+    def end_headers(self):
+        super().end_headers()
+        if self._head_only:
+            self.wfile = _HeadBodySuppressor(self.wfile)
+
+
 class _ThreadPoolMixIn(socketserver.ThreadingMixIn):
     """Use a fixed-size thread pool instead of one thread per request. Prevents thread exhaustion."""
 
@@ -224,7 +257,7 @@ def _handle_chat_stream(body_bytes: bytes):
     return None
 
 
-class _ViewerHandler(BaseHTTPRequestHandler):
+class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
     """Serve the pre-rendered HTML on GET; GET /api/models for model list;
     GET /api/data for on-demand tile data; GET /api/meta for profile metadata;
     POST /api/chat for AI chat."""
@@ -1264,7 +1297,7 @@ def serve_timeline(
 # ── Mode 3: Evidence View ────────────────────────────────────────
 
 
-class _EvidenceHandler(BaseHTTPRequestHandler):
+class _EvidenceHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
     """Serve the Evidence View HTML; GET /api/data for progressive kernel tiles."""
 
     html_bytes: bytes = b""

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -84,6 +84,56 @@ def _post(handler, path: str):
     return result
 
 
+def _head(handler, path: str, *, html: bytes = b"<html>"):
+    if handler is web._ViewerHandler:
+        old_html = handler.html_bytes
+        handler.html_bytes = html
+    else:
+        old_html = None
+    server = web._ThreadedHTTPServer(("127.0.0.1", 0), handler)
+    thread = threading.Thread(target=server.handle_request, daemon=True)
+    thread.start()
+    conn = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+    conn.request("HEAD", path)
+    response = conn.getresponse()
+    result = (
+        response.status,
+        response.read(),
+        response.getheader("Content-Type"),
+        response.getheader("Content-Length"),
+    )
+    conn.close()
+    thread.join(timeout=5)
+    server.server_close()
+    if handler is web._ViewerHandler:
+        handler.html_bytes = old_html
+    return result
+
+
+@pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])
+def test_web_surfaces_head_matches_get_headers_without_body(handler):
+    get_status, get_body, get_content_type = _get(handler, "/")
+    head_status, head_body, head_content_type, head_length = _head(handler, "/")
+
+    assert head_status == get_status == 200
+    assert head_content_type == get_content_type
+    assert head_length == str(len(get_body))
+    assert head_body == b""
+
+
+@pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])
+def test_web_surfaces_head_preserves_json_404_contract(handler):
+    get_status, get_body, get_content_type = _get(handler, "/api/does-not-exist")
+    head_status, head_body, head_content_type, head_length = _head(
+        handler, "/api/does-not-exist"
+    )
+
+    assert head_status == get_status == 404
+    assert head_content_type == get_content_type
+    assert head_length == str(len(get_body))
+    assert head_body == b""
+
+
 @pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])
 def test_web_surfaces_return_404_for_unknown_paths(handler):
     status, body, content_type = _get(handler, "/api/definitely-not-real")


### PR DESCRIPTION
## Summary

Fixes issue #471 by adding a shared HEAD-to-GET dispatch path for the timeline, evidence, and diff web handlers.

HEAD responses reuse the existing GET routing and headers, including `Content-Length`, while a small response writer suppresses the body after headers are emitted. This preserves the existing JSON 404 behavior and avoids a second route table.

## Validation

- `PYTHONPATH=src pytest tests/test_web_foundation.py tests/test_cli_usage_errors.py -q` — 43 passed
- HEAD root and unknown `/api/*` contract tests for all three surfaces
- Ruff and `git diff --check`

Closes #471.
