### PR TITLE
fix(cli): guard every trim consumer

### DIFF
--- a/docs/user/time-windows.md
+++ b/docs/user/time-windows.md
@@ -62,30 +62,25 @@ captures rarely share a clock — the example above is a real pair whose windows
 
 A window that *partly* overlaps is accepted and clipped. That is a legitimate request.
 
-### Commands that do not check
+### Commands that check
 
-Six commands skip this check. Given a window that selects nothing they produce an empty result
-rather than an error:
+The profile-backed commands apply the same check. Given a window that selects nothing they reject it
+with `Error [TRIM_OUT_OF_RANGE]` rather than returning an empty result that could be mistaken for a
+profile with no kernels:
 
 ```
 $ nsys-ai skill run top_kernels perf.sqlite --trim 0 1
-(No kernels found)
+Error [TRIM_OUT_OF_RANGE]: --trim 0.000 1.000 selects no part of this profile…
 ```
 
-| Command | What you get instead of an error |
+| Command | Out-of-range behavior |
 |---|---|
-| `skill run` | `(No kernels found)` |
-| `agent analyze` | A report header, then `(No kernels found)` |
-| `cutracer plan`, `cutracer analyze`, `cutracer run` | `(No kernels found — nothing to instrument)` |
-| `diff-web` | A served page with an empty comparison on it |
+| `skill run`, `agent analyze` | Coded `TRIM_OUT_OF_RANGE` error |
+| `cutracer plan`, `cutracer analyze`, `cutracer run` | Coded `TRIM_OUT_OF_RANGE` error |
+| `diff-web` | Coded `TRIM_OUT_OF_RANGE` error before the server starts |
 
-That output is indistinguishable from a capture that genuinely has no kernels, which is the whole
-reason the check exists elsewhere. `diff-web` is the most confusing of the six, because the empty
-result is a rendered page rather than a line of text.
-
-Until this is unified, treat an unexpected empty result from any of the six as a trim-window question
-first: re-run the same window through `diagnose`, which does check, and it will tell you whether the
-window or the capture is the problem.
+A window that partly overlaps is still accepted and clipped. A genuinely empty capture remains a
+valid empty result; the guard only rejects a requested window that selects no part of the capture.
 
 ## Selecting an iteration instead of seconds
 

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -61,10 +61,10 @@ Almost always the capture clock. `--trim` is measured on Nsight's clock, which d
 zero, so a window that looks reasonable can sit entirely before the first event. Run `nsys-ai info`
 to see the real window. [Time windows](./time-windows.md) covers this in full.
 
-Six commands do not perform this check and return an empty result instead of an error: `skill run`,
-`agent analyze`, `diff-web`, and the three `cutracer` sub-commands. If one of them comes back empty,
-re-run the same window through `diagnose`, which does check. See
-[Time windows](./time-windows.md#commands-that-do-not-check).
+These commands now reject an out-of-range `--trim` window before analysis starts. If a legitimate
+in-range request comes back empty, inspect the profile's activity coverage rather than treating the
+empty result as proof that the requested window was outside the capture. See
+[Time windows](./time-windows.md#commands-that-check).
 
 ### `This profile has no CUPTI_ACTIVITY_KIND_KERNEL table`
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -216,6 +216,7 @@ def _cutracer_analyze(args, _profile):
     fmt = getattr(args, "format", "table")
     # cutracer_analysis skill expects trim in nanoseconds.
     trim = _parse_trim(args)
+    _check_trim_window_for_path(trim, profile_path, _profile)
 
     if not trace_dir.exists():
         print(f"Error: trace_dir not found: {trace_dir}", file=sys.stderr)
@@ -254,6 +255,7 @@ def _cutracer_run(args, _profile):
     device = getattr(args, "device", 0) or 0
     # build_plan expects (start_s, end_s) and performs ns conversion itself.
     trim = tuple(args.trim) if getattr(args, "trim", None) else None
+    trim_ns = _parse_trim(args)
     dry_run = getattr(args, "dry_run", False)
     backend = getattr(args, "backend", "local")
     modal_save = getattr(args, "modal_save", None)
@@ -270,6 +272,7 @@ def _cutracer_run(args, _profile):
         )
 
     with _profile.open(profile_path) as prof:
+        _check_trim_window(trim_ns, prof)
         plan = build_plan(
             prof.conn,
             profile_path=profile_path,
@@ -402,6 +405,7 @@ def _cutracer_plan(args, _profile):
     profile_path = args.profile
     # build_plan expects (start_s, end_s) and performs ns conversion itself.
     trim = tuple(args.trim) if getattr(args, "trim", None) else None
+    trim_ns = _parse_trim(args)
     top_n = getattr(args, "top_n", 5)
     device = getattr(args, "device", 0) or 0
     output_dir = getattr(args, "output_dir", "./cutracer_out") or "./cutracer_out"
@@ -410,6 +414,7 @@ def _cutracer_plan(args, _profile):
     save_path = getattr(args, "save", None)
 
     with _profile.open(profile_path) as prof:
+        _check_trim_window(trim_ns, prof)
         plan = build_plan(
             prof.conn,
             profile_path=profile_path,
@@ -1550,6 +1555,8 @@ def _cmd_diff_web(args, _profile):
     from nsys_ai.diff_web import serve_diff_web
 
     trim = _parse_trim(args)
+    _check_trim_window_for_path(trim, args.before, _profile, label="before")
+    _check_trim_window_for_path(trim, args.after, _profile, label="after")
     with _profile.open(args.before) as before, _profile.open(args.after) as after:
         serve_diff_web(
             before,
@@ -2202,6 +2209,7 @@ def _cmd_skill(args, _profile):
 
         fmt = getattr(args, "format", "text")
         no_cache = getattr(args, "no_cache", False)
+        trim = getattr(args, "trim", None)
         # Same ingest policy and three-tier SQLite fallback as Profile and
         # open_profile_readonly. This also makes .nsys-rep inputs use their
         # existing parquetdir instead of treating the capture as SQLite.
@@ -2217,13 +2225,14 @@ def _cmd_skill(args, _profile):
 
         # Build trim kwargs if --trim was provided
         trim_kwargs = {}
-        trim = getattr(args, "trim", None)
         if trim:
             trim_kwargs["trim_start_ns"] = int(trim[0] * 1e9)
             trim_kwargs["trim_end_ns"] = int(trim[1] * 1e9)
 
         # Resolve --iteration N to trim range (conflicts with --trim)
         iteration_n = getattr(args, "iteration", None)
+        if trim and iteration_n is None:
+            _check_trim_window_for_path(_parse_trim(args), args.profile, _profile)
         if iteration_n is not None:
             if trim:
                 print("Error: --iteration and --trim cannot be used together", file=sys.stderr)
@@ -2482,6 +2491,7 @@ def _cmd_agent(args, _profile):
         trim = getattr(args, "trim", None)
         if trim:
             trim_ns = (int(trim[0] * 1e9), int(trim[1] * 1e9))
+            _check_trim_window_for_path(trim_ns, args.profile, _profile)
         agent = Agent(args.profile, trim_ns=trim_ns)
         try:
             print(agent.analyze())

--- a/tests/test_cli_usage_errors.py
+++ b/tests/test_cli_usage_errors.py
@@ -232,6 +232,39 @@ def test_session_verbs_reject_trim_outside_the_profile_window(command, extra):
         assert "before profile:" in result.stderr, result.stderr
 
 
+@pytest.mark.parametrize(
+    ("command", "args", "needs_side_label"),
+    [
+        ("skill", ["run", "top_kernels"], False),
+        ("agent", ["analyze"], False),
+        ("cutracer", ["plan"], False),
+        ("cutracer", ["analyze", str(ROOT / "tests" / "fixtures" / "cutracer")], False),
+        ("cutracer", ["run", "--launch-cmd", "true", "--dry-run"], False),
+        ("diff-web", [str(PROFILE)], True),
+    ],
+)
+def test_every_trim_consumer_rejects_an_out_of_range_window(command, args, needs_side_label):
+    """Every profile-backed --trim entry point must share the range guard."""
+    if command == "skill":
+        argv = [command, *args, str(PROFILE), "--trim", "0", "1", "--format", "json"]
+    elif command == "agent":
+        argv = [command, *args, str(PROFILE), "--trim", "0", "1"]
+    elif command == "cutracer":
+        argv = [command, *args, str(PROFILE), "--trim", "0", "1"]
+        if args[0] == "analyze":
+            argv = [command, *args[:1], str(PROFILE), args[1], "--trim", "0", "1"]
+    else:
+        argv = [command, str(PROFILE), str(PROFILE), "--trim", "0", "1", "--no-browser"]
+
+    result = _run_cli(*argv, timeout=30.0)
+
+    assert result.returncode == 2, (argv, result.returncode, result.stdout, result.stderr)
+    assert "Traceback" not in result.stdout + result.stderr
+    assert "Error [TRIM_OUT_OF_RANGE]:" in result.stderr, result.stderr
+    if needs_side_label:
+        assert "before profile:" in result.stderr, result.stderr
+
+
 def test_optimize_checks_trim_before_starting_the_loop(monkeypatch):
     """An invalid optimize window must stop before the runner can capture."""
     from argparse import Namespace


### PR DESCRIPTION
## Summary

Fixes #486 by routing every profile-backed `--trim` consumer through the existing range guard.

- Guard `skill run` and `agent analyze` before analysis starts.
- Guard `cutracer plan`, `cutracer analyze`, and `cutracer run`.
- Guard both `diff-web` profiles before starting the server, preserving the `before profile:` / `after profile:` label.
- Keep the explicit `--iteration` conflict behavior unchanged.
- Update the time-window and troubleshooting documentation to describe the unified behavior.
- Add one regression matrix covering all six commands.

## Verification

- `tests/test_cli_usage_errors.py` — 33 passed
- `tests/test_cli.py` — 69 passed
- `tests/test_profile_modes.py` — 26 passed
- `ruff check` and `git diff --check` — passed
- Real CLI smoke against `tests/fixtures/h100_2gpu_1s.sqlite`: all six commands returned exit 2 with `Error [TRIM_OUT_OF_RANGE]`; `diff-web` identified `before profile:` and did not start a server.

## Scope

The existing `_check_trim_window` implementation and error contract are unchanged. This PR only closes the unguarded call sites and corrects the documentation.
