### PR TITLE
feat(web): expose shared runner ask transport

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -180,8 +180,7 @@ evidence, and the evidence-first answer:
 ```console
 $ curl -s http://127.0.0.1:8144/api/ask \
     -H 'Content-Type: application/json' \
-    -d '{"session_id":"run-001","session_root":"/tmp/nsys-run-001",\
-         "question":"what is the bottleneck?","use_llm":false}'
+    -d '{"session_id":"run-001","session_root":"/tmp/nsys-run-001","question":"what is the bottleneck?","use_llm":false}'
 ```
 
 `use_llm` is optional. When enabled and a provider is configured, the model may triage or summarize

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -173,6 +173,20 @@ The directory is the contract: its `session.json` and artifacts are opened by th
 TUI from any working directory. A bare value such as `--session run-001` remains supported and
 continues to mean `.nsys-ai/sessions/run-001` relative to the current directory.
 
+The Web viewer exposes the same ask workflow as JSON at `POST /api/ask`. Pass either a profile path
+or a session handoff directory; the response includes the selected registered skills, structured
+evidence, and the evidence-first answer:
+
+```console
+$ curl -s http://127.0.0.1:8144/api/ask \
+    -H 'Content-Type: application/json' \
+    -d '{"session_id":"run-001","session_root":"/tmp/nsys-run-001",\
+         "question":"what is the bottleneck?","use_llm":false}'
+```
+
+`use_llm` is optional. When enabled and a provider is configured, the model may triage or summarize
+the registered evidence; it never replaces the runner's skill execution or writes profile SQL.
+
 The optional MCP transport exposes the same read-only handoff as `get_session`; it returns the
 SessionStore projection rather than a second MCP-specific session schema.
 

--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -93,35 +93,17 @@ class Agent:
             log.debug("LLM model/key resolution failed", exc_info=True)
             model, api_key = None, None
         has_llm = bool(model and api_key)
-
-        evidence = runner.run_diagnose_pack(
+        answer, _evidence, _selected = runner.answer_question(
             self.conn,
-            trim_kwargs=self._trim_kwargs,
-            skill_names=["root_cause_matcher"],
-        )
-        triage_rows = evidence.get("root_cause_matcher", [])
-        selected = (
-            self._try_llm_triage(question, triage_rows)
-            if has_llm
-            else self._select_skills(question)
-        )
-        selected = [skill for skill in selected if skill and skill != "root_cause_matcher"]
-        if not selected:
-            selected = list(runner.ASK_FALLBACK)
-        evidence.update(
-            runner.run_diagnose_pack(
-                self.conn, trim_kwargs=self._trim_kwargs, skill_names=selected
-            )
-        )
-        llm_summary = (
-            self._try_llm_synthesis(question, evidence, summary_only=True) if has_llm else None
-        )
-        return self._format_evidence_first_answer(
             question,
-            evidence,
-            selected_skills=["root_cause_matcher", *selected],
-            llm_summary=llm_summary,
+            profile_path=self.profile_path,
+            trim_kwargs=self._trim_kwargs,
+            use_llm=has_llm,
+            profile=self.profile,
+            triage_selector=self._try_llm_triage if has_llm else None,
+            summary_provider=self._try_llm_synthesis if has_llm else None,
         )
+        return answer
 
     def run_skill(self, skill_name: str, **kwargs) -> str:
         """Run one registered skill by name."""

--- a/src/nsys_ai/agent/runner.py
+++ b/src/nsys_ai/agent/runner.py
@@ -151,6 +151,62 @@ def run_question_evidence(
     return evidence, selected
 
 
+def answer_question(
+    conn,
+    question: str,
+    *,
+    profile_path: str = "",
+    trim_kwargs: Mapping | None = None,
+    use_llm: bool = False,
+    profile=None,
+    triage_selector=None,
+    summary_provider=None,
+) -> tuple[str, dict[str, list[dict]], list[str]]:
+    """Run the canonical ask workflow and build its evidence-first answer.
+
+    This is the transport-neutral ask contract.  Callers provide a profile
+    connection and only choose presentation details; triage, the four-skill
+    cap, evidence collection, and answer shaping stay in this runner.
+    ``use_llm`` permits optional planner/synthesizer calls, but the returned
+    answer remains usable and deterministic when no provider is configured.
+    """
+    if triage_selector is None:
+        evidence, selected = run_question_evidence(
+            conn,
+            question,
+            trim_kwargs=trim_kwargs,
+            use_llm=use_llm,
+        )
+    else:
+        evidence = _execute_pack(conn, ["root_cause_matcher"], trim_kwargs)
+        selected = triage_selector(question, evidence.get("root_cause_matcher", []))
+        selected = [
+            skill for skill in selected
+            if skill and skill != "root_cause_matcher" and get_skill(skill) is not None
+        ][:4]
+        if not selected:
+            selected = list(ASK_FALLBACK)[:4]
+        evidence.update(_execute_pack(conn, selected, trim_kwargs))
+    selected_with_triage = ["root_cause_matcher", *selected]
+    llm_summary = None
+    if use_llm:
+        if summary_provider is not None:
+            llm_summary = summary_provider(question, evidence, summary_only=True)
+        else:
+            llm_summary = synthesize_evidence(
+                question, evidence, summary_only=True, profile=profile
+            )
+    answer = format_evidence_first_answer(
+        question,
+        evidence,
+        selected_with_triage,
+        profile_path=profile_path,
+        trim_kwargs=trim_kwargs,
+        llm_summary=llm_summary,
+    )
+    return answer, evidence, selected_with_triage
+
+
 def _first_actionable_row(rows: list[dict]) -> dict | None:
     for row in rows:
         if _is_usable_evidence_row(row):

--- a/src/nsys_ai/agent/runner.py
+++ b/src/nsys_ai/agent/runner.py
@@ -134,15 +134,26 @@ def run_question_evidence(
     *,
     trim_kwargs: Mapping | None = None,
     use_llm: bool = False,
+    skill_selector=None,
 ) -> tuple[dict[str, list[dict]], list[str]]:
-    """Run triage plus selected skills; return evidence and the selected list."""
+    """Run triage plus selected skills; return evidence and the selected list.
+
+    ``skill_selector`` is an optional transport-provided planner hook.  It
+    receives ``(question, triage_rows)`` and returns candidate skill names;
+    the runner still validates them against the registry and applies the
+    four-skill cap.
+    """
     triage = _execute_pack(conn, ["root_cause_matcher"], trim_kwargs)
-    selected = select_skills_for_question(
-        question,
-        triage.get("root_cause_matcher", []),
-        use_llm=use_llm,
-    )
-    selected = [skill for skill in selected if skill != "root_cause_matcher"]
+    triage_rows = triage.get("root_cause_matcher", [])
+    if skill_selector is None:
+        selected = select_skills_for_question(question, triage_rows, use_llm=use_llm)
+    else:
+        selected = skill_selector(question, triage_rows)
+    selected = [
+        skill
+        for skill in (selected if isinstance(selected, (list, tuple)) else [])
+        if skill and skill != "root_cause_matcher" and get_skill(skill) is not None
+    ][:4]
     if not selected:
         selected = list(ASK_FALLBACK)[:4]
     evidence = dict(triage)
@@ -170,23 +181,13 @@ def answer_question(
     ``use_llm`` permits optional planner/synthesizer calls, but the returned
     answer remains usable and deterministic when no provider is configured.
     """
-    if triage_selector is None:
-        evidence, selected = run_question_evidence(
-            conn,
-            question,
-            trim_kwargs=trim_kwargs,
-            use_llm=use_llm,
-        )
-    else:
-        evidence = _execute_pack(conn, ["root_cause_matcher"], trim_kwargs)
-        selected = triage_selector(question, evidence.get("root_cause_matcher", []))
-        selected = [
-            skill for skill in selected
-            if skill and skill != "root_cause_matcher" and get_skill(skill) is not None
-        ][:4]
-        if not selected:
-            selected = list(ASK_FALLBACK)[:4]
-        evidence.update(_execute_pack(conn, selected, trim_kwargs))
+    evidence, selected = run_question_evidence(
+        conn,
+        question,
+        trim_kwargs=trim_kwargs,
+        use_llm=use_llm,
+        skill_selector=triage_selector,
+    )
     selected_with_triage = ["root_cause_matcher", *selected]
     llm_summary = None
     if use_llm:

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -1006,8 +1006,9 @@ def ask_completion(body_bytes: bytes) -> dict:
             profile_path = snapshot.state.before_profile.path
             session_id = location.session_id
             session_root = os.fspath(location.root)
-        except Exception as exc:
-            return {"error": f"could not load session: {exc}"}
+        except Exception:
+            _log.exception("Ask session setup failed")
+            return {"error": "could not load session."}
     if not profile_path:
         return {"error": "ask requires profile_path or session_id."}
 
@@ -1030,8 +1031,9 @@ def ask_completion(body_bytes: bytes) -> dict:
         conn, _sqlite_path, _system_prompt, _query_runner = _prepare_session(
             os.fspath(profile_path), [], {}
         )
-    except Exception as exc:
-        return {"error": f"Profile error: {exc}"}
+    except Exception:
+        _log.exception("Ask profile setup failed")
+        return {"error": "could not load profile."}
 
     try:
         from .agent.runner import answer_question
@@ -1050,9 +1052,9 @@ def ask_completion(body_bytes: bytes) -> dict:
             "evidence": evidence,
             "session_id": session_id,
         }
-    except Exception as exc:
+    except Exception:
         _log.exception("Shared ask runner failed")
-        return {"error": f"Ask error: {exc}"}
+        return {"error": "ask failed.", "_http_status": 500}
     finally:
         conn.close()
 

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -972,6 +972,91 @@ def chat_completion(body_bytes: bytes) -> dict | None:
     return {"content": content, "actions": actions, "findings": []}
 
 
+def ask_completion(body_bytes: bytes) -> dict:
+    """Handle the transport-neutral ``POST /api/ask`` contract.
+
+    Unlike the conversational chat endpoint, this route exposes the shared
+    deterministic runner directly: triage and registered skills produce the
+    evidence, then the runner shapes the answer.  An LLM is optional and is
+    limited to planner/synthesizer work when credentials are available.
+    """
+    try:
+        payload = json.loads(body_bytes.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        return {"error": "Invalid request body."}
+    if not isinstance(payload, dict):
+        return {"error": "JSON object required."}
+
+    question = str(payload.get("question") or "").strip()
+    if not question:
+        return {"error": "question is required."}
+
+    profile_path = payload.get("profile_path")
+    session_id = payload.get("session_id")
+    session_root = payload.get("session_root") or ".nsys-ai/sessions"
+    if not profile_path and session_id:
+        try:
+            from .session_cli import resolve_session_location
+            from .session_store import SessionStore
+
+            location = resolve_session_location(session_id, root=session_root)
+            snapshot = SessionStore(location.root).load(location.session_id)
+            if snapshot.state.before_profile is None:
+                return {"error": "session has no before profile."}
+            profile_path = snapshot.state.before_profile.path
+            session_id = location.session_id
+            session_root = os.fspath(location.root)
+        except Exception as exc:
+            return {"error": f"could not load session: {exc}"}
+    if not profile_path:
+        return {"error": "ask requires profile_path or session_id."}
+
+    trim_kwargs = {}
+    trim_keys = ("trim_start_ns", "trim_end_ns")
+    supplied_trim = [key in payload for key in trim_keys]
+    if any(supplied_trim):
+        if not all(supplied_trim):
+            return {"error": "trim_start_ns and trim_end_ns must be provided together."}
+        try:
+            trim_kwargs = {key: int(payload[key]) for key in trim_keys}
+        except (TypeError, ValueError, OverflowError):
+            return {"error": "trim bounds must be integer nanoseconds."}
+        if trim_kwargs["trim_start_ns"] >= trim_kwargs["trim_end_ns"]:
+            return {"error": "trim_start_ns must be less than trim_end_ns."}
+
+    try:
+        model, api_key = _get_model_and_key(payload.get("model"))
+        use_llm = payload.get("use_llm", True) is not False and bool(model and api_key)
+        conn, _sqlite_path, _system_prompt, _query_runner = _prepare_session(
+            os.fspath(profile_path), [], {}
+        )
+    except Exception as exc:
+        return {"error": f"Profile error: {exc}"}
+
+    try:
+        from .agent.runner import answer_question
+
+        answer, evidence, selected = answer_question(
+            conn,
+            question,
+            profile_path=os.fspath(profile_path),
+            trim_kwargs=trim_kwargs,
+            use_llm=use_llm,
+        )
+        return {
+            "answer": answer,
+            "question": question,
+            "selected_skills": selected,
+            "evidence": evidence,
+            "session_id": session_id,
+        }
+    except Exception as exc:
+        _log.exception("Shared ask runner failed")
+        return {"error": f"Ask error: {exc}"}
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # SSE helper
 # ---------------------------------------------------------------------------

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -276,6 +276,18 @@ def _handle_chat_request(body_bytes: bytes) -> dict | None:
     return None
 
 
+def _handle_ask_request(body_bytes: bytes) -> dict | None:
+    """Handle the shared-runner Web ask transport."""
+    try:
+        from . import chat
+
+        if hasattr(chat, "ask_completion"):
+            return chat.ask_completion(body_bytes)
+    except ImportError:
+        pass
+    return None
+
+
 def _handle_chat_stream(body_bytes: bytes):
     """Return generator yielding SSE bytes for stream=true, or None for 501."""
     try:
@@ -924,6 +936,28 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                 self._handle_loop_decision()
             except (json.JSONDecodeError, UnicodeDecodeError, ValueError, KeyError, TypeError) as e:
                 self._json_response({"error": str(e)}, 400)
+            return
+        if path == "/api/ask":
+            content_length = int(self.headers.get("Content-Length", 0))
+            body = self.rfile.read(content_length) if content_length else b"{}"
+            try:
+                payload = json.loads(body.decode("utf-8"))
+                if isinstance(payload, dict) and self.__class__._session_id is not None:
+                    payload["session_id"] = self.__class__._session_id
+                    payload["session_root"] = self.__class__._session_root
+                    body = json.dumps(payload).encode("utf-8")
+            except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
+                pass
+            out = _handle_ask_request(body)
+            if out is None:
+                self.send_response(501)
+                self.send_header("Content-Type", "application/json; charset=utf-8")
+                self.end_headers()
+                self.wfile.write(b'{"error":"LLM not configured"}')
+                return
+            status = 400 if out.get("error") else 200
+            resp = json.dumps(out, default=str).encode("utf-8")
+            _send_body(self, resp, "application/json; charset=utf-8", status)
             return
         if path != "/api/chat":
             if path.startswith("/api/"):

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -950,12 +950,14 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                 pass
             out = _handle_ask_request(body)
             if out is None:
-                self.send_response(501)
-                self.send_header("Content-Type", "application/json; charset=utf-8")
-                self.end_headers()
-                self.wfile.write(b'{"error":"LLM not configured"}')
+                _send_body(
+                    self,
+                    b'{"error":"ask transport unavailable"}',
+                    "application/json; charset=utf-8",
+                    501,
+                )
                 return
-            status = 400 if out.get("error") else 200
+            status = int(out.pop("_http_status", 400 if out.get("error") else 200))
             resp = json.dumps(out, default=str).encode("utf-8")
             _send_body(self, resp, "application/json; charset=utf-8", status)
             return

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -55,6 +55,42 @@ def test_runner_does_not_repeat_root_cause_triage(monkeypatch):
     assert "root_cause_matcher" not in selected
 
 
+def test_runner_validates_transport_skill_selector_and_caps_it(monkeypatch):
+    from nsys_ai.agent import runner
+
+    calls = []
+
+    def fake_execute(_conn, names, _trim):
+        calls.append(names)
+        return {name: [{"value": 1}] for name in names}
+
+    monkeypatch.setattr(runner, "_execute_pack", fake_execute)
+    evidence, selected = runner.run_question_evidence(
+        "conn",
+        "why?",
+        skill_selector=lambda _question, _rows: [
+            "unknown_skill",
+            "top_kernels",
+            "gpu_idle_gaps",
+            "memory_transfers",
+            "overlap_breakdown",
+            "nccl_breakdown",
+        ],
+    )
+
+    assert selected == [
+        "top_kernels",
+        "gpu_idle_gaps",
+        "memory_transfers",
+        "overlap_breakdown",
+    ]
+    assert "unknown_skill" not in evidence
+    assert calls == [
+        ["root_cause_matcher"],
+        ["top_kernels", "gpu_idle_gaps", "memory_transfers", "overlap_breakdown"],
+    ]
+
+
 def test_runner_formats_abstention_as_unavailable_evidence():
     from nsys_ai.agent.runner import format_evidence_first_answer
 
@@ -84,8 +120,8 @@ def test_runner_answer_question_is_the_shared_transport_contract(monkeypatch):
 
     calls = {}
 
-    def fake_evidence(conn, question, *, trim_kwargs, use_llm):
-        calls["evidence"] = (conn, question, trim_kwargs, use_llm)
+    def fake_evidence(conn, question, *, trim_kwargs, use_llm, skill_selector):
+        calls["evidence"] = (conn, question, trim_kwargs, use_llm, skill_selector)
         return {"root_cause_matcher": [{"pattern": "slow"}]}, ["top_kernels"]
 
     def fake_format(question, evidence, selected, **kwargs):
@@ -111,5 +147,6 @@ def test_runner_answer_question_is_the_shared_transport_contract(monkeypatch):
         "why?",
         {"trim_start_ns": 1, "trim_end_ns": 2},
         False,
+        None,
     )
     assert calls["format"][2] == ["root_cause_matcher", "top_kernels"]

--- a/tests/test_agent_runner.py
+++ b/tests/test_agent_runner.py
@@ -77,3 +77,39 @@ def test_runner_does_not_synthesize_without_usable_evidence(monkeypatch):
     assert runner.synthesize_evidence(
         "why?", {"top_kernels": [{"_abstained": True, "reason": "missing"}]}
     ) is None
+
+
+def test_runner_answer_question_is_the_shared_transport_contract(monkeypatch):
+    from nsys_ai.agent import runner
+
+    calls = {}
+
+    def fake_evidence(conn, question, *, trim_kwargs, use_llm):
+        calls["evidence"] = (conn, question, trim_kwargs, use_llm)
+        return {"root_cause_matcher": [{"pattern": "slow"}]}, ["top_kernels"]
+
+    def fake_format(question, evidence, selected, **kwargs):
+        calls["format"] = (question, evidence, selected, kwargs)
+        return "answer"
+
+    monkeypatch.setattr(runner, "run_question_evidence", fake_evidence)
+    monkeypatch.setattr(runner, "format_evidence_first_answer", fake_format)
+
+    answer, evidence, selected = runner.answer_question(
+        "conn",
+        "why?",
+        profile_path="profile.nsys-rep",
+        trim_kwargs={"trim_start_ns": 1, "trim_end_ns": 2},
+        use_llm=False,
+    )
+
+    assert answer == "answer"
+    assert evidence == {"root_cause_matcher": [{"pattern": "slow"}]}
+    assert selected == ["root_cause_matcher", "top_kernels"]
+    assert calls["evidence"] == (
+        "conn",
+        "why?",
+        {"trim_start_ns": 1, "trim_end_ns": 2},
+        False,
+    )
+    assert calls["format"][2] == ["root_cause_matcher", "top_kernels"]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -269,6 +269,59 @@ def test_web_chat_import_failure_uses_not_configured_contract(monkeypatch):
     assert web._handle_chat_request(b"{}") is None
 
 
+def test_ask_completion_uses_shared_runner(monkeypatch):
+    conn = MagicMock()
+    monkeypatch.setattr(
+        chat_mod,
+        "_prepare_session",
+        lambda *_args: (conn, "/profile.sqlite", "system", None),
+    )
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: (None, None))
+
+    captured = {}
+
+    def fake_answer(conn_arg, question, **kwargs):
+        captured.update({"conn": conn_arg, "question": question, **kwargs})
+        return "grounded answer", {"top_kernels": [{"name": "gemm"}]}, ["top_kernels"]
+
+    monkeypatch.setattr("nsys_ai.agent.runner.answer_question", fake_answer)
+    out = chat_mod.ask_completion(
+        json.dumps(
+            {
+                "profile_path": "/profile.nsys-rep",
+                "question": "why is this slow?",
+                "trim_start_ns": 10,
+                "trim_end_ns": 20,
+                "use_llm": False,
+            }
+        ).encode()
+    )
+
+    assert out["answer"] == "grounded answer"
+    assert out["selected_skills"] == ["top_kernels"]
+    assert captured["conn"] is conn
+    assert captured["question"] == "why is this slow?"
+    assert captured["trim_kwargs"] == {"trim_start_ns": 10, "trim_end_ns": 20}
+    conn.close.assert_called_once()
+
+
+def test_ask_completion_rejects_incomplete_trim():
+    out = chat_mod.ask_completion(
+        b'{"profile_path":"profile.sqlite","question":"why?","trim_start_ns":1}'
+    )
+    assert out == {"error": "trim_start_ns and trim_end_ns must be provided together."}
+
+
+def test_web_ask_import_failure_uses_not_configured_contract(monkeypatch):
+    from nsys_ai import chat, web
+
+    def unavailable(_body):
+        raise ImportError("optional AI backend is unavailable")
+
+    monkeypatch.setattr(chat, "ask_completion", unavailable)
+    assert web._handle_ask_request(b"{}") is None
+
+
 def test_chat_completion_success_mock(monkeypatch):
     """With mocked litellm, returns content and actions from completion."""
     fake_message = MagicMock(content="Hello.", tool_calls=[])

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -233,6 +233,37 @@ def test_viewer_returns_json_404_for_unknown_post_api():
     assert b"not found" in body
 
 
+def test_viewer_ask_route_delegates_to_shared_transport(monkeypatch):
+    from nsys_ai import web
+
+    monkeypatch.setattr(web, "_handle_ask_request", lambda body: {"answer": "ok"})
+    old_session = web._ViewerHandler._session_id
+    old_root = web._ViewerHandler._session_root
+    web._ViewerHandler._session_id = None
+    try:
+        server = web._ThreadedHTTPServer(("127.0.0.1", 0), web._ViewerHandler)
+        thread = threading.Thread(target=server.handle_request, daemon=True)
+        thread.start()
+        conn = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+        conn.request(
+            "POST",
+            "/api/ask",
+            body=json.dumps({"question": "why?"}),
+            headers={"Content-Type": "application/json"},
+        )
+        response = conn.getresponse()
+        status, body = response.status, response.read()
+        conn.close()
+        thread.join(timeout=5)
+        server.server_close()
+    finally:
+        web._ViewerHandler._session_id = old_session
+        web._ViewerHandler._session_root = old_root
+
+    assert status == 200
+    assert json.loads(body) == {"answer": "ok"}
+
+
 def test_timeline_canvas_reads_the_shared_token_palette():
     javascript = open("src/nsys_ai/templates/timeline.js", encoding="utf-8").read()
     tokens = open("src/nsys_ai/templates/tokens.css", encoding="utf-8").read()


### PR DESCRIPTION
## Summary

- add the shared runner's canonical `answer_question()` workflow
- route CLI `Agent.ask` through that workflow while preserving its provider hooks
- expose the same workflow as Web `POST /api/ask`
- accept either `profile_path` or a SessionStore handoff (`session_id` + `session_root`)
- document the JSON transport and add route/validation/runner coverage

## Why

This is the next independently mergeable slice for #434. CLI ask and Web ask now share triage,
registered skill execution, the four-skill cap, evidence-first formatting, and optional LLM
planner/synthesis behavior. The Web transport does not create a second SQL or analysis path.

## Validation

- focused runner/chat/Web/session/tool suite: `152 passed`
- `ruff`, `py_compile`, `git diff --check`: passed
- real `h100_2gpu_1s.sqlite` Web ask: returned `root_cause_matcher`, `top_kernels`, and
  `gpu_idle_gaps` evidence with `use_llm=false`
- real `/home/rich-wsl/fastvideo/profile_results/perf.nsys-rep` Web ask: completed in 117.87s via
  parquet ingest and returned evidence-first output with no error
- session-only handoff E2E: loaded the before profile from SessionStore without `profile_path`

The first full local run was performed while a stale `nsys-ai` server owned port 8144, causing
port-sensitive loop/web subprocesses to hit the wrong server. After clearing that process, the
same branch passed the full suite with `2475 passed, 0 failed`; the named loop/web suites passed
`43/43` in 9.31s. Live endpoint checks passed against both Web and timeline-web.

Review follow-ups are included in commit `70b5d76`: the selector branch is centralized and covered,
the 501 text is transport-specific, and server-side errors no longer expose raw exception text.

Advances #434; does not close the epic. Remaining work includes converging the conversational Web
chat/SSE lifecycle and publishing ask/diagnose artifacts where the session contract requires them.
