### PR TITLE
perf(web): bind before NVTX tree warmup

### DIFF
--- a/src/nsys_ai/nvtx_tree.py
+++ b/src/nsys_ai/nvtx_tree.py
@@ -148,53 +148,84 @@ def _build_single_thread_tree(
         """,
         (tid, rt_lo, rt_hi),
     )
-
-    # Build projected entries: each NVTX span → projected GPU bounds + child kernels
-    entries = []  # list of {name, gpu_start, gpu_end, cpu_start, cpu_end, kernels: [...]}
-
+    # Project runtime launches onto NVTX ranges with one chronological sweep.
+    # The old implementation restarted at runtime index zero for every NVTX
+    # row.  A parent range spanning a busy training step therefore revisited
+    # the same runtime prefix thousands of times.  Keeping the active NVTX
+    # stack means each runtime row is considered once per nesting level, which
+    # is the amount of information the final tree can actually represent.
+    nvtx_records = []
     for n in nvtx_rows:
-        text, cpu_start, cpu_end = n["text"], n["start"], n["end"]
-        if not text:
+        if n["text"]:
+            nvtx_records.append(
+                {
+                    "name": n["text"],
+                    "cpu_start": n["start"],
+                    "cpu_end": n["end"],
+                    "kernels": [],
+                    "gpu_start": None,
+                    "gpu_end": None,
+                }
+            )
+
+    active = []
+    next_nvtx = 0
+    for rt in rt_rows:
+        rt_start, rt_end = rt["start"], rt["end"]
+        while next_nvtx < len(nvtx_records) and nvtx_records[next_nvtx]["cpu_start"] <= rt_start:
+            active.append(nvtx_records[next_nvtx])
+            next_nvtx += 1
+        active = [record for record in active if record["cpu_end"] >= rt_end]
+        containing = [
+            record
+            for record in active
+            if record["cpu_start"] <= rt_start and record["cpu_end"] >= rt_end
+        ]
+        k = kmap.get(rt["correlationId"])
+        if not containing or not k:
             continue
 
-        # Find correlated kernels on this GPU
-        child_kernels = []
-        for rt in rt_rows:
-            if rt["start"] > cpu_end:
-                break
-            if rt["start"] >= cpu_start and rt["end"] <= cpu_end:
-                k = kmap.get(rt["correlationId"])
-                if k:
-                    child_kernels.append(
-                        dict(
-                            name=k["name"],
-                            demangled=k.get("demangled", ""),
-                            start=k["start"],
-                            end=k["end"],
-                            stream=k["stream"],
-                            type="kernel",
-                            children=[],
-                        )
-                    )
+        kernel = dict(
+            name=k["name"],
+            demangled=k.get("demangled", ""),
+            start=k["start"],
+            end=k["end"],
+            stream=k["stream"],
+            type="kernel",
+            children=[],
+        )
+        for record in containing:
+            record["gpu_start"] = (
+                k["start"]
+                if record["gpu_start"] is None
+                else min(record["gpu_start"], k["start"])
+            )
+            record["gpu_end"] = (
+                k["end"] if record["gpu_end"] is None else max(record["gpu_end"], k["end"])
+            )
+        # Only the innermost range needs a direct kernel child.  Ancestors are
+        # retained through their projected bounds and receive the nested node;
+        # this is equivalent to the old post-build deduplication without
+        # materialising the same kernel in every ancestor first.
+        innermost = max(containing, key=lambda record: record["cpu_start"])
+        innermost["kernels"].append(kernel)
 
-        if not child_kernels:
+    # Build projected entries: each NVTX span with direct or nested GPU work.
+    entries = []  # list of {name, gpu_start, gpu_end, cpu_start, cpu_end, kernels: [...]}
+    for record in nvtx_records:
+        if record["gpu_start"] is None:
             continue
-
-        gpu_start = min(k["start"] for k in child_kernels)
-        gpu_end = max(k["end"] for k in child_kernels)
-
-        if gpu_end < trim[0] or gpu_start > trim[1]:
+        if record["gpu_end"] < trim[0] or record["gpu_start"] > trim[1]:
             continue
-
         entries.append(
             dict(
-                name=text,
-                start=gpu_start,
-                end=gpu_end,
-                cpu_start=cpu_start,
-                cpu_end=cpu_end,
+                name=record["name"],
+                start=record["gpu_start"],
+                end=record["gpu_end"],
+                cpu_start=record["cpu_start"],
+                cpu_end=record["cpu_end"],
                 type="nvtx",
-                kernels=child_kernels,
+                kernels=record["kernels"],
                 children=[],
             )
         )

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -336,6 +336,8 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
     _trim: tuple[int, int] | None = None
     _tree_data: list[dict] = []
     _tree_configured: bool = False
+    _tree_build_done: threading.Event | None = None
+    _tree_build_error: str | None = None
     _tree_device: int | None = None
     _tree_trim: tuple[int, int] | None = None
 
@@ -455,8 +457,14 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
         """Return a bounded tree slice for the lazy NVTX tree viewer."""
         from urllib.parse import parse_qs, urlparse
 
+        if self.__class__._tree_build_error:
+            self._json_response({"error": "tree build failed"}, 500)
+            return
         if not self.__class__._tree_configured:
-            self._json_response({"error": "tree data is not configured"}, 500)
+            self._json_response(
+                {"status": "building", "message": "tree data is still building"},
+                202,
+            )
             return
         qs = parse_qs(urlparse(self.path).query)
         path = str(qs.get("path", [""])[0])
@@ -1090,14 +1098,42 @@ def serve(prof, device: int, trim: tuple[int, int], *, port: int = 8142, open_br
     _ViewerHandler.prof = prof
     _ViewerHandler._tree_device = device
     _ViewerHandler._tree_trim = trim
-    _ViewerHandler._tree_data = to_json(build_nvtx_tree(prof, device, trim))
-    _ViewerHandler._tree_configured = True
+    _ViewerHandler._tree_data = []
+    _ViewerHandler._tree_configured = False
+    _ViewerHandler._tree_build_error = None
     html = generate_html(prof, device, trim, embed_data=False)
     _ViewerHandler.html_bytes = html.encode("utf-8")
 
     server = _bind_local_server(port, _ViewerHandler)
     open_url = f"http://127.0.0.1:{server.server_address[1]}" if open_browser else None
-    _run_server(server, open_url, prof)
+    tree_done = threading.Event()
+    _ViewerHandler._tree_build_done = tree_done
+
+    def _warm_tree() -> None:
+        t0 = _time.monotonic()
+        try:
+            print("Building NVTX tree in background...", flush=True)
+            _ViewerHandler._tree_data = to_json(build_nvtx_tree(prof, device, trim))
+            print(
+                f"NVTX tree ready in {_time.monotonic() - t0:.1f}s "
+                f"({len(_ViewerHandler._tree_data)} roots)",
+                flush=True,
+            )
+        except Exception as exc:
+            _ViewerHandler._tree_build_error = str(exc)
+            _log.exception("Background NVTX tree build failed")
+        finally:
+            _ViewerHandler._tree_configured = True
+            tree_done.set()
+
+    print(f"Web viewer at http://127.0.0.1:{server.server_address[1]}", flush=True)
+    threading.Thread(target=_warm_tree, name="web-nvtx-tree-warmup", daemon=True).start()
+    try:
+        _run_server(server, open_url, prof)
+    finally:
+        # Keep the Profile alive until the worker has stopped using its DuckDB
+        # connection, matching the timeline-web background build contract.
+        tree_done.wait()
 
 
 # ── Mode 2: Horizontal timeline viewer ──────────────────────────

--- a/tests/test_nvtx_tree.py
+++ b/tests/test_nvtx_tree.py
@@ -9,6 +9,7 @@ formats work and Tree/Timeline load without OperationalError.
 """
 
 import sqlite3
+import time
 
 from nsys_ai import profile as _profile
 from nsys_ai.nvtx_tree import build_nvtx_tree
@@ -47,3 +48,53 @@ def test_build_nvtx_tree_text_id_schema(tmp_path):
     with _profile.open(str(db_path)) as prof:
         roots = build_nvtx_tree(prof, device=0, trim=(0, 5_000_000_000))
     assert isinstance(roots, list)
+
+
+def test_build_single_thread_tree_scales_runtime_lookup_with_window(monkeypatch):
+    """NVTX rows must not rescan the runtime prefix from index zero."""
+    from nsys_ai import nvtx_tree
+
+    count = 2_000
+    nvtx_rows = [
+        {"text": f"range-{i}", "start": i * 10, "end": i * 10 + 5}
+        for i in range(count)
+    ]
+    runtime_rows = [
+        {"start": i * 10, "end": i * 10 + 1, "correlationId": i}
+        for i in range(count)
+    ]
+    kmap = {
+        i: {
+            "name": f"kernel-{i}",
+            "demangled": "",
+            "start": i * 10,
+            "end": i * 10 + 1,
+            "stream": 0,
+        }
+        for i in range(count)
+    }
+
+    class Adapter:
+        def resolve_activity_tables(self):
+            return {"nvtx": "NVTX_EVENTS", "runtime": "CUPTI_ACTIVITY_KIND_RUNTIME"}
+
+    class Profile:
+        adapter = Adapter()
+        _nvtx_has_text_id = False
+
+        def _duckdb_query(self, query, params=()):
+            if "FROM NVTX_EVENTS" in query:
+                return nvtx_rows
+            if "FROM CUPTI_ACTIVITY_KIND_RUNTIME" in query:
+                return runtime_rows
+            raise AssertionError(query)
+
+    monkeypatch.setattr(nvtx_tree, "_runtime_table", lambda _profile: "runtime")
+    started = time.monotonic()
+    roots = nvtx_tree._build_single_thread_tree(
+        Profile(), 0, (0, count * 10 + 5), 7, kmap, pad=0
+    )
+    elapsed = time.monotonic() - started
+
+    assert roots
+    assert elapsed < 1.0

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -48,6 +48,30 @@ def test_tree_web_shell_does_not_embed_profile_data(minimal_nsys_db_path):
     assert "/api/tree" in html
 
 
+def test_tree_web_binds_before_background_tree_build(monkeypatch):
+    events = []
+
+    class FakeServer:
+        server_address = ("127.0.0.1", 9911)
+
+    def bind(_port, _handler):
+        events.append("bind")
+        return FakeServer()
+
+    def build(*_args):
+        events.append("build")
+        return []
+
+    monkeypatch.setattr(web, "_bind_local_server", bind)
+    monkeypatch.setattr(web, "_run_server", lambda *_args: events.append("serve"))
+    monkeypatch.setattr(web, "generate_html", lambda *_args, **_kwargs: "<html>")
+    monkeypatch.setattr("nsys_ai.nvtx_tree.build_nvtx_tree", build)
+
+    web.serve(object(), 0, (0, 1), port=9911, open_browser=False)
+
+    assert events.index("bind") < events.index("build")
+
+
 def test_tree_web_endpoint_returns_bounded_slices():
     old_data = web._ViewerHandler._tree_data
     old_configured = web._ViewerHandler._tree_configured
@@ -231,6 +255,25 @@ def test_viewer_returns_json_404_for_unknown_post_api():
     assert status == 404
     assert content_type.startswith("application/json")
     assert b"not found" in body
+
+
+def test_viewer_tree_reports_background_building_state():
+    old_configured = web._ViewerHandler._tree_configured
+    old_error = web._ViewerHandler._tree_build_error
+    web._ViewerHandler._tree_configured = False
+    web._ViewerHandler._tree_build_error = None
+    try:
+        status, body, content_type = _get(web._ViewerHandler, "/api/tree?depth=0")
+    finally:
+        web._ViewerHandler._tree_configured = old_configured
+        web._ViewerHandler._tree_build_error = old_error
+
+    assert status == 202
+    assert content_type.startswith("application/json")
+    assert json.loads(body) == {
+        "status": "building",
+        "message": "tree data is still building",
+    }
 
 
 def test_viewer_ask_route_delegates_to_shared_transport(monkeypatch):


### PR DESCRIPTION
## Summary

- Bind the `nsys-ai web` socket and serve the shell before the NVTX tree is built.
- Build the tree in a background worker and expose a documented `202 building` response from `/api/tree` while it is warming.
- Replace the per-NVTX runtime-prefix rescan with one chronological sweep, preserving nested ranges while projecting kernels to the innermost containing range.

## Verification

- `tests/test_nvtx_tree.py` and `tests/test_web_foundation.py`: 33 passed.
- `ruff check` and `git diff --check`: clean.
- Real `perf_h100_sp1_fa3.sqlite`, 10% window: 196 roots in 1.096s (the prior bisect implementation took 64.23s for this smoke window).

Closes #490. Part of #387.
