### PR TITLE
fix(skills): abstain on ambiguous root-cause windows

### DIFF
--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -539,17 +539,16 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                 }
             )
         findings.append(
-            {
-                "pattern": "Excessive Synchronization (abstained)",
-                "severity": "info",
-                "evidence": sync_abstention["reason"],
-                "recommendation": (
+            abstain(
+                sync_abstention["reason"],
+                pattern="Excessive Synchronization (abstained)",
+                severity="info",
+                evidence=sync_abstention["reason"],
+                recommendation=(
                     "Attribute synchronization time per host thread, or use a "
                     "thread-aware denominator before ranking this pattern."
                 ),
-                "_abstained": True,
-                "reason": sync_abstention["reason"],
-            }
+            )[0]
         )
 
     if not findings:

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -518,7 +518,26 @@ def _execute(conn: sqlite3.Connection, **kwargs):
     if not is_abstention(memset_findings):
         findings += memset_findings
 
-    if sync_abstention and findings:
+    if sync_abstention:
+        # Preserve all other checks.  A synchronization denominator can be
+        # unavailable even when the remaining checks ran successfully; that
+        # must not collapse the composite skill into a list-level abstention.
+        if not findings:
+            findings.append(
+                {
+                    "pattern": "Root Cause Analysis Incomplete",
+                    "severity": "info",
+                    "evidence": (
+                        "Other root-cause checks found no patterns, but "
+                        "synchronization could not be scored: "
+                        f"{sync_abstention['reason']}"
+                    ),
+                    "recommendation": (
+                        "Attribute synchronization time per host thread before "
+                        "treating this profile as free of synchronization issues."
+                    ),
+                }
+            )
         findings.append(
             {
                 "pattern": "Excessive Synchronization (abstained)",
@@ -528,12 +547,10 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                     "Attribute synchronization time per host thread, or use a "
                     "thread-aware denominator before ranking this pattern."
                 ),
-                "abstained": True,
+                "_abstained": True,
                 "reason": sync_abstention["reason"],
             }
         )
-    elif sync_abstention:
-        findings = [sync_abstention]
 
     if not findings:
         findings.append(

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -81,6 +81,51 @@ def _resolve_active_device(conn, kwargs: dict) -> dict:
     return kwargs
 
 
+def _empty_trim_window(conn, kwargs: dict) -> list[dict] | None:
+    """Return an abstention when a requested window has no GPU activity.
+
+    The matcher used to treat an empty trim as a clean profile because every
+    check returned no rows and the generic healthy fallback ran.  That is not
+    evidence of health: there was simply nothing to inspect.  Check all
+    devices here, before device selection, so an idle requested device does
+    not mask activity on another GPU.
+    """
+    if kwargs.get("trim_start_ns") is None and kwargs.get("trim_end_ns") is None:
+        return None
+
+    try:
+        adapter = wrap_connection(conn)
+        kernel_table = adapter.resolve_activity_tables().get("kernel")
+        if not kernel_table:
+            return None
+        trim_sql, trim_params = _trim_event_clause(kwargs)
+        row = adapter.execute(
+            f"SELECT 1 FROM {kernel_table} WHERE 1=1{trim_sql} LIMIT 1",
+            trim_params,
+        ).fetchone()
+    except DB_ERRORS as e:
+        _log.debug("root_cause_matcher (trim activity check): %s", e, exc_info=True)
+        return None
+
+    if row:
+        return None
+
+    start = kwargs.get("trim_start_ns")
+    end = kwargs.get("trim_end_ns")
+    bounds = []
+    if start is not None:
+        bounds.append(f"start >= {int(start)} ns")
+    if end is not None:
+        bounds.append(f"end <= {int(end)} ns")
+    window = " and ".join(bounds) or "the requested trim window"
+    return abstain(
+        f"No GPU kernel activity falls within {window}; root-cause checks "
+        "cannot determine whether this window is healthy.",
+        trim_start_ns=start,
+        trim_end_ns=end,
+    )
+
+
 def _small_kernel_launch_summary(rows: list[dict]) -> tuple[int, int]:
     """Return (launch occurrences, kernel types) below the 10us threshold."""
     qualifying = []
@@ -101,7 +146,12 @@ def _small_kernel_launch_summary(rows: list[dict]) -> tuple[int, int]:
 
 def _execute(conn: sqlite3.Connection, **kwargs):
     """Run all pattern matchers against the profile."""
+    empty_window = _empty_trim_window(conn, kwargs)
+    if empty_window is not None:
+        return empty_window
+
     findings = []
+    sync_abstention = None
 
     # Gather evidence from skills (forward trim kwargs)
 
@@ -457,12 +507,33 @@ def _execute(conn: sqlite3.Connection, **kwargs):
     # --- nsys anti-pattern checks (direct SQL) ---
     # These cover the 4 expert-rule recipes from nsys:
     # cuda_api_sync, cuda_memcpy_sync, cuda_memcpy_async, cuda_memset_sync
-    findings += _check_sync_apis(conn, **kwargs)
+    sync_findings = _check_sync_apis(conn, **kwargs)
+    if is_abstention(sync_findings):
+        sync_abstention = sync_findings[0]
+    else:
+        findings += sync_findings
     findings += _check_sync_memcpy(conn, **kwargs)
     findings += _check_pageable_memcpy(conn, **kwargs)
     memset_findings = _check_sync_memset(conn, **kwargs)
     if not is_abstention(memset_findings):
         findings += memset_findings
+
+    if sync_abstention and findings:
+        findings.append(
+            {
+                "pattern": "Excessive Synchronization (abstained)",
+                "severity": "info",
+                "evidence": sync_abstention["reason"],
+                "recommendation": (
+                    "Attribute synchronization time per host thread, or use a "
+                    "thread-aware denominator before ranking this pattern."
+                ),
+                "abstained": True,
+                "reason": sync_abstention["reason"],
+            }
+        )
+    elif sync_abstention:
+        findings = [sync_abstention]
 
     if not findings:
         findings.append(
@@ -826,11 +897,18 @@ def _check_sync_apis(conn: sqlite3.Connection, **kwargs):
         wall_ns = (wall_end - wall_start) if wall_start is not None and wall_end is not None else 0
         wall_ms = wall_ns / 1e6
         wall_pct = (total_sync_ns / wall_ns * 100) if wall_ns > 0 else 0
-        if (
-            total_sync_ms >= 1.0
-            and threshold_pct >= 2.0
-            and 0 <= wall_pct <= 100
-        ):
+        if total_sync_ms >= 1.0 and threshold_pct >= 2.0:
+            if wall_pct > 100:
+                return abstain(
+                    f"{call_count} sync calls total {total_sync_ms:.1f}ms, which "
+                    f"is {wall_pct:.1f}% of the {wall_ms:.1f}ms runtime wall "
+                    "span. Concurrent host-thread intervals overlap, so a "
+                    "single wall-time denominator would be misleading; "
+                    "per-thread attribution is required.",
+                    pattern="Excessive Synchronization",
+                    wall_pct=round(wall_pct, 1),
+                    total_sync_ms=round(total_sync_ms, 1),
+                )
             return [
                 {
                     "pattern": "Excessive Synchronization",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -750,7 +750,7 @@ def test_root_cause_sync_and_pageable_checks_honor_trim(minimal_nsys_conn):
 
 def test_root_cause_sync_abstains_for_overlapping_host_threads(minimal_nsys_conn):
     """Overlapping host-thread sync intervals must not become a >100% warning."""
-    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.base import is_abstention, is_abstention_row
     from nsys_ai.skills.builtins.root_cause_matcher import _check_sync_apis
     from nsys_ai.skills.registry import get_skill
 
@@ -777,14 +777,14 @@ def test_root_cause_sync_abstains_for_overlapping_host_threads(minimal_nsys_conn
         row for row in rows if row.get("pattern") == "Excessive Synchronization (abstained)"
     )
     assert composite["severity"] == "info"
-    assert composite["_abstained"] is True
+    assert is_abstention_row(composite)
 
 
 def test_root_cause_sync_abstention_preserves_other_clean_checks(
     minimal_nsys_conn, monkeypatch
 ):
     """A partial abstention must not make the whole composite skill unusable."""
-    from nsys_ai.skills.base import abstain, is_abstention
+    from nsys_ai.skills.base import abstain, is_abstention, is_abstention_row
     from nsys_ai.skills.builtins import root_cause_matcher
 
     monkeypatch.setattr(root_cause_matcher, "_safe_execute", lambda *_args, **_kwargs: [])
@@ -804,7 +804,7 @@ def test_root_cause_sync_abstention_preserves_other_clean_checks(
     assert not is_abstention(rows)
     assert rows[0]["pattern"] == "Root Cause Analysis Incomplete"
     assert rows[1]["pattern"] == "Excessive Synchronization (abstained)"
-    assert rows[1]["_abstained"] is True
+    assert is_abstention_row(rows[1])
 
 
 def test_root_cause_sync_percentage_names_wall_time_denominator(minimal_nsys_conn):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -777,7 +777,34 @@ def test_root_cause_sync_abstains_for_overlapping_host_threads(minimal_nsys_conn
         row for row in rows if row.get("pattern") == "Excessive Synchronization (abstained)"
     )
     assert composite["severity"] == "info"
-    assert composite["abstained"] is True
+    assert composite["_abstained"] is True
+
+
+def test_root_cause_sync_abstention_preserves_other_clean_checks(
+    minimal_nsys_conn, monkeypatch
+):
+    """A partial abstention must not make the whole composite skill unusable."""
+    from nsys_ai.skills.base import abstain, is_abstention
+    from nsys_ai.skills.builtins import root_cause_matcher
+
+    monkeypatch.setattr(root_cause_matcher, "_safe_execute", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        root_cause_matcher,
+        "_check_sync_apis",
+        lambda *_args, **_kwargs: abstain("overlapping host threads"),
+    )
+    monkeypatch.setattr(root_cause_matcher, "_check_sync_memcpy", lambda *_args, **_kwargs: [])
+    monkeypatch.setattr(
+        root_cause_matcher, "_check_pageable_memcpy", lambda *_args, **_kwargs: []
+    )
+    monkeypatch.setattr(root_cause_matcher, "_check_sync_memset", lambda *_args, **_kwargs: [])
+
+    rows = root_cause_matcher._execute(minimal_nsys_conn)
+
+    assert not is_abstention(rows)
+    assert rows[0]["pattern"] == "Root Cause Analysis Incomplete"
+    assert rows[1]["pattern"] == "Excessive Synchronization (abstained)"
+    assert rows[1]["_abstained"] is True
 
 
 def test_root_cause_sync_percentage_names_wall_time_denominator(minimal_nsys_conn):

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -740,9 +740,44 @@ def test_root_cause_sync_and_pageable_checks_honor_trim(minimal_nsys_conn):
 
     skill = get_skill("root_cause_matcher")
     rows = skill.execute(minimal_nsys_conn, trim_start_ns=0, trim_end_ns=1)
-    patterns = {row["pattern"] for row in rows}
+    patterns = {row.get("pattern") for row in rows}
     assert "Excessive Synchronization" not in patterns
     assert "Pageable Memory in Async Memcpy" not in patterns
+    assert rows[0]["_abstained"] is True
+    assert "No GPU kernel activity" in rows[0]["reason"]
+    assert "No Known Anti-Patterns Detected" not in patterns
+
+
+def test_root_cause_sync_abstains_for_overlapping_host_threads(minimal_nsys_conn):
+    """Overlapping host-thread sync intervals must not become a >100% warning."""
+    from nsys_ai.skills.base import is_abstention
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_sync_apis
+    from nsys_ai.skills.registry import get_skill
+
+    # Two different host threads block over the same interval.  Summing their
+    # durations is valid for a cost total, but not as a percentage of one
+    # global runtime wall span.
+    minimal_nsys_conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME "
+        "(globalTid, correlationId, start, end, nameId) VALUES (?, ?, ?, ?, ?)",
+        [
+            (101, 106, 5_000_000, 35_000_000, 20),
+            (102, 107, 5_000_000, 35_000_000, 20),
+        ],
+    )
+
+    direct_rows = _check_sync_apis(minimal_nsys_conn)
+    assert is_abstention(direct_rows)
+    assert direct_rows[0]["wall_pct"] > 100
+    assert "Concurrent host-thread intervals overlap" in direct_rows[0]["reason"]
+
+    rows = get_skill("root_cause_matcher").execute(minimal_nsys_conn)
+    assert not any(row.get("pattern") == "Excessive Synchronization" for row in rows)
+    composite = next(
+        row for row in rows if row.get("pattern") == "Excessive Synchronization (abstained)"
+    )
+    assert composite["severity"] == "info"
+    assert composite["abstained"] is True
 
 
 def test_root_cause_sync_percentage_names_wall_time_denominator(minimal_nsys_conn):


### PR DESCRIPTION
## Summary

Follow up the merged #500 root-cause trim change with explicit handling for two cases where an empty result is misleading:

- A trim window with no GPU kernels now returns a typed abstention instead of `No Known Anti-Patterns Detected`.
- Synchronization intervals whose summed duration exceeds the runtime wall span (for example, overlapping host threads on a multi-GPU capture) no longer disappear behind a `<= 100%` guard. The direct checker abstains with the denominator reason; the composite matcher exposes that state as an info-level, non-warning result when other findings are available.

## Tests

- Root-cause tests: 12 passed.
- Skills/root-cause suites: 74 passed.
- Full suite excluding the environment-sensitive skip-policy meta-test: 2469 passed, 147 skipped, 4 xfailed.
- Real `/home/rich-wsl/fastvideo/profile_results/perf.parquetdir` smoke: multi-GPU synchronization is visible as `Excessive Synchronization (abstained)` info, and an empty trim returns typed abstention.

The full suite also reports 2475 passed before the existing `test_every_skip_has_a_known_reason` failure (`No test profile` is not in its local allowlist); that failure is unrelated to this change.

Follow-up to #493 and #500.
