### PR TITLE
refactor(web): centralize shared visual tokens

### DIFF
--- a/src/nsys_ai/diff_web.py
+++ b/src/nsys_ai/diff_web.py
@@ -78,6 +78,10 @@ class _DiffHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
             self._serve_asset("timeline.css", "text/css; charset=utf-8")
             return
 
+        if path == "/assets/tokens.css":
+            self._serve_asset("tokens.css", "text/css; charset=utf-8")
+            return
+
         if path == "/assets/timeline.js":
             self._serve_asset("timeline.js", "application/javascript; charset=utf-8")
             return
@@ -258,33 +262,33 @@ _DIFF_HTML = """<!doctype html>
     <link rel="stylesheet" href="/assets/timeline.css" />
     <style>
       body { font-family: system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
-             margin: 0; padding: 1.5rem; background: #050816; color: #f5f5f5;
+             margin: 0; padding: 1.5rem; background: var(--diff-bg); color: var(--diff-text);
              min-height: 100vh; overflow-y: auto; overflow-x: hidden; }
       h1 { margin-top: 0; font-size: 1.4rem; }
       .paths { font-size: 0.9rem; margin-bottom: 1rem; }
       .paths code { word-break: break-all; }
       .layout { display: grid; grid-template-columns: 1.4fr 1fr; gap: 1.5rem; align-items: flex-start; }
       .layout-timeline { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1.5rem; }
-      .timeline-container { height: 400px; position: relative; border-radius: 0.5rem; overflow: hidden; border: 1px solid rgba(148,163,184,0.25); background: #000; }
-      .card { background: rgba(15,23,42,0.9); border-radius: 0.75rem; padding: 1rem 1.25rem; box-shadow: 0 18px 45px rgba(15,23,42,0.9); border: 1px solid rgba(148,163,184,0.25);}
+      .timeline-container { height: 400px; position: relative; border-radius: 0.5rem; overflow: hidden; border: 1px solid var(--diff-border); background: #000; }
+      .card { background: var(--diff-surface); border-radius: 0.75rem; padding: 1rem 1.25rem; box-shadow: 0 18px 45px rgba(15,23,42,0.9); border: 1px solid var(--diff-border);}
       .card h2 { margin: 0 0 0.5rem 0; font-size: 1.0rem; }
 
-      .pill { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 999px; background: rgba(148,163,184,0.25); font-size: 0.75rem; margin-right: 0.25rem; }
+      .pill { display: inline-block; padding: 0.1rem 0.5rem; border-radius: 999px; background: var(--diff-border); font-size: 0.75rem; margin-right: 0.25rem; }
       table { width: 100%; border-collapse: collapse; font-size: 0.85rem; }
       th, td { padding: 0.35rem 0.4rem; text-align: right; border-bottom: 1px solid rgba(30,41,59,0.9); }
       th:nth-child(2), td:nth-child(2) { text-align: left; }
-      th { font-weight: 600; color: #e5e7eb; background: rgba(15,23,42,0.9); position: sticky; top: 0; }
+      th { font-weight: 600; color: var(--text); background: var(--diff-surface); position: sticky; top: 0; }
       tbody tr:nth-child(even) { background: rgba(15,23,42,0.6); }
-      .delta-bad { color: #f87171; }
-      .delta-good { color: #4ade80; }
-      .warnings { color: #facc15; font-size: 0.85rem; }
+      .delta-bad { color: var(--verdict-worse); }
+      .delta-good { color: var(--verdict-better); }
+      .warnings { color: var(--heat-50); font-size: 0.85rem; }
       .warnings li { margin-bottom: 0.15rem; }
-      .section-title { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em; color: #9ca3af; margin-bottom: 0.35rem; }
+      .section-title { font-size: 0.85rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--diff-label); margin-bottom: 0.35rem; }
       .overlap-grid { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 0.4rem 0.75rem; font-size: 0.8rem; }
       .overlap-grid div span { display: block; }
-      .overlap-label { color: #9ca3af; }
+      .overlap-label { color: var(--diff-label); }
       .overlap-value { font-weight: 600; }
-      .badge { font-size: 0.75rem; padding: 0.05rem 0.4rem; border-radius: 999px; border: 1px solid rgba(148,163,184,0.4); }
+      .badge { font-size: 0.75rem; padding: 0.05rem 0.4rem; border-radius: 999px; border: 1px solid var(--diff-border); }
     </style>
   </head>
   <body>

--- a/src/nsys_ai/templates/nvtx_tree.html
+++ b/src/nsys_ai/templates/nvtx_tree.html
@@ -5,29 +5,10 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>NVTX Stack Trace - $GPU_LABEL</title>
+    <link rel="stylesheet" href="$TOKENS_HREF">
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify@3.2.4/dist/purify.min.js"></script>
     <style>
-        :root {
-            --bg: #0d1117;
-            --surface: #161b22;
-            --border: #30363d;
-            --text: #e6edf3;
-            --text-dim: #8b949e;
-            --accent: #58a6ff;
-            --nvtx: #1f6feb;
-            --kernel: #238636;
-            --kernel-bg: #0d3117;
-            --heat-0: #238636;
-            --heat-25: #6fad3b;
-            --heat-50: #d4a72c;
-            --heat-75: #db6d28;
-            --heat-100: #da3633;
-            --nccl: #d2a8ff;
-            --memcpy: #f97583;
-            --bubble: #f8514966
-        }
-
         * {
             box-sizing: border-box;
             margin: 0;

--- a/src/nsys_ai/templates/timeline.css
+++ b/src/nsys_ai/templates/timeline.css
@@ -1,26 +1,4 @@
-        :root {
-            --bg: #0d1117;
-            --surface: #161b22;
-            --surface-raised: #1c2128;
-            --border: #30363d;
-            --border-subtle: #21262d;
-            --text: #e6edf3;
-            --text-dim: #8b949e;
-            --text-muted: #6e7681;
-            --accent: #79b8ff;
-            --accent-dim: #58a6ff;
-            --accent-subtle: rgba(56, 139, 253, 0.12);
-            --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-            --font-mono: "SF Mono", "Cascadia Code", "Fira Code", ui-monospace, monospace;
-            --nvtx: #4a6fa5;
-            --kernel: #238636;
-            --nccl: #d2a8ff;
-            --heat-0: #238636;
-            --heat-50: #d4a72c;
-            --heat-100: #da3633;
-            --sel: #264f78;
-            --chrome-h: 88px;
-        }
+        @import url("tokens.css");
 
         * {
             box-sizing: border-box;

--- a/src/nsys_ai/templates/tokens.css
+++ b/src/nsys_ai/templates/tokens.css
@@ -1,0 +1,39 @@
+/* Shared dark data-visualization tokens for every web surface. */
+:root {
+    --bg: #0d1117;
+    --surface: #161b22;
+    --surface-raised: #1c2128;
+    --border: #30363d;
+    --border-subtle: #21262d;
+    --text: #e6edf3;
+    --text-dim: #8b949e;
+    --text-muted: #6e7681;
+    --accent: #79b8ff;
+    --accent-dim: #58a6ff;
+    --accent-subtle: rgba(56, 139, 253, 0.12);
+    --font-ui: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+    --font-mono: "SF Mono", "Cascadia Code", "Fira Code", ui-monospace, monospace;
+
+    --nvtx: #1f6feb;
+    --kernel: #238636;
+    --kernel-bg: #0d3117;
+    --nccl: #d2a8ff;
+    --memcpy: #f97583;
+    --bubble: #f8514966;
+
+    --heat-0: #238636;
+    --heat-25: #6fad3b;
+    --heat-50: #d4a72c;
+    --heat-75: #db6d28;
+    --heat-100: #da3633;
+    --sel: #264f78;
+    --chrome-h: 88px;
+
+    --diff-bg: #050816;
+    --diff-surface: rgba(15, 23, 42, 0.9);
+    --diff-border: rgba(148, 163, 184, 0.25);
+    --diff-text: #f5f5f5;
+    --diff-label: #9ca3af;
+    --verdict-better: #58a6ff;
+    --verdict-worse: #f0883e;
+}

--- a/src/nsys_ai/viewer.py
+++ b/src/nsys_ai/viewer.py
@@ -65,7 +65,13 @@ def _escape_json_for_html_attr(value) -> str:
     )
 
 
-def generate_html(prof, device: int, trim: tuple[int, int]) -> str:
+def generate_html(
+    prof,
+    device: int,
+    trim: tuple[int, int],
+    *,
+    tokens_href: str = "/assets/tokens.css",
+) -> str:
     """Generate a standalone HTML page showing the NVTX stack trace."""
     roots = build_nvtx_tree(prof, device, trim)
     tree_json = to_json(roots)
@@ -90,13 +96,18 @@ def generate_html(prof, device: int, trim: tuple[int, int]) -> str:
         PROFILE_ID=profile_id,
         PROFILE_PATH=safe_profile_path,
         DB_AGENT_ENABLED="1" if db_agent_enabled else "",
+        TOKENS_HREF=tokens_href,
     )
 
 
 def write_html(prof, device: int, trim: tuple[int, int], path: str):
     """Generate and write the HTML viewer to a file."""
+    tokens_name = "tokens.css"
+    out_dir = os.path.dirname(os.path.abspath(path))
     with open(path, "w", encoding="utf-8", newline="\n") as f:
-        f.write(generate_html(prof, device, trim))
+        f.write(generate_html(prof, device, trim, tokens_href=tokens_name))
+    with open(os.path.join(out_dir, tokens_name), "w", encoding="utf-8", newline="\n") as f:
+        f.write(_read_template_text(tokens_name))
 
 
 def _collect_nvtx_annotations(
@@ -400,6 +411,8 @@ def write_timeline_html(prof, device: int, trim: tuple[int, int], path: str):
     # Export sidecar static assets so generated HTML remains self-contained on disk.
     with open(os.path.join(out_dir, css_name), "w", encoding="utf-8", newline="\n") as f:
         f.write(_read_template_text("timeline.css"))
+    with open(os.path.join(out_dir, "tokens.css"), "w", encoding="utf-8", newline="\n") as f:
+        f.write(_read_template_text("tokens.css"))
     with open(os.path.join(out_dir, js_name), "w", encoding="utf-8", newline="\n") as f:
         f.write(_read_template_text("timeline.js"))
 

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -42,7 +42,7 @@ _TEMPLATE_DIR = os.path.join(os.path.dirname(__file__), "templates")
 def _template_asset_version() -> str:
     """Cache-bust token from template mtimes (changes when timeline UI is edited)."""
     latest = 0.0
-    for name in ("timeline.html", "timeline.css", "timeline.js"):
+    for name in ("timeline.html", "timeline.css", "timeline.js", "tokens.css"):
         path = os.path.join(_TEMPLATE_DIR, name)
         try:
             latest = max(latest, os.path.getmtime(path))
@@ -283,6 +283,9 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
         path = self.path.split("?")[0]
         if path == "/assets/timeline.css":
             self._serve_asset("timeline.css", "text/css; charset=utf-8")
+            return
+        if path == "/assets/tokens.css":
+            self._serve_asset("tokens.css", "text/css; charset=utf-8")
             return
         if path == "/assets/timeline.js":
             self._serve_asset("timeline.js", "application/javascript; charset=utf-8")
@@ -1307,6 +1310,9 @@ class _EvidenceHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
         if path == "/assets/evidence.css":
             # Reuse the existing timeline.css asset for evidence CSS.
             self._serve_asset("timeline.css", "text/css; charset=utf-8")
+            return
+        if path == "/assets/tokens.css":
+            self._serve_asset("tokens.css", "text/css; charset=utf-8")
             return
         if path == "/assets/evidence.js":
             # Reuse the existing timeline.js asset for evidence JS.

--- a/tests/test_timeline_web_data.py
+++ b/tests/test_timeline_web_data.py
@@ -226,10 +226,13 @@ def test_timeline_html_export_writes_sidecar_assets(minimal_nsys_db_path, tmp_pa
 
     out_css = tmp_path / "timeline.css"
     out_js = tmp_path / "timeline.js"
+    out_tokens = tmp_path / "tokens.css"
     assert out_html.exists()
     assert out_css.exists()
     assert out_js.exists()
+    assert out_tokens.exists()
 
     html_text = out_html.read_text(encoding="utf-8")
     assert 'href="timeline.css"' in html_text
     assert 'src="timeline.js"' in html_text
+    assert '@import url("tokens.css")' in out_css.read_text(encoding="utf-8")

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -34,6 +34,16 @@ def test_gpu_label_preserves_fractional_memory_precision():
     ) == "GPU 0 - H200, 150.1GB"
 
 
+@pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])
+def test_web_surfaces_serve_shared_tokens_asset(handler):
+    status, body, content_type = _get(handler, "/assets/tokens.css")
+
+    assert status == 200
+    assert content_type.startswith("text/css")
+    assert b"--accent:" in body
+    assert b"--heat-75:" in body
+
+
 def test_summary_commentary_omits_empty_gpu_name():
     summary = {
         "device": 0,


### PR DESCRIPTION
## Summary

First foundation checkpoint for issue #458: centralize the shared web visual tokens.

- Adds `templates/tokens.css` as the single source for the shared dark-surface, typography, timeline, heat, diff, and verdict tokens.
- Makes `timeline.css`, `nvtx_tree.html`, and diff-web consume the shared definitions.
- Serves `/assets/tokens.css` from timeline, evidence, and diff handlers.
- Keeps static `web` and `timeline-html` exports usable by writing a local `tokens.css` sidecar.
- Includes tokens in asset cache-busting.

This PR intentionally does not finish the canvas JavaScript bridge or the remaining palette validation work; those are the next #458 checkpoint.

## Validation

- `PYTHONPATH=src pytest tests/test_web_foundation.py tests/test_timeline_web_data.py -q` — 32 passed
- Ruff and `git diff --check`
