### PR TITLE
docs: split the user guide into task, concept and reference pages

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
-# Nsight Systems — Agent Knowledge Base
+# nsys-ai documentation
 
-> **Purpose:** Machine-readable documentation for the nsys-agent. Each file covers one topic from the official NVIDIA documentation, saved as plain markdown for easy querying, embedding, and retrieval.
+> **How this is organised.** `user/` is for operating the tool and `dev/` is for maintaining it. The
+> numbered files are excerpts of NVIDIA's own Nsight Systems documentation, kept as plain markdown so
+> the agent can query them; the rest are this project's guides.
 
 ## ⚠️ Version Awareness
 
@@ -18,6 +20,8 @@ Always check `nsys --version` on the target system and cross-reference with the 
 
 | File | Topic | Source |
 |------|-------|--------|
+| [user/profile-inputs.md](./user/profile-inputs.md) | What to hand nsys-ai, and how each input is read | Project Guide |
+| [dev/ingest-policy.md](./dev/ingest-policy.md) | How profile inputs are resolved, and why call sites must not bypass it | Project Guide |
 | [user-guide.md](./user-guide.md) | nsys-ai end to end: capture, diagnose, propose, diff, decide | Project Guide |
 | [guided-loop-setup.md](./guided-loop-setup.md) | The same loop driven from the timeline web UI | Project Guide |
 | [doctor.md](./doctor.md) | Environment and profile health checks | Project Guide |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,45 @@
 # nsys-ai documentation
 
-> **How this is organised.** `user/` is for operating the tool and `dev/` is for maintaining it. The
-> numbered files are excerpts of NVIDIA's own Nsight Systems documentation, kept as plain markdown so
-> the agent can query them; the rest are this project's guides.
+Two audiences, kept apart. **User guide** is for operating the tool; **developer guide** is for
+changing it. The **Nsight Systems reference** section holds excerpts of NVIDIA's own documentation,
+kept as plain markdown so the agent can query them.
 
-## ⚠️ Version Awareness
+New here? Start with the [user guide](./user-guide.md), which walks a capture end to end.
 
-Nsight Systems evolves across releases. The SQLite export schema, CLI flags, and available trace types change between versions. Files in this knowledge base are annotated with the source version where applicable.
+## User guide
 
-**Key version differences to watch for:**
-- SQLite table names and columns may change between major versions
-- New trace types are added (e.g., advanced NCCL tracing in 2025.6.1)
-- CLI flags may be deprecated or renamed
-- New `--pytorch` options added in recent versions
+Operating the tool.
 
-Always check `nsys --version` on the target system and cross-reference with the versioned docs at `https://docs.nvidia.com/nsight-systems/<VERSION>/`.
+| Page | Topic |
+|------|-------|
+| [user-guide.md](./user-guide.md) | nsys-ai end to end: capture, diagnose, propose, diff, decide |
+| [user/profile-inputs.md](./user/profile-inputs.md) | The three inputs it accepts, and what conversion happens |
+| [user/time-windows.md](./user/time-windows.md) | Narrowing analysis with `--trim` and `--iteration` |
+| [user/troubleshooting.md](./user/troubleshooting.md) | Symptoms, what they mean, and what to change |
+| [user/environment-variables.md](./user/environment-variables.md) | Every variable, its default, and when to change it |
+| [guided-loop-setup.md](./guided-loop-setup.md) | The same loop driven from the timeline web UI |
+| [doctor.md](./doctor.md) | Environment and profile health checks |
+| [ci-diff-gate.md](./ci-diff-gate.md) | Capture, compare, and gate performance regressions in CI |
+| [cutracer-instruction-analysis.md](./cutracer-instruction-analysis.md) | Instruction-level drill-down (`cutracer` + `cutracer_analysis`) |
+| [cutracer-modal.md](./cutracer-modal.md) | Running CUTracer on Modal (serverless GPU, no local GPU needed) |
 
-## File Index
+## Developer guide
 
-| File | Topic | Source |
+Changing the tool. These describe contracts rather than usage, and assume you are reading the source
+alongside them.
+
+| Page | Topic |
+|------|-------|
+| [dev/ingest-policy.md](./dev/ingest-policy.md) | How a profile path becomes an open backend, and why call sites must not bypass it |
+| [support-matrix.md](./support-matrix.md) | Committed export schemas verified by CI |
+
+## Nsight Systems reference
+
+Excerpts of NVIDIA's documentation, for looking up a flag, a table, or an API without leaving the
+repository.
+
+| Page | Topic | Source |
 |------|-------|--------|
-| [user/profile-inputs.md](./user/profile-inputs.md) | What to hand nsys-ai, and how each input is read | Project Guide |
-| [dev/ingest-policy.md](./dev/ingest-policy.md) | How profile inputs are resolved, and why call sites must not bypass it | Project Guide |
-| [user-guide.md](./user-guide.md) | nsys-ai end to end: capture, diagnose, propose, diff, decide | Project Guide |
-| [guided-loop-setup.md](./guided-loop-setup.md) | The same loop driven from the timeline web UI | Project Guide |
-| [doctor.md](./doctor.md) | Environment and profile health checks | Project Guide |
-| [support-matrix.md](./support-matrix.md) | Committed export schemas verified by CI | Project Guide |
-| [ci-diff-gate.md](./ci-diff-gate.md) | Capture, compare, and gate performance regressions in CI | Project Guide |
 | [01-cli-reference.md](./01-cli-reference.md) | CLI commands, flags, and example command lines | User Guide |
 | [02-sqlite-schema.md](./02-sqlite-schema.md) | SQLite export schema and common queries | Exporter Docs (v2022.4) |
 | [03-nvtx-annotations.md](./03-nvtx-annotations.md) | NVTX API for instrumenting applications | User Guide |
@@ -34,21 +47,33 @@ Always check `nsys --version` on the target system and cross-reference with the 
 | [05-nccl-tracing.md](./05-nccl-tracing.md) | NCCL collective communication tracing | User Guide |
 | [06-python-pytorch.md](./06-python-pytorch.md) | Python and PyTorch profiling support | User Guide |
 | [07-container-profiling.md](./07-container-profiling.md) | Docker/container profiling setup | User Guide |
-| [08-focused-profiling.md](./08-focused-profiling.md) | Limiting profile scope with cudaProfilerApi and NVTX capture ranges | User Guide |
-| [cutracer-instruction-analysis.md](./cutracer-instruction-analysis.md) | Instruction-level drill-down workflow (`cutracer` + `cutracer_analysis`) | Project Guide |
-| [cutracer-modal.md](./cutracer-modal.md) | Running CUTracer on Modal (serverless GPU, no local GPU needed) | Project Guide |
-| [09-performance-questions-mfu.html](./09-performance-questions-mfu.html) | Curated high-impact performance questions and MFU calculation playbook | Project Guide |
+| [08-focused-profiling.md](./08-focused-profiling.md) | Limiting scope with cudaProfilerApi and NVTX capture ranges | User Guide |
+| [09-performance-questions-mfu.html](./09-performance-questions-mfu.html) | Curated performance questions and MFU calculation playbook | Project Guide |
 
-## How This Knowledge Base Is Used
+### Version awareness
 
-1. **Agent context seeding** — Load relevant files as context when the agent starts a profiling task
-2. **Query answering** — Search files for specific CLI flags, SQL queries, or API patterns
-3. **Version tracking** — Compare against actual nsys version to detect capability differences
-4. **Workflow templates** — Copy example commands and SQL queries directly into profiling scripts
+Nsight Systems evolves across releases: the export schema, CLI flags, and available trace types all
+change between versions. Files in this section are annotated with the source version where
+applicable. What to watch for:
 
-## Source URLs
+- Table names and columns change between major versions
+- New trace types are added (advanced NCCL tracing in 2025.6.1, for example)
+- CLI flags are deprecated or renamed
+- New `--pytorch` options appear in recent versions
 
-All content is derived from official NVIDIA documentation:
-- **User Guide:** https://docs.nvidia.com/nsight-systems/UserGuide/index.html
-- **SQLite Exporter (2022.4):** https://docs.nvidia.com/nsight-systems/2022.4/nsys-exporter/examples.html
-- **Latest Exporter:** https://docs.nvidia.com/nsight-systems/nsys-exporter/index.html
+Check `nsys --version` on the target system and cross-reference the versioned documentation at
+`https://docs.nvidia.com/nsight-systems/<VERSION>/`. For what this project has actually tested
+against, see the [support matrix](./support-matrix.md).
+
+**Source URLs**
+
+- User Guide: https://docs.nvidia.com/nsight-systems/UserGuide/index.html
+- SQLite Exporter (2022.4): https://docs.nvidia.com/nsight-systems/2022.4/nsys-exporter/examples.html
+- Latest Exporter: https://docs.nvidia.com/nsight-systems/nsys-exporter/index.html
+
+## How the agent uses this
+
+1. **Context seeding** — relevant files are loaded as context when the agent starts a profiling task
+2. **Query answering** — files are searched for specific CLI flags, SQL queries, or API patterns
+3. **Version tracking** — compared against the actual nsys version to detect capability differences
+4. **Workflow templates** — example commands and SQL queries copied directly into profiling scripts

--- a/docs/dev/ingest-policy.md
+++ b/docs/dev/ingest-policy.md
@@ -1,0 +1,135 @@
+# Ingest policy
+
+Every command that reads a profile makes the same decision in the same place. This page describes that
+decision, the three functions that expose it, and what goes wrong when a call site skips them — which
+has happened, more than once, in ways that were invisible until someone pointed a real capture at the
+tool.
+
+## One decision, three entry points
+
+The decision lives in `resolve_profile()` in `profile.py` and returns a `ProfileResolution`:
+
+```python
+@dataclass(frozen=True)
+class ProfileResolution:
+    source_path: str        # what the user typed
+    resolved_path: str      # what will actually be opened
+    storage_kind: StorageKind          # "nsys-rep" | "parquetdir" | "sqlite"
+    backend: Literal["sqlite", "parquetdir"]
+    cache_mode: Literal["auto", "direct"]
+```
+
+Three functions expose it, and which one you want depends on what you are allowed to do:
+
+| Function | Returns | May run `nsys export` | Use when |
+|---|---|---|---|
+| `resolve_profile()` | `ProfileResolution` | yes | You need the full decision, including the backend |
+| `resolve_profile_path()` | `str` | yes | You only need a path to open |
+| `find_ingested_profile()` | `ProfileResolution \| None` | **no** | You must not write or convert |
+
+`find_ingested_profile()` is the read-only counterpart. It applies the same precedence but returns
+`None` instead of converting, so a caller that must not have side effects — the MCP server is the one
+today — can still follow the policy rather than inventing its own rule.
+
+## The decision
+
+```
+input is a directory, or ends .parquetdir / .nsys-cache
+    policy=sqlite  -> ExportError: SQLite ingest policy cannot open a parquetdir
+    otherwise      -> parquetdir backend, read in place
+
+input ends .nsys-rep
+    policy=auto or parquetdir -> convert to <stem>.parquetdir, parquetdir backend
+    policy=sqlite             -> convert to <stem>.sqlite, sqlite backend, cache_mode=direct
+
+anything else (treated as SQLite)
+    policy=parquetdir -> ExportError: parquetdir ingest requires a parquetdir or .nsys-rep
+    policy=sqlite     -> sqlite backend, cache_mode=direct
+    policy=auto       -> sqlite backend, cache_mode=auto
+```
+
+`policy` comes from `resolve_ingest_policy()`, which reads `NSYS_AI_INGEST` (`auto` by default). An
+explicit `backend=` argument overrides the environment for one call; that is how `skill run`
+implements `--no-cache`.
+
+## Reuse and staleness
+
+Converting a `.nsys-rep` is the expensive step, so `_resolve_parquetdir_path()` reuses an existing
+directory when both hold:
+
+- `<stem>.parquetdir` exists, and its mtime is **not older** than the capture's
+- `inspect_local_parquetdir()` accepts it as a complete export
+
+Otherwise it runs `nsys export --type=parquetdir --include-blobs=true`. Note the staleness test is
+mtime, not content — copying a capture can invalidate a directory whose contents are still correct.
+That is deliberate: the cheap test that never serves stale data is better than the expensive one that
+sometimes does.
+
+If `nsys` is not on `PATH`, `ExportToolMissingError` names the manual command rather than failing
+generically.
+
+## `NSYS_AI_INGEST` and `NSYS_AI_CACHE_MODE` are different knobs
+
+They are easy to confuse and control different layers:
+
+- **`NSYS_AI_INGEST`** (`auto` | `parquetdir` | `sqlite`) chooses the **storage** a profile is read
+  from. It is consumed inside `resolve_profile()`, so it only reaches call sites that go through it.
+- **`NSYS_AI_CACHE_MODE`** (`auto` | `direct` | `parquet`) chooses whether the **SQLite path** builds
+  its Parquet query cache. It is read by `open_auto_db()` and is irrelevant once the parquetdir
+  backend is selected.
+
+A caller that hardcodes a path past `resolve_profile()` silently ignores the first of these. That is
+not hypothetical — see below.
+
+## Call it. Do not reimplement it.
+
+Current call sites:
+
+```
+resolve_profile_path()   chat.py · cli/handlers.py · diagnose_command.py · optimize_command.py
+                         profile_runner.py · propose_command.py · region_mfu.py · tui_textual.py
+resolve_profile()        ai/backend/profile_db_tool.py · cli/handlers.py
+find_ingested_profile()  mcp_server.py
+```
+
+Two call sites once did not, and both produced failures that looked like something else:
+
+- **`skill run`** passed the user's path straight to the SQLite opener. On a capture whose only
+  ingested form was a parquetdir, it reported *"This profile has no CUPTI_ACTIVITY_KIND_KERNEL table …
+  the capture did not trace that activity kind"* — describing the capture, while a parquetdir holding
+  2.19 million kernel rows sat beside it. On a bare `.nsys-rep` it handed the capture's bytes to
+  SQLite and returned *"file is not a database"*.
+- **The MCP server** required a `.sqlite` sidecar, so it refused captures the CLI read without
+  complaint, and read a different backend than `diagnose` did when both existed.
+
+Both are fixed. They are recorded here because the failure mode is the same in each case and it is not
+obvious from the symptom: **bypassing the policy does not produce a missing-file error. It produces a
+plausible, wrong statement about the capture.**
+
+If you are adding a code path that opens a profile:
+
+- Call one of the three functions. If none fits, the missing case belongs in `profile.py`, not in your
+  module.
+- Do not derive `<stem>.sqlite` or `<stem>.parquetdir` yourself. The precedence, the staleness rule and
+  the policy override all live in one place so they can change in one place.
+- If you cannot afford a conversion, use `find_ingested_profile()` and handle `None`. Do not reach for
+  a private helper because the public one might export.
+- Report an absent store with a command the user can run. `find_ingested_profile()` returning `None`
+  means "nothing ingested yet", not "broken profile".
+
+## What a change here has to preserve
+
+- `NSYS_AI_INGEST` reaches every entry point. A new call site that does not consult
+  `resolve_ingest_policy()` makes the variable silently partial, which is worse than not having it.
+- The read-only guarantee of `find_ingested_profile()`. It must never convert, and never write beside
+  the capture.
+- `.sqlite` inputs keep working unchanged. They are the compatibility path, not a deprecated one, and
+  committed test fixtures are all `.sqlite`.
+- Errors name the input and the way out. `ExportToolMissingError` prints the `nsys export` command;
+  the parquetdir/sqlite policy conflicts name the environment variable that resolves them.
+
+## Related
+
+- [What to hand nsys-ai](../user/profile-inputs.md) — the same rules from the user's side
+- [Support matrix](../support-matrix.md) — export schema versions covered by tests
+- [doctor](../doctor.md) — what to run when a capture will not open

--- a/docs/dev/ingest-policy.md
+++ b/docs/dev/ingest-policy.md
@@ -43,7 +43,7 @@ input ends .nsys-rep
     policy=sqlite             -> convert to <stem>.sqlite, sqlite backend, cache_mode=direct
 
 anything else (treated as SQLite)
-    policy=parquetdir -> ExportError: parquetdir ingest requires a parquetdir or .nsys-rep
+    policy=parquetdir -> ExportError: Parquetdir ingest requires a parquetdir directory or a .nsys-rep input.
     policy=sqlite     -> sqlite backend, cache_mode=direct
     policy=auto       -> sqlite backend, cache_mode=auto
 ```
@@ -68,18 +68,19 @@ sometimes does.
 If `nsys` is not on `PATH`, `ExportToolMissingError` names the manual command rather than failing
 generically.
 
-## `NSYS_AI_INGEST` and `NSYS_AI_CACHE_MODE` are different knobs
+## Where the two environment variables are consumed
 
-They are easy to confuse and control different layers:
+`NSYS_AI_INGEST` and `NSYS_AI_CACHE_MODE` are easy to confuse. Their values are documented in
+[Environment variables](../user/environment-variables.md); what matters here is where each is read:
 
-- **`NSYS_AI_INGEST`** (`auto` | `parquetdir` | `sqlite`) chooses the **storage** a profile is read
-  from. It is consumed inside `resolve_profile()`, so it only reaches call sites that go through it.
-- **`NSYS_AI_CACHE_MODE`** (`auto` | `direct` | `parquet`) chooses whether the **SQLite path** builds
-  its Parquet query cache. It is read by `open_auto_db()` and is irrelevant once the parquetdir
-  backend is selected.
+- **`NSYS_AI_INGEST`** is consumed by `resolve_ingest_policy()`, which is called from inside
+  `resolve_profile()`. It therefore reaches exactly those call sites that go through one of the three
+  entry points, and no others.
+- **`NSYS_AI_CACHE_MODE`** is consumed by `open_auto_db()` in `parquet_cache.py`, one layer down, and
+  is irrelevant once the parquetdir backend has been selected.
 
-A caller that hardcodes a path past `resolve_profile()` silently ignores the first of these. That is
-not hypothetical — see below.
+The consequence is the reason this page exists: a caller that derives a path itself does not fail
+loudly, it just silently ignores `NSYS_AI_INGEST`. That is not hypothetical — see below.
 
 ## Call it. Do not reimplement it.
 
@@ -131,5 +132,7 @@ If you are adding a code path that opens a profile:
 ## Related
 
 - [What to hand nsys-ai](../user/profile-inputs.md) — the same rules from the user's side
+- [Environment variables](../user/environment-variables.md) — `NSYS_AI_INGEST` and `NSYS_AI_CACHE_MODE` values
+- [Troubleshooting](../user/troubleshooting.md) — the symptoms a policy bypass produces
 - [Support matrix](../support-matrix.md) — export schema versions covered by tests
 - [doctor](../doctor.md) — what to run when a capture will not open

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -77,8 +77,8 @@ Four things land in `run-before/`:
 
 | File | What it is |
 |------|------------|
-| `profile.sqlite` | The exported profile. Every other command reads this. |
-| `profile.nsys-rep` | The native Nsight report, for the Nsight GUI. |
+| `profile.nsys-rep` | The capture itself. Hand this to any command. |
+| `profile.sqlite` | A SQLite export of the same capture, for tools that want one. |
 | `runspec.json` | Exactly how this run was launched. Section 5 explains why this matters. |
 | `stdout.log`, `stderr.log` | Your workload's own output. |
 
@@ -89,8 +89,9 @@ capture, so you never have to name sessions yourself.
 activity is an error, not a silent empty file. Add `--dry-run` to print the plan without running
 anything.
 
-If you already have a `.sqlite` or `.nsys-rep` from `nsys` directly, skip this step — every command
-below accepts either.
+If you already have a `.nsys-rep`, a `.sqlite` or a `parquetdir` from `nsys` directly, skip this step.
+Every command below accepts any of them; see [what to hand nsys-ai](./user/profile-inputs.md) for how
+each is read.
 
 ## 3. Look at it
 

--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -1,0 +1,92 @@
+# Environment variables
+
+Every setting below has a working default. This page exists for the cases where the default is wrong
+for your machine — a shared cache location in CI, a memory-constrained box, reproducing a result from
+an older release.
+
+Variables are read at the point of use, not at startup, so exporting one for a shell session or
+prefixing a single command both work:
+
+```bash
+NSYS_AI_INGEST=sqlite nsys-ai diagnose perf.nsys-rep
+```
+
+Unless noted, an unset variable and an empty one mean the same thing, and an unrecognised value is
+ignored rather than fatal — some warn, most are silent.
+
+## Storage and ingest
+
+| Variable | Default | Description |
+|---|---|---|
+| `NSYS_AI_INGEST` | `auto` | Which storage a profile is read from. `auto` converts `.nsys-rep` to a parquetdir and reads `.sqlite` in place; `parquetdir` refuses `.sqlite` inputs; `sqlite` converts `.nsys-rep` to `.sqlite`, refuses parquetdir inputs, and forces the cache mode to `direct` — see the note below. See [What to hand nsys-ai](./profile-inputs.md). |
+| `NSYS_AI_CACHE_MODE` | `auto` | Whether the SQLite path builds a Parquet query cache. `direct` queries the `.sqlite` in place with no cache; `parquet` forces the cache even when it is judged unaffordable; `auto` decides on free disk and profile size. Ignored once the parquetdir backend is in use, and overridden entirely by `NSYS_AI_INGEST=sqlite`. An unrecognised value warns and falls back to `auto`. |
+| `NSYS_AI_BASELINE_ROOT` | `.nsys-ai-baselines` (relative to the working directory) | Where the local baseline store lives. Point CI jobs at one absolute path so `baseline tag` and `diff --against baseline:X` agree regardless of which directory the job ran from. An explicit `--root` still wins. |
+
+## Performance and memory
+
+| Variable | Default | Description |
+|---|---|---|
+| `NSYS_AI_DUCKDB_THREADS` | DuckDB's own default (one per core) | `SET threads` for the query engine. Lower it on a shared machine. Non-numeric or non-positive values are ignored silently. |
+| `NSYS_AI_DUCKDB_TEMP_DIRECTORY` | DuckDB's own default | Spill directory for large `GROUP BY` and join operations. Set it when the default temp filesystem is small or slow; the directory is created if missing. Failures to create or set it are ignored, and the query proceeds unspilled. |
+| `NSYS_AI_DEFER_NVTX_KERNEL_MAP` | deferred | Set to `0`, `false`, `no` or `off` to build the NVTX-to-kernel map during cache construction instead of on first use. Deferring makes `warm` finish sooner; building eagerly makes the first `nvtx_kernel_map` query fast. |
+| `NSYS_AI_ALWAYS_BUILD_NVTX_KERNEL_MAP` | unset | Set to `1`, `true`, `yes` or `on` to force the eager build. Overrides the two variables above, and is the setting that makes "cache ready" mean every artifact is present. |
+| `NSYS_AI_DEFER_NVTX_KERNEL_MAP_MB` | unset | Make the choice size-dependent: defer only when the profile is at least this many megabytes, build eagerly below it. An unparseable value logs a warning and defers. |
+
+## Skills and analysis
+
+| Variable | Default | Description |
+|---|---|---|
+| `NSYS_AI_CUSTOM_SKILLS_DIR` | unset | Directory of additional skill definitions to load alongside the built-ins. Equivalent to `--skills-dir`, which takes precedence. |
+| `NSYS_AI_SKILLS_DIR` | the packaged `agent_skills` directory | Where prompt and skill text files are loaded from. Intended for testing and for packaging layouts that relocate package data; changing it in normal use will make skills fail to load. |
+| `NSYS_AI_ROOT_CAUSES_DIR` | unset | Directory of root-cause definitions for `root-cause`. Equivalent to `--root-causes-dir`, which takes precedence. |
+| `NSYS_AI_MANIFEST_AUTO_TRIM` | enabled | Set to `0`, `false`, `no` or `off` to stop the profile health manifest from auto-selecting an iteration window. Disable it when you want the manifest to describe the whole capture. |
+
+## AI features
+
+These affect `ask`, `chat`, `agent` and the LLM-backed parts of `diagnose`. They do nothing in a
+core install without the `[agent]` or `[chat]` extras.
+
+| Variable | Default | Description |
+|---|---|---|
+| `NSYS_AI_MODEL` | the first model with credentials present | Preferred model ID. It is honoured only when the matching provider API key is also set; otherwise the first available model is used instead, silently. |
+| `NSYS_AI_DB_AGENT` | disabled | Set to a truthy value to give the agent the `query_profile_db` tool, letting it write SQL against the profile rather than only calling skills. |
+
+## Output
+
+| Variable | Default | Description |
+|---|---|---|
+| `NSYS_AI_AGENT` | unset | Set to exactly `1` to switch CLI output to a machine-readable form intended for external AI agents. Any other value, including `true`, leaves human-readable output in place. |
+
+## Notes on a few of these
+
+**`NSYS_AI_INGEST=sqlite` also turns off the query cache.** This is the surprising part. Selecting
+the SQLite policy sets the cache mode to `direct` for the whole run, so queries go against the
+`.sqlite` in place and no Parquet cache is built — regardless of what `NSYS_AI_CACHE_MODE` says.
+A `.sqlite` read under the default `auto` policy *does* get a cache when one is affordable, so the
+same file is faster to query without this variable than with it.
+
+Use it when you need the older behaviour reproduced exactly — comparing against a number produced
+before the parquetdir backend became the default, or producing a `.sqlite` to open in another tool.
+It is a compatibility path, not a deprecated one. Do not leave it set in a shell profile.
+
+**The three NVTX-map variables interact.** `NSYS_AI_ALWAYS_BUILD_NVTX_KERNEL_MAP` is checked first
+and wins outright. Then `NSYS_AI_DEFER_NVTX_KERNEL_MAP=0` forces the eager build. Only if neither
+applies is `NSYS_AI_DEFER_NVTX_KERNEL_MAP_MB` consulted, and with none of the three set the map is
+deferred. Setting the size threshold alone is the usual choice: it keeps small profiles eager, where
+the sweep costs a fraction of a second, and defers the large ones where it does not.
+
+**Ignored-value behaviour differs.** `NSYS_AI_CACHE_MODE` and `NSYS_AI_DEFER_NVTX_KERNEL_MAP_MB`
+warn on values they cannot use; `NSYS_AI_DUCKDB_THREADS` and `NSYS_AI_DUCKDB_TEMP_DIRECTORY` fail
+silently and keep the default. If a tuning variable appears to have had no effect, check the spelling
+before concluding it does not work.
+
+**`NSYS_AI_INGEST` and `NSYS_AI_CACHE_MODE` are different layers.** The first chooses which storage
+is read; the second chooses whether the SQLite path builds a query cache. Setting the second has no
+effect once the first has selected a parquetdir. See [Ingest policy](../dev/ingest-policy.md) for
+where each is consumed.
+
+## Related
+
+- [What to hand nsys-ai](./profile-inputs.md) — the inputs each command accepts
+- [Troubleshooting](./troubleshooting.md) — symptoms and what to change
+- [Ingest policy](../dev/ingest-policy.md) — how storage selection is implemented

--- a/docs/user/profile-inputs.md
+++ b/docs/user/profile-inputs.md
@@ -1,0 +1,137 @@
+# What to hand nsys-ai
+
+Give it the `.nsys-rep` your capture produced. Everything else is the tool's problem.
+
+```bash
+nsys-ai doctor perf.nsys-rep
+nsys-ai diagnose perf.nsys-rep
+nsys-ai timeline-web perf.nsys-rep
+```
+
+You do not need to export anything first, and you do not need to know which storage format a
+particular command prefers.
+
+## The three inputs
+
+| You have | What happens |
+|---|---|
+| `perf.nsys-rep` | Converted once to `perf.parquetdir` beside it, then read from there |
+| `perf.parquetdir` | Read directly |
+| `perf.sqlite` | Read directly, with a query cache built beside it |
+
+A `.nsys-rep` is the native Nsight Systems report and what `nsys` writes by default. A `parquetdir` is
+a directory of Parquet files that `nsys export` produces; it is what nsys-ai converts to, because
+analysis queries run against it directly. A `.sqlite` is the older export format — still fully
+supported, and the right input when it is what you already have.
+
+## The first run on a `.nsys-rep` is slower
+
+Converting is the one expensive step, and it happens once:
+
+```
+$ nsys-ai diagnose perf.nsys-rep
+[nsys-ai] Building analysis cache for a 634MB profile (~6s, once per profile) ...
+```
+
+The conversion writes `perf.parquetdir` next to `perf.nsys-rep`. Every later command on the same
+capture reuses it and starts immediately. Delete the directory and the next command rebuilds it.
+
+Conversion runs `nsys export`, so Nsight Systems has to be on your `PATH`. If it is not, the error says
+so and prints the command to run by hand.
+
+Two things cause a rebuild rather than a reuse:
+
+- **The capture is newer than the directory beside it.** Overwrite `perf.nsys-rep` and the stale
+  `perf.parquetdir` is ignored. Modification time is the test, so copying a capture around can trigger
+  a rebuild even when the contents did not change.
+- **The directory is not a complete export.** A conversion interrupted halfway leaves something that
+  fails inspection; it is replaced rather than half-read.
+
+## Your Nsight version has to be new enough
+
+A `.nsys-rep` written by a newer Nsight Systems than the one on your machine cannot be converted:
+
+```
+Exportation error: Report was created in Nsight Systems version (2026.3.1),
+newer than your current version (2026.2.1).
+```
+
+That is `nsys export` refusing, not nsys-ai. Upgrading Nsight Systems fixes it. Older captures are
+fine — the export schema is versioned, and the versions covered by tests are listed in the
+[support matrix](../support-matrix.md).
+
+If you are unsure, `nsys-ai doctor <profile>` reports the schema version it found and whether the
+capture is readable before you spend time on anything else.
+
+## Which commands take which input
+
+All of them accept any of the three. Most need nothing but the path:
+
+```bash
+nsys-ai doctor perf.nsys-rep
+nsys-ai diagnose perf.nsys-rep
+nsys-ai ask perf.nsys-rep "why is the GPU idle?"
+nsys-ai summary perf.nsys-rep
+nsys-ai skill run top_kernels perf.nsys-rep
+nsys-ai web perf.nsys-rep
+nsys-ai timeline-web perf.nsys-rep
+nsys-ai evidence build perf.nsys-rep
+nsys-ai diff before.nsys-rep after.nsys-rep
+nsys-ai review before.nsys-rep after.nsys-rep
+```
+
+Two still ask for more than a path:
+
+- `nsys-ai report` requires `--gpu` and `--trim`.
+- `nsys-ai analyze` requires `--trim` for its text output; `--format json` runs on the whole capture.
+
+## Choosing the storage yourself
+
+You will not normally need this. When you do, `NSYS_AI_INGEST` overrides the default everywhere:
+
+| Value | Effect |
+|---|---|
+| `auto` | The default described above |
+| `parquetdir` | Only read a parquetdir; refuse a `.sqlite` input |
+| `sqlite` | Convert a `.nsys-rep` to `.sqlite` instead, and refuse a parquetdir input |
+
+`NSYS_AI_INGEST=sqlite` is the useful one. It reproduces the older behaviour, which is worth having
+when comparing against a result produced before parquetdir became the default, or when you want a
+`.sqlite` you can open in another tool.
+
+Asking for something impossible fails immediately and says why:
+
+```
+$ NSYS_AI_INGEST=sqlite nsys-ai diagnose perf.parquetdir
+Error [EXPORT_ERROR]: SQLite ingest policy cannot open a parquetdir; use NSYS_AI_INGEST=parquetdir.
+```
+
+## A trim window is on the capture clock
+
+`--trim START END` is in seconds measured on the capture's own clock, which does not start at zero. A
+profile whose first GPU work is at 34.8 s has nothing in `--trim 0 5`, and the commands say so rather
+than returning an empty result:
+
+```
+Error [TRIM_OUT_OF_RANGE]: --trim 0.000 5.000 selects no part of this profile, whose
+window is 34.808 s to 812.508 s on the capture clock. Use a window inside that range,
+or omit --trim.
+```
+
+`nsys-ai doctor` prints the capture's duration, and the error above prints the real window, so you do
+not have to guess twice.
+
+## When something looks wrong
+
+Run `nsys-ai doctor <profile>` first. It checks that the capture opens, and reports its export schema
+version, GPU count, NVTX and NCCL event counts, and profiler overhead — marking which of those is a
+problem rather than leaving you to compare numbers.
+
+A capture that opens but produces very little is usually a device-selection question rather than an
+ingest one. `nsys-ai diagnose` analyses the first GPU present in the capture; if you name one that is
+not there, it lists the ones that are:
+
+```
+$ nsys-ai diagnose perf.nsys-rep --gpu 0
+Error [USAGE_ERROR]: GPU device 0 is not present in the profile; available devices: 1, 2, 3, 4, 5, 6, 7
+```

--- a/docs/user/profile-inputs.md
+++ b/docs/user/profile-inputs.md
@@ -24,7 +24,10 @@ a directory of Parquet files that `nsys export` produces; it is what nsys-ai con
 analysis queries run against it directly. A `.sqlite` is the older export format — still fully
 supported, and the right input when it is what you already have.
 
-## The first run on a `.nsys-rep` is slower
+Every command accepts all three. A few need more than a path; see
+[which commands need extra flags](./troubleshooting.md#some-commands-need-more-than-a-path).
+
+## The first run is slower
 
 Converting is the one expensive step, and it happens once:
 
@@ -39,51 +42,15 @@ capture reuses it and starts immediately. Delete the directory and the next comm
 Conversion runs `nsys export`, so Nsight Systems has to be on your `PATH`. If it is not, the error says
 so and prints the command to run by hand.
 
-Two things cause a rebuild rather than a reuse:
+## What causes a rebuild
+
+Two things, and neither is content-based:
 
 - **The capture is newer than the directory beside it.** Overwrite `perf.nsys-rep` and the stale
   `perf.parquetdir` is ignored. Modification time is the test, so copying a capture around can trigger
   a rebuild even when the contents did not change.
 - **The directory is not a complete export.** A conversion interrupted halfway leaves something that
   fails inspection; it is replaced rather than half-read.
-
-## Your Nsight version has to be new enough
-
-A `.nsys-rep` written by a newer Nsight Systems than the one on your machine cannot be converted:
-
-```
-Exportation error: Report was created in Nsight Systems version (2026.3.1),
-newer than your current version (2026.2.1).
-```
-
-That is `nsys export` refusing, not nsys-ai. Upgrading Nsight Systems fixes it. Older captures are
-fine — the export schema is versioned, and the versions covered by tests are listed in the
-[support matrix](../support-matrix.md).
-
-If you are unsure, `nsys-ai doctor <profile>` reports the schema version it found and whether the
-capture is readable before you spend time on anything else.
-
-## Which commands take which input
-
-All of them accept any of the three. Most need nothing but the path:
-
-```bash
-nsys-ai doctor perf.nsys-rep
-nsys-ai diagnose perf.nsys-rep
-nsys-ai ask perf.nsys-rep "why is the GPU idle?"
-nsys-ai summary perf.nsys-rep
-nsys-ai skill run top_kernels perf.nsys-rep
-nsys-ai web perf.nsys-rep
-nsys-ai timeline-web perf.nsys-rep
-nsys-ai evidence build perf.nsys-rep
-nsys-ai diff before.nsys-rep after.nsys-rep
-nsys-ai review before.nsys-rep after.nsys-rep
-```
-
-Two still ask for more than a path:
-
-- `nsys-ai report` requires `--gpu` and `--trim`.
-- `nsys-ai analyze` requires `--trim` for its text output; `--format json` runs on the whole capture.
 
 ## Choosing the storage yourself
 
@@ -97,7 +64,8 @@ You will not normally need this. When you do, `NSYS_AI_INGEST` overrides the def
 
 `NSYS_AI_INGEST=sqlite` is the useful one. It reproduces the older behaviour, which is worth having
 when comparing against a result produced before parquetdir became the default, or when you want a
-`.sqlite` you can open in another tool.
+`.sqlite` you can open in another tool. It also disables the query cache for the whole run, so do not
+leave it set — see [Environment variables](./environment-variables.md#notes-on-a-few-of-these).
 
 Asking for something impossible fails immediately and says why:
 
@@ -106,32 +74,9 @@ $ NSYS_AI_INGEST=sqlite nsys-ai diagnose perf.parquetdir
 Error [EXPORT_ERROR]: SQLite ingest policy cannot open a parquetdir; use NSYS_AI_INGEST=parquetdir.
 ```
 
-## A trim window is on the capture clock
+## Where to go next
 
-`--trim START END` is in seconds measured on the capture's own clock, which does not start at zero. A
-profile whose first GPU work is at 34.8 s has nothing in `--trim 0 5`, and the commands say so rather
-than returning an empty result:
-
-```
-Error [TRIM_OUT_OF_RANGE]: --trim 0.000 5.000 selects no part of this profile, whose
-window is 34.808 s to 812.508 s on the capture clock. Use a window inside that range,
-or omit --trim.
-```
-
-`nsys-ai doctor` prints the capture's duration, and the error above prints the real window, so you do
-not have to guess twice.
-
-## When something looks wrong
-
-Run `nsys-ai doctor <profile>` first. It checks that the capture opens, and reports its export schema
-version, GPU count, NVTX and NCCL event counts, and profiler overhead — marking which of those is a
-problem rather than leaving you to compare numbers.
-
-A capture that opens but produces very little is usually a device-selection question rather than an
-ingest one. `nsys-ai diagnose` analyses the first GPU present in the capture; if you name one that is
-not there, it lists the ones that are:
-
-```
-$ nsys-ai diagnose perf.nsys-rep --gpu 0
-Error [USAGE_ERROR]: GPU device 0 is not present in the profile; available devices: 1, 2, 3, 4, 5, 6, 7
-```
+- [Time windows](./time-windows.md) — how `--trim` is measured
+- [Troubleshooting](./troubleshooting.md) — a capture that will not open, or opens and produces nothing
+- [Environment variables](./environment-variables.md) — the full list
+- [Ingest policy](../dev/ingest-policy.md) — the same rules from the maintainer's side

--- a/docs/user/time-windows.md
+++ b/docs/user/time-windows.md
@@ -1,0 +1,154 @@
+# Time windows
+
+Most analysis is about part of a capture, not all of it. A profile that ran for four minutes
+contains warm-up, a few hundred steady-state iterations, and shutdown, and averaging them together
+hides the thing you are looking for.
+
+There are two ways to narrow the window. Pick the one that matches what you know:
+
+| You know | Use | Available on |
+|---|---|---|
+| The seconds you care about | `--trim START_S END_S` | 31 commands — nearly all of them |
+| Which training iteration you care about | `--iteration N` | `diff` and `skill run` |
+
+The two flags interact differently on each of the commands that take both, so see
+[combining the two](#combining-the-two) before passing them together.
+
+## The capture clock does not start at zero
+
+This is the one thing that surprises people, and it costs an afternoon when it goes unnoticed.
+
+`--trim` is read on the **capture clock**: the timestamps Nsight Systems recorded, which are relative
+to session start, not to the first event. A profile whose first kernel lands 155 seconds in has a
+window that begins at 155 seconds. `--trim 0 1` on that profile does not mean "the first second of
+GPU work" — it means a window that ends 154 seconds before anything happened.
+
+Ask the profile for its window before trimming:
+
+```
+$ nsys-ai info perf.sqlite
+Profile: perf.sqlite
+  Nsight version (heuristic): 2026.2.1.210
+  GPUs: [0, 1]
+  Kernels: 3442  |  NVTX: 16782
+  Time: 155.360s - 156.321s
+```
+
+So the trim window for the middle third of that capture is:
+
+```bash
+nsys-ai skill run top_kernels perf.sqlite --trim 155.68 156.00
+```
+
+Units are seconds, accepted as floats, and converted to nanoseconds internally. Both bounds are
+required; there is no open-ended form.
+
+## An impossible window is usually an error, not an empty result
+
+A window that selects nothing is almost always a mistake about the clock rather than a real request
+for zero rows, so most commands refuse it up front and name both windows:
+
+```
+$ nsys-ai diff before.sqlite after.sqlite --trim 0 1
+Error [TRIM_OUT_OF_RANGE]: before profile: --trim 0.000 1.000 selects no part of this
+profile, whose window is 60.112 s to 60.411 s on the capture clock. Use a window inside
+that range, or omit --trim.
+```
+
+Three shapes are rejected: a window entirely before the capture, one entirely after it, and an empty
+or inverted one such as `--trim 156 156`, which sits inside the capture and still selects nothing. On
+a two-profile command the message says which side failed, because `--trim` applies to both and two
+captures rarely share a clock — the example above is a real pair whose windows are 60.1 s and 72.9 s.
+
+A window that *partly* overlaps is accepted and clipped. That is a legitimate request.
+
+### Commands that do not check
+
+Six commands skip this check. Given a window that selects nothing they produce an empty result
+rather than an error:
+
+```
+$ nsys-ai skill run top_kernels perf.sqlite --trim 0 1
+(No kernels found)
+```
+
+| Command | What you get instead of an error |
+|---|---|
+| `skill run` | `(No kernels found)` |
+| `agent analyze` | A report header, then `(No kernels found)` |
+| `cutracer plan`, `cutracer analyze`, `cutracer run` | `(No kernels found — nothing to instrument)` |
+| `diff-web` | A served page with an empty comparison on it |
+
+That output is indistinguishable from a capture that genuinely has no kernels, which is the whole
+reason the check exists elsewhere. `diff-web` is the most confusing of the six, because the empty
+result is a rendered page rather than a line of text.
+
+Until this is unified, treat an unexpected empty result from any of the six as a trim-window question
+first: re-run the same window through `diagnose`, which does check, and it will tell you whether the
+window or the capture is the problem.
+
+## Selecting an iteration instead of seconds
+
+When the interesting unit is "one training step" rather than "these seconds", let the tool find the
+boundaries:
+
+```bash
+nsys-ai skill run top_kernels perf.sqlite --iteration 0
+```
+
+Iteration boundaries come from NVTX markers when the capture has them, and fall back to a kernel-gap
+heuristic when it does not. The marker name defaults to `sample_0`; `--marker` changes it.
+
+Prefer this over hand-computed seconds when it applies. It survives re-capturing the same workload,
+where the absolute clock does not — and on `diff` it is the only way to compare like with like, since
+two captures of the same workload do not share a clock.
+
+```bash
+nsys-ai diff before.sqlite after.sqlite --iteration 0
+```
+
+Each side gets its own window here: iteration 0 is located separately in each profile, so the
+comparison is between the same logical step rather than the same wall-clock seconds.
+
+If the index does not exist, you are told the range that does:
+
+```
+Error: iteration 99 out of range (0..2)
+```
+
+### Combining the two
+
+The two commands that accept both flags treat the combination differently. This is worth knowing
+before you assume either behaviour:
+
+| Command | `--trim` together with `--iteration` |
+|---|---|
+| `skill run` | Refused — `Error: --iteration and --trim cannot be used together` |
+| `diff` | Composed — `--trim` limits the span iteration boundaries are searched for, then the chosen iteration's own bounds become the window |
+
+So on `diff` the pair is a narrowing search ("find iteration 0 within this span"), while on
+`skill run` it is an ambiguous request and is rejected.
+
+## Which commands accept `--trim`
+
+Effectively all of them: 31 commands take it, so assume it is available rather than checking.
+
+Seven commands read a profile and do *not*, each for a reason worth knowing:
+
+| Command | Why there is no window |
+|---|---|
+| `info`, `doctor` | They describe the capture as a whole — a window would defeat the purpose |
+| `warm` | It builds the cache for the whole capture, so later windowed queries are fast |
+| `baseline tag` | A baseline snapshots the entire profile; trim at comparison time instead |
+| `ask`, `chat`, `agent ask` | Conversational, and the window is something you say in the question |
+
+For `ask` and `chat` the window goes in the question itself — "in the second half of the run",
+"during iteration 3". Understand what that is and is not: `--trim` filters the data before any
+analysis runs, whereas a window described in words is a request the model may or may not apply to
+every query it issues. When the number has to be right, get it from a command that takes `--trim`.
+
+## Related
+
+- [What to hand nsys-ai](./profile-inputs.md) — the inputs each command accepts
+- [Troubleshooting](./troubleshooting.md) — an empty result that is not about trimming
+- [Environment variables](./environment-variables.md) — `NSYS_AI_MANIFEST_AUTO_TRIM` and the rest

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -90,24 +90,38 @@ cause is elsewhere.
 
 ### The results describe a GPU you did not ask for
 
-`root-cause` substitutes a different device when the one you selected has no kernels on it. Multi-GPU
-captures often leave device 0 idle while devices 1-7 do the work, and returning nothing there would
-be less useful than answering about a device that ran something.
+The `root_cause_matcher` skill substitutes a different device when the one selected has no kernels on
+it. Multi-GPU captures often leave device 0 idle while devices 1-7 do the work, and returning nothing
+there would be less useful than answering about a device that actually ran something.
 
-The substitution is silent — nothing in the output says it happened. If a per-device number looks
-wrong, check the per-GPU kernel counts in `nsys-ai info` and pass `--gpu` explicitly.
+You will meet this through `nsys-ai root-cause`, through `nsys-ai skill run root_cause_matcher`, or
+by asking a question that routes to it — one containing "why", "root cause" or "diagnosis".
+
+The substitution is silent: nothing in the output says which device the answer is about. If a
+per-device number looks wrong, check the per-GPU kernel counts that `nsys-ai info` prints and pass
+`--gpu` explicitly.
 
 ## The command is slow
 
 ### The first command on a capture takes seconds before printing anything
 
 ```
-[nsys-ai] Building analysis cache for a 634MB profile (~6s, once per profile) ...
+[nsys-ai] Building analysis cache for a 634MB profile (~6s, once per profile;
+queries afterwards are 4-5x faster).
+[nsys-ai] The first NVTX-attributing query then builds the kernel map (~8s more,
+also once per profile).
+[nsys-ai] Set NSYS_AI_CACHE_MODE=direct to skip the build and query the SQLite
+export in place.
 ```
 
-Expected. The capture is being converted once into a form queries can run against, and the result is
-written beside it. Every later command on the same capture starts immediately. See
+Expected, and it says so. The capture is being converted once into a form queries can run against,
+and the result is written beside it. Every later command on the same capture starts immediately. See
 [What to hand nsys-ai](./profile-inputs.md).
+
+Note the second line: the NVTX-to-kernel map is built lazily, so there is a *second* one-off pause
+later, the first time you run something that attributes kernels to NVTX ranges. That is not a second
+cache build. [`NSYS_AI_DEFER_NVTX_KERNEL_MAP`](./environment-variables.md) moves it into the first
+build if you would rather pay once.
 
 If it happens *every* time, the conversion output is not being kept: check that the directory holding
 the capture is writable, and that the capture's modification time is not being updated by whatever

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -1,0 +1,195 @@
+# Troubleshooting
+
+Organised by what you saw, not by which subsystem produced it. Each entry gives the message or
+behaviour, what it actually means, and what to change.
+
+Two general notes before the list. Errors carry a bracketed code — `Error [TRIM_OUT_OF_RANGE]: …` —
+which is stable across releases and worth searching for. And `nsys-ai doctor <profile>` answers most
+"will this capture work" questions in one command; run it before working through anything below.
+
+## The profile will not open
+
+### `Error [EXPORT_TOOL_MISSING]` — conversion requires 'nsys' on PATH
+
+```
+Error [EXPORT_TOOL_MISSING]: Profile is .nsys-rep; conversion requires 'nsys'
+(NVIDIA Nsight Systems) on PATH. Install Nsight Systems or export manually:
+nsys export --type parquetdir --include-blobs=true -o <out.parquetdir>
+--force-overwrite=true <file.nsys-rep>
+```
+
+A `.nsys-rep` has to be converted before it can be queried, and the converter is Nsight Systems
+itself. Either install it — `apt-get install nsight-systems-cli`, or the CUDA toolkit installer —
+or run the printed command on a machine that has it and copy the result across.
+
+The printed command is the exact one that would have run, including the flags. Do not simplify it:
+`--include-blobs=true` is what preserves NVTX payloads, and without it NVTX-based analysis comes back
+empty later, with no error at the point of failure.
+
+### `file is not a database`
+
+A file that is not a SQLite database was handed to something that expected one — most often a
+`.nsys-rep` passed to a tool that does not convert. Every nsys-ai command converts for you, so if
+this comes from nsys-ai on a current release it is a bug worth reporting with the command line.
+
+### `SQLite ingest policy cannot open a parquetdir`
+
+```
+Error [EXPORT_ERROR]: SQLite ingest policy cannot open a parquetdir;
+use NSYS_AI_INGEST=parquetdir.
+```
+
+`NSYS_AI_INGEST` is set to `sqlite` — possibly in a shell profile or CI job you have forgotten
+about — and the input is a parquetdir. Unset it, or set it to `auto`.
+
+The symmetric case has its own message:
+
+```
+Error [EXPORT_ERROR]: Parquetdir ingest requires a parquetdir directory or a
+.nsys-rep input.
+```
+
+Here `NSYS_AI_INGEST=parquetdir` met a `.sqlite`. There is nothing to convert from — a `.sqlite`
+export cannot be turned back into a parquetdir — so the fix is `auto`, which reads it in place. See
+[Environment variables](./environment-variables.md).
+
+## The command runs but produces nothing
+
+### An empty result after `--trim`
+
+Almost always the capture clock. `--trim` is measured on Nsight's clock, which does not start at
+zero, so a window that looks reasonable can sit entirely before the first event. Run `nsys-ai info`
+to see the real window. [Time windows](./time-windows.md) covers this in full.
+
+Six commands do not perform this check and return an empty result instead of an error: `skill run`,
+`agent analyze`, `diff-web`, and the three `cutracer` sub-commands. If one of them comes back empty,
+re-run the same window through `diagnose`, which does check. See
+[Time windows](./time-windows.md#commands-that-do-not-check).
+
+### `This profile has no CUPTI_ACTIVITY_KIND_KERNEL table`
+
+```
+This profile has no CUPTI_ACTIVITY_KIND_KERNEL table, so 'top_kernels' cannot run.
+Either the capture did not trace that activity kind, or the export names it something
+this version does not recognise as a variant.
+```
+
+Two genuinely different causes, and the message says so because it cannot tell them apart:
+
+- **The capture did not trace CUDA.** Check the `nsys profile` command that produced it — without
+  `--trace=cuda` (or a default that includes it) there are no kernel rows to find. Confirm with
+  `nsys-ai info`, which reports a kernel count of 0.
+- **The export uses a table name this version does not know.** Newer Nsight releases version their
+  table names. `nsys-ai doctor` reports the export schema version; compare it against
+  [the support matrix](../support-matrix.md).
+
+A third cause used to exist — the profile was read from the wrong storage, so a parquetdir holding
+millions of kernel rows sat unread beside the capture. That path is fixed, but if you see this
+message alongside a populated `.parquetdir`, report it; the symptom describes the capture and the
+cause is elsewhere.
+
+### The results describe a GPU you did not ask for
+
+`root-cause` substitutes a different device when the one you selected has no kernels on it. Multi-GPU
+captures often leave device 0 idle while devices 1-7 do the work, and returning nothing there would
+be less useful than answering about a device that ran something.
+
+The substitution is silent — nothing in the output says it happened. If a per-device number looks
+wrong, check the per-GPU kernel counts in `nsys-ai info` and pass `--gpu` explicitly.
+
+## The command is slow
+
+### The first command on a capture takes seconds before printing anything
+
+```
+[nsys-ai] Building analysis cache for a 634MB profile (~6s, once per profile) ...
+```
+
+Expected. The capture is being converted once into a form queries can run against, and the result is
+written beside it. Every later command on the same capture starts immediately. See
+[What to hand nsys-ai](./profile-inputs.md).
+
+If it happens *every* time, the conversion output is not being kept: check that the directory holding
+the capture is writable, and that the capture's modification time is not being updated by whatever
+copies it into place.
+
+### `Not building an analysis cache … queries will be several times slower`
+
+```
+Not building an analysis cache (<reason>); querying the SQLite export directly.
+Queries will be several times slower.
+```
+
+Free disk or profile size failed the affordability check, so the query cache was skipped. The run is
+correct, just slow. Free space, move the profile to a larger filesystem, or force the cache with
+`NSYS_AI_CACHE_MODE=parquet` if you know the space is there.
+
+This is a warning rather than an error precisely so it is visible — a silently degraded run is worse
+than a slow one you know about.
+
+### Queries spill or run out of memory on a large capture
+
+Set `NSYS_AI_DUCKDB_TEMP_DIRECTORY` to a filesystem with room, and lower `NSYS_AI_DUCKDB_THREADS` if
+the machine is shared. Both are in [Environment variables](./environment-variables.md).
+
+## Some commands need more than a path
+
+Fourteen commands will not run on a profile path alone. This is by design, but the argparse message
+is terse, so here is what each one wants:
+
+| Command | Also needs |
+|---|---|
+| `diff`, `diff-web`, `review` | A second profile — `<before> <after>` (`diff` also accepts `--against`; `review` also accepts `--session`) |
+| `export` | `--trim` |
+| `report` | `--gpu` and `--trim` |
+| `optimize` | `--repo` |
+| `propose` | `--finding-id` |
+| `ask` | A question, as well as the profile |
+| `agent`, `baseline`, `cutracer`, `evidence`, `root-cause`, `skill` | A sub-command first — these are command groups, so it is `skill run <name> <profile>`, not `skill <profile>` |
+
+`chat` additionally requires a real terminal, and refuses with `Error [NOT_A_TERMINAL]` when stdin is
+a pipe. Run it interactively rather than from a script.
+
+## Getting more detail
+
+`nsys-ai doctor <profile>` is the first thing to run and the right thing to attach to a bug report.
+It checks the environment and the capture together, and every failed check carries the command that
+fixes it:
+
+```
+$ nsys-ai doctor perf.sqlite
+Profile: perf.sqlite
+  id: nsys2:sha256:51a2d0fc015ee251f4bb4272ef65586f518d1bf0403761a0f37c3e8a462e0b0c
+
+Profile support
+  SQLite analysis                [OK  ]  stdlib sqlite3
+  .nsys-rep conversion           [OK  ]  /usr/local/bin/nsys
+  Parquet cache                  [OK  ]  duckdb + pyarrow
+
+Profile health
+  Schema compatibility           [OK  ]  export schema 3.25.0
+  Duration                       [OK  ]  1.0s
+  GPUs                           [OK  ]  2
+  GPU model                      [WARN]  unknown
+                                    -> GPU model missing from CUPTI TARGET_INFO;
+                                       MFU / efficiency cannot be computed.
+```
+
+Four sections: **System** (Python, nsys-ai, platform), **Profile support** (whether each backend is
+usable at all), **Optional features** (AI providers, CUTracer), and **Profile health** (the capture's
+own schema version, duration, and GPUs).
+
+`[WARN]` is worth reading rather than skipping. The example above explains why an MFU number will be
+missing later, at the point where the cause is visible rather than at the point where the number is
+absent.
+
+`doctor` also accepts `--format json`. So do `diff`, `skill run`, `skill list`, `evidence build` and
+`cutracer analyze` — six commands in total, not all of them, so check `--help` before assuming it is
+available. The JSON output usually carries fields the human-readable rendering omits.
+
+## Related
+
+- [What to hand nsys-ai](./profile-inputs.md) — the three inputs and how they are chosen
+- [Time windows](./time-windows.md) — `--trim`, `--iteration`, and the capture clock
+- [Environment variables](./environment-variables.md) — every tuning knob and its default
+- [Support matrix](../support-matrix.md) — export schema versions covered by tests

--- a/site/index.html
+++ b/site/index.html
@@ -551,7 +551,7 @@
         <a href="/" class="nav-brand">nsys-ai</a>
         <div class="nav-links">
             <a href="https://pypi.org/project/nsys-ai/">PyPI</a>
-            <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/01-cli-reference.md">Docs</a>
+            <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/README.md">Docs</a>
             <a href="https://github.com/GindaChen/nsys-ai" class="github-btn">
                 <svg viewBox="0 0 16 16">
                     <path
@@ -765,6 +765,24 @@
             <h2>📚 Documentation</h2>
             <p class="subtitle">Comprehensive guides for Nsight Systems profiling</p>
             <div class="docs-grid">
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user/profile-inputs.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">What to hand nsys-ai</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">User guide</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/doctor.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">doctor</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/support-matrix.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">Support matrix</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/ci-diff-gate.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">CI diff gate</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/ingest-policy.md" class="doc-link">
+                    <span class="doc-num">dev</span><span class="doc-title">Ingest policy</span>
+                </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/01-cli-reference.md" class="doc-link">
                     <span class="doc-num">01</span><span class="doc-title">CLI Reference</span>
                 </a>

--- a/site/index.html
+++ b/site/index.html
@@ -768,6 +768,15 @@
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user/profile-inputs.md" class="doc-link">
                     <span class="doc-num">→</span><span class="doc-title">What to hand nsys-ai</span>
                 </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user/time-windows.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">Time windows</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user/troubleshooting.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">Troubleshooting</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user/environment-variables.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">Environment variables</span>
+                </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md" class="doc-link">
                     <span class="doc-num">→</span><span class="doc-title">User guide</span>
                 </a>

--- a/tests/test_docs_index.py
+++ b/tests/test_docs_index.py
@@ -1,0 +1,73 @@
+"""Documentation is findable, asserted rather than assumed.
+
+There are two hand-maintained indexes — `docs/README.md` for people reading the repository and
+`site/index.html` for people arriving at the project page — and nothing connected them. They had
+already drifted: the site listed eight numbered files and none of the project guides.
+
+A page nobody can reach is not written, so both indexes are checked here. The check is deliberately
+narrow: it covers `docs/user/` and `docs/dev/`, the two directories whose contents are meant to be
+navigable, and says nothing about the rest of `docs/`.
+"""
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+DOCS = REPO / "docs"
+README = DOCS / "README.md"
+SITE = REPO / "site" / "index.html"
+
+#: Directories whose pages must appear in both indexes.
+INDEXED_DIRECTORIES = ("user", "dev")
+
+
+def _indexed_pages() -> list[str]:
+    pages = []
+    for directory in INDEXED_DIRECTORIES:
+        for path in sorted((DOCS / directory).glob("*.md")):
+            pages.append(f"{directory}/{path.name}")
+    return pages
+
+
+def test_there_is_something_to_index():
+    """Guard the guard: an empty glob would make every assertion below vacuous."""
+    pages = _indexed_pages()
+    assert pages, f"no pages found under {INDEXED_DIRECTORIES}; the check below would pass on nothing"
+
+
+def test_every_page_is_listed_in_the_repository_index():
+    body = README.read_text(encoding="utf-8")
+    missing = [page for page in _indexed_pages() if f"./{page}" not in body]
+    assert not missing, (
+        "pages missing from docs/README.md: "
+        + ", ".join(missing)
+        + "\n\nAdd a row to its file index. A page nobody can find is not written."
+    )
+
+
+def test_every_page_is_linked_from_the_site():
+    body = SITE.read_text(encoding="utf-8")
+    missing = [page for page in _indexed_pages() if f"/docs/{page}" not in body]
+    assert not missing, (
+        "pages missing from site/index.html: "
+        + ", ".join(missing)
+        + "\n\nDocumentation is not published to the site — the landing page links GitHub blobs — so a"
+        " new page is invisible there until this list is edited."
+    )
+
+
+def test_site_doc_links_point_at_files_that_exist():
+    """A link to a renamed or deleted page is worse than no link."""
+    body = SITE.read_text(encoding="utf-8")
+    linked = set(re.findall(r"blob/main/(docs/[^\"'\s]+\.(?:md|html))", body))
+    assert linked, "no documentation links found in site/index.html"
+    broken = sorted(path for path in linked if not (REPO / path).is_file())
+    assert not broken, "site/index.html links to files that do not exist: " + ", ".join(broken)
+
+
+def test_repository_index_links_point_at_files_that_exist():
+    body = README.read_text(encoding="utf-8")
+    linked = set(re.findall(r"\]\(\./([^)]+\.(?:md|html))\)", body))
+    assert linked, "no documentation links found in docs/README.md"
+    broken = sorted(path for path in linked if not (DOCS / path).is_file())
+    assert not broken, "docs/README.md links to files that do not exist: " + ", ".join(broken)

--- a/tests/test_docs_index.py
+++ b/tests/test_docs_index.py
@@ -71,3 +71,32 @@ def test_repository_index_links_point_at_files_that_exist():
     assert linked, "no documentation links found in docs/README.md"
     broken = sorted(path for path in linked if not (DOCS / path).is_file())
     assert not broken, "docs/README.md links to files that do not exist: " + ", ".join(broken)
+
+
+def _heading_anchors(path: Path) -> set[str]:
+    """GitHub's slug rule, reduced to what these documents actually use."""
+    anchors = set()
+    for heading in re.findall(r"^#+\s+(.+)$", path.read_text(encoding="utf-8"), re.M):
+        slug = re.sub(r"[^a-z0-9\s-]", "", heading.lower()).strip().replace(" ", "-")
+        anchors.add(slug)
+    return anchors
+
+
+def test_cross_page_links_resolve():
+    """The pages link to each other heavily, so a rename breaks navigation silently.
+
+    Anchors are checked too. A link to a section that has been retitled still renders as a
+    working link and lands the reader at the top of the page, which is the failure that is
+    hardest to notice by reading the diff.
+    """
+    broken = []
+    for page in _indexed_pages():
+        path = DOCS / page
+        for _text, target in re.findall(r"\[([^\]]+)\]\((\.[^)]+)\)", path.read_text(encoding="utf-8")):
+            file_part, _, anchor = target.partition("#")
+            destination = (path.parent / file_part).resolve()
+            if not destination.is_file():
+                broken.append(f"{page} -> {target} (no such file)")
+            elif anchor and anchor not in _heading_anchors(destination):
+                broken.append(f"{page} -> {target} (no such heading)")
+    assert not broken, "broken links between documentation pages:\n  " + "\n  ".join(broken)


### PR DESCRIPTION
## Summary

- Document what a user can hand nsys-ai and how each input is read, now that `.nsys-rep` resolves to a parquetdir by default.
- Document the ingest policy for maintainers, including why call sites must go through it rather than deriving paths themselves.
- Split the user documentation into one page per question — task, concept, reference and troubleshooting — rather than one page that answers five.
- Split `docs/` into `user/` and `dev/`, and make index drift a test failure instead of a habit.

## Changes

**User guide — four pages, one job each**

- `docs/user/profile-inputs.md` — the task page. The three accepted inputs, what the first conversion writes, what triggers a rebuild, and `NSYS_AI_INGEST`.
- `docs/user/time-windows.md` — the concept page. Why the capture clock does not start at zero, what `--trim` is measured against, `--iteration` as the alternative, and how the two combine (`skill run` refuses the pair, `diff` composes it).
- `docs/user/troubleshooting.md` — organised by symptom rather than by subsystem, each entry quoting the message verbatim and saying what to change.
- `docs/user/environment-variables.md` — a reference table of all fifteen `NSYS_AI_*` variables with their defaults, followed by notes on the interactions that are not obvious from the table. None of these were documented anywhere.

The first of those had grown to answer five different questions — what to hand it, why the first run is slow, which commands need extra flags, how time windows work, and why analysis comes back empty. It now answers the first and links the rest.

**Developer guide**

- `docs/dev/ingest-policy.md` — `ProfileResolution`, the three entry points and when each applies, the decision table, the reuse/staleness rule, the current call sites, and what a change here has to preserve. The `NSYS_AI_INGEST` versus `NSYS_AI_CACHE_MODE` section now covers where each is *consumed* and defers their values to the reference page.

**Correction**

- `docs/user-guide.md` said of `profile.sqlite`: *"The exported profile. Every other command reads this."* That stopped being true when `.nsys-rep` began resolving to a parquetdir. Corrected, and the "skip this step" paragraph now names all three inputs and links the new page.

**Indexes**

- `docs/README.md` — one flat table of nineteen files became three sections: user guide, developer guide, and Nsight Systems reference. The version-awareness note moved under the reference section, which is what it is about.
- `site/index.html` — adds the three new pages to the documentation grid.

**Tests**

- `tests/test_docs_index.py` — asserts every page under `docs/user/` and `docs/dev/` appears in both indexes, and that neither index links a file that does not exist.
- Adds a check that links *between* pages resolve, anchors included. The split multiplies cross-references, and a link to a retitled section still renders as a working link that silently lands the reader at the top of the page — the failure hardest to catch by reading a diff.

## Backward compatibility

Yes. Documentation and tests; no source changes.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally — 2450 passed, 141 skipped, 4 xfailed
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path

Every command line, flag, default and error message quoted in these pages was run and copied from its
output rather than read from the source. That caught six errors in my own first draft, which are worth
listing because they are the kind a reviewer cannot see:

- `--trim` is accepted by 31 commands across two parsers, not the 11 top-level ones. The CLI has a
  second, legacy parser reached through `LEGACY_ROUTED_COMMANDS`, invisible to a scan of `_build_parser`.
- `--iteration` is on `diff` as well as `skill run`, and the two commands treat `--iteration` with
  `--trim` differently — one refuses the pair, the other composes it.
- `--format json` is on six commands, not "most".
- `doctor` prints no table inventory; it prints System, Profile support, Optional features and Profile health.
- `NSYS_AI_INGEST=sqlite` also forces the cache mode to `direct`, so it silently disables the query
  cache — a more useful thing to document than the vague "slower on large captures" I had written.
- The trim-range guard is skipped by six commands, not the one I first found.

The index test was checked in both directions: adding a page missing from the indexes fails it, and
retitling a linked section fails the new anchor check.

## Out of scope

- The remaining `#482` pages: session contract, skill execution pipeline, surface adapter principles, RunSpec/verification contract, diff and verdict usage, known limits, and the 0.3.0 migration note.
- Fixing the six commands that skip the trim-range check. Filed as #486; these pages document the current behaviour, and #486 carries updating them as an acceptance criterion.
- Publishing the documentation to the site. The landing page still links GitHub blobs, which is why the index has to be maintained by hand and why the test exists.

## Linked issues

Part of #482.
