### PR TITLE
feat(web): expose shared ask runner over SSE

### DIFF
--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -1059,6 +1059,37 @@ def ask_completion(body_bytes: bytes) -> dict:
         conn.close()
 
 
+def ask_completion_stream(body_bytes: bytes):
+    """Yield the shared ask result through the transport-neutral SSE contract.
+
+    ``answer_question`` is a batch runner, so this adapter emits the complete
+    evidence-first answer as one ``text`` event after analysis finishes.  The
+    important invariant is that SSE and JSON call the same runner and expose
+    the same selected skills/evidence in ``done``; a later incremental runner
+    can add events without creating another analysis path.
+    """
+    result = ask_completion(body_bytes)
+    status = int(result.pop("_http_status", 400 if result.get("error") else 200))
+    if result.get("error"):
+        yield _sse_event("text", {"chunk": result["error"]})
+        yield _sse_event("done", {"error": result["error"], "status": status})
+        return
+
+    answer = str(result.get("answer") or "")
+    if answer:
+        yield _sse_event("text", {"chunk": answer})
+    yield _sse_event(
+        "done",
+        {
+            "question": result.get("question", ""),
+            "selected_skills": result.get("selected_skills", []),
+            "evidence": result.get("evidence", {}),
+            "session_id": result.get("session_id"),
+            "status": status,
+        },
+    )
+
+
 # ---------------------------------------------------------------------------
 # SSE helper
 # ---------------------------------------------------------------------------

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -288,6 +288,18 @@ def _handle_ask_request(body_bytes: bytes) -> dict | None:
     return None
 
 
+def _handle_ask_stream_request(body_bytes: bytes):
+    """Return the shared-runner ask SSE generator, or None when unavailable."""
+    try:
+        from . import chat
+
+        if hasattr(chat, "ask_completion_stream"):
+            return chat.ask_completion_stream(body_bytes)
+    except ImportError:
+        pass
+    return None
+
+
 def _handle_chat_stream(body_bytes: bytes):
     """Return generator yielding SSE bytes for stream=true, or None for 501."""
     try:
@@ -940,14 +952,39 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
         if path == "/api/ask":
             content_length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(content_length) if content_length else b"{}"
+            stream_requested = False
             try:
                 payload = json.loads(body.decode("utf-8"))
                 if isinstance(payload, dict) and self.__class__._session_id is not None:
+                    stream_requested = payload.get("stream") is True
                     payload["session_id"] = self.__class__._session_id
                     payload["session_root"] = self.__class__._session_root
                     body = json.dumps(payload).encode("utf-8")
+                elif isinstance(payload, dict):
+                    stream_requested = payload.get("stream") is True
             except (json.JSONDecodeError, UnicodeDecodeError, TypeError):
                 pass
+            if stream_requested:
+                gen = _handle_ask_stream_request(body)
+                if gen is None:
+                    _send_body(
+                        self,
+                        b'{"error":"ask transport unavailable"}',
+                        "application/json; charset=utf-8",
+                        501,
+                    )
+                    return
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Cache-Control", "no-cache")
+                self.send_header("Connection", "close")
+                self.send_header("X-Accel-Buffering", "no")
+                self.end_headers()
+                for chunk in gen:
+                    self.wfile.write(chunk)
+                    self.wfile.flush()
+                self.close_connection = True
+                return
             out = _handle_ask_request(body)
             if out is None:
                 _send_body(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -312,6 +312,42 @@ def test_ask_completion_rejects_incomplete_trim():
     assert out == {"error": "trim_start_ns and trim_end_ns must be provided together."}
 
 
+def test_ask_completion_stream_uses_the_json_runner_contract(monkeypatch):
+    monkeypatch.setattr(
+        chat_mod,
+        "ask_completion",
+        lambda _body: {
+            "answer": "grounded answer",
+            "question": "why?",
+            "selected_skills": ["top_kernels"],
+            "evidence": {"top_kernels": [{"name": "gemm"}]},
+            "session_id": "s1",
+        },
+    )
+
+    events = list(chat_mod.ask_completion_stream(b'{"question":"why?"}'))
+
+    assert events[0].startswith(b"event: text\n")
+    assert json.loads(events[0].split(b"data: ", 1)[1]) == {"chunk": "grounded answer"}
+    assert events[1].startswith(b"event: done\n")
+    done = json.loads(events[1].split(b"data: ", 1)[1])
+    assert done["selected_skills"] == ["top_kernels"]
+    assert done["evidence"]["top_kernels"][0]["name"] == "gemm"
+    assert done["session_id"] == "s1"
+
+
+def test_ask_completion_stream_preserves_generic_errors(monkeypatch):
+    monkeypatch.setattr(
+        chat_mod,
+        "ask_completion",
+        lambda _body: {"error": "ask failed.", "_http_status": 500},
+    )
+
+    events = list(chat_mod.ask_completion_stream(b"{}"))
+    done = json.loads(events[-1].split(b"data: ", 1)[1])
+    assert done == {"error": "ask failed.", "status": 500}
+
+
 def test_web_ask_import_failure_uses_not_configured_contract(monkeypatch):
     from nsys_ai import chat, web
 

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -264,6 +264,46 @@ def test_viewer_ask_route_delegates_to_shared_transport(monkeypatch):
     assert json.loads(body) == {"answer": "ok"}
 
 
+def test_viewer_ask_route_supports_shared_runner_sse(monkeypatch):
+    from nsys_ai import web
+
+    monkeypatch.setattr(
+        web,
+        "_handle_ask_stream_request",
+        lambda body: iter(
+            [
+                b'event: text\ndata: {"chunk":"ok"}\n\n',
+                b'event: done\ndata: {"selected_skills":[]}\n\n',
+            ]
+        ),
+    )
+    old_session = web._ViewerHandler._session_id
+    web._ViewerHandler._session_id = None
+    try:
+        server = web._ThreadedHTTPServer(("127.0.0.1", 0), web._ViewerHandler)
+        thread = threading.Thread(target=server.handle_request, daemon=True)
+        thread.start()
+        conn = http.client.HTTPConnection("127.0.0.1", server.server_address[1], timeout=5)
+        conn.request(
+            "POST",
+            "/api/ask",
+            body=json.dumps({"question": "why?", "stream": True}),
+            headers={"Content-Type": "application/json"},
+        )
+        response = conn.getresponse()
+        status, content_type, body = response.status, response.getheader("Content-Type"), response.read()
+        conn.close()
+        thread.join(timeout=5)
+        server.server_close()
+    finally:
+        web._ViewerHandler._session_id = old_session
+
+    assert status == 200
+    assert content_type.startswith("text/event-stream")
+    assert body.startswith(b"event: text\n")
+    assert b'event: done\ndata: {"selected_skills":[]}' in body
+
+
 def test_timeline_canvas_reads_the_shared_token_palette():
     javascript = open("src/nsys_ai/templates/timeline.js", encoding="utf-8").read()
     tokens = open("src/nsys_ai/templates/tokens.css", encoding="utf-8").read()


### PR DESCRIPTION
## Summary

- add `stream: true` support to `POST /api/ask`;
- expose the shared `answer_question()` result through the existing `text | done` SSE event contract;
- include the same question, selected registered skills, structured evidence, and session id in `done`;
- keep the deterministic runner batch-oriented and emit the complete answer once analysis finishes, leaving incremental generation to a future runner capability;
- add JSON/error and live HTTP route coverage.

This is an independently mergeable #434 slice. It does not replace the existing conversational `/api/chat` SSE path.

## Verification

- focused chat/web suite: `111 passed in 2.74s`;
- `ruff check` passes;
- `git diff --check` passes.
