### PR TITLE
feat(web): persist session ask handoff log

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -185,6 +185,9 @@ $ curl -s http://127.0.0.1:8144/api/ask \
 
 `use_llm` is optional. When enabled and a provider is configured, the model may triage or summarize
 the registered evidence; it never replaces the runner's skill execution or writes profile SQL.
+When the request is opened with a session, the response also returns `session_log: "logs/ask.jsonl"`;
+each completed ask is appended there as a handoff record without changing the session artifact
+manifest.
 
 The optional MCP transport exposes the same read-only handoff as `get_session`; it returns the
 SessionStore projection rather than a second MCP-specific session schema.

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -19,6 +19,7 @@ import logging
 import os
 import sys
 from collections.abc import Callable
+from datetime import datetime, timezone
 
 # ---------------------------------------------------------------------------
 # Sub-module re-exports — keep the public API stable for existing callers.
@@ -205,6 +206,44 @@ def _session_finding_sink(
             writer.publish_findings(report, before_profile=before)
 
     return publish
+
+
+def _record_session_ask(
+    session_id: str | None,
+    session_root: str | None,
+    *,
+    question: str,
+    answer: str,
+    selected_skills: list[str],
+    evidence: dict[str, list[dict]],
+    profile_path: str,
+    trim_kwargs: dict,
+) -> str | None:
+    """Persist one transport-neutral ask result for a Web session.
+
+    The log is deliberately additive and does not mutate the SessionStore
+    phase or findings artifact.  CLI/TUI analysis remains the owner of those
+    phase-bearing artifacts; Web ask contributes the conversational handoff
+    record that the next surface can inspect.
+    """
+    if not session_id:
+        return None
+    from .session_store import SessionStore
+
+    record = {
+        "schema_version": "0.1",
+        "kind": "ask",
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+        "question": question,
+        "answer": answer,
+        "selected_skills": list(selected_skills),
+        "evidence": evidence,
+        "profile_path": profile_path,
+        "trim": dict(trim_kwargs),
+    }
+    with SessionStore(session_root or ".nsys-ai/sessions").writer(session_id) as writer:
+        writer.append_log("ask", record)
+    return "logs/ask.jsonl"
 
 
 def _runner_prefill(system_prompt: str, conn, messages: list) -> tuple[str, bool]:
@@ -1045,12 +1084,35 @@ def ask_completion(body_bytes: bytes) -> dict:
             trim_kwargs=trim_kwargs,
             use_llm=use_llm,
         )
+        try:
+            session_log = _record_session_ask(
+                session_id,
+                session_root,
+                question=question,
+                answer=answer,
+                selected_skills=selected,
+                evidence=evidence,
+                profile_path=os.fspath(profile_path),
+                trim_kwargs=trim_kwargs,
+            )
+        except Exception:
+            _log.exception("Ask session handoff failed")
+            return {
+                "error": "ask completed but session handoff failed.",
+                "answer": answer,
+                "question": question,
+                "selected_skills": selected,
+                "evidence": evidence,
+                "session_id": session_id,
+                "_http_status": 500,
+            }
         return {
             "answer": answer,
             "question": question,
             "selected_skills": selected,
             "evidence": evidence,
             "session_id": session_id,
+            "session_log": session_log,
         }
     except Exception:
         _log.exception("Shared ask runner failed")
@@ -1085,6 +1147,7 @@ def ask_completion_stream(body_bytes: bytes):
             "selected_skills": result.get("selected_skills", []),
             "evidence": result.get("evidence", {}),
             "session_id": result.get("session_id"),
+            "session_log": result.get("session_log"),
             "status": status,
         },
     )

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -72,6 +72,7 @@ DECISIONS_SCHEMA_VERSION = "0.1"
 SessionPhase = Literal["diagnose", "propose", "reprofile", "diff", "accept"]
 _PHASES = frozenset({"diagnose", "propose", "reprofile", "diff", "accept"})
 _SESSION_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+_LOG_NAME = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 _ARTIFACT_PATHS = {
     "runspec": "runspec.json",
     "findings": "findings.json",
@@ -718,6 +719,41 @@ class SessionWriter:
         if self._handle is not None:
             self._handle.close()
             self._handle = None
+
+    def append_log(self, name: str, record: Mapping[str, Any]) -> None:
+        """Append one JSON record to a session log under the writer lease.
+
+        Logs are intentionally outside ``session.json`` and the artifact
+        manifest: they are an append-only conversational/audit trail, not a
+        source artifact that drives phase validation.  The writer lease makes
+        concurrent Web requests serialize their appends, while ``O_APPEND``
+        keeps each record at the end of the file after a process restart.
+        """
+        self._ensure_open()
+        if not isinstance(name, str) or not _LOG_NAME.fullmatch(name):
+            raise ValueError("session log name must be a lowercase identifier")
+        if not isinstance(record, Mapping):
+            raise TypeError("session log record must be a mapping")
+        _require_json_serializable(record, f"session log {name}")
+        payload = json.dumps(
+            dict(record), ensure_ascii=False, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8") + b"\n"
+        log_path = self.store._session_dir(self.session_id) / "logs" / f"{name}.jsonl"
+        descriptor = os.open(
+            log_path,
+            os.O_WRONLY | os.O_CREAT | os.O_APPEND,
+            0o600,
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "ab", closefd=True) as stream:
+                stream.write(payload)
+                stream.flush()
+                os.fsync(stream.fileno())
+            descriptor = -1
+        finally:
+            if descriptor != -1:
+                os.close(descriptor)
 
     def publish_runspec(
         self,

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,5 +1,6 @@
 """Unit tests for nsys_ai.chat (AI Brain + Navigator)."""
 
+import hashlib
 import json
 import sys
 from unittest.mock import MagicMock, patch
@@ -305,6 +306,60 @@ def test_ask_completion_uses_shared_runner(monkeypatch):
     conn.close.assert_called_once()
 
 
+def test_ask_completion_persists_session_handoff_log(tmp_path, monkeypatch):
+    from nsys_ai.profile_reference import LocalProfileReference
+    from nsys_ai.session_store import SessionStore
+
+    profile = tmp_path / "profile.sqlite"
+    profile.write_bytes(b"profile")
+    reference = LocalProfileReference(
+        path=str(profile.absolute()),
+        profile_id="nsys2:sha256:" + hashlib.sha256(b"profile").hexdigest(),
+        schema_version="3.25.0",
+        product_version="2026.2.1.106",
+        kernel_count=1,
+    )
+    sessions = tmp_path / "sessions"
+    SessionStore(sessions).create("ask-001", before_profile=reference)
+
+    conn = MagicMock()
+    monkeypatch.setattr(
+        chat_mod,
+        "_prepare_session",
+        lambda *_args: (conn, str(profile), "system", None),
+    )
+    monkeypatch.setattr(chat_mod, "_get_model_and_key", lambda preferred=None: (None, None))
+    monkeypatch.setattr(
+        "nsys_ai.agent.runner.answer_question",
+        lambda *_args, **_kwargs: (
+            "grounded answer",
+            {"top_kernels": [{"name": "gemm"}]},
+            ["top_kernels"],
+        ),
+    )
+
+    out = chat_mod.ask_completion(
+        json.dumps(
+            {
+                "session_id": "ask-001",
+                "session_root": str(sessions),
+                "question": "why is this slow?",
+                "use_llm": False,
+            }
+        ).encode()
+    )
+
+    assert out["session_id"] == "ask-001"
+    assert out["session_log"] == "logs/ask.jsonl"
+    record = json.loads((sessions / "ask-001" / "logs" / "ask.jsonl").read_text())
+    assert record["kind"] == "ask"
+    assert record["question"] == "why is this slow?"
+    assert record["answer"] == "grounded answer"
+    assert record["selected_skills"] == ["top_kernels"]
+    assert record["evidence"]["top_kernels"][0]["name"] == "gemm"
+    conn.close.assert_called_once()
+
+
 def test_ask_completion_rejects_incomplete_trim():
     out = chat_mod.ask_completion(
         b'{"profile_path":"profile.sqlite","question":"why?","trim_start_ns":1}'
@@ -334,6 +389,7 @@ def test_ask_completion_stream_uses_the_json_runner_contract(monkeypatch):
     assert done["selected_skills"] == ["top_kernels"]
     assert done["evidence"]["top_kernels"][0]["name"] == "gemm"
     assert done["session_id"] == "s1"
+    assert done["session_log"] is None
 
 
 def test_ask_completion_stream_preserves_generic_errors(monkeypatch):

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -368,6 +368,26 @@ def test_complete_session_round_trip_uses_exact_layout_and_local_references(tmp_
     )
 
 
+def test_session_writer_appends_private_jsonl_log_without_manifest_mutation(tmp_path):
+    session_dir = tmp_path / "sessions" / "ask-001"
+    profile = _profile_reference(tmp_path / "before.sqlite", "ask-before")
+    store = SessionStore(tmp_path / "sessions")
+    store.create("ask-001", before_profile=profile)
+
+    with store.writer("ask-001") as writer:
+        writer.append_log("ask", {"schema_version": "0.1", "question": "why?"})
+        writer.append_log("ask", {"schema_version": "0.1", "question": "what next?"})
+
+    log_path = session_dir / "logs" / "ask.jsonl"
+    assert stat.S_IMODE(log_path.stat().st_mode) == 0o600
+    assert [json.loads(line) for line in log_path.read_text().splitlines()] == [
+        {"question": "why?", "schema_version": "0.1"},
+        {"question": "what next?", "schema_version": "0.1"},
+    ]
+    manifest = json.loads((session_dir / "session.json").read_text())
+    assert all(value is None for value in manifest["artifacts"].values())
+
+
 def test_rejected_finding_reopens_session_for_a_different_finding(tmp_path):
     before = _profile_reference(tmp_path / "before.sqlite", "before")
     after = _profile_reference(tmp_path / "after.sqlite", "after")


### PR DESCRIPTION
## Summary

Implements the next #434 handoff slice for the shared Web ask path.

- Persist completed `/api/ask` results in `<session>/logs/ask.jsonl`.
- Keep the log append-only and outside `session.json` / the artifact manifest.
- Serialize concurrent appends under the existing `SessionStore` writer lease with `O_APPEND`, mode `0600`, and fsync.
- Return `session_log` from JSON and SSE ask transports.
- Document the handoff record in the user guide.

Each record includes the question, answer, selected skills, evidence, profile path, trim bounds, schema version, and UTC timestamp. A failed handoff is surfaced as HTTP 500 instead of silently claiming the session was updated.

Closes the session-lifecycle slice described in #434; the epic remains open for the remaining conversational/session projection work.

## Verification

- `ruff check` — passed
- Focused chat/session tests — `224 passed`
- Full suite with absolute worktree `PYTHONPATH` — `2481 passed, 147 skipped, 4 xfailed`
- One existing environment-policy failure remains in `tests/test_ci_coverage.py::test_every_skip_has_a_known_reason`: the environment has no test profile and reports `No test profile`.
- Live Web checkpoint on `mock.sqlite`: JSON ask and SSE ask both completed; two records were appended to `logs/ask.jsonl`, mode `0600`, and the session artifact manifest remained unchanged.
