### PR TITLE
refactor(analysis): align report and diagnose contracts

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -55,6 +55,8 @@ def _cmd_diagnose(args, _profile):
             web=bool(getattr(args, "web", False)),
             port=getattr(args, "port", 8144),
             open_browser=not bool(getattr(args, "no_browser", False)),
+            output=getattr(args, "output", None),
+            format=getattr(args, "format", "text"),
         )
     except DiagnoseCommandError as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -654,6 +654,19 @@ def _build_parser():
         action="store_true",
         help="Don't auto-open a browser with --web",
     )
+    p.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format; json uses the canonical EvidenceReport envelope",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        metavar="PATH",
+        help="Also save the canonical findings JSON to PATH",
+    )
     p.set_defaults(handler=_cmd_diagnose)
 
     p = sub.add_parser(
@@ -860,7 +873,18 @@ def _build_parser():
 
     p = sub.add_parser("report", help="Generate performance report")
     _add_gpu_trim(p)
-    p.add_argument("-o", "--output", default=None, help="Write markdown report to file")
+    p.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        help="Output format; json uses the canonical EvidenceReport envelope",
+    )
+    p.add_argument(
+        "-o",
+        "--output",
+        default=None,
+        help="Write markdown, or canonical findings JSON with --format json",
+    )
     p.set_defaults(handler=_cmd_report)
 
     p = sub.add_parser("diff", help="Compare two profiles (before/after)")

--- a/src/nsys_ai/diagnose_command.py
+++ b/src/nsys_ai/diagnose_command.py
@@ -7,6 +7,7 @@ publication and user-facing output.
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from typing import TextIO
@@ -39,6 +40,8 @@ def run_diagnose(
     web: bool = False,
     port: int = 8144,
     open_browser: bool = True,
+    output: str | os.PathLike[str] | None = None,
+    format: str = "text",
     session_root: str | os.PathLike[str] = ".nsys-ai/sessions",
     stdout: TextIO = sys.stdout,
     stderr: TextIO = sys.stderr,
@@ -49,9 +52,9 @@ def run_diagnose(
     callers can reuse this path without fabricating an argparse Namespace.
 
     Defaults match ``evidence build`` for the parameters this verb forwards
-    (``gpu`` defaults to the first device in the profile). It does not forward ``--analyzers``, ``--format``,
-    or ``--output``: the default pack always runs, evidence prints to stdout,
-    and findings land in the session.
+    (``gpu`` defaults to the first device in the profile). ``format=json``
+    emits the same EvidenceReport envelope used by ``analyze --format json``;
+    the session artifact remains the handoff source of truth.
 
     ``--web`` with only ``session_id`` opens the persisted session without
     re-running analysis.
@@ -71,6 +74,8 @@ def run_diagnose(
 
     if not os.fspath(profile_path):
         raise DiagnoseCommandError("profile path is required")
+    if format not in {"text", "json"}:
+        raise DiagnoseCommandError(f"unsupported diagnose format: {format}")
 
     raw = os.path.abspath(os.path.expanduser(os.fspath(profile_path)))
     try:
@@ -115,45 +120,61 @@ def run_diagnose(
         requested_session if requested_session else resolved_id,
         root=session_root,
     )
-    print(f"Session: {resolved_id}", file=stdout)
-    print(f"Findings artifact: {directory / 'findings.json'}", file=stdout)
-    print(f"── Evidence Findings ({len(report.findings)}) ──", file=stdout)
-    sev_icons = {"critical": "🔴", "warning": "🟡", "info": "🔵"}
-    for finding in report.findings:
-        icon = sev_icons.get(finding.severity, "⚪")
-        dur_ms = (finding.end_ns - finding.start_ns) / 1e6 if finding.end_ns else 0
-        print(f"  {icon} [{finding.type}] {finding.label}  ({dur_ms:.1f}ms)", file=stdout)
-        if finding.note:
-            print(f"      {finding.note}", file=stdout)
+    if format == "json":
+        print(json.dumps(report.to_dict(), indent=2), file=stdout)
+    else:
+        print(f"Session: {resolved_id}", file=stdout)
+        print(f"Findings artifact: {directory / 'findings.json'}", file=stdout)
+        print(f"── Evidence Findings ({len(report.findings)}) ──", file=stdout)
+        sev_icons = {"critical": "🔴", "warning": "🟡", "info": "🔵"}
+        for finding in report.findings:
+            icon = sev_icons.get(finding.severity, "⚪")
+            dur_ms = (finding.end_ns - finding.start_ns) / 1e6 if finding.end_ns else 0
+            print(f"  {icon} [{finding.type}] {finding.label}  ({dur_ms:.1f}ms)", file=stdout)
+            if finding.note:
+                print(f"      {finding.note}", file=stdout)
 
-    if report.skipped:
-        print(f"── Limitations / skipped analyses ({len(report.skipped)}) ──", file=stdout)
-        for entry in report.skipped:
+        if report.skipped:
+            print(f"── Limitations / skipped analyses ({len(report.skipped)}) ──", file=stdout)
+            for entry in report.skipped:
+                print(
+                    f"  {entry.analyzer} ({entry.skill}) — skipped: {entry.reason}",
+                    file=stdout,
+                )
+        else:
+            print("── Limitations / skipped analyses ──", file=stdout)
+            print("  (none)", file=stdout)
+
+        top_id = next((f.id for f in report.findings if f.id), None)
+        if top_id:
             print(
-                f"  {entry.analyzer} ({entry.skill}) — skipped: {entry.reason}",
+                "Next: nsys-ai propose --session "
+                f"{session_ref} --finding-id {top_id} --runspec <runspec.json>",
                 file=stdout,
             )
-    else:
-        print("── Limitations / skipped analyses ──", file=stdout)
-        print("  (none)", file=stdout)
+        else:
+            print(
+                "Next: no actionable finding id to propose from; "
+                f"re-open with nsys-ai diagnose --session {session_ref} --web",
+                file=stdout,
+            )
+        print(
+            f"Or open the same session: nsys-ai diagnose --session {session_ref} --web",
+            file=stdout,
+        )
 
-    top_id = next((f.id for f in report.findings if f.id), None)
-    if top_id:
-        print(
-            "Next: nsys-ai propose --session "
-            f"{session_ref} --finding-id {top_id} --runspec <runspec.json>",
-            file=stdout,
-        )
-    else:
-        print(
-            "Next: no actionable finding id to propose from; "
-            f"re-open with nsys-ai diagnose --session {session_ref} --web",
-            file=stdout,
-        )
-    print(
-        f"Or open the same session: nsys-ai diagnose --session {session_ref} --web",
-        file=stdout,
-    )
+    if output:
+        from .annotation import save_findings
+
+        try:
+            output_path = os.fspath(output)
+            output_parent = os.path.dirname(os.path.abspath(output_path))
+            os.makedirs(output_parent, exist_ok=True)
+            save_findings(report, output_path)
+        except OSError as exc:
+            raise DiagnoseCommandError(f"could not write findings: {exc}") from exc
+        if format == "json":
+            print(f"Saved findings: {output}", file=stderr)
 
     if web:
         return _open_session_web(

--- a/src/nsys_ai/report.py
+++ b/src/nsys_ai/report.py
@@ -11,7 +11,6 @@ import statistics
 
 from .gpu_label import format_gpu_label
 from .overlap import (
-    detect_iterations,
     format_iterations,
     format_nccl,
     format_overlap,
@@ -64,6 +63,32 @@ def _iteration_regression_flags(iters: list[dict]) -> list[str]:
     return flags
 
 
+def _run_iteration_skill(prof: Profile, device: int, trim: tuple[int, int]) -> list[dict]:
+    """Run iteration analysis through the canonical skill registry.
+
+    ``report`` is a presentation surface, so it must not maintain a second
+    implementation of iteration detection beside ``diagnose`` and Web chat.
+    The registry skill owns the SQL/schema compatibility and abstention policy;
+    this adapter only keeps rows that are valid iteration records for the
+    legacy report formatter.
+    """
+    from .skills.registry import run_skill
+
+    rows = run_skill(
+        "iteration_timing",
+        prof.query_conn(),
+        raw=True,
+        device=device,
+        trim_start_ns=trim[0],
+        trim_end_ns=trim[1],
+    )
+    return [
+        row
+        for row in rows
+        if isinstance(row, dict) and "iteration" in row and "duration_ms" in row
+    ]
+
+
 def run_analyze(prof: Profile, device: int, trim: tuple[int, int]) -> dict:
     """
     Run all analyses and return a structured dict for formatting.
@@ -73,7 +98,7 @@ def run_analyze(prof: Profile, device: int, trim: tuple[int, int]) -> dict:
     summary = gpu_summary(prof, device, trim)
     overlap = overlap_analysis(prof, device, trim)
     nccl = nccl_breakdown(prof, device, trim)
-    iters = detect_iterations(prof, device, trim)
+    iters = _run_iteration_skill(prof, device, trim)
     iters_regression = _iteration_regression_flags(iters) if iters else []
     nvtx_summary = _nvtx_hierarchy_summary(prof, device, trim)
 

--- a/tests/test_surface_analysis_contract.py
+++ b/tests/test_surface_analysis_contract.py
@@ -1,0 +1,87 @@
+"""Regression tests for the shared CLI analysis contract."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def test_report_iteration_analysis_uses_registry(monkeypatch):
+    from nsys_ai import report
+
+    calls: list[tuple[str, dict]] = []
+    expected = [{"iteration": 0, "duration_ms": 12.5, "gpu_start_ns": 10}]
+
+    def fake_run_skill(name, conn, *, raw, **kwargs):
+        calls.append((name, {"raw": raw, **kwargs, "conn": conn}))
+        return expected
+
+    monkeypatch.setattr("nsys_ai.skills.registry.run_skill", fake_run_skill)
+    profile = SimpleNamespace(query_conn=lambda: "shared-connection")
+
+    rows = report._run_iteration_skill(profile, 2, (100, 200))
+
+    assert rows == expected
+    assert calls == [
+        (
+            "iteration_timing",
+            {
+                "raw": True,
+                "device": 2,
+                "trim_start_ns": 100,
+                "trim_end_ns": 200,
+                "conn": "shared-connection",
+            },
+        )
+    ]
+
+
+def test_diagnose_json_matches_published_findings(tmp_path: Path):
+    from nsys_ai.diagnose_command import run_diagnose
+
+    fixture = Path(__file__).parent / "fixtures" / "h100_2gpu_1s.sqlite"
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+    output = tmp_path / "nested" / "findings.json"
+
+    assert (
+        run_diagnose(
+            profile_path=fixture,
+            session_id="json-contract",
+            gpu=0,
+            session_root=tmp_path / "sessions",
+            format="json",
+            output=output,
+            stdout=stdout,
+            stderr=stderr,
+        )
+        == 0
+    )
+
+    rendered = json.loads(stdout.getvalue())
+    saved = json.loads(output.read_text(encoding="utf-8"))
+    published = json.loads(
+        (tmp_path / "sessions" / "json-contract" / "findings.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert rendered == saved == published
+    assert "Session:" not in stdout.getvalue()
+    assert f"Saved findings: {output}" in stderr.getvalue()
+
+
+def test_report_and_diagnose_expose_the_same_json_format():
+    from nsys_ai.cli.parsers import _build_parser
+
+    parser = _build_parser()
+    diagnose = parser.parse_args(
+        ["diagnose", "profile.sqlite", "--format", "json", "--output", "findings.json"]
+    )
+    report = parser.parse_args(
+        ["report", "profile.sqlite", "--gpu", "0", "--trim", "1", "2", "--format", "json"]
+    )
+
+    assert diagnose.format == report.format == "json"
+    assert diagnose.output == "findings.json"


### PR DESCRIPTION
## Summary

- route the legacy `report` iteration section through the canonical `iteration_timing` skill registry
- add a shared `EvidenceReport` JSON transport to `diagnose` and `report`
- keep SessionStore publication as the handoff source and verify stdout, `--output`, and session findings stay identical

## Why

This is the first concrete slice for #403 and #434. Surface presentation can differ, but profile analysis and machine-readable findings must come from the same registered skill contract. The previous report path called `detect_iterations` directly while diagnose used the registry skill, and diagnose had no JSON transport.

## Validation

- focused: `45 passed`
- full: `2440 passed, 147 skipped, 4 xfailed`
- full-suite baseline failure: `tests/test_ci_coverage.py::test_every_skip_has_a_known_reason` reports the pre-existing `No test profile` skip from `tests/test_integration.py` when `NSYS_AI_TEST_PROFILE` is not configured
- real profile: `/home/rich-wsl/fastvideo/profile_results/perf.nsys-rep`
  - `diagnose --format json` exited 0
  - schema `0.1`, 42 findings
  - stdout, `--output`, and SessionStore `findings.json` matched byte-for-byte after JSON parsing

Closes #403 partially; advances #434. The Web chat exploratory SQL removal remains a follow-up.
