### PR TITLE
feat(cli): persist ask session handoff

### DIFF
--- a/src/nsys_ai/agent/loop.py
+++ b/src/nsys_ai/agent/loop.py
@@ -85,6 +85,10 @@ class Agent:
 
     def ask(self, question: str) -> str:
         """Run deterministic triage/deep-dive evidence, then synthesize it."""
+        return self.ask_result(question)[0]
+
+    def ask_result(self, question: str) -> tuple[str, dict[str, list[dict]], list[str]]:
+        """Return the answer plus runner evidence for session handoff callers."""
         try:
             from ..chat_config import _get_model_and_key
 
@@ -93,7 +97,7 @@ class Agent:
             log.debug("LLM model/key resolution failed", exc_info=True)
             model, api_key = None, None
         has_llm = bool(model and api_key)
-        answer, _evidence, _selected = runner.answer_question(
+        return runner.answer_question(
             self.conn,
             question,
             profile_path=self.profile_path,
@@ -103,7 +107,6 @@ class Agent:
             triage_selector=self._try_llm_triage if has_llm else None,
             summary_provider=self._try_llm_synthesis if has_llm else None,
         )
-        return answer
 
     def run_skill(self, skill_name: str, **kwargs) -> str:
         """Run one registered skill by name."""

--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -19,7 +19,6 @@ import logging
 import os
 import sys
 from collections.abc import Callable
-from datetime import datetime, timezone
 
 # ---------------------------------------------------------------------------
 # Sub-module re-exports — keep the public API stable for existing callers.
@@ -219,31 +218,19 @@ def _record_session_ask(
     profile_path: str,
     trim_kwargs: dict,
 ) -> str | None:
-    """Persist one transport-neutral ask result for a Web session.
+    """Compatibility wrapper for the shared session ask-log publisher."""
+    from .session_cli import append_ask_log
 
-    The log is deliberately additive and does not mutate the SessionStore
-    phase or findings artifact.  CLI/TUI analysis remains the owner of those
-    phase-bearing artifacts; Web ask contributes the conversational handoff
-    record that the next surface can inspect.
-    """
-    if not session_id:
-        return None
-    from .session_store import SessionStore
-
-    record = {
-        "schema_version": "0.1",
-        "kind": "ask",
-        "recorded_at": datetime.now(timezone.utc).isoformat(),
-        "question": question,
-        "answer": answer,
-        "selected_skills": list(selected_skills),
-        "evidence": evidence,
-        "profile_path": profile_path,
-        "trim": dict(trim_kwargs),
-    }
-    with SessionStore(session_root or ".nsys-ai/sessions").writer(session_id) as writer:
-        writer.append_log("ask", record)
-    return "logs/ask.jsonl"
+    return append_ask_log(
+        session_id,
+        session_root,
+        question=question,
+        answer=answer,
+        selected_skills=selected_skills,
+        evidence=evidence,
+        profile_path=profile_path,
+        trim_kwargs=trim_kwargs,
+    )
 
 
 def _last_user_question(messages: list) -> str:

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -2524,11 +2524,31 @@ def _cmd_agent(args, _profile):
 def _cmd_ask(args, _profile):
     """Simplified alias for `agent ask`."""
     from nsys_ai.agent.loop import Agent
+    from nsys_ai.session_cli import (
+        DEFAULT_SESSION_ROOT,
+        append_ask_log,
+        resolve_session_location,
+    )
 
     profile_path = _resolve_ask_profile(args)
+    location = resolve_session_location(
+        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
+    )
     agent = Agent(profile_path)
     try:
-        print(agent.ask(args.question))
+        answer, evidence, selected = agent.ask_result(args.question)
+        if location is not None:
+            append_ask_log(
+                location.session_id,
+                location.root,
+                question=args.question,
+                answer=answer,
+                selected_skills=selected,
+                evidence=evidence,
+                profile_path=profile_path,
+                trim_kwargs=agent._trim_kwargs,
+            )
+        print(answer)
     finally:
         agent.close()
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -2510,12 +2510,7 @@ def _cmd_agent(args, _profile):
         finally:
             agent.close()
     elif args.agent_action == "ask":
-        profile_path = _resolve_ask_profile(args)
-        agent = Agent(profile_path)
-        try:
-            print(agent.ask(args.question))
-        finally:
-            agent.close()
+        print(_run_cli_ask(args))
     else:
         print("Usage: nsys-ai agent {analyze,ask} ...")
         sys.exit(1)
@@ -2523,6 +2518,11 @@ def _cmd_agent(args, _profile):
 
 def _cmd_ask(args, _profile):
     """Simplified alias for `agent ask`."""
+    print(_run_cli_ask(args))
+
+
+def _run_cli_ask(args) -> str:
+    """Run either public CLI ask entry point and publish its session handoff."""
     from nsys_ai.agent.loop import Agent
     from nsys_ai.session_cli import (
         DEFAULT_SESSION_ROOT,
@@ -2548,7 +2548,7 @@ def _cmd_ask(args, _profile):
                 profile_path=profile_path,
                 trim_kwargs=agent._trim_kwargs,
             )
-        print(answer)
+        return answer
     finally:
         agent.close()
 

--- a/src/nsys_ai/session_cli.py
+++ b/src/nsys_ai/session_cli.py
@@ -10,6 +10,7 @@ import os
 import shlex
 from collections.abc import Mapping
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,36 @@ from .session_store import (
 )
 
 DEFAULT_SESSION_ROOT = ".nsys-ai/sessions"
+
+
+def append_ask_log(
+    session_id: str | None,
+    session_root: str | os.PathLike[str] | None,
+    *,
+    question: str,
+    answer: str,
+    selected_skills: list[str],
+    evidence: Mapping[str, list[dict]],
+    profile_path: str,
+    trim_kwargs: Mapping,
+) -> str | None:
+    """Append one completed ask handoff for any transport."""
+    if not session_id:
+        return None
+    record = {
+        "schema_version": "0.1",
+        "kind": "ask",
+        "recorded_at": datetime.now(timezone.utc).isoformat(),
+        "question": question,
+        "answer": answer,
+        "selected_skills": list(selected_skills),
+        "evidence": dict(evidence),
+        "profile_path": profile_path,
+        "trim": dict(trim_kwargs),
+    }
+    with SessionStore(session_root or DEFAULT_SESSION_ROOT).writer(session_id) as writer:
+        writer.append_log("ask", record)
+    return "logs/ask.jsonl"
 
 
 @dataclass(frozen=True)

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -77,6 +77,55 @@ def test_session_directory_can_be_used_by_publish_facade(tmp_path: Path):
     assert (handoff / "findings.json").is_file()
 
 
+def test_cli_ask_persists_completed_session_handoff(tmp_path: Path, monkeypatch, capsys):
+    """The CLI ask facade writes the same evidence-first handoff log as Web/TUI."""
+    from nsys_ai.cli import handlers
+    from nsys_ai.profile_runner import build_local_profile_reference
+
+    profile = BEFORE.resolve()
+    reference = build_local_profile_reference(profile)
+    handoff = tmp_path / "cli-ask-session"
+    SessionStore(handoff.parent).create(handoff.name, before_profile=reference)
+
+    class FakeAgent:
+        def __init__(self, profile_path):
+            self.profile_path = profile_path
+            self._trim_kwargs = {}
+
+        def ask_result(self, question):
+            assert question == "why is this slow?"
+            return (
+                "## Summary\nGrounded",
+                {"top_kernels": [{"name": "gemm"}]},
+                ["root_cause_matcher", "top_kernels"],
+            )
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr("nsys_ai.agent.loop.Agent", FakeAgent)
+    handlers._cmd_ask(
+        type(
+            "Args",
+            (),
+            {
+                "profile": None,
+                "session": str(handoff),
+                "question": "why is this slow?",
+            },
+        )(),
+        None,
+    )
+    assert "Grounded" in capsys.readouterr().out
+
+    record = json.loads(
+        (handoff / "logs" / "ask.jsonl").read_text(encoding="utf-8")
+    )
+    assert record["question"] == "why is this slow?"
+    assert record["selected_skills"] == ["root_cause_matcher", "top_kernels"]
+    assert record["evidence"]["top_kernels"][0]["name"] == "gemm"
+
+
 def _subprocess_environment(**extra: str) -> dict[str, str]:
     environment = dict(os.environ)
     source = str(ROOT / "src")


### PR DESCRIPTION
## Summary

Refs #434.

- add `Agent.ask_result()` so CLI callers retain the canonical answer/evidence/selected-skills tuple
- publish CLI `ask --session` completions to `logs/ask.jsonl`
- move the ask-log writer into `session_cli.py` and keep the Web/TUI compatibility wrapper on that shared facade
- cover the CLI session handoff contract and preserve the existing `Agent.ask()` string API

This closes the remaining CLI side of the conversational session-log slice; #434 remains open until the final cross-surface release-gate audit.

## Verification

- `PYTHONPATH=src /home/rich-wsl/nsys-ai-e2e-main/.venv/bin/python -m pytest tests/test_agent.py tests/test_session_cli.py tests/test_chat.py tests/test_tui_chat_panel.py -q --tb=short` — 107 passed
- `ruff check src/nsys_ai/session_cli.py src/nsys_ai/chat.py src/nsys_ai/agent/loop.py src/nsys_ai/cli/handlers.py tests/test_session_cli.py`
- real CLI session E2E: `diagnose <h100_2gpu_1s.sqlite> --session <dir>` followed by `ask --session <dir> ...` produced `findings.json`, `session.json`, and `logs/ask.jsonl` with root-cause/top-kernel/idle-gap evidence
