### PR TITLE
perf(timeline-web): add resolution-aware data buckets

### DIFF
--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -51,31 +51,31 @@ const overviewCtx = overviewCanvas ? overviewCanvas.getContext('2d') : null;
 // ── Tile Cache ──
 class TileCache {
     constructor(maxBytes = 100 * 1024 * 1024) {
-        this.tiles = new Map();  // key "start_s-end_s|resolution" → {data, ts, sizeEst}
+        this.tiles = new Map();  // key "start_s-end_s|maxBuckets" → {data, ts, sizeEst}
         this.maxBytes = maxBytes;
         this.currentBytes = 0;
         this.nvtxReady = new Set();
         this._dirty = true;
         this._cachedMerge = null;
     }
-    key(startS, endS, resolution = 0) {
-        return `${startS.toFixed(1)}-${endS.toFixed(1)}|r:${Math.max(0, Math.round(resolution))}`;
+    key(startS, endS, maxBuckets = 0) {
+        return `${startS.toFixed(1)}-${endS.toFixed(1)}|b:${Math.max(0, Math.round(maxBuckets))}`;
     }
-    baseKey(startS, endS) { return `${startS.toFixed(1)}-${endS.toFixed(1)}|r:`; }
-    has(startS, endS, resolution = 0) { return this.tiles.has(this.key(startS, endS, resolution)); }
-    nvtxKey(startS, endS, gpuId, resolution = 0) { return `${this.key(startS, endS, resolution)}|gpu:${gpuId}`; }
-    hasNvtx(startS, endS, gpuId, resolution = 0) { return this.nvtxReady.has(this.nvtxKey(startS, endS, gpuId, resolution)); }
-    markNvtx(startS, endS, gpuId, resolution = 0) { this.nvtxReady.add(this.nvtxKey(startS, endS, gpuId, resolution)); }
-    get(startS, endS, resolution = 0) {
-        const k = this.key(startS, endS, resolution);
+    baseKey(startS, endS) { return `${startS.toFixed(1)}-${endS.toFixed(1)}|b:`; }
+    has(startS, endS, maxBuckets = 0) { return this.tiles.has(this.key(startS, endS, maxBuckets)); }
+    nvtxKey(startS, endS, gpuId, maxBuckets = 0) { return `${this.key(startS, endS, maxBuckets)}|gpu:${gpuId}`; }
+    hasNvtx(startS, endS, gpuId, maxBuckets = 0) { return this.nvtxReady.has(this.nvtxKey(startS, endS, gpuId, maxBuckets)); }
+    markNvtx(startS, endS, gpuId, maxBuckets = 0) { this.nvtxReady.add(this.nvtxKey(startS, endS, gpuId, maxBuckets)); }
+    get(startS, endS, maxBuckets = 0) {
+        const k = this.key(startS, endS, maxBuckets);
         const entry = this.tiles.get(k);
         if (entry) entry.ts = Date.now();
         return entry ? entry.data : null;
     }
-    put(startS, endS, data, resolution = 0) {
-        const k = this.key(startS, endS, resolution);
+    put(startS, endS, data, maxBuckets = 0) {
+        const k = this.key(startS, endS, maxBuckets);
         // A tile can be exact when zoomed in and aggregate when zoomed out.
-        // Keep only the current resolution so stale variants cannot be merged.
+        // Keep only the current bucket budget so stale variants cannot be merged.
         const prefix = this.baseKey(startS, endS);
         for (const oldKey of this.tiles.keys()) {
             if (oldKey !== k && oldKey.startsWith(prefix)) {
@@ -115,8 +115,8 @@ class TileCache {
         }
         this._dirty = true;
     }
-    mergeNvtx(startS, endS, nvtxData, gpuId, resolution = 0) {
-        const k = this.key(startS, endS, resolution);
+    mergeNvtx(startS, endS, nvtxData, gpuId, maxBuckets = 0) {
+        const k = this.key(startS, endS, maxBuckets);
         const entry = this.tiles.get(k);
         if (!entry || !entry.data || !entry.data.gpus || !nvtxData || !nvtxData.gpus) return;
         let mergedTargetGpu = false;
@@ -128,7 +128,7 @@ class TileCache {
             mergedTargetGpu = true;
         }
         if (mergedTargetGpu) {
-            this.markNvtx(startS, endS, gpuId, resolution);
+            this.markNvtx(startS, endS, gpuId, maxBuckets);
             this._dirty = true;
         }
     }
@@ -218,7 +218,7 @@ function hideLoading() {
 }
 
 // ── Fetch data for a time window ──
-function resolutionForTile(startS, endS) {
+function maxBucketsForTile(startS, endS) {
     const width = Math.max(256, Math.floor((canvas.clientWidth || canvas.width / (window.devicePixelRatio || 1)) - LABEL_W));
     const tileSpan = Math.max(endS - startS, 0.001);
     const viewSpan = Math.max((viewEnd - viewStart) / 1e9, 0.001);
@@ -228,18 +228,18 @@ function resolutionForTile(startS, endS) {
 }
 
 async function fetchTile(startS, endS, { requestNvtx = false } = {}) {
-    const resolution = resolutionForTile(startS, endS);
-    if (tileCache.has(startS, endS, resolution)) return tileCache.get(startS, endS, resolution);
-    const tileKey = tileCache.key(startS, endS, resolution);
+    const maxBuckets = maxBucketsForTile(startS, endS);
+    if (tileCache.has(startS, endS, maxBuckets)) return tileCache.get(startS, endS, maxBuckets);
+    const tileKey = tileCache.key(startS, endS, maxBuckets);
     if (tileInflight.has(tileKey)) return tileInflight.get(tileKey);
     const pfx = BOOT.API_PREFIX || '';
-    const request = fetch(`${pfx}/api/data?start_s=${startS}&end_s=${endS}&resolution=${resolution}&kernels=1&nvtx=0`)
+    const request = fetch(`${pfx}/api/data?start_s=${startS}&end_s=${endS}&max_buckets=${maxBuckets}&kernels=1&nvtx=0`)
         .then(async resp => {
             if (!resp.ok) throw new Error(`tile request failed (${resp.status})`);
             const data = await resp.json();
             if (data.error) throw new Error(data.error);
-            tileCache.put(startS, endS, data, resolution);
-            if (requestNvtx && showNVTX) void fetchTileNvtx(startS, endS, currentActiveGpuId(), resolution);
+            tileCache.put(startS, endS, data, maxBuckets);
+            if (requestNvtx && showNVTX) void fetchTileNvtx(startS, endS, currentActiveGpuId(), maxBuckets);
             return data;
         })
         .catch(err => {
@@ -266,9 +266,9 @@ function currentActiveGpuId() {
     return null;
 }
 
-async function fetchTileNvtx(startS, endS, gpuId, resolution = resolutionForTile(startS, endS)) {
-    const key = `${tileCache.key(startS, endS, resolution)}|gpu:${gpuId}`;
-    if (tileCache.hasNvtx(startS, endS, gpuId, resolution) || nvtxInflight.has(key)) return;
+async function fetchTileNvtx(startS, endS, gpuId, maxBuckets = maxBucketsForTile(startS, endS)) {
+    const key = `${tileCache.key(startS, endS, maxBuckets)}|gpu:${gpuId}`;
+    if (tileCache.hasNvtx(startS, endS, gpuId, maxBuckets) || nvtxInflight.has(key)) return;
     nvtxInflight.add(key);
     updateNvtxLoadingIndicator();
     try {
@@ -277,7 +277,7 @@ async function fetchTileNvtx(startS, endS, gpuId, resolution = resolutionForTile
         if (!resp.ok) throw new Error(`NVTX request failed (${resp.status})`);
         const data = await resp.json();
         if (data.error) throw new Error(data.error);
-        tileCache.mergeNvtx(startS, endS, data, gpuId, resolution);
+        tileCache.mergeNvtx(startS, endS, data, gpuId, maxBuckets);
         rebuildDataFromCache();
         draw();
     } catch (err) {
@@ -322,7 +322,7 @@ async function ensureTilesForView(vStart, vEnd) {
     const promises = [];
     for (let s = startS; s < endS; s += TILE_WINDOW_S) {
         if (!renderLockIntersects(s, s + TILE_WINDOW_S)) continue;
-        if (!tileCache.has(s, s + TILE_WINDOW_S, resolutionForTile(s, s + TILE_WINDOW_S))) {
+        if (!tileCache.has(s, s + TILE_WINDOW_S, maxBucketsForTile(s, s + TILE_WINDOW_S))) {
             promises.push(fetchTile(s, s + TILE_WINDOW_S));
         }
     }
@@ -346,9 +346,9 @@ function maybeFetchNvtxForCurrentView() {
     if (activeGpu === null || activeGpu === undefined) return;
     for (let s = startS; s < endS; s += TILE_WINDOW_S) {
         if (!renderLockIntersects(s, s + TILE_WINDOW_S)) continue;
-        const resolution = resolutionForTile(s, s + TILE_WINDOW_S);
-        if (tileCache.has(s, s + TILE_WINDOW_S, resolution)) {
-            void fetchTileNvtx(s, s + TILE_WINDOW_S, activeGpu, resolution);
+        const maxBuckets = maxBucketsForTile(s, s + TILE_WINDOW_S);
+        if (tileCache.has(s, s + TILE_WINDOW_S, maxBuckets)) {
+            void fetchTileNvtx(s, s + TILE_WINDOW_S, activeGpu, maxBuckets);
         }
     }
 }
@@ -364,10 +364,10 @@ function prefetchAdjacent() {
         if (profileMeta) {
             const pStartS = profileMeta.time_range_ns[0] / 1e9;
             const pEndS = profileMeta.time_range_ns[1] / 1e9;
-            if (before[0] >= pStartS && renderLockIntersects(before[0], before[1]) && !tileCache.has(before[0], before[1], resolutionForTile(before[0], before[1]))) {
+            if (before[0] >= pStartS && renderLockIntersects(before[0], before[1]) && !tileCache.has(before[0], before[1], maxBucketsForTile(before[0], before[1]))) {
                 fetchTile(before[0], before[1], { requestNvtx: false }).then(() => { rebuildDataFromCache(); draw(); });
             }
-            if (after[1] <= pEndS && renderLockIntersects(after[0], after[1]) && !tileCache.has(after[0], after[1], resolutionForTile(after[0], after[1]))) {
+            if (after[1] <= pEndS && renderLockIntersects(after[0], after[1]) && !tileCache.has(after[0], after[1], maxBucketsForTile(after[0], after[1]))) {
                 fetchTile(after[0], after[1], { requestNvtx: false }).then(() => { rebuildDataFromCache(); draw(); });
             }
         }
@@ -1568,18 +1568,17 @@ function drawKernelBlock(k, y, W, options = {}) {
     const bY = y + 2;
     const bH = STREAM_H - 4;
     if (k.aggregate === true) {
-        const aggregateColor = '#8b949e';
-        ctx.fillStyle = aggregateColor;
+        ctx.fillStyle = P.textDim;
         ctx.globalAlpha = 0.86;
         ctx.fillRect(x1, bY, w, bH);
         ctx.globalAlpha = 1;
         ctx.save();
         ctx.setLineDash([3, 2]);
-        ctx.strokeStyle = '#c9d1d9';
+        ctx.strokeStyle = P.text;
         ctx.strokeRect(x1 + 0.5, bY + 0.5, w - 1, bH - 1);
         ctx.restore();
         if (options.label && w > 24) {
-            ctx.fillStyle = '#11161d';
+            ctx.fillStyle = P.bg;
             ctx.textAlign = 'left';
             ctx.textBaseline = 'middle';
             ctx.save();

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -51,26 +51,42 @@ const overviewCtx = overviewCanvas ? overviewCanvas.getContext('2d') : null;
 // ── Tile Cache ──
 class TileCache {
     constructor(maxBytes = 100 * 1024 * 1024) {
-        this.tiles = new Map();  // key "start_s-end_s" → {data, ts, sizeEst}
+        this.tiles = new Map();  // key "start_s-end_s|resolution" → {data, ts, sizeEst}
         this.maxBytes = maxBytes;
         this.currentBytes = 0;
         this.nvtxReady = new Set();
         this._dirty = true;
         this._cachedMerge = null;
     }
-    key(startS, endS) { return `${startS.toFixed(1)}-${endS.toFixed(1)}`; }
-    has(startS, endS) { return this.tiles.has(this.key(startS, endS)); }
-    nvtxKey(startS, endS, gpuId) { return `${this.key(startS, endS)}|gpu:${gpuId}`; }
-    hasNvtx(startS, endS, gpuId) { return this.nvtxReady.has(this.nvtxKey(startS, endS, gpuId)); }
-    markNvtx(startS, endS, gpuId) { this.nvtxReady.add(this.nvtxKey(startS, endS, gpuId)); }
-    get(startS, endS) {
-        const k = this.key(startS, endS);
+    key(startS, endS, resolution = 0) {
+        return `${startS.toFixed(1)}-${endS.toFixed(1)}|r:${Math.max(0, Math.round(resolution))}`;
+    }
+    baseKey(startS, endS) { return `${startS.toFixed(1)}-${endS.toFixed(1)}|r:`; }
+    has(startS, endS, resolution = 0) { return this.tiles.has(this.key(startS, endS, resolution)); }
+    nvtxKey(startS, endS, gpuId, resolution = 0) { return `${this.key(startS, endS, resolution)}|gpu:${gpuId}`; }
+    hasNvtx(startS, endS, gpuId, resolution = 0) { return this.nvtxReady.has(this.nvtxKey(startS, endS, gpuId, resolution)); }
+    markNvtx(startS, endS, gpuId, resolution = 0) { this.nvtxReady.add(this.nvtxKey(startS, endS, gpuId, resolution)); }
+    get(startS, endS, resolution = 0) {
+        const k = this.key(startS, endS, resolution);
         const entry = this.tiles.get(k);
         if (entry) entry.ts = Date.now();
         return entry ? entry.data : null;
     }
-    put(startS, endS, data) {
-        const k = this.key(startS, endS);
+    put(startS, endS, data, resolution = 0) {
+        const k = this.key(startS, endS, resolution);
+        // A tile can be exact when zoomed in and aggregate when zoomed out.
+        // Keep only the current resolution so stale variants cannot be merged.
+        const prefix = this.baseKey(startS, endS);
+        for (const oldKey of this.tiles.keys()) {
+            if (oldKey !== k && oldKey.startsWith(prefix)) {
+                const old = this.tiles.get(oldKey);
+                this.currentBytes -= old ? old.sizeEst : 0;
+                this.tiles.delete(oldKey);
+                for (const readyKey of this.nvtxReady) {
+                    if (readyKey.startsWith(oldKey + '|')) this.nvtxReady.delete(readyKey);
+                }
+            }
+        }
         const sizeEst = JSON.stringify(data).length * 2;  // rough byte estimate
         const previous = this.tiles.get(k);
         if (previous) this.currentBytes -= previous.sizeEst;
@@ -99,8 +115,8 @@ class TileCache {
         }
         this._dirty = true;
     }
-    mergeNvtx(startS, endS, nvtxData, gpuId) {
-        const k = this.key(startS, endS);
+    mergeNvtx(startS, endS, nvtxData, gpuId, resolution = 0) {
+        const k = this.key(startS, endS, resolution);
         const entry = this.tiles.get(k);
         if (!entry || !entry.data || !entry.data.gpus || !nvtxData || !nvtxData.gpus) return;
         let mergedTargetGpu = false;
@@ -112,7 +128,7 @@ class TileCache {
             mergedTargetGpu = true;
         }
         if (mergedTargetGpu) {
-            this.markNvtx(startS, endS, gpuId);
+            this.markNvtx(startS, endS, gpuId, resolution);
             this._dirty = true;
         }
     }
@@ -202,18 +218,28 @@ function hideLoading() {
 }
 
 // ── Fetch data for a time window ──
+function resolutionForTile(startS, endS) {
+    const width = Math.max(256, Math.floor((canvas.clientWidth || canvas.width / (window.devicePixelRatio || 1)) - LABEL_W));
+    const tileSpan = Math.max(endS - startS, 0.001);
+    const viewSpan = Math.max((viewEnd - viewStart) / 1e9, 0.001);
+    // A tile gets the fraction of the viewport's pixel budget that it occupies.
+    // Zooming into a sub-range therefore restores exact records for that tile.
+    return Math.max(64, Math.min(100000, Math.round(width * tileSpan / viewSpan)));
+}
+
 async function fetchTile(startS, endS, { requestNvtx = false } = {}) {
-    if (tileCache.has(startS, endS)) return tileCache.get(startS, endS);
-    const tileKey = tileCache.key(startS, endS);
+    const resolution = resolutionForTile(startS, endS);
+    if (tileCache.has(startS, endS, resolution)) return tileCache.get(startS, endS, resolution);
+    const tileKey = tileCache.key(startS, endS, resolution);
     if (tileInflight.has(tileKey)) return tileInflight.get(tileKey);
     const pfx = BOOT.API_PREFIX || '';
-    const request = fetch(`${pfx}/api/data?start_s=${startS}&end_s=${endS}&kernels=1&nvtx=0`)
+    const request = fetch(`${pfx}/api/data?start_s=${startS}&end_s=${endS}&resolution=${resolution}&kernels=1&nvtx=0`)
         .then(async resp => {
             if (!resp.ok) throw new Error(`tile request failed (${resp.status})`);
             const data = await resp.json();
             if (data.error) throw new Error(data.error);
-            tileCache.put(startS, endS, data);
-            if (requestNvtx && showNVTX) void fetchTileNvtx(startS, endS, currentActiveGpuId());
+            tileCache.put(startS, endS, data, resolution);
+            if (requestNvtx && showNVTX) void fetchTileNvtx(startS, endS, currentActiveGpuId(), resolution);
             return data;
         })
         .catch(err => {
@@ -240,9 +266,9 @@ function currentActiveGpuId() {
     return null;
 }
 
-async function fetchTileNvtx(startS, endS, gpuId) {
-    const key = `${tileCache.key(startS, endS)}|gpu:${gpuId}`;
-    if (tileCache.hasNvtx(startS, endS, gpuId) || nvtxInflight.has(key)) return;
+async function fetchTileNvtx(startS, endS, gpuId, resolution = resolutionForTile(startS, endS)) {
+    const key = `${tileCache.key(startS, endS, resolution)}|gpu:${gpuId}`;
+    if (tileCache.hasNvtx(startS, endS, gpuId, resolution) || nvtxInflight.has(key)) return;
     nvtxInflight.add(key);
     updateNvtxLoadingIndicator();
     try {
@@ -251,7 +277,7 @@ async function fetchTileNvtx(startS, endS, gpuId) {
         if (!resp.ok) throw new Error(`NVTX request failed (${resp.status})`);
         const data = await resp.json();
         if (data.error) throw new Error(data.error);
-        tileCache.mergeNvtx(startS, endS, data, gpuId);
+        tileCache.mergeNvtx(startS, endS, data, gpuId, resolution);
         rebuildDataFromCache();
         draw();
     } catch (err) {
@@ -296,7 +322,7 @@ async function ensureTilesForView(vStart, vEnd) {
     const promises = [];
     for (let s = startS; s < endS; s += TILE_WINDOW_S) {
         if (!renderLockIntersects(s, s + TILE_WINDOW_S)) continue;
-        if (!tileCache.has(s, s + TILE_WINDOW_S)) {
+        if (!tileCache.has(s, s + TILE_WINDOW_S, resolutionForTile(s, s + TILE_WINDOW_S))) {
             promises.push(fetchTile(s, s + TILE_WINDOW_S));
         }
     }
@@ -320,8 +346,9 @@ function maybeFetchNvtxForCurrentView() {
     if (activeGpu === null || activeGpu === undefined) return;
     for (let s = startS; s < endS; s += TILE_WINDOW_S) {
         if (!renderLockIntersects(s, s + TILE_WINDOW_S)) continue;
-        if (tileCache.has(s, s + TILE_WINDOW_S)) {
-            void fetchTileNvtx(s, s + TILE_WINDOW_S, activeGpu);
+        const resolution = resolutionForTile(s, s + TILE_WINDOW_S);
+        if (tileCache.has(s, s + TILE_WINDOW_S, resolution)) {
+            void fetchTileNvtx(s, s + TILE_WINDOW_S, activeGpu, resolution);
         }
     }
 }
@@ -337,10 +364,10 @@ function prefetchAdjacent() {
         if (profileMeta) {
             const pStartS = profileMeta.time_range_ns[0] / 1e9;
             const pEndS = profileMeta.time_range_ns[1] / 1e9;
-            if (before[0] >= pStartS && renderLockIntersects(before[0], before[1]) && !tileCache.has(before[0], before[1])) {
+            if (before[0] >= pStartS && renderLockIntersects(before[0], before[1]) && !tileCache.has(before[0], before[1], resolutionForTile(before[0], before[1]))) {
                 fetchTile(before[0], before[1], { requestNvtx: false }).then(() => { rebuildDataFromCache(); draw(); });
             }
-            if (after[1] <= pEndS && renderLockIntersects(after[0], after[1]) && !tileCache.has(after[0], after[1])) {
+            if (after[1] <= pEndS && renderLockIntersects(after[0], after[1]) && !tileCache.has(after[0], after[1], resolutionForTile(after[0], after[1]))) {
                 fetchTile(after[0], after[1], { requestNvtx: false }).then(() => { rebuildDataFromCache(); draw(); });
             }
         }
@@ -1540,6 +1567,28 @@ function drawKernelBlock(k, y, W, options = {}) {
     const w = Math.max(MIN_BLOCK_W, x2 - x1);
     const bY = y + 2;
     const bH = STREAM_H - 4;
+    if (k.aggregate === true) {
+        const aggregateColor = '#8b949e';
+        ctx.fillStyle = aggregateColor;
+        ctx.globalAlpha = 0.86;
+        ctx.fillRect(x1, bY, w, bH);
+        ctx.globalAlpha = 1;
+        ctx.save();
+        ctx.setLineDash([3, 2]);
+        ctx.strokeStyle = '#c9d1d9';
+        ctx.strokeRect(x1 + 0.5, bY + 0.5, w - 1, bH - 1);
+        ctx.restore();
+        if (options.label && w > 24) {
+            ctx.fillStyle = '#11161d';
+            ctx.textAlign = 'left';
+            ctx.textBaseline = 'middle';
+            ctx.save();
+            ctx.beginPath(); ctx.rect(x1 + 1, bY, w - 2, bH); ctx.clip();
+            ctx.fillText(`▦ ${Number(k.record_count || 0).toLocaleString()} events`, x1 + 3, bY + bH / 2);
+            ctx.restore();
+        }
+        return;
+    }
     const isMatch = !searchQuery || searchKernelMatches.has(k);
     const isSel = k === selectedKernel;
     const isNcclK = String(k.name || '').toLowerCase().includes('nccl');
@@ -1826,6 +1875,18 @@ function showDetail(item) {
     }
 
     const k = item;
+    if (k.aggregate === true) {
+        const gpuLabel = isMultiGPU ? ` &nbsp;|&nbsp; GPU ${k._gpu}` : '';
+        const occupancy = Number(k.occupancy || 0) * 100;
+        document.getElementById('detail').className = '';
+        document.getElementById('detail').innerHTML =
+            `<div class="detail-name">▦ Aggregate bucket</div>` +
+            `<div class="detail-dur">${Number(k.record_count || 0).toLocaleString()} records${gpuLabel} &nbsp;|&nbsp; ` +
+            `${occupancy.toFixed(1)}% busy &nbsp;|&nbsp; ${fmtNs(k.start_ns)} → ${fmtNs(k.end_ns)}</div>` +
+            `<div class="detail-path horizontal">Dominant: ${escH(k.dominant_type || 'kernel')} · ${escH(k.dominant_name || '(unnamed)')} · ` +
+            `longest ${fmtDur(k.max_duration_ms || 0)}</div>`;
+        return;
+    }
     const displayPath = kernelPathForDisplay(k);
     const pathInfo = renderPathHtml(displayPath);
     const gpuLabel = isMultiGPU ? ` &nbsp;|&nbsp; GPU ${k._gpu}` : '';
@@ -2503,7 +2564,10 @@ function onSearch() {
         matcher = { test: (s) => s.toLowerCase().includes(q) };
     }
     if (matcher) {
-        kernels.forEach(k => { if (matcher.test(k.name)) searchKernelMatches.add(k); });
+        kernels.forEach(k => {
+            if (k.aggregate === true) return;
+            if (matcher.test(k.name)) searchKernelMatches.add(k);
+        });
         nvtxSpans.forEach(s => {
             if (matcher.test(s.name || '')) searchNvtxMatches.add(nvtxKey(s));
         });

--- a/src/nsys_ai/viewer.py
+++ b/src/nsys_ai/viewer.py
@@ -285,6 +285,231 @@ def build_timeline_gpu_data(
     return gpu_entries
 
 
+def _timeline_record_union(prof, device: int, trim: tuple[int, int]) -> tuple[str, list]:
+    """Return the DuckDB record relation used by on-demand timeline LOD."""
+    start_ns, end_ns = trim
+    branches = []
+    params: list = []
+    if prof.schema.kernel_table:
+        branches.append(
+            f"""
+            SELECT k.start AS start_ns, k.[end] AS end_ns, k.streamId AS stream,
+                   s.value AS name, 'kernel' AS type
+            FROM {prof.schema.kernel_table} k
+            JOIN StringIds s ON k.shortName = s.id
+            WHERE k.deviceId = ? AND k.[end] >= ? AND k.start <= ?
+            """
+        )
+        params.extend((device, start_ns, end_ns))
+    tables = prof.adapter.resolve_activity_tables()
+    memcpy_table = tables.get("memcpy")
+    if memcpy_table:
+        branches.append(
+            f"""
+            SELECT m.start AS start_ns, m.[end] AS end_ns, m.streamId AS stream,
+                   '[CUDA memcpy ' || CASE m.copyKind
+                     WHEN 1 THEN 'H2D' WHEN 2 THEN 'D2H' WHEN 8 THEN 'D2D'
+                     WHEN 10 THEN 'P2P' ELSE 'kind=' || CAST(m.copyKind AS VARCHAR)
+                   END || ']' AS name, 'memcpy' AS type
+            FROM {memcpy_table} m
+            WHERE m.deviceId = ? AND m.[end] >= ? AND m.start <= ?
+            """
+        )
+        params.extend((device, start_ns, end_ns))
+    memset_table = tables.get("memset")
+    if memset_table:
+        branches.append(
+            f"""
+            SELECT m.start AS start_ns, m.[end] AS end_ns, m.streamId AS stream,
+                   '[CUDA memset]' AS name, 'memset' AS type
+            FROM {memset_table} m
+            WHERE m.deviceId = ? AND m.[end] >= ? AND m.start <= ?
+            """
+        )
+        params.extend((device, start_ns, end_ns))
+    if not branches:
+        return "SELECT CAST(NULL AS BIGINT) AS start_ns, CAST(NULL AS BIGINT) AS end_ns, NULL AS stream, NULL AS name, NULL AS type WHERE FALSE", []
+    return " UNION ALL ".join(branches), params
+
+
+def build_timeline_gpu_data_lod(
+    prof,
+    devices,
+    trim: tuple[int, int],
+    max_buckets: int,
+) -> list[dict]:
+    """Build exact or bucketed timeline rows directly from DuckDB.
+
+    The progressive endpoint uses this path when a resolution is supplied, so
+    a zoomed-out request does not materialise the full profile payload just to
+    throw most of it away in Python.  Exact requests still use the canonical
+    timeline builder, preserving selection fields and NVTX path enrichment.
+    """
+    from collections.abc import Sequence
+
+    devices_list = list(devices) if isinstance(devices, Sequence) else [devices]
+    result = []
+    for device in devices_list:
+        relation, relation_params = _timeline_record_union(prof, device, trim)
+        count_row = prof._duckdb_query(
+            f"SELECT COUNT(*) AS record_count FROM ({relation}) records",
+            relation_params,
+        )
+        record_count = int(count_row[0]["record_count"] or 0) if count_row else 0
+        if record_count <= max_buckets:
+            result.extend(
+                build_timeline_gpu_data(
+                    prof,
+                    device,
+                    trim,
+                    include_kernels=True,
+                    include_nvtx=False,
+                )
+            )
+            continue
+
+        start_ns, end_ns = trim
+        bucket_count = min(max_buckets, record_count)
+        bucket_width = (end_ns - start_ns) / bucket_count
+        aggregate_sql = f"""
+            WITH records AS ({relation}),
+            clipped AS (
+                SELECT GREATEST(start_ns, ?) AS start_ns,
+                       LEAST(end_ns, ?) AS end_ns,
+                       end_ns - start_ns AS duration_ns, type, name
+                FROM records
+                WHERE end_ns >= ? AND start_ns <= ?
+            ),
+            bucketed AS (
+                SELECT *,
+                       CAST(FLOOR((start_ns - ?) / ?) AS BIGINT) AS first_bucket,
+                       CAST(FLOOR((GREATEST(start_ns, end_ns - 1) - ?) / ?) AS BIGINT) AS last_bucket
+                FROM clipped
+            ),
+            expanded AS (
+                SELECT b.*, r.bucket
+                FROM bucketed b,
+                     LATERAL range(b.first_bucket, b.last_bucket + 1) r(bucket)
+                WHERE b.first_bucket <= ? AND b.last_bucket >= 0
+            ),
+            segments AS (
+                SELECT bucket,
+                       GREATEST(start_ns, CAST(? + bucket * ? AS BIGINT)) AS seg_start,
+                       LEAST(end_ns, CAST(? + (bucket + 1) * ? AS BIGINT)) AS seg_end
+                FROM expanded
+                WHERE end_ns > start_ns
+            ),
+            ordered AS (
+                SELECT *, MAX(seg_end) OVER (
+                    PARTITION BY bucket ORDER BY seg_start, seg_end
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+                ) AS previous_end
+                FROM segments
+            ),
+            marked AS (
+                SELECT *, CASE WHEN previous_end IS NULL OR seg_start > previous_end THEN 1 ELSE 0 END AS is_new
+                FROM ordered
+            ),
+            islands AS (
+                SELECT *, SUM(is_new) OVER (
+                    PARTITION BY bucket ORDER BY seg_start, seg_end
+                    ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW
+                ) AS island
+                FROM marked
+            ),
+            busy AS (
+                SELECT bucket, SUM(island_end - island_start) AS busy_ns
+                FROM (
+                    SELECT bucket, island, MIN(seg_start) AS island_start, MAX(seg_end) AS island_end
+                    FROM islands GROUP BY bucket, island
+                ) merged
+                GROUP BY bucket
+            ),
+            stats AS (
+                SELECT bucket, COUNT(*) AS record_count, MAX(duration_ns) AS max_duration_ns
+                FROM expanded GROUP BY bucket
+            ),
+            type_counts AS (
+                SELECT bucket, type, COUNT(*) AS count
+                FROM expanded GROUP BY bucket, type
+            ),
+            top_types AS (
+                SELECT bucket, type FROM type_counts
+                QUALIFY ROW_NUMBER() OVER (PARTITION BY bucket ORDER BY count DESC, type) = 1
+            ),
+            name_counts AS (
+                SELECT bucket, name, COUNT(*) AS count
+                FROM expanded GROUP BY bucket, name
+            ),
+            top_names AS (
+                SELECT bucket, name FROM name_counts
+                QUALIFY ROW_NUMBER() OVER (PARTITION BY bucket ORDER BY count DESC, name) = 1
+            )
+            SELECT stats.bucket, stats.record_count, stats.max_duration_ns,
+                   busy.busy_ns, top_types.type AS dominant_type, top_names.name AS dominant_name
+            FROM stats JOIN busy USING (bucket)
+            JOIN top_types USING (bucket) JOIN top_names USING (bucket)
+            ORDER BY stats.bucket
+        """
+        params = list(relation_params)
+        params.extend(
+            [
+                start_ns,
+                end_ns,
+                start_ns,
+                end_ns,
+                start_ns,
+                bucket_width,
+                start_ns,
+                bucket_width,
+                bucket_count - 1,
+                start_ns,
+                bucket_width,
+                start_ns,
+                bucket_width,
+            ]
+        )
+        rows = prof._duckdb_query(aggregate_sql, params)
+        kernels = []
+        for row in rows:
+            bucket = int(row["bucket"])
+            bucket_start = int(start_ns + bucket * bucket_width)
+            bucket_end = int(start_ns + (bucket + 1) * bucket_width)
+            busy_ns = int(row["busy_ns"] or 0)
+            kernels.append(
+                {
+                    "type": "aggregate",
+                    "aggregate": True,
+                    "name": f"[Aggregate] {int(row['record_count']):,} records",
+                    "start_ns": bucket_start,
+                    "end_ns": bucket_end,
+                    "duration_ms": round(busy_ns / 1e6, 3),
+                    "stream": "__aggregate__",
+                    "path": "",
+                    "record_count": int(row["record_count"]),
+                    "busy_ns": busy_ns,
+                    "occupancy": busy_ns / max(bucket_end - bucket_start, 1),
+                    "max_duration_ms": round(int(row["max_duration_ns"] or 0) / 1e6, 3),
+                    "dominant_type": row["dominant_type"],
+                    "dominant_name": row["dominant_name"],
+                }
+            )
+        result.append(
+            {
+                "id": device,
+                "kernels": kernels,
+                "nvtx_spans": [],
+                "lod": {
+                    "mode": "aggregate",
+                    "record_count": record_count,
+                    "bucket_count": len(kernels),
+                    "max_buckets": max_buckets,
+                },
+            }
+        )
+    return result
+
+
 def generate_timeline_data_json(prof, devices, trim: tuple[int, int]) -> str:
     """Return JSON string of per-GPU kernel/NVTX data for a time window.
 

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -290,7 +290,7 @@ def _handle_chat_stream(body_bytes: bytes):
 
 class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
     """Serve the pre-rendered HTML on GET; GET /api/models for model list;
-    GET /api/data for on-demand tile data (with optional resolution LOD);
+    GET /api/data for on-demand tile data (with optional max_buckets LOD);
     GET /api/meta for profile metadata;
     POST /api/chat for AI chat."""
 
@@ -533,11 +533,14 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
         """Return kernel/NVTX data for a requested time window (from pre-built cache)."""
         from urllib.parse import parse_qs, urlparse
 
+        qs = parse_qs(urlparse(self.path).query)
+        if qs.get("resolution", [None])[0] not in (None, ""):
+            self._json_response({"error": "resolution is obsolete; use max_buckets"}, 400)
+            return
         prebuilt = self.__class__._prebuilt_data
         if not prebuilt:
             self._json_response({"error": "no prebuilt data"}, 500)
             return
-        qs = parse_qs(urlparse(self.path).query)
         try:
             start_s = float(qs.get("start_s", [0])[0])
             end_s = float(qs.get("end_s", [5])[0])
@@ -561,12 +564,12 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
             f"gpu={gpu_filter if gpu_filter is not None else 'all'})...",
             flush=True,
         )
-        resolution = None
-        if qs.get("resolution", [None])[0] not in (None, ""):
+        max_buckets = None
+        if qs.get("max_buckets", [None])[0] not in (None, ""):
             try:
-                resolution = max(1, min(100_000, int(qs["resolution"][0])))
+                max_buckets = max(1, min(100_000, int(qs["max_buckets"][0])))
             except (TypeError, ValueError):
-                self._json_response({"error": "resolution must be a positive integer"}, 400)
+                self._json_response({"error": "max_buckets must be a positive integer"}, 400)
                 return
         try:
             nvtx_spans_by_gpu = None
@@ -591,7 +594,7 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                 }
 
             lod_by_gpu = {}
-            if resolution is not None and kernels_requested and self.__class__.prof is not None:
+            if max_buckets is not None and kernels_requested and self.__class__.prof is not None:
                 try:
                     lod_by_gpu = {
                         entry["id"]: entry
@@ -599,7 +602,7 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                             self.__class__.prof,
                             self.__class__.devices,
                             (start_ns, end_ns),
-                            resolution,
+                            max_buckets,
                         )
                     }
                 except Exception:
@@ -620,9 +623,9 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                         )
                     if nvtx_spans_by_gpu is not None:
                         filtered["nvtx_spans"] = nvtx_spans_by_gpu.get(filtered["id"], [])
-                    if resolution is not None and kernels_requested and filtered.get("lod") is None:
+                    if max_buckets is not None and kernels_requested and filtered.get("lod") is None:
                         filtered = _aggregate_timeline_gpu_entry(
-                            filtered, start_ns, end_ns, resolution
+                            filtered, start_ns, end_ns, max_buckets
                         )
                     gpu_entries.append(filtered)
                 else:

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -211,6 +211,7 @@ class _ThreadedHTTPServer(_ThreadPoolMixIn, socketserver.ThreadingMixIn, HTTPSer
 
 from .viewer import (  # noqa: E402
     build_timeline_gpu_data,
+    build_timeline_gpu_data_lod,
     generate_evidence_html,
     generate_html,
     generate_timeline_html,
@@ -289,7 +290,8 @@ def _handle_chat_stream(body_bytes: bytes):
 
 class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
     """Serve the pre-rendered HTML on GET; GET /api/models for model list;
-    GET /api/data for on-demand tile data; GET /api/meta for profile metadata;
+    GET /api/data for on-demand tile data (with optional resolution LOD);
+    GET /api/meta for profile metadata;
     POST /api/chat for AI chat."""
 
     html_bytes: bytes = b""
@@ -559,6 +561,13 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
             f"gpu={gpu_filter if gpu_filter is not None else 'all'})...",
             flush=True,
         )
+        resolution = None
+        if qs.get("resolution", [None])[0] not in (None, ""):
+            try:
+                resolution = max(1, min(100_000, int(qs["resolution"][0])))
+            except (TypeError, ValueError):
+                self._json_response({"error": "resolution must be a positive integer"}, 400)
+                return
         try:
             nvtx_spans_by_gpu = None
             if self.__class__._prebuilt_nvtx_mode == "background" and nvtx_requested:
@@ -581,19 +590,40 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                     for dev in annotate_devices
                 }
 
+            lod_by_gpu = {}
+            if resolution is not None and kernels_requested and self.__class__.prof is not None:
+                try:
+                    lod_by_gpu = {
+                        entry["id"]: entry
+                        for entry in build_timeline_gpu_data_lod(
+                            self.__class__.prof,
+                            self.__class__.devices,
+                            (start_ns, end_ns),
+                            resolution,
+                        )
+                    }
+                except Exception:
+                    _log.exception("DuckDB timeline LOD query failed; using cached payload")
+
             # Filter pre-built data by time window
             gpu_entries = []
             for gpu_data in prebuilt:
                 if "kernels" in gpu_data:
-                    filtered = _filter_timeline_gpu_entry(
-                        gpu_data,
-                        start_ns,
-                        end_ns,
-                        filter_kernels=kernels_requested,
-                        filter_nvtx=self.__class__._prebuilt_nvtx_mode == "full",
-                    )
+                    filtered = lod_by_gpu.get(gpu_data.get("id"))
+                    if filtered is None:
+                        filtered = _filter_timeline_gpu_entry(
+                            gpu_data,
+                            start_ns,
+                            end_ns,
+                            filter_kernels=kernels_requested,
+                            filter_nvtx=self.__class__._prebuilt_nvtx_mode == "full",
+                        )
                     if nvtx_spans_by_gpu is not None:
                         filtered["nvtx_spans"] = nvtx_spans_by_gpu.get(filtered["id"], [])
+                    if resolution is not None and kernels_requested and filtered.get("lod") is None:
+                        filtered = _aggregate_timeline_gpu_entry(
+                            filtered, start_ns, end_ns, resolution
+                        )
                     gpu_entries.append(filtered)
                 else:
                     # Backward-compatible fallback for older in-memory format.
@@ -1074,6 +1104,125 @@ def _filter_timeline_gpu_entry(
     else:
         nvtx_spans = []
     return {"id": gpu_entry.get("id"), "kernels": kernels, "nvtx_spans": nvtx_spans}
+
+
+def _aggregate_timeline_gpu_entry(
+    gpu_entry: dict,
+    start_ns: int,
+    end_ns: int,
+    max_buckets: int,
+) -> dict:
+    """Summarise a dense kernel payload into at most ``max_buckets`` bins.
+
+    This is deliberately a request-time representation.  An aggregate is not
+    a kernel: it carries the number of records, busy-time union, longest
+    record, and dominant categories so the UI can label it as derived data.
+    Busy time is an interval union rather than a sum of durations; concurrent
+    streams must not make a bucket look more than 100% occupied.
+    """
+    kernels = [
+        kernel
+        for kernel in gpu_entry.get("kernels", [])
+        if kernel.get("end_ns", 0) >= start_ns and kernel.get("start_ns", 0) <= end_ns
+    ]
+    if not kernels or max_buckets <= 0 or end_ns <= start_ns:
+        return {
+            "id": gpu_entry.get("id"),
+            "kernels": kernels,
+            "nvtx_spans": gpu_entry.get("nvtx_spans", []),
+        }
+    if len(kernels) <= max_buckets:
+        return {
+            "id": gpu_entry.get("id"),
+            "kernels": kernels,
+            "nvtx_spans": gpu_entry.get("nvtx_spans", []),
+            "lod": {"mode": "exact", "record_count": len(kernels)},
+        }
+
+    bucket_count = min(max_buckets, len(kernels))
+    span_ns = end_ns - start_ns
+    bucket_width = span_ns / bucket_count
+    buckets: list[dict] = [
+        {"intervals": [], "count": 0, "max_duration_ns": 0, "types": {}, "names": {}}
+        for _ in range(bucket_count)
+    ]
+
+    for kernel in kernels:
+        raw_start = int(kernel.get("start_ns", start_ns))
+        raw_end = int(kernel.get("end_ns", raw_start))
+        clipped_start = max(start_ns, raw_start)
+        clipped_end = min(end_ns, raw_end)
+        if clipped_end <= clipped_start:
+            continue
+        first = max(0, min(bucket_count - 1, int((clipped_start - start_ns) / bucket_width)))
+        last = max(
+            first,
+            min(bucket_count - 1, int((max(clipped_start, clipped_end - 1) - start_ns) / bucket_width)),
+        )
+        duration_ns = max(0, raw_end - raw_start)
+        kind = str(kernel.get("type") or "kernel")
+        name = str(kernel.get("name") or "(unnamed)")
+        for bucket_index in range(first, last + 1):
+            bucket_start = int(start_ns + bucket_index * bucket_width)
+            bucket_end = int(start_ns + (bucket_index + 1) * bucket_width)
+            interval_start = max(clipped_start, bucket_start)
+            interval_end = min(clipped_end, bucket_end)
+            if interval_end <= interval_start:
+                continue
+            bucket = buckets[bucket_index]
+            bucket["intervals"].append((interval_start, interval_end))
+            bucket["count"] += 1
+            bucket["max_duration_ns"] = max(bucket["max_duration_ns"], duration_ns)
+            bucket["types"][kind] = bucket["types"].get(kind, 0) + 1
+            bucket["names"][name] = bucket["names"].get(name, 0) + 1
+
+    aggregate_rows = []
+    for bucket_index, bucket in enumerate(buckets):
+        if not bucket["count"]:
+            continue
+        intervals = sorted(bucket["intervals"])
+        union_ns = 0
+        union_start, union_end = intervals[0]
+        for interval_start, interval_end in intervals[1:]:
+            if interval_start > union_end:
+                union_ns += union_end - union_start
+                union_start, union_end = interval_start, interval_end
+            else:
+                union_end = max(union_end, interval_end)
+        union_ns += union_end - union_start
+        dominant_type = max(bucket["types"].items(), key=lambda item: (item[1], item[0]))[0]
+        dominant_name = max(bucket["names"].items(), key=lambda item: (item[1], item[0]))[0]
+        bucket_start = int(start_ns + bucket_index * bucket_width)
+        bucket_end = int(start_ns + (bucket_index + 1) * bucket_width)
+        aggregate_rows.append(
+            {
+                "type": "aggregate",
+                "aggregate": True,
+                "name": f"[Aggregate] {bucket['count']:,} records",
+                "start_ns": bucket_start,
+                "end_ns": bucket_end,
+                "duration_ms": round(union_ns / 1e6, 3),
+                "stream": "__aggregate__",
+                "path": "",
+                "record_count": bucket["count"],
+                "busy_ns": union_ns,
+                "occupancy": union_ns / max(bucket_end - bucket_start, 1),
+                "max_duration_ms": round(bucket["max_duration_ns"] / 1e6, 3),
+                "dominant_type": dominant_type,
+                "dominant_name": dominant_name,
+            }
+        )
+    return {
+        "id": gpu_entry.get("id"),
+        "kernels": aggregate_rows,
+        "nvtx_spans": gpu_entry.get("nvtx_spans", []),
+        "lod": {
+            "mode": "aggregate",
+            "record_count": len(kernels),
+            "bucket_count": len(aggregate_rows),
+            "max_buckets": max_buckets,
+        },
+    }
 
 
 def serve_timeline(

--- a/tests/test_timeline_web_data.py
+++ b/tests/test_timeline_web_data.py
@@ -72,10 +72,11 @@ def test_timeline_web_duckdb_lod_returns_bounded_rows(minimal_nsys_db_path):
     assert all(row["aggregate"] is True for row in result[0]["kernels"])
 
 
-def test_timeline_web_frontend_requests_resolution_and_marks_aggregates():
+def test_timeline_web_frontend_requests_max_buckets_and_marks_aggregates():
     javascript = Path("src/nsys_ai/templates/timeline.js").read_text(encoding="utf-8")
 
-    assert "resolution=${resolution}" in javascript
+    assert "max_buckets=${maxBuckets}" in javascript
+    assert "resolution=" not in javascript
     assert "k.aggregate === true" in javascript
     assert "Aggregate bucket" in javascript
 

--- a/tests/test_timeline_web_data.py
+++ b/tests/test_timeline_web_data.py
@@ -1,14 +1,83 @@
 import json
 import sqlite3
+from pathlib import Path
 
 from nsys_ai.profile import Profile
 from nsys_ai.viewer import (
     build_timeline_gpu_data,
+    build_timeline_gpu_data_lod,
     generate_timeline_data_json,
     generate_timeline_html,
     write_timeline_html,
 )
-from nsys_ai.web import _build_timeline_overview, _slice_nvtx_spans
+from nsys_ai.web import (
+    _aggregate_timeline_gpu_entry,
+    _build_timeline_overview,
+    _slice_nvtx_spans,
+)
+
+
+def test_timeline_web_lod_uses_interval_union_and_marks_aggregates():
+    entry = {
+        "id": 0,
+        "kernels": [
+            {"type": "kernel", "name": "long", "start_ns": 0, "end_ns": 60, "stream": 1},
+            {"type": "kernel", "name": "overlap", "start_ns": 40, "end_ns": 100, "stream": 2},
+            {"type": "kernel", "name": "short", "start_ns": 20, "end_ns": 30, "stream": 1},
+        ],
+        "nvtx_spans": [{"name": "phase", "start": 0, "end": 100}],
+    }
+
+    result = _aggregate_timeline_gpu_entry(entry, 0, 100, 2)
+
+    assert result["lod"] == {
+        "mode": "aggregate",
+        "record_count": 3,
+        "bucket_count": 2,
+        "max_buckets": 2,
+    }
+    assert len(result["kernels"]) == 2
+    assert all(row["aggregate"] is True for row in result["kernels"])
+    assert [row["record_count"] for row in result["kernels"]] == [3, 2]
+    # Both buckets are fully busy after merging overlapping stream intervals.
+    assert [row["busy_ns"] for row in result["kernels"]] == [50, 50]
+    assert all(row["occupancy"] == 1.0 for row in result["kernels"])
+    assert result["nvtx_spans"] == entry["nvtx_spans"]
+
+
+def test_timeline_web_lod_keeps_small_windows_exact():
+    entry = {
+        "id": 0,
+        "kernels": [
+            {"type": "kernel", "name": "one", "start_ns": 10, "end_ns": 20},
+            {"type": "kernel", "name": "two", "start_ns": 30, "end_ns": 40},
+        ],
+        "nvtx_spans": [],
+    }
+
+    result = _aggregate_timeline_gpu_entry(entry, 0, 100, 2)
+
+    assert result["lod"]["mode"] == "exact"
+    assert result["kernels"] == entry["kernels"]
+
+
+def test_timeline_web_duckdb_lod_returns_bounded_rows(minimal_nsys_db_path):
+    with Profile(minimal_nsys_db_path) as prof:
+        trim = (0, 5_000_000)
+        result = build_timeline_gpu_data_lod(prof, [0], trim, max_buckets=2)
+
+    assert result[0]["lod"]["mode"] == "aggregate"
+    assert result[0]["lod"]["record_count"] > 2
+    assert len(result[0]["kernels"]) <= 2
+    assert all(row["aggregate"] is True for row in result[0]["kernels"])
+
+
+def test_timeline_web_frontend_requests_resolution_and_marks_aggregates():
+    javascript = Path("src/nsys_ai/templates/timeline.js").read_text(encoding="utf-8")
+
+    assert "resolution=${resolution}" in javascript
+    assert "k.aggregate === true" in javascript
+    assert "Aggregate bucket" in javascript
 
 
 def test_timeline_web_kernel_first_keeps_kernels_outside_nvtx(minimal_nsys_db_path):

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -82,6 +82,14 @@ def test_tree_slice_preserves_children_marker_without_mutating_source():
     assert source[0]["children"] == [{"path": "child"}]
 
 
+def test_timeline_data_rejects_obsolete_resolution_parameter():
+    status, body, content_type = _get(web._ViewerHandler, "/api/data?resolution=2000")
+
+    assert status == 400
+    assert content_type.startswith("application/json")
+    assert b"use max_buckets" in body
+
+
 @pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])
 def test_web_surfaces_serve_shared_tokens_asset(handler):
     status, body, content_type = _get(handler, "/assets/tokens.css")


### PR DESCRIPTION
## Summary

Closes #470.

- Adds an optional `resolution` axis to `/api/data`.
- Runs dense requests directly against DuckDB instead of filtering the full cached payload in Python.
- Uses interval union for busy time, plus record count, longest record, and dominant type/name per bucket.
- Keeps low-density requests exact so kernel selection and hover retain real records.
- Marks aggregate rows in the response and renders them as visibly derived buckets in the timeline.
- Includes the resolution in the progressive tile cache key so zoom levels cannot reuse the wrong payload.

## Validation

- `PYTHONPATH=src pytest tests/test_timeline_web_data.py tests/test_web_foundation.py tests/test_web_compression.py -q` — 40 passed
- Ruff, `node --check`, and `git diff --check` pass
- Real fastvideo profile: 4 GPUs, 2,883,201 records, full-range LOD response in 1.46s, 2.73 MB JSON, 7,569 aggregate rows
- Real fastvideo 5-second zoom: 24 exact kernel rows

The existing full-profile startup cache remains unchanged; this PR addresses request-time payload and query cost.
