### PR TITLE
feat(timeline): keep workflow discoverable at edge

### DIFF
--- a/src/nsys_ai/templates/timeline.css
+++ b/src/nsys_ai/templates/timeline.css
@@ -771,6 +771,58 @@
             display: flex;
         }
 
+        #workflowEdgeTab {
+            position: absolute;
+            top: 50%;
+            right: 0;
+            z-index: 25;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 5px;
+            min-width: 34px;
+            max-width: 42px;
+            padding: 10px 7px;
+            border: 1px solid var(--border);
+            border-right: none;
+            border-radius: 7px 0 0 7px;
+            background: var(--surface-raised);
+            color: var(--accent);
+            box-shadow: -3px 4px 12px rgba(0, 0, 0, 0.28);
+            cursor: pointer;
+            font: 600 10px var(--font-ui);
+            transform: translateY(-50%);
+            writing-mode: vertical-rl;
+        }
+
+        #workflowEdgeTab:hover,
+        #workflowEdgeTab:focus-visible {
+            background: var(--accent-subtle);
+            border-color: var(--accent-dim);
+            color: var(--text);
+            outline: none;
+        }
+
+        #workflowEdgeTab[hidden] {
+            display: none;
+        }
+
+        #workflowEdgeProgress {
+            color: var(--text-dim);
+            font-size: 9px;
+        }
+
+        @media (max-width: 960px) {
+            #workflowEdgeTab {
+                top: auto;
+                bottom: 24px;
+                max-width: none;
+                border-right: 1px solid var(--border);
+                writing-mode: horizontal-tb;
+                transform: none;
+            }
+        }
+
         #inspectorTabs {
             min-height: 42px;
             flex-shrink: 0;

--- a/src/nsys_ai/templates/timeline.html
+++ b/src/nsys_ai/templates/timeline.html
@@ -216,6 +216,11 @@
                 </section>
             </div>
         </div>
+        <button type="button" id="workflowEdgeTab" aria-controls="inspectorRail" aria-expanded="false"
+            aria-label="Open Workflow inspector" title="Open Workflow inspector (W)" onclick="toggleLoop()">
+            <span id="workflowEdgeLabel">Workflow</span>
+            <span id="workflowEdgeProgress" aria-hidden="true"></span>
+        </button>
     </div>
     <div class="tooltip" id="tooltip" style="display:none"></div>
     <div class="settings-panel" id="settingsPanel" style="display:none">

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -3203,6 +3203,12 @@ function updateWorkflowEdgeTab() {
         : 'Open Workflow inspector');
 }
 
+function applyLoopState(state) {
+    LOOP_STATE = state || {};
+    updateWorkflowEdgeTab();
+    loopRenderState();
+}
+
 function toggleChat() {
     toggleInspector('chat');
 }
@@ -4377,8 +4383,7 @@ async function loopFetchState() {
     let data = {};
     try { data = text ? JSON.parse(text) : {}; } catch (_) { data = {}; }
     if (!resp.ok) throw new Error(data.error || text || resp.statusText);
-    LOOP_STATE = data;
-    loopRenderState();
+    applyLoopState(data);
     return LOOP_STATE;
 }
 
@@ -4393,13 +4398,11 @@ async function loopPost(path, payload) {
     try { data = text ? JSON.parse(text) : {}; } catch (_) { data = {}; }
     if (!resp.ok) {
         if (data.state) {
-            LOOP_STATE = data.state;
-            loopRenderState();
+            applyLoopState(data.state);
         }
         throw new Error(data.error || text || resp.statusText);
     }
-    LOOP_STATE = data.state || data;
-    loopRenderState();
+    applyLoopState(data.state || data);
     return data;
 }
 
@@ -4408,7 +4411,6 @@ function loopRenderState() {
     const phase = LOOP_STATE.phase || 'diagnose';
     const phaseIdx = LOOP_PHASE_ORDER.indexOf(phase);
     const suggested = loopSuggestedPhase(LOOP_STATE);
-    updateWorkflowEdgeTab();
 
     const badge = document.getElementById('loopPhaseBadge');
     if (badge) badge.textContent = phase.charAt(0).toUpperCase() + phase.slice(1);

--- a/src/nsys_ai/templates/timeline.js
+++ b/src/nsys_ai/templates/timeline.js
@@ -3160,6 +3160,7 @@ function setInspectorMode(mode) {
         const button = document.getElementById(buttonId);
         if (button) button.classList.toggle('active', buttonMode === mode);
     }
+    updateWorkflowEdgeTab();
 
     if (mode === 'chat') {
         const input = document.getElementById('chatInput');
@@ -3176,6 +3177,30 @@ function closeInspector() {
 
 function toggleInspector(mode) {
     setInspectorMode(activeInspectorMode === mode ? null : mode);
+}
+
+function updateWorkflowEdgeTab() {
+    const tab = document.getElementById('workflowEdgeTab');
+    if (!tab) return;
+
+    const railOpen = Boolean(activeInspectorMode);
+    tab.hidden = railOpen;
+    tab.setAttribute('aria-expanded', activeInspectorMode === 'loop' ? 'true' : 'false');
+
+    const label = document.getElementById('workflowEdgeLabel');
+    const progress = document.getElementById('workflowEdgeProgress');
+    const phase = LOOP_STATE?.phase || '';
+    const phaseIdx = LOOP_PHASE_ORDER.indexOf(phase);
+    const step = phaseIdx >= 0 ? phaseIdx + 1 : null;
+    const phaseLabel = phase ? phase.charAt(0).toUpperCase() + phase.slice(1) : '';
+    if (label) label.textContent = phaseLabel || 'Workflow';
+    if (progress) progress.textContent = step ? `${step}/${LOOP_PHASE_ORDER.length}` : '';
+    tab.title = step
+        ? `Open Workflow: ${phaseLabel} (${step}/${LOOP_PHASE_ORDER.length})`
+        : 'Open Workflow inspector (W)';
+    tab.setAttribute('aria-label', step
+        ? `Open Workflow inspector, ${phaseLabel}, step ${step} of ${LOOP_PHASE_ORDER.length}`
+        : 'Open Workflow inspector');
 }
 
 function toggleChat() {
@@ -4383,6 +4408,7 @@ function loopRenderState() {
     const phase = LOOP_STATE.phase || 'diagnose';
     const phaseIdx = LOOP_PHASE_ORDER.indexOf(phase);
     const suggested = loopSuggestedPhase(LOOP_STATE);
+    updateWorkflowEdgeTab();
 
     const badge = document.getElementById('loopPhaseBadge');
     if (badge) badge.textContent = phase.charAt(0).toUpperCase() + phase.slice(1);

--- a/tests/test_timeline_web_data.py
+++ b/tests/test_timeline_web_data.py
@@ -235,6 +235,11 @@ def test_timeline_web_template_uses_external_assets(minimal_nsys_db_path):
     assert 'id="inspectorTabChat"' in html
     assert 'id="inspectorTabFindings"' in html
     assert 'id="inspectorTabLoop"' in html
+    assert 'id="workflowEdgeTab"' in html
+    assert 'id="workflowEdgeLabel"' in html
+    assert 'id="workflowEdgeProgress"' in html
+    assert 'aria-controls="inspectorRail"' in html
+    assert 'onclick="toggleLoop()"' in html
     assert 'data-inspector-panel="chat"' in html
     assert 'data-inspector-panel="findings"' in html
     assert 'data-inspector-panel="loop"' in html
@@ -267,6 +272,17 @@ def test_timeline_web_template_has_nvtx_command_controls(minimal_nsys_db_path):
     assert 'id="chatCapabilities"' in html
     assert "fit_nvtx_range" in html
     assert "Go to NVTX" in html
+
+
+def test_workflow_edge_tab_contract_is_wired():
+    css = Path("src/nsys_ai/templates/timeline.css").read_text(encoding="utf-8")
+    js = Path("src/nsys_ai/templates/timeline.js").read_text(encoding="utf-8")
+
+    assert "#workflowEdgeTab[hidden]" in css
+    assert "@media (max-width: 960px)" in css
+    assert "function updateWorkflowEdgeTab()" in js
+    assert "tab.hidden = railOpen" in js
+    assert "loopRenderState()" in js
 
 
 def test_timeline_template_declutters_inspector_and_annotations(minimal_nsys_db_path):

--- a/tests/test_timeline_web_data.py
+++ b/tests/test_timeline_web_data.py
@@ -1,5 +1,6 @@
 import json
 import sqlite3
+import subprocess
 from pathlib import Path
 
 from nsys_ai.profile import Profile
@@ -281,8 +282,77 @@ def test_workflow_edge_tab_contract_is_wired():
     assert "#workflowEdgeTab[hidden]" in css
     assert "@media (max-width: 960px)" in css
     assert "function updateWorkflowEdgeTab()" in js
-    assert "tab.hidden = railOpen" in js
-    assert "loopRenderState()" in js
+    assert "function applyLoopState(state)" in js
+
+
+def _extract_js_function(source, name):
+    marker = f"function {name}("
+    start = source.index(marker)
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"unterminated JavaScript function: {name}")
+
+
+def test_workflow_edge_tab_wiring_changes_real_dom_state():
+    source = Path("src/nsys_ai/templates/timeline.js").read_text(encoding="utf-8")
+    update_tab = _extract_js_function(source, "updateWorkflowEdgeTab")
+    apply_state = _extract_js_function(source, "applyLoopState")
+    set_mode = _extract_js_function(source, "setInspectorMode")
+
+    harness = f"""
+const elements = new Map();
+function element() {{
+    return {{
+        hidden: false,
+        textContent: '',
+        title: '',
+        attrs: {{}},
+        classList: {{ toggle() {{}} }},
+        setAttribute(name, value) {{ this.attrs[name] = value; }},
+        focus() {{}},
+    }};
+}}
+for (const id of [
+    'workflowEdgeTab', 'workflowEdgeLabel', 'workflowEdgeProgress', 'inspectorRail',
+    'chatSidebar', 'findingsSidebar', 'loopSidebar', 'inspectorTabChat',
+    'inspectorTabFindings', 'inspectorTabLoop', 'chatBtn', 'findingsBtn', 'loopBtn',
+]) elements.set(id, element());
+const document = {{ getElementById(id) {{ return elements.get(id) || null; }} }};
+const FINDINGS = [];
+const INSPECTOR_PANELS = {{ chat: 'chatSidebar', findings: 'findingsSidebar', loop: 'loopSidebar' }};
+const LOOP_PHASE_ORDER = ['diagnose', 'propose', 'reprofile', 'diff', 'accept'];
+let activeInspectorMode = null;
+let LOOP_STATE = null;
+function loopFetchState() {{}}
+function loopRenderState() {{}}
+function resize() {{}}
+{update_tab}
+{apply_state}
+{set_mode}
+
+setInspectorMode('chat');
+if (!elements.get('workflowEdgeTab').hidden) throw new Error('edge tab stayed visible while inspector was open');
+setInspectorMode(null);
+if (elements.get('workflowEdgeTab').hidden) throw new Error('edge tab stayed hidden after inspector close');
+applyLoopState({{ phase: 'diff' }});
+if (elements.get('workflowEdgeLabel').textContent !== 'Diff') throw new Error('edge tab phase was not updated');
+if (elements.get('workflowEdgeProgress').textContent !== '4/5') throw new Error('edge tab progress was not updated');
+"""
+    result = subprocess.run(
+        ["node", "--input-type=commonjs"],
+        input=harness,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
 
 
 def test_timeline_template_declutters_inspector_and_annotations(minimal_nsys_db_path):


### PR DESCRIPTION
## Summary

Implements #487 as a small follow-up to #395/#396.

- Keep a narrow Workflow tab at the right edge while the shared inspector is closed.
- Show the current loop phase and progress (`n/5`) when loop state is available.
- Reopen the existing shared inspector through `toggleInspector('loop')` / `toggleLoop()`.
- Hide the edge tab while Chat, Evidence, or Workflow is open.
- Preserve the loop/session state and existing toolbar/keyboard behavior.
- Use a horizontal edge action on narrow viewports while retaining the responsive drawer.
- Add template, CSS/JS contract coverage.

## Verification

- `PYTHONPATH="$PWD/src" pytest -q tests/test_timeline_web_data.py tests/test_loop_api.py tests/test_loop_state.py tests/test_timeline_logic.py tests/test_web_foundation.py tests/test_web_session.py` — 82 passed
- `node --check src/nsys_ai/templates/timeline.js` — passed
- `git diff --check` — passed
- Real profile smoke with `/home/rich-wsl/fastvideo/profile_results/perf.nsys-rep`:
  - timeline web started successfully
  - `/` contained the shared inspector and Workflow edge-tab contract
  - `/assets/timeline.css` and `/assets/timeline.js` returned 200
  - `/api/loop/state` returned the active session and `diagnose` phase

## Scope

Presentation/discoverability only. The loop state machine, session artifacts, API routes, and shared inspector ownership are unchanged.
