### PR TITLE
perf(web): move NVTX tree data behind API

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1719,9 +1719,9 @@ def _cmd_web(args, _profile):
     from nsys_ai.web import serve
 
     with _profile.open(args.profile) as prof:
-        trim = _parse_trim(args)
-        _check_trim_window(trim, prof)
-        serve(prof, args.gpu, trim, port=args.port, open_browser=not args.no_browser)
+        gpu = args.gpu if args.gpu is not None else (prof.meta.devices[0] if prof.meta.devices else 0)
+        trim = _resolve_trim_window(_parse_trim(args), prof)
+        serve(prof, gpu, trim, port=args.port, open_browser=not args.no_browser)
 
 
 def _cmd_open(args, _profile):

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -755,7 +755,7 @@ def _build_parser():
     p.set_defaults(handler=_cmd_open)
 
     p = sub.add_parser("web", help="Serve interactive web viewer")
-    _add_gpu_trim(p)
+    _add_gpu_trim(p, gpu_required=False, trim_required=False)
     p.add_argument("--port", type=int, default=8142, help="HTTP port (default: 8142)")
     p.add_argument("--no-browser", action="store_true", help="Don't auto-open browser")
     p.set_defaults(handler=_cmd_web)

--- a/src/nsys_ai/templates/nvtx_tree.html
+++ b/src/nsys_ai/templates/nvtx_tree.html
@@ -1022,7 +1022,10 @@
     <div class="tooltip" id="tooltip" style="display:none"></div>
 
     <script>
-        const DATA = $DATA;
+        const API_PREFIX = "$API_PREFIX";
+        let DATA = [];
+        let fullDataPromise = null;
+        let fullDataLoaded = false;
         const PROFILE_PATH = $PROFILE_PATH;
         const DB_AGENT_ENABLED = "$DB_AGENT_ENABLED" === "1";
         let heatEnabled = false, demangledMode = false, searchMode = 'path', currentTab = 'tree', scopeActive = false, scopedData = null, scopePath = null;
@@ -1053,6 +1056,48 @@
         function getTopNVTX(nodes, depth) { const r = []; nodes.forEach(n => { if (n.type === 'nvtx') { r.push({ name: n.name, path: n.path, start_ns: n.start_ns, end_ns: n.end_ns, duration_ms: n.duration_ms }); if (depth > 0 && n.children) r.push(...getTopNVTX(n.children, depth - 1)) } }); return r }
 
         function activeData() { return scopedData || DATA }
+
+        function treeUrl(path, depth) {
+            let url = (API_PREFIX || '') + '/api/tree?depth=' + encodeURIComponent(depth);
+            if (path) url += '&path=' + encodeURIComponent(path);
+            return url;
+        }
+        async function fetchTree(path, depth) {
+            const response = await fetch(treeUrl(path, depth));
+            if (!response.ok) throw new Error('tree request failed (' + response.status + ')');
+            const payload = await response.json();
+            if (payload.error) throw new Error(payload.error);
+            return Array.isArray(payload.nodes) ? payload.nodes : [];
+        }
+        function setTreeData(nodes) {
+            DATA = Array.isArray(nodes) ? nodes : [];
+            const stats = countNodes(DATA);
+            document.getElementById('stats').innerHTML =
+                '<span>NVTX: <strong>' + stats.nvtx + '</strong></span>' +
+                '<span>Kernels: <strong>' + stats.kern + '</strong></span>' +
+                '<span>Total GPU: <strong>' + stats.totalMs.toFixed(1) + 'ms</strong></span>';
+            let html = ''; DATA.forEach(n => html += renderNode(n, 0));
+            document.getElementById('tree').innerHTML = html;
+            updateTreeExpandButtons();
+        }
+        async function ensureFullData() {
+            if (fullDataLoaded) return DATA;
+            if (!fullDataPromise) {
+                fullDataPromise = fetchTree('', 'full').then(nodes => {
+                    fullDataLoaded = true;
+                    setTreeData(nodes);
+                    return DATA;
+                });
+            }
+            return fullDataPromise;
+        }
+        async function loadInitialTree() {
+            try {
+                setTreeData(await fetchTree('', 2));
+            } catch (error) {
+                document.getElementById('tree').textContent = 'Failed to load tree: ' + error.message;
+            }
+        }
 
         // = Profile context (Issue #6) =
         function getTimeRangeFromData(nodes) {
@@ -1198,17 +1243,23 @@
             document.querySelectorAll('.tab-panel').forEach(p => p.classList.toggle('active', p.id === 'panel-' + tab));
             document.getElementById('treeControls').style.display = tab === 'tree' ? 'flex' : 'none';
             document.getElementById('searchBar').style.display = (tab === 'tree' || tab === 'kernels') ? 'block' : 'none';
-            if (tab === 'kernels') renderKernelView();
-            if (tab === 'scan') renderScanView();
-            if (tab === 'scanv2') renderScanV2();
-            if (tab === 'streams') renderStreamView();
-            if (tab === 'aggregate') renderAggView();
-            if (tab === 'patterns') renderPatternView();
+            if (tab !== 'tree') {
+                ensureFullData().then(() => {
+                    if (tab === 'kernels') renderKernelView();
+                    if (tab === 'scan') renderScanView();
+                    if (tab === 'scanv2') renderScanV2();
+                    if (tab === 'streams') renderStreamView();
+                    if (tab === 'aggregate') renderAggView();
+                    if (tab === 'patterns') renderPatternView();
+                }).catch(error => {
+                    document.getElementById('tree').textContent = 'Failed to load profile data: ' + error.message;
+                });
+            }
         }
 
         // = Tree view =
         function renderNode(node, depth) {
-            const hasC = node.children && node.children.length > 0, isK = node.type === 'kernel', cls = isK ? 'kernel' : 'nvtx';
+            const hasC = (node.children && node.children.length > 0) || node.has_children === true, isK = node.type === 'kernel', cls = isK ? 'kernel' : 'nvtx';
             const icon = isK ? '⚡' : '📦', toggle = hasC ? '▶' : ' ';
             const displayName = (demangledMode && isK && node.demangled) ? node.demangled : node.name;
             const stream = node.stream !== undefined ? '<span class="stream">[stream ' + node.stream + ']</span>' : '';
@@ -1224,10 +1275,45 @@
             h += '<div class="node-header" onclick="toggleNode(this)">';
             h += '<span class="toggle">' + toggle + '</span><span class="icon">' + icon + '</span>';
             h += '<span class="name">' + escHtml(displayName) + '</span>' + stream + dur + ' ' + heatBar + pctLabel + '</div>';
-            if (hasC) { h += '<div class="children' + (depth > 1 ? ' collapsed' : '') + '">'; node.children.forEach(c => h += renderNode(c, depth + 1)); h += '</div>' }
+            if (hasC) {
+                const lazy = node.has_children === true && !(node.children && node.children.length);
+                h += '<div class="children' + (depth > 1 || lazy ? ' collapsed' : '') + '" data-lazy="' + (lazy ? '1' : '0') + '">';
+                if (node.children) node.children.forEach(c => h += renderNode(c, depth + 1));
+                h += '</div>';
+            }
             h += '</div>'; return h;
         }
-        function toggleNode(hdr) { const c = hdr.nextElementSibling; if (!c || !c.classList.contains('children')) return; c.classList.toggle('collapsed'); hdr.querySelector('.toggle').textContent = c.classList.contains('collapsed') ? '▶' : '▼' }
+        async function toggleNode(hdr) {
+            const c = hdr.nextElementSibling;
+            if (!c || !c.classList.contains('children')) return;
+            if (c.dataset.lazy === '1' && c.dataset.loaded !== '1') {
+                const nodeEl = hdr.parentElement;
+                c.classList.remove('collapsed');
+                c.textContent = 'Loading…';
+                try {
+                    const children = await fetchTree(nodeEl.dataset.path || '', 2);
+                    c.textContent = '';
+                    children.forEach(child => c.insertAdjacentHTML('beforeend', renderNode(child, Number(nodeEl.dataset.depth || 0) + 1)));
+                    c.dataset.loaded = '1';
+                    c.dataset.lazy = '0';
+                    const target = findTreeNode(DATA, nodeEl.dataset.path || '');
+                    if (target) { target.children = children; delete target.has_children; }
+                } catch (error) {
+                    c.textContent = 'Failed to load children: ' + error.message;
+                    return;
+                }
+            }
+            c.classList.toggle('collapsed');
+            hdr.querySelector('.toggle').textContent = c.classList.contains('collapsed') ? '▶' : '▼';
+        }
+        function findTreeNode(nodes, path) {
+            for (const node of nodes) {
+                if (node.path === path) return node;
+                const found = findTreeNode(node.children || [], path);
+                if (found) return found;
+            }
+            return null;
+        }
         function updateTreeExpandButtons() {
             document.getElementById('expandAllBtn').classList.toggle('active', treeExpandState === 'all');
             document.getElementById('collapseAllBtn').classList.toggle('active', treeExpandState === 'none');
@@ -2087,9 +2173,8 @@
         }
 
         // = Initial render =
-        const stats = countNodes(DATA);
-        document.getElementById('stats').innerHTML = '<span>NVTX: <strong>' + stats.nvtx + '</strong></span><span>Kernels: <strong>' + stats.kern + '</strong></span><span>Total GPU: <strong>' + stats.totalMs.toFixed(1) + 'ms</strong></span>';
-        let html = ''; DATA.forEach(n => html += renderNode(n, 0)); document.getElementById('tree').innerHTML = html;
+        document.getElementById('tree').textContent = 'Loading tree…';
+        loadInitialTree();
         renderChatHistory();
     </script>
 </body>

--- a/src/nsys_ai/viewer.py
+++ b/src/nsys_ai/viewer.py
@@ -71,10 +71,15 @@ def generate_html(
     trim: tuple[int, int],
     *,
     tokens_href: str = "/assets/tokens.css",
+    embed_data: bool = True,
 ) -> str:
-    """Generate a standalone HTML page showing the NVTX stack trace."""
-    roots = build_nvtx_tree(prof, device, trim)
-    tree_json = to_json(roots)
+    """Generate the NVTX stack trace page.
+
+    ``embed_data=False`` produces the small web shell; the server supplies the
+    tree through ``/api/tree``.  Standalone exports keep the historical inline
+    data behaviour unless the caller explicitly opts into the shell.
+    """
+    tree_json = to_json(build_nvtx_tree(prof, device, trim)) if embed_data else []
 
     gpu_info = prof.meta.gpu_info.get(device)
     gpu_label = format_gpu_label(device, gpu_info)
@@ -97,6 +102,7 @@ def generate_html(
         PROFILE_PATH=safe_profile_path,
         DB_AGENT_ENABLED="1" if db_agent_enabled else "",
         TOKENS_HREF=tokens_href,
+        API_PREFIX="",
     )
 
 

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -55,6 +55,36 @@ def _versioned_asset_url(path: str) -> str:
     return f"{path}?v={_template_asset_version()}"
 
 
+def _find_tree_path(nodes: list[dict], path: str) -> dict | None:
+    """Find a serialized NVTX node by its stable display path."""
+    for node in nodes:
+        if node.get("path") == path:
+            return node
+        children = node.get("children") or []
+        found = _find_tree_path(children, path)
+        if found is not None:
+            return found
+    return None
+
+
+def _slice_tree_nodes(nodes: list[dict], depth: int | None) -> list[dict]:
+    """Copy a tree to *depth*, preserving a marker for unloaded children."""
+    result = []
+    for node in nodes:
+        copied = {key: value for key, value in node.items() if key != "children"}
+        children = node.get("children") or []
+        if children:
+            if depth is None or depth > 0:
+                copied["children"] = _slice_tree_nodes(
+                    children, None if depth is None else depth - 1
+                )
+            else:
+                copied["children"] = []
+                copied["has_children"] = True
+        result.append(copied)
+    return result
+
+
 #: Below this, the gzip header costs more than the compression saves.
 _MIN_COMPRESS_BYTES = 1024
 
@@ -278,6 +308,10 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
     _session_id: str | None = None  # SessionStore id (always set by serve_timeline)
     _session_root: str = ".nsys-ai/sessions"
     _trim: tuple[int, int] | None = None
+    _tree_data: list[dict] = []
+    _tree_configured: bool = False
+    _tree_device: int | None = None
+    _tree_trim: tuple[int, int] | None = None
 
     def do_GET(self):
         path = self.path.split("?")[0]
@@ -301,6 +335,9 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                 options = []
                 default = None
             self._json_response({"default": default, "options": options})
+            return
+        if path == "/api/tree":
+            self._handle_tree()
             return
         if path == "/api/meta":
             self._handle_meta()
@@ -387,6 +424,35 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                 "profile_id": self.__class__._profile_id,
             }
         )
+
+    def _handle_tree(self):
+        """Return a bounded tree slice for the lazy NVTX tree viewer."""
+        from urllib.parse import parse_qs, urlparse
+
+        if not self.__class__._tree_configured:
+            self._json_response({"error": "tree data is not configured"}, 500)
+            return
+        qs = parse_qs(urlparse(self.path).query)
+        path = str(qs.get("path", [""])[0])
+        depth_raw = str(qs.get("depth", ["2"])[0]).lower()
+        if depth_raw == "full":
+            depth = None
+        else:
+            try:
+                depth = max(0, min(8, int(depth_raw)))
+            except ValueError:
+                self._json_response({"error": "depth must be an integer or full"}, 400)
+                return
+
+        source = self.__class__._tree_data
+        if path:
+            source = _find_tree_path(source, path)
+            if source is None:
+                self._json_response({"error": "tree path not found", "path": path}, 404)
+                return
+            source = source.get("children") or []
+        nodes = _slice_tree_nodes(source, depth)
+        self._json_response({"nodes": nodes, "path": path, "depth": depth_raw})
 
     def _handle_search(self):
         """Search the complete pre-built profile, including unloaded tiles."""
@@ -912,7 +978,15 @@ def serve(prof, device: int, trim: tuple[int, int], *, port: int = 8142, open_br
     """Start a local HTTP server serving the interactive HTML viewer.
     If the requested port is in use, tries port 0 (system assigns a free port) and opens that URL.
     """
-    html = generate_html(prof, device, trim)
+    from .nvtx_tree import build_nvtx_tree
+    from .tree import to_json
+
+    _ViewerHandler.prof = prof
+    _ViewerHandler._tree_device = device
+    _ViewerHandler._tree_trim = trim
+    _ViewerHandler._tree_data = to_json(build_nvtx_tree(prof, device, trim))
+    _ViewerHandler._tree_configured = True
+    html = generate_html(prof, device, trim, embed_data=False)
     _ViewerHandler.html_bytes = html.encode("utf-8")
 
     server = _bind_local_server(port, _ViewerHandler)

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import http.client
+import json
 import threading
 from types import SimpleNamespace
 
@@ -9,7 +10,10 @@ import pytest
 from nsys_ai import web
 from nsys_ai.diff_web import _DIFF_HTML, _DiffHandler
 from nsys_ai.gpu_label import format_gpu_label, format_gpu_narrative_label
+from nsys_ai.profile import Profile
 from nsys_ai.summary import auto_commentary
+from nsys_ai.viewer import generate_html
+from nsys_ai.web import _slice_tree_nodes
 
 
 def test_gpu_label_omits_missing_metadata():
@@ -32,6 +36,49 @@ def test_gpu_label_preserves_fractional_memory_precision():
         0,
         SimpleNamespace(name="H200", pci_bus="", sm_count=0, memory_bytes=150_100_000_000),
     ) == "GPU 0 - H200, 150.1GB"
+
+
+def test_tree_web_shell_does_not_embed_profile_data(minimal_nsys_db_path):
+    with Profile(minimal_nsys_db_path) as prof:
+        html = generate_html(prof, 0, prof.meta.time_range, embed_data=False)
+
+    assert len(html) < 200_000
+    assert "let DATA = [];" in html
+    assert "/api/tree" in html
+
+
+def test_tree_web_endpoint_returns_bounded_slices():
+    old_data = web._ViewerHandler._tree_data
+    old_configured = web._ViewerHandler._tree_configured
+    web._ViewerHandler._tree_data = [
+        {
+            "type": "nvtx",
+            "name": "root",
+            "path": "root",
+            "children": [{"type": "kernel", "name": "child", "path": "root > child"}],
+        }
+    ]
+    web._ViewerHandler._tree_configured = True
+    try:
+        status, body, content_type = _get(web._ViewerHandler, "/api/tree?depth=0")
+    finally:
+        web._ViewerHandler._tree_data = old_data
+        web._ViewerHandler._tree_configured = old_configured
+
+    payload = json.loads(body)
+    assert status == 200
+    assert content_type.startswith("application/json")
+    assert payload["nodes"][0]["has_children"] is True
+    assert "children" not in payload["nodes"][0] or payload["nodes"][0]["children"] == []
+
+
+def test_tree_slice_preserves_children_marker_without_mutating_source():
+    source = [{"path": "root", "children": [{"path": "child"}]}]
+
+    result = _slice_tree_nodes(source, 0)
+
+    assert result[0]["has_children"] is True
+    assert source[0]["children"] == [{"path": "child"}]
 
 
 @pytest.mark.parametrize("handler", [web._ViewerHandler, web._EvidenceHandler, _DiffHandler])


### PR DESCRIPTION
## Summary

Closes #455.

- Serves the NVTX tree as a small shell; profile data is fetched from `/api/tree`.
- Adds bounded tree slices with lazy child loading and a `depth=full` path for the secondary views.
- Returns JSON 404s for missing tree paths instead of falling through to the HTML document.
- Keeps standalone `viewer` exports unchanged; only the web transport opts out of inline data.
- Makes `web <profile>` default to the first GPU and the full capture, while preserving explicit `--gpu` and `--trim` validation.
- Keeps `nsys-ai open` on the same viewer path.

## Validation

- `PYTHONPATH=src pytest tests/test_web_foundation.py tests/test_timeline_web_data.py -q` — 35 passed
- CLI parser smoke test: `web profile.sqlite` resolves `gpu=None`, `trim=None` for handler defaults
- `tests/test_cli.py -k 'help or subcommands'` — 17 passed
- Ruff, Python compile, extracted NVTX tree JavaScript syntax, and `git diff --check` pass
- Real fastvideo 5-second web shell: 115,317 bytes; profile payload is no longer embedded in the HTML
