### PR TITLE
feat(tui): persist completed chat handoff

### DIFF
--- a/src/nsys_ai/tree/chat.py
+++ b/src/nsys_ai/tree/chat.py
@@ -196,6 +196,9 @@ class ChatPanel(Widget):
 
         content = ""
         actions: list[dict] = []
+        runner_evidence: dict[str, list[dict]] = {}
+        runner_selected: list[str] = []
+        completed = False
         try:
             stream = chat_mod.stream_agent_loop(
                 model=model,
@@ -223,9 +226,34 @@ class ChatPanel(Widget):
                     if act:
                         actions.append(act)
                 elif t == "done":
+                    runner_evidence = ev.get("evidence") or {}
+                    runner_selected = list(ev.get("selected_skills") or [])
+                    completed = True
                     break
         except Exception as e:
             content = f"Error: {e}"
+
+        if completed and self._session_id and self._db_path and runner_evidence:
+            try:
+                session_log = chat_mod._record_session_ask(
+                    self._session_id,
+                    self._session_root,
+                    question=user_msg,
+                    answer=content,
+                    selected_skills=runner_selected,
+                    evidence=runner_evidence,
+                    profile_path=self._db_path,
+                    trim_kwargs={},
+                )
+                self.app.call_from_thread(
+                    self._on_system_event,
+                    f"Session handoff saved: {session_log}",
+                )
+            except Exception:
+                self.app.call_from_thread(
+                    self._on_system_event,
+                    "Session handoff failed; the chat response is still available.",
+                )
 
         # Distill history
         try:

--- a/tests/test_tui_chat_panel.py
+++ b/tests/test_tui_chat_panel.py
@@ -1,0 +1,120 @@
+"""Session handoff tests for the shared tree/timeline ChatPanel."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from textual.app import App, ComposeResult
+
+from nsys_ai.profile_runner import build_local_profile_reference
+from nsys_ai.session_store import SessionStore
+from nsys_ai.tree.chat import ChatPanel
+
+PROFILE = Path(__file__).parent / "fixtures" / "h100_2gpu_1s.sqlite"
+
+
+class _ChatHost(App):
+    def __init__(self, panel: ChatPanel) -> None:
+        super().__init__()
+        self.panel = panel
+
+    def compose(self) -> ComposeResult:
+        yield self.panel
+
+
+async def _until(pilot, predicate, limit: int = 300) -> bool:
+    for _ in range(limit):
+        if predicate():
+            return True
+        await pilot.pause()
+    return predicate()
+
+
+@pytest.mark.asyncio
+async def test_chat_panel_persists_completed_runner_handoff(tmp_path, monkeypatch):
+    """A completed TUI turn writes the same ask record as Web transports."""
+    from nsys_ai import chat as chat_mod
+
+    session_root = tmp_path / "sessions"
+    SessionStore(session_root).create(
+        "tui-chat-001",
+        before_profile=build_local_profile_reference(str(PROFILE.absolute())),
+    )
+
+    captured: dict = {}
+
+    def fake_stream(**kwargs):
+        captured.update(kwargs)
+        yield {"type": "text", "content": "Grounded answer"}
+        yield {
+            "type": "done",
+            "selected_skills": ["root_cause_matcher", "top_kernels"],
+            "evidence": {"top_kernels": [{"name": "gemm"}]},
+        }
+
+    monkeypatch.setattr(chat_mod, "get_default_model", lambda: "test/model")
+    monkeypatch.setattr(chat_mod, "stream_agent_loop", fake_stream)
+
+    panel = ChatPanel(
+        db_path=str(PROFILE.absolute()),
+        session_id="tui-chat-001",
+        session_root=str(session_root),
+    )
+    app = _ChatHost(panel)
+
+    async with app.run_test(size=(100, 20)) as pilot:
+        field = panel.query_one("#chat-input")
+        field.focus()
+        field.value = "why is this slow?"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: bool(captured))
+        assert await _until(pilot, lambda: not panel.is_running)
+
+    record_path = session_root / "tui-chat-001" / "logs" / "ask.jsonl"
+    record = json.loads(record_path.read_text(encoding="utf-8"))
+    assert record["kind"] == "ask"
+    assert record["question"] == "why is this slow?"
+    assert record["answer"] == "Grounded answer"
+    assert record["selected_skills"] == ["root_cause_matcher", "top_kernels"]
+    assert record["evidence"]["top_kernels"][0]["name"] == "gemm"
+    assert captured["prefill_evidence"] is True
+
+
+@pytest.mark.asyncio
+async def test_chat_panel_does_not_persist_incomplete_turn(tmp_path, monkeypatch):
+    """A cancelled/error turn must not create a misleading completed ask log."""
+    from nsys_ai import chat as chat_mod
+
+    session_root = tmp_path / "sessions"
+    SessionStore(session_root).create(
+        "tui-chat-002",
+        before_profile=build_local_profile_reference(str(PROFILE.absolute())),
+    )
+
+    calls: list[dict] = []
+
+    def incomplete_stream(**kwargs):
+        calls.append(kwargs)
+        yield {"type": "text", "content": "partial"}
+
+    monkeypatch.setattr(chat_mod, "get_default_model", lambda: "test/model")
+    monkeypatch.setattr(chat_mod, "stream_agent_loop", incomplete_stream)
+
+    panel = ChatPanel(
+        db_path=str(PROFILE.absolute()),
+        session_id="tui-chat-002",
+        session_root=str(session_root),
+    )
+    app = _ChatHost(panel)
+
+    async with app.run_test(size=(100, 20)) as pilot:
+        field = panel.query_one("#chat-input")
+        field.focus()
+        field.value = "why is this slow?"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: bool(calls))
+        assert await _until(pilot, lambda: not panel.is_running)
+
+    assert not (session_root / "tui-chat-002" / "logs" / "ask.jsonl").exists()


### PR DESCRIPTION
## Summary

Refs #434.

- persist completed tree/timeline `ChatPanel` turns to the active session's `logs/ask.jsonl`
- use the runner `selected_skills` and `evidence` carried by the shared `stream_agent_loop` done event
- keep cancelled, errored, or incomplete turns out of the completed ask log
- add a real Textual session-host test for both completed and incomplete turns

This completes the TUI side of the conversational session-log slice; #434 remains open for the final cross-surface release-gate review.

## Verification

- `PYTHONPATH=src /home/rich-wsl/nsys-ai-e2e-main/.venv/bin/python -m pytest tests/test_chat.py tests/test_tui_chat_app.py tests/test_tui_chat_panel.py tests/test_tui_tree_app.py tests/test_tui_timeline_app.py tests/test_web_foundation.py tests/test_loop_api.py tests/test_loop_state.py tests/test_e2e_golden_loop.py -q --tb=short` — 168 passed
- `ruff check src/nsys_ai/tree/chat.py tests/test_tui_chat_panel.py`
- `git diff --check`
