### PR TITLE
fix(web): bound lazy NVTX tree slices

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -189,6 +189,11 @@ When the request is opened with a session, the response also returns `session_lo
 each completed ask is appended there as a handoff record without changing the session artifact
 manifest.
 
+The NVTX tree viewer loads bounded slices from `GET /api/tree`. `depth` controls levels,
+`limit` caps children per node, and `max_nodes` caps the complete response. A response with
+`"truncated": true` is intentionally partial; nodes may also carry `has_more` and
+`children_total` so clients do not mistake the visible children for the complete profile.
+
 The optional MCP transport exposes the same read-only handoff as `get_session`; it returns the
 SessionStore projection rather than a second MCP-specific session schema.
 

--- a/src/nsys_ai/templates/nvtx_tree.html
+++ b/src/nsys_ai/templates/nvtx_tree.html
@@ -57,6 +57,13 @@
             color: var(--text)
         }
 
+        .tree-more {
+            color: var(--text-dim);
+            font-size: 11px;
+            padding: 2px 0 2px 24px;
+            font-style: italic
+        }
+
         /* Controls */
         .controls {
             display: flex;
@@ -1067,7 +1074,10 @@
             if (!response.ok) throw new Error('tree request failed (' + response.status + ')');
             const payload = await response.json();
             if (payload.error) throw new Error(payload.error);
-            return Array.isArray(payload.nodes) ? payload.nodes : [];
+            return {
+                nodes: Array.isArray(payload.nodes) ? payload.nodes : [],
+                truncated: payload.truncated === true,
+            };
         }
         function setTreeData(nodes) {
             DATA = Array.isArray(nodes) ? nodes : [];
@@ -1083,9 +1093,9 @@
         async function ensureFullData() {
             if (fullDataLoaded) return DATA;
             if (!fullDataPromise) {
-                fullDataPromise = fetchTree('', 'full').then(nodes => {
-                    fullDataLoaded = true;
-                    setTreeData(nodes);
+                fullDataPromise = fetchTree('', 'full').then(payload => {
+                    fullDataLoaded = !payload.truncated;
+                    setTreeData(payload.nodes);
                     return DATA;
                 });
             }
@@ -1093,7 +1103,7 @@
         }
         async function loadInitialTree() {
             try {
-                setTreeData(await fetchTree('', 2));
+                setTreeData((await fetchTree('', 2)).nodes);
             } catch (error) {
                 document.getElementById('tree').textContent = 'Failed to load tree: ' + error.message;
             }
@@ -1259,7 +1269,7 @@
 
         // = Tree view =
         function renderNode(node, depth) {
-            const hasC = (node.children && node.children.length > 0) || node.has_children === true, isK = node.type === 'kernel', cls = isK ? 'kernel' : 'nvtx';
+            const hasC = (node.children && node.children.length > 0) || node.has_children === true || node.has_more === true, isK = node.type === 'kernel', cls = isK ? 'kernel' : 'nvtx';
             const icon = isK ? '⚡' : '📦', toggle = hasC ? '▶' : ' ';
             const displayName = (demangledMode && isK && node.demangled) ? node.demangled : node.name;
             const stream = node.stream !== undefined ? '<span class="stream">[stream ' + node.stream + ']</span>' : '';
@@ -1279,6 +1289,10 @@
                 const lazy = node.has_children === true && !(node.children && node.children.length);
                 h += '<div class="children' + (depth > 1 || lazy ? ' collapsed' : '') + '" data-lazy="' + (lazy ? '1' : '0') + '">';
                 if (node.children) node.children.forEach(c => h += renderNode(c, depth + 1));
+                if (node.has_more) {
+                    const total = node.children_total ? ' of ' + node.children_total : '';
+                    h += '<div class="tree-more">Showing a bounded slice' + total + ' children</div>';
+                }
                 h += '</div>';
             }
             h += '</div>'; return h;
@@ -1291,13 +1305,19 @@
                 c.classList.remove('collapsed');
                 c.textContent = 'Loading…';
                 try {
-                    const children = await fetchTree(nodeEl.dataset.path || '', 2);
+                    const payload = await fetchTree(nodeEl.dataset.path || '', 2);
+                    const children = payload.nodes;
                     c.textContent = '';
                     children.forEach(child => c.insertAdjacentHTML('beforeend', renderNode(child, Number(nodeEl.dataset.depth || 0) + 1)));
+                    if (payload.truncated) c.insertAdjacentHTML('beforeend', '<div class="tree-more">Showing a bounded child slice</div>');
                     c.dataset.loaded = '1';
                     c.dataset.lazy = '0';
                     const target = findTreeNode(DATA, nodeEl.dataset.path || '');
-                    if (target) { target.children = children; delete target.has_children; }
+                    if (target) {
+                        target.children = children;
+                        delete target.has_children;
+                        if (payload.truncated) target.has_more = true;
+                    }
                 } catch (error) {
                     c.textContent = 'Failed to load children: ' + error.message;
                     return;

--- a/src/nsys_ai/web.py
+++ b/src/nsys_ai/web.py
@@ -67,22 +67,75 @@ def _find_tree_path(nodes: list[dict], path: str) -> dict | None:
     return None
 
 
-def _slice_tree_nodes(nodes: list[dict], depth: int | None) -> list[dict]:
-    """Copy a tree to *depth*, preserving a marker for unloaded children."""
-    result = []
-    for node in nodes:
-        copied = {key: value for key, value in node.items() if key != "children"}
-        children = node.get("children") or []
-        if children:
-            if depth is None or depth > 0:
-                copied["children"] = _slice_tree_nodes(
-                    children, None if depth is None else depth - 1
-                )
-            else:
-                copied["children"] = []
-                copied["has_children"] = True
-        result.append(copied)
+_TREE_CHILD_LIMIT = 256
+_TREE_CHILD_LIMIT_MAX = 2_000
+_TREE_NODE_LIMIT = 10_000
+_TREE_NODE_LIMIT_MAX = 20_000
+
+
+def _slice_tree_nodes(
+    nodes: list[dict],
+    depth: int | None,
+    *,
+    limit: int = _TREE_CHILD_LIMIT,
+    max_nodes: int | None = None,
+) -> list[dict]:
+    """Copy a tree to *depth* with bounded fan-out and response size.
+
+    ``has_children`` continues to mean that a lazy child request is possible.
+    ``has_more`` is stronger: the current response contains only the first
+    *limit* children (or reached *max_nodes*), so a consumer must not treat
+    the returned subtree as complete.
+    """
+    remaining = max_nodes
+
+    def walk(items: list[dict], remaining_nodes: int | None, item_depth: int | None):
+        truncated = len(items) > limit
+        if remaining_nodes is not None and len(items) > remaining_nodes:
+            truncated = True
+        result = []
+        for node in items[:limit]:
+            if remaining_nodes is not None and remaining_nodes <= 0:
+                truncated = True
+                break
+            if remaining_nodes is not None:
+                remaining_nodes -= 1
+            copied = {key: value for key, value in node.items() if key != "children"}
+            children = node.get("children") or []
+            if children:
+                if item_depth is None or item_depth > 0:
+                    child_depth = None if item_depth is None else item_depth - 1
+                    child_nodes, child_truncated, remaining_nodes = walk(
+                        children, remaining_nodes, child_depth
+                    )
+                    copied["children"] = child_nodes
+                    if child_truncated:
+                        truncated = True
+                        copied["has_more"] = True
+                        copied["children_total"] = len(children)
+                else:
+                    copied["children"] = []
+                    copied["has_children"] = True
+            result.append(copied)
+        return result, truncated, remaining_nodes
+
+    result, _truncated, _remaining = walk(nodes, remaining, depth)
     return result
+
+
+def _tree_slice_has_more(nodes: list[dict]) -> bool:
+    """Return whether a serialized tree contains an explicitly partial node."""
+    for node in nodes:
+        if node.get("has_more"):
+            return True
+        if _tree_slice_has_more(node.get("children") or []):
+            return True
+    return False
+
+
+def _count_tree_nodes(nodes: list[dict]) -> int:
+    """Count nodes in an already bounded serialized tree."""
+    return sum(1 + _count_tree_nodes(node.get("children") or []) for node in nodes)
 
 
 #: Below this, the gzip header costs more than the compression saves.
@@ -477,6 +530,30 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
             except ValueError:
                 self._json_response({"error": "depth must be an integer or full"}, 400)
                 return
+        try:
+            limit = int(qs.get("limit", [_TREE_CHILD_LIMIT])[0])
+            max_nodes = int(qs.get("max_nodes", [_TREE_NODE_LIMIT])[0])
+        except (TypeError, ValueError):
+            self._json_response(
+                {"error": "limit and max_nodes must be positive integers"}, 400
+            )
+            return
+        if not 1 <= limit <= _TREE_CHILD_LIMIT_MAX:
+            self._json_response(
+                {"error": f"limit must be between 1 and {_TREE_CHILD_LIMIT_MAX}"},
+                400,
+            )
+            return
+        if not 1 <= max_nodes <= _TREE_NODE_LIMIT_MAX:
+            self._json_response(
+                {
+                    "error": (
+                        f"max_nodes must be between 1 and {_TREE_NODE_LIMIT_MAX}"
+                    )
+                },
+                400,
+            )
+            return
 
         source = self.__class__._tree_data
         if path:
@@ -485,8 +562,23 @@ class _ViewerHandler(_HeadRequestMixin, BaseHTTPRequestHandler):
                 self._json_response({"error": "tree path not found", "path": path}, 404)
                 return
             source = source.get("children") or []
-        nodes = _slice_tree_nodes(source, depth)
-        self._json_response({"nodes": nodes, "path": path, "depth": depth_raw})
+        nodes = _slice_tree_nodes(source, depth, limit=limit, max_nodes=max_nodes)
+        truncated = (
+            len(source) > limit
+            or len(source) > max_nodes
+            or _tree_slice_has_more(nodes)
+        )
+        self._json_response(
+            {
+                "nodes": nodes,
+                "path": path,
+                "depth": depth_raw,
+                "limit": limit,
+                "max_nodes": max_nodes,
+                "returned_nodes": _count_tree_nodes(nodes),
+                "truncated": truncated,
+            }
+        )
 
     def _handle_search(self):
         """Search the complete pre-built profile, including unloaded tiles."""

--- a/tests/test_web_foundation.py
+++ b/tests/test_web_foundation.py
@@ -106,6 +106,55 @@ def test_tree_slice_preserves_children_marker_without_mutating_source():
     assert source[0]["children"] == [{"path": "child"}]
 
 
+def test_tree_web_endpoint_reports_and_enforces_fanout_limit():
+    old_data = web._ViewerHandler._tree_data
+    old_configured = web._ViewerHandler._tree_configured
+    web._ViewerHandler._tree_data = [
+        {
+            "type": "nvtx",
+            "name": "root",
+            "path": "root",
+            "children": [
+                {"type": "kernel", "name": f"child-{index}", "path": f"root > {index}"}
+                for index in range(5)
+            ],
+        }
+    ]
+    web._ViewerHandler._tree_configured = True
+    try:
+        status, body, _content_type = _get(
+            web._ViewerHandler, "/api/tree?depth=1&limit=2&max_nodes=3"
+        )
+    finally:
+        web._ViewerHandler._tree_data = old_data
+        web._ViewerHandler._tree_configured = old_configured
+
+    payload = json.loads(body)
+    root = payload["nodes"][0]
+    assert status == 200
+    assert payload["truncated"] is True
+    assert payload["limit"] == 2
+    assert payload["max_nodes"] == 3
+    assert payload["returned_nodes"] == 3
+    assert len(root["children"]) == 2
+    assert root["has_more"] is True
+    assert root["children_total"] == 5
+
+
+def test_tree_web_endpoint_rejects_unbounded_limits():
+    old_configured = web._ViewerHandler._tree_configured
+    web._ViewerHandler._tree_configured = True
+    try:
+        status, body, _content_type = _get(
+            web._ViewerHandler, "/api/tree?limit=2001"
+        )
+    finally:
+        web._ViewerHandler._tree_configured = old_configured
+
+    assert status == 400
+    assert "limit must be between" in json.loads(body)["error"]
+
+
 def test_timeline_data_rejects_obsolete_resolution_parameter():
     status, body, content_type = _get(web._ViewerHandler, "/api/data?resolution=2000")
 


### PR DESCRIPTION
## Summary

Fixes #506 by making the lazy NVTX tree response bounded by fan-out and total node count.

- Add `limit` (default 256, max 2000) for children per node.
- Add `max_nodes` (default 10000, max 20000) for the complete serialized response.
- Return `truncated`, `returned_nodes`, `limit`, and `max_nodes` metadata.
- Mark partial child lists with `has_more` and `children_total`.
- Keep the existing `has_children` lazy marker and `202 building` response unchanged.
- Update the tree viewer to show bounded-slice notices instead of treating partial data as complete.
- Document the endpoint contract and add regression coverage for fan-out, total caps, and invalid limits.

## Verification

- `ruff check` — passed
- `node --check` on the embedded NVTX tree script — passed
- Web/session/NVTX focused suite — `39 passed`
- Live `perf.sqlite` checkpoint (`--trim 100 200`):
  - `/api/tree?depth=1` returned about `154 KB` instead of the previously observed `72 MB`.
  - `returned_nodes=577`, `truncated=true`.
  - Large children reported `has_more=true` and `children_total` values of `2764` and `164868` while returning at most 256 children.
  - `limit=2&max_nodes=3` enforced the total cap.
  - A request during background build still returned HTTP 202 with the existing building marker.
