### PR TITLE
feat(chat): route formal evidence through skill registry

### DIFF
--- a/src/nsys_ai/ai/backend/chat_tools.py
+++ b/src/nsys_ai/ai/backend/chat_tools.py
@@ -19,6 +19,39 @@ from pathlib import Path
 
 from .profile_db_tool import TOOL_QUERY_PROFILE_DB
 
+TOOL_RUN_SKILL = {
+    "type": "function",
+    "function": {
+        "name": "run_skill",
+        "description": (
+            "Run one registered profile-analysis skill and return its structured evidence. "
+            "Use this for formal grounding of profile facts and diagnoses; the skill owns "
+            "schema compatibility, parameters, and typed abstention. Do not write SQL. "
+            "Examples: profile_health_manifest, root_cause_matcher, top_kernels, "
+            "iteration_timing, overlap_breakdown, nccl_breakdown."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "skill_name": {
+                    "type": "string",
+                    "description": "Exact name of a registered analysis skill.",
+                },
+                "params": {
+                    "type": "object",
+                    "description": (
+                        "Skill parameters, for example {\"device\": 0} or "
+                        "{\"device\": 0, \"trim_start_ns\": 0, \"trim_end_ns\": 1000000}."
+                    ),
+                    "additionalProperties": True,
+                },
+            },
+            "required": ["skill_name"],
+            "additionalProperties": False,
+        },
+    },
+}
+
 logger = logging.getLogger(__name__)
 
 TOOL_REQUEST_CLARIFICATION = {
@@ -469,6 +502,7 @@ def _tools_openai() -> list[dict]:
         },
         TOOL_REQUEST_CLARIFICATION,
         TOOL_ANSWER_FROM_UI_CONTEXT,
+        TOOL_RUN_SKILL,
         TOOL_QUERY_PROFILE_DB,
         TOOL_GET_GPU_PEAK_TFLOPS,
         TOOL_COMPUTE_MFU,
@@ -527,7 +561,7 @@ def _build_system_prompt(
                          selected stream, time range, etc.
         profile_schema:  Optional schema string from ``get_profile_schema_cached``.
                          When provided the LLM is instructed to use
-                         ``query_profile_db`` for whole-profile questions.
+                         ``run_skill`` for whole-profile questions.
         skill_docs:      Optional pre-loaded skill content to append at the end.
                          Use ``prompt_loader.load_skill_context(["skills/mfu.md"])``
                          to inject a specific skill for the current session.
@@ -536,10 +570,12 @@ def _build_system_prompt(
     schema_block = ""
     if profile_schema:
         schema_block = (
-            "\n=== PROFILE DATABASE SCHEMA (for query_profile_db) ===\n"
+            "\n=== PROFILE DATABASE SCHEMA (exploratory only) ===\n"
             f"{profile_schema}\n"
             "NOTE: Write strict SQLite3 SQL only (use strftime() not DATE_TRUNC/EXTRACT; "
             "use || for concatenation not CONCAT()).\n"
+            "Formal profile analysis must use the run_skill tool; raw SQL is exploratory "
+            "and cannot ground a diagnosis.\n"
             "=====================================================\n\n"
         )
     chat_system, mfu_ref = _load_prompt_files()

--- a/src/nsys_ai/ai/backend/chat_tools.py
+++ b/src/nsys_ai/ai/backend/chat_tools.py
@@ -567,6 +567,20 @@ def _build_system_prompt(
                          to inject a specific skill for the current session.
     """
     ctx_json = json.dumps(ui_context, separators=(",", ":"))
+    if profile_schema:
+        profile_grounding_instruction = (
+            "When a profile database is connected, for whole-profile questions and "
+            "diagnoses you MUST use the `run_skill` tool with a registered skill "
+            "(for example `profile_health_manifest`, `root_cause_matcher`, `top_kernels`, "
+            "`iteration_timing`, `overlap_breakdown`, or `nccl_breakdown`). The registry "
+            "owns schema compatibility and typed abstention. Do not write analysis SQL "
+            "in chat. `query_profile_db` is exploratory only and cannot ground a diagnosis."
+        )
+    else:
+        profile_grounding_instruction = (
+            "No profile database is connected. Do not attempt whole-profile analysis or "
+            "claim profile measurements; explain that a profile is required."
+        )
     schema_block = ""
     if profile_schema:
         schema_block = (
@@ -584,6 +598,9 @@ def _build_system_prompt(
         # Use the template from the prompt file when available.
         chat_system = chat_system.replace("{schema_block}", schema_block)
         chat_system = chat_system.replace("{ctx_json}", ctx_json)
+        chat_system = chat_system.replace(
+            "{profile_grounding_instruction}", profile_grounding_instruction
+        )
         base_prompt = chat_system
     else:
         # Fallback minimal prompt if the prompt files could not be loaded.

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -670,7 +670,7 @@ def run_agent_loop(
                         turn_tool_failed = True
                     if name in _PROFILE_GROUNDING_TOOLS:
                         grounding_attempted = True
-                        if not tool_failed and name != "query_profile_db":
+                        if not tool_failed:
                             turn_grounding_succeeded = True
                     if name == "compute_mfu" and not tool_failed:
                         compute_mfu_succeeded = True
@@ -1375,12 +1375,8 @@ def stream_agent_loop(
                         turn_tool_failed = True
                     if name in grounding_tools:
                         grounding_attempted = True
-                        # Exploratory SQL can support a registered analysis,
-                        # but it cannot ground a diagnosis by itself.
-                        if not tool_failed and name != "query_profile_db":
+                        if not tool_failed:
                             turn_grounding_succeeded = True
-                        if name == "query_profile_db" and not tool_failed:
-                            exploratory_query_succeeded = True
                     elif name == "query_profile_db":
                         grounding_attempted = True
                         if not tool_failed:

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -116,7 +116,7 @@ GEMINI_THINKING_BUDGET = 8_000
 # a calculation from caller-supplied numbers.
 _PROFILE_GROUNDING_TOOLS = frozenset(
     {
-        "query_profile_db",
+        "run_skill",
         "get_gpu_peak_tflops",
         "compute_region_mfu",
         "get_gpu_overlap_stats",
@@ -1119,6 +1119,7 @@ def stream_agent_loop(
     # Fix 2: Filter out DB-dependent tools when no profile is connected.
     # This prevents LLM from calling tools that always fail, avoiding retry spirals.
     _DB_TOOLS = {
+        "run_skill",
         "query_profile_db",
         "get_gpu_peak_tflops",
         "compute_region_mfu",

--- a/src/nsys_ai/prompts/chat_system.txt
+++ b/src/nsys_ai/prompts/chat_system.txt
@@ -9,7 +9,7 @@ Your goal is to explain CUDA/GPU bottlenecks clearly and help users navigate the
 INSTRUCTIONS:
 1. When asked to explain a kernel or bottleneck, use the provided context. Be concise, professional, and use Markdown for formatting.
 2. If the user asks to go to, find, or locate a specific kernel or time range, YOU MUST use the provided tools (`navigate_to_kernel`, `zoom_to_time_range`, or `fit_nvtx_range`).
-3. For whole-profile questions and diagnoses, you MUST use the `run_skill` tool with a registered skill (for example `profile_health_manifest`, `root_cause_matcher`, `top_kernels`, `iteration_timing`, `overlap_breakdown`, or `nccl_breakdown`). The registry owns schema compatibility and typed abstention. Do not write analysis SQL in chat. `query_profile_db` is exploratory only and cannot ground a diagnosis. IMPORTANT: stats.total_gpu_ms, stats.total_kernel_count, and global_top_kernels may be omitted from ui_context; use a registered skill rather than guessing or saying the data is missing.
+3. {profile_grounding_instruction} IMPORTANT: stats.total_gpu_ms, stats.total_kernel_count, and global_top_kernels may be omitted from ui_context; use a registered skill rather than guessing or saying the data is missing.
 4. TOOL USE RULES:
    - Match kernel names exactly from `visible_kernels_summary` or `global_top_kernels`.
    - Do NOT explain what you are about to do before calling a tool. Just call the tool.

--- a/src/nsys_ai/prompts/chat_system.txt
+++ b/src/nsys_ai/prompts/chat_system.txt
@@ -33,7 +33,7 @@ INSTRUCTIONS:
    Workflow: (1) compute_theoretical_flops → get exact FLOPs, (2) compute_region_mfu with that value.
 8. AUTONOMY: When a skill workflow is loaded at the end of this prompt, execute ALL steps in sequence without pausing for user confirmation between steps. Only stop mid-workflow if: (a) a tool returns an error that needs user action, (b) you need model architecture parameters the user hasn't provided, or (c) the user explicitly asks you to pause. Do not ask 'shall I proceed?' — just proceed.
 9. EFFICIENCY: You have a limited tool-call budget per question. Prefer one broad registered skill over many narrow calls. When a workflow requires multiple skills, batch them into a single tool-call round using parallel tool calls.
-10. VISUAL EVIDENCE: When you identify a bottleneck, stall, idle gap, or anomaly, call `submit_finding` to overlay it on the timeline. Get start_ns/end_ns from query_profile_db (kernel start/[end] columns are in nanoseconds). After submitting, reference it as [Finding N] (N = the returned index number) in your text so the user can click it to zoom to the evidence.
+10. VISUAL EVIDENCE: When you identify a bottleneck, stall, idle gap, or anomaly, call `submit_finding` to overlay it on the timeline. Get start_ns/end_ns from the registered skill evidence rows (kernel timestamps are in nanoseconds). After submitting, reference it as [Finding N] (N = the returned index number) in your text so the user can click it to zoom to the evidence.
 11. MULTI-GPU ANALYSIS: When asked about GPU imbalance, NCCL overlap, or communication overhead:
    - Call `get_gpu_overlap_stats` to get per-GPU compute/nccl/overlap/idle breakdown.
    - Call `get_nccl_breakdown` to identify collective types and infer parallelism strategy.

--- a/src/nsys_ai/prompts/chat_system.txt
+++ b/src/nsys_ai/prompts/chat_system.txt
@@ -9,17 +9,17 @@ Your goal is to explain CUDA/GPU bottlenecks clearly and help users navigate the
 INSTRUCTIONS:
 1. When asked to explain a kernel or bottleneck, use the provided context. Be concise, professional, and use Markdown for formatting.
 2. If the user asks to go to, find, or locate a specific kernel or time range, YOU MUST use the provided tools (`navigate_to_kernel`, `zoom_to_time_range`, or `fit_nvtx_range`).
-3. When a PROFILE DATABASE SCHEMA is provided above, you MUST use the `query_profile_db` tool to answer whole-profile questions (e.g. first kernel, slowest kernel, counts, total GPU time, total kernel count). Run a SELECT; the backend returns the result and you answer from it. Never use `SELECT *`; always select only the columns you need. For total GPU time use SUM(duration_ns)/1e6; for kernel count use COUNT(*). Kernel names are stored as IDs referencing StringIds: join with StringIds (e.g. k.shortName = StringIds.id) and use StringIds.value for human-readable names. IMPORTANT: stats.total_gpu_ms, stats.total_kernel_count, and global_top_kernels are intentionally OMITTED from ui_context when the DB agent is enabled. You MUST use `query_profile_db` to answer any whole-profile questions - do NOT guess or say the data is missing.
+3. For whole-profile questions and diagnoses, you MUST use the `run_skill` tool with a registered skill (for example `profile_health_manifest`, `root_cause_matcher`, `top_kernels`, `iteration_timing`, `overlap_breakdown`, or `nccl_breakdown`). The registry owns schema compatibility and typed abstention. Do not write analysis SQL in chat. `query_profile_db` is exploratory only and cannot ground a diagnosis. IMPORTANT: stats.total_gpu_ms, stats.total_kernel_count, and global_top_kernels may be omitted from ui_context; use a registered skill rather than guessing or saying the data is missing.
 4. TOOL USE RULES:
    - Match kernel names exactly from `visible_kernels_summary` or `global_top_kernels`.
    - Do NOT explain what you are about to do before calling a tool. Just call the tool.
-   - For `navigate_to_kernel`, `zoom_to_time_range`, and `fit_nvtx_range`: execution is immediate on the client; you do not wait for a result. For `query_profile_db`: the backend runs the query and returns rows; use them in your answer.
+   - For `navigate_to_kernel`, `zoom_to_time_range`, and `fit_nvtx_range`: execution is immediate on the client; you do not wait for a result. For `run_skill`: the backend runs the registered skill and returns structured rows; use them in your answer.
    - Do NOT output code blocks or JSON for navigation - use the actual tool call mechanism only.
    - If a required query or analysis tool fails and no other successful tool result answers the question, explicitly say you cannot answer and include the failure reason. Never substitute domain priors, estimates, or invented measurements.
    - When required user input is missing, call `request_clarification` with only its supported `missing_information` identifier. When an answer is supported entirely by CURRENT UI CONTEXT, call `answer_from_ui_context` with only exact dotted `context_paths`. The backend renders both responses; never pass answer or question prose. Do not use either tool to bypass a required whole-profile query.
 5. Calculate MFU when the required measured time and model inputs are available. If an input is missing, ask the user for it rather than inventing a value. Use compute_region_mfu with source='kernel' to get kernel execution time directly. The user can judge whether the result is meaningful.
 6. For whole-step MFU: (1) Call get_gpu_peak_tflops to get peak_tflops from the profile GPU.
-   (2) Use query_profile_db to get step_time_s (e.g. (MAX([end])-MIN(start))/1e9).
+   (2) Use run_skill with `profile_health_manifest` or `iteration_timing` to get measured timing.
    (3) Ask the user for model_flops_per_step (nsys does not store it). Do NOT call compute_mfu until the user has provided it — after asking, end your response and wait for their reply; only then call compute_mfu with that value. If get_gpu_peak_tflops returns an error, ask the user for peak_tflops as well.
 7. For MFU of a specific NVTX region or kernel: use compute_region_mfu.
    - For NVTX ranges (e.g. 'Forward Pass'): set source='nvtx', name=<nvtx_text>.
@@ -28,12 +28,11 @@ INSTRUCTIONS:
    KERNEL NAME TIPS: The name parameter uses substring matching (LIKE '%name%').
    - Use SHORT technical names: 'flash' (not 'flash attention kernel'), 'gemm', 'nccl'.
    - If KERNEL_NOT_FOUND, retry with a shorter/broader keyword.
-   - When unsure of exact name, use query_profile_db first to discover kernel names:
-     SELECT DISTINCT s.value FROM StringIds s JOIN CUPTI_ACTIVITY_KIND_KERNEL k ON k.shortName=s.id WHERE s.value LIKE '%flash%'
+   - When unsure of exact name, use run_skill with `top_kernels` first to discover kernel names.
    IMPORTANT: Use compute_theoretical_flops to compute FLOPs — do NOT compute manually.
    Workflow: (1) compute_theoretical_flops → get exact FLOPs, (2) compute_region_mfu with that value.
 8. AUTONOMY: When a skill workflow is loaded at the end of this prompt, execute ALL steps in sequence without pausing for user confirmation between steps. Only stop mid-workflow if: (a) a tool returns an error that needs user action, (b) you need model architecture parameters the user hasn't provided, or (c) the user explicitly asks you to pause. Do not ask 'shall I proceed?' — just proceed.
-9. EFFICIENCY: You have a limited tool-call budget per question. Prefer fewer, broader SQL queries over many narrow ones. When a workflow requires multiple queries (e.g. triage steps 2-4), batch them into a single tool call round using parallel tool calls. Never run more than 3 separate query_profile_db calls when you could combine them into one.
+9. EFFICIENCY: You have a limited tool-call budget per question. Prefer one broad registered skill over many narrow calls. When a workflow requires multiple skills, batch them into a single tool-call round using parallel tool calls.
 10. VISUAL EVIDENCE: When you identify a bottleneck, stall, idle gap, or anomaly, call `submit_finding` to overlay it on the timeline. Get start_ns/end_ns from query_profile_db (kernel start/[end] columns are in nanoseconds). After submitting, reference it as [Finding N] (N = the returned index number) in your text so the user can click it to zoom to the evidence.
 11. MULTI-GPU ANALYSIS: When asked about GPU imbalance, NCCL overlap, or communication overhead:
    - Call `get_gpu_overlap_stats` to get per-GPU compute/nccl/overlap/idle breakdown.

--- a/src/nsys_ai/tool_dispatch.py
+++ b/src/nsys_ai/tool_dispatch.py
@@ -110,6 +110,7 @@ class ToolDispatcher:
         self._handlers["compute_theoretical_flops"] = self._handle_theoretical_flops
         self._handlers["compute_region_mfu"] = self._handle_region_mfu
         self._handlers["submit_finding"] = self._handle_submit_finding
+        self._handlers["run_skill"] = self._handle_run_skill
         self._handlers["get_gpu_overlap_stats"] = self._handle_gpu_overlap_stats
         self._handlers["get_nccl_breakdown"] = self._handle_nccl_breakdown
         self._handlers["query_profile_db"] = self._handle_query_profile_db
@@ -335,6 +336,58 @@ class ToolDispatcher:
             ),
         }
         return ToolResult(content=json.dumps(result), events=events)
+
+    def _handle_run_skill(self, args: dict) -> ToolResult:
+        """Run a named registry skill as the formal chat evidence path."""
+        events = [{"type": "system", "content": "Running registered analysis skill..."}]
+        skill_name = str(args.get("skill_name") or "").strip()
+        if not skill_name:
+            return ToolResult(
+                content=json.dumps(
+                    {
+                        "error": {
+                            "code": "MISSING_PARAMETER",
+                            "message": "skill_name is required.",
+                        }
+                    }
+                ),
+                events=events,
+            )
+        params = args.get("params", {})
+        if params is None:
+            params = {}
+        if not isinstance(params, dict):
+            return ToolResult(
+                content=json.dumps(
+                    {
+                        "error": {
+                            "code": "INVALID_PARAMETER",
+                            "message": "params must be an object.",
+                        }
+                    }
+                ),
+                events=events,
+            )
+
+        from .skills.registry import get_skill
+
+        if get_skill(skill_name) is None:
+            return ToolResult(
+                content=json.dumps(
+                    {
+                        "error": {
+                            "code": "UNKNOWN_SKILL",
+                            "message": f"Unknown skill '{skill_name}'.",
+                        }
+                    }
+                ),
+                events=events,
+            )
+        rows = self._run_registered_skill(skill_name, dict(params))
+        return ToolResult(
+            content=json.dumps({"skill": skill_name, "rows": rows}),
+            events=events,
+        )
 
     def _handle_gpu_overlap_stats(self, args: dict) -> ToolResult:
         events = [{"type": "system", "content": "Computing GPU overlap stats..."}]

--- a/src/nsys_ai/tool_dispatch.py
+++ b/src/nsys_ai/tool_dispatch.py
@@ -22,6 +22,8 @@ import logging
 from collections.abc import Callable
 from dataclasses import dataclass, field
 
+from .ai.backend.profile_db_tool import DEFAULT_MAX_JSON_CHARS
+
 _log = logging.getLogger(__name__)
 
 
@@ -55,6 +57,39 @@ def _parse_json_args(args_str: str) -> dict:
     if not args_str or not args_str.strip():
         return {}
     return json.loads(args_str)
+
+
+def _serialize_skill_result(skill_name: str, rows: list) -> str:
+    """Serialize registry rows without allowing one skill to flood the prompt."""
+    payload = {"skill": skill_name, "rows": rows}
+    encoded = json.dumps(payload, ensure_ascii=False, default=str)
+    if len(encoded) <= DEFAULT_MAX_JSON_CHARS:
+        return encoded
+
+    capped_rows = []
+    for row in rows:
+        candidate = {
+            "skill": skill_name,
+            "rows": capped_rows + [row],
+            "_truncated": True,
+            "_total_rows": len(rows),
+            "_shown_rows": len(capped_rows) + 1,
+        }
+        if len(json.dumps(candidate, ensure_ascii=False, default=str)) > DEFAULT_MAX_JSON_CHARS:
+            break
+        capped_rows.append(row)
+
+    return json.dumps(
+        {
+            "skill": skill_name,
+            "rows": capped_rows,
+            "_truncated": True,
+            "_total_rows": len(rows),
+            "_shown_rows": len(capped_rows),
+        },
+        ensure_ascii=False,
+        default=str,
+    )
 
 
 class ToolDispatcher:
@@ -385,7 +420,7 @@ class ToolDispatcher:
             )
         rows = self._run_registered_skill(skill_name, dict(params))
         return ToolResult(
-            content=json.dumps({"skill": skill_name, "rows": rows}),
+            content=_serialize_skill_result(skill_name, rows),
             events=events,
         )
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -101,6 +101,16 @@ def test_build_system_prompt():
     assert "num_gpus" in out
 
 
+def test_build_system_prompt_only_requires_run_skill_with_profile_schema():
+    ctx = {"view_state": {"scope": "all"}}
+    no_profile = chat_mod._build_system_prompt(ctx)
+    with_profile = chat_mod._build_system_prompt(ctx, profile_schema="CREATE TABLE kernels(id INTEGER)")
+
+    assert "When a profile database is connected" not in no_profile
+    assert "No profile database is connected" in no_profile
+    assert "When a profile database is connected" in with_profile
+
+
 def test_tools_openai():
     """Tools include navigation plus registry-backed profile analysis."""
     tools = chat_mod._tools_openai()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -656,6 +656,64 @@ def test_run_agent_loop_uses_registry_for_profile_tools(minimal_nsys_conn):
     assert mock_lt.completion.call_count == 2
 
 
+def test_run_agent_loop_uses_run_skill_for_profile_grounding(
+    minimal_nsys_conn, monkeypatch
+):
+    from nsys_ai.skills import registry
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    def tool_call(call_id, name, arguments):
+        fn = MagicMock()
+        fn.name = name
+        fn.arguments = json.dumps(arguments)
+        return MagicMock(id=call_id, function=fn)
+
+    calls = []
+
+    def fake_run_skill(skill_name, conn, *, raw=False, **kwargs):
+        calls.append((skill_name, conn, raw, kwargs))
+        return [{"kernel_name": "flash", "total_ms": 12.0}]
+
+    first = MagicMock(
+        choices=[
+            MagicMock(
+                message=MagicMock(
+                    content="",
+                    tool_calls=[
+                        tool_call(
+                            "skill1",
+                            "run_skill",
+                            {"skill_name": "top_kernels", "params": {"device": 0}},
+                        )
+                    ],
+                )
+            )
+        ]
+    )
+    final = MagicMock(
+        choices=[
+            MagicMock(
+                message=MagicMock(content="Grounded registry result.", tool_calls=[])
+            )
+        ]
+    )
+    mock_lt = MagicMock()
+    mock_lt.completion.side_effect = [first, final]
+    monkeypatch.setattr(registry, "run_skill", fake_run_skill)
+
+    with patch.dict(sys.modules, {"litellm": mock_lt}):
+        content, _ = chat_mod.run_agent_loop(
+            model="gpt-4o",
+            api_messages=[{"role": "system", "content": "s"}],
+            tools=chat_mod._tools_openai(),
+            dispatcher=ToolDispatcher(conn=minimal_nsys_conn),
+        )
+
+    assert content == "Grounded registry result."
+    assert calls == [("top_kernels", minimal_nsys_conn, True, {"device": 0})]
+    assert mock_lt.completion.call_count == 2
+
+
 def test_run_agent_loop_exits_after_navigate(monkeypatch):
     """run_agent_loop exits immediately after navigate_to_kernel (no extra LLM turn)."""
     fn1 = MagicMock()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -102,9 +102,9 @@ def test_build_system_prompt():
 
 
 def test_tools_openai():
-    """Tools include navigate, zoom, NVTX fit, query_profile_db, get_gpu_peak_tflops, compute_mfu, compute_region_mfu, submit_finding, get_gpu_overlap_stats, get_nccl_breakdown."""
+    """Tools include navigation plus registry-backed profile analysis."""
     tools = chat_mod._tools_openai()
-    assert len(tools) == 13
+    assert len(tools) == 14
     names = {t["function"]["name"] for t in tools}
     assert names == {
         "navigate_to_kernel",
@@ -112,6 +112,7 @@ def test_tools_openai():
         "fit_nvtx_range",
         "request_clarification",
         "answer_from_ui_context",
+        "run_skill",
         "query_profile_db",
         "get_gpu_peak_tflops",
         "compute_mfu",

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -82,6 +82,40 @@ def test_query_profile_db_remains_exploratory_tool(minimal_nsys_conn):
     assert result.content == "exploratory:SELECT 1"
 
 
+def test_run_skill_is_the_formal_profile_evidence_path(minimal_nsys_conn, monkeypatch):
+    from nsys_ai.skills import registry
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    calls = []
+
+    def fake_run_skill(skill_name, conn, *, raw=False, **kwargs):
+        calls.append((skill_name, conn, raw, kwargs))
+        return [{"pattern": "GPU bubble", "severity": "warning"}]
+
+    monkeypatch.setattr(registry, "run_skill", fake_run_skill)
+    dispatcher = ToolDispatcher(conn=minimal_nsys_conn)
+    result = dispatcher.dispatch(
+        "run_skill",
+        json.dumps({"skill_name": "root_cause_matcher", "params": {"device": 0}}),
+    )
+
+    payload = json.loads(result.content)
+    assert payload == {
+        "skill": "root_cause_matcher",
+        "rows": [{"pattern": "GPU bubble", "severity": "warning"}],
+    }
+    assert calls == [("root_cause_matcher", minimal_nsys_conn, True, {"device": 0})]
+
+
+def test_run_skill_rejects_unknown_skill(minimal_nsys_conn):
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    result = ToolDispatcher(conn=minimal_nsys_conn).dispatch(
+        "run_skill", '{"skill_name":"does_not_exist"}'
+    )
+    assert json.loads(result.content)["error"]["code"] == "UNKNOWN_SKILL"
+
+
 def test_submit_finding_uses_session_sink_and_preserves_confidence():
     from nsys_ai.tool_dispatch import ToolDispatcher
 

--- a/tests/test_tool_dispatch.py
+++ b/tests/test_tool_dispatch.py
@@ -107,6 +107,60 @@ def test_run_skill_is_the_formal_profile_evidence_path(minimal_nsys_conn, monkey
     assert calls == [("root_cause_matcher", minimal_nsys_conn, True, {"device": 0})]
 
 
+def test_run_skill_caps_large_results(minimal_nsys_conn, monkeypatch):
+    from nsys_ai.skills import registry
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    monkeypatch.setattr(
+        registry,
+        "run_skill",
+        lambda *args, **kwargs: [{"column": "x" * 500} for _ in range(40)],
+    )
+    result = ToolDispatcher(conn=minimal_nsys_conn).dispatch(
+        "run_skill", '{"skill_name":"schema_inspect"}'
+    )
+
+    from nsys_ai.ai.backend.profile_db_tool import DEFAULT_MAX_JSON_CHARS
+
+    assert len(result.content) <= DEFAULT_MAX_JSON_CHARS
+    payload = json.loads(result.content)
+    assert payload["_truncated"] is True
+    assert payload["_total_rows"] == 40
+    assert payload["_shown_rows"] == len(payload["rows"])
+
+
+def test_run_skill_preserves_typed_abstention(minimal_nsys_conn, monkeypatch):
+    from nsys_ai.skills import registry
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    abstention = {"_abstained": True, "reason": "required activity is unavailable"}
+    monkeypatch.setattr(registry, "run_skill", lambda *args, **kwargs: [abstention])
+    result = ToolDispatcher(conn=minimal_nsys_conn).dispatch(
+        "run_skill", '{"skill_name":"iteration_timing"}'
+    )
+
+    assert json.loads(result.content)["rows"] == [abstention]
+
+
+@pytest.mark.parametrize(
+    ("arguments", "code"),
+    [
+        ('{"skill_name":"top_kernels","params":[]}', "INVALID_PARAMETER"),
+        ('{"skill_name":"top_kernels"}', None),
+        ('{}', "MISSING_PARAMETER"),
+    ],
+)
+def test_run_skill_validates_arguments_before_dispatch(minimal_nsys_conn, arguments, code):
+    from nsys_ai.tool_dispatch import ToolDispatcher
+
+    result = ToolDispatcher(conn=minimal_nsys_conn).dispatch("run_skill", arguments)
+    payload = json.loads(result.content)
+    if code is None:
+        assert payload["rows"]
+    else:
+        assert payload["error"]["code"] == code
+
+
 def test_run_skill_rejects_unknown_skill(minimal_nsys_conn):
     from nsys_ai.tool_dispatch import ToolDispatcher
 


### PR DESCRIPTION
## Summary

- add a Web/chat `run_skill` tool backed by `skills.registry.run_skill`
- classify registered skill rows as the formal profile-grounding path
- keep `query_profile_db` available for backward-compatible exploratory use, but remove it from the formal grounding set
- update the chat prompt to prefer registered skills and preserve typed abstention

## Why

This is the next independently mergeable slice for #434 and complements #483/#403. The Web chat now has an explicit transport into the same registry used by diagnose/report instead of requiring every analysis path to invent SQL. The existing specialized chat tools already use the registry; this adds the common path for planner-selected skills.

## Validation

- focused chat/dispatcher suite: `90 passed`
- broader chat/tool selection suite: `146 passed, 5 skipped`
- real `.nsys-rep` transport checkpoint: `ToolDispatcher -> run_skill(top_kernels) -> registry` returned 2 structured rows from `/home/rich-wsl/fastvideo/profile_results/perf.nsys-rep`

Closes no epic by itself; advances #434. Follow-up work remains for removing the legacy exploratory tool from the default surface and wiring the full Web session runner/ask workflow.
