### PR TITLE
feat(tui): persist standalone chat session handoff

### DIFF
--- a/src/nsys_ai/chat.py
+++ b/src/nsys_ai/chat.py
@@ -1247,7 +1247,8 @@ def stream_agent_loop(
     * ``{"type": "system", "content": str}``   — status / warning message
     * ``{"type": "action", "action": dict}``   — navigation/zoom action
     * ``{"type": "done",   "usage": dict, "selected_skills": list,
-      "evidence": dict}`` — final event with runner handoff metadata
+      "evidence": dict, "completed": bool}`` — final event with runner
+      handoff metadata; ``completed`` is false when the turn ended in an error
 
     When *diff_context* is set, uses Phase C diff tools and no single-profile DB.
     *diff_paths* must be (before_path, after_path) for the system prompt.
@@ -1288,7 +1289,7 @@ def stream_agent_loop(
         import litellm
     except ImportError:
         yield {"type": "text", "content": "LLM not available (install litellm)."}
-        yield {"type": "done", "usage": {}}
+        yield {"type": "done", "usage": {}, "completed": False}
         return
 
     # Per-request finding counter (replaces old module-level global).
@@ -1318,12 +1319,12 @@ def stream_agent_loop(
             )
         except (RuntimeError, NsysAiError) as e:
             yield {"type": "text", "content": f"Profile error: {e}"}
-            yield {"type": "done", "usage": {}}
+            yield {"type": "done", "usage": {}, "completed": False}
             return
         except Exception as e:
             _log.warning("Profile session setup failed: %s", e, exc_info=True)
             yield {"type": "text", "content": f"Error loading profile data: {e}"}
-            yield {"type": "done", "usage": {}}
+            yield {"type": "done", "usage": {}, "completed": False}
             return
 
     # Fix 2: Filter out DB-dependent tools when no profile is connected.
@@ -1356,13 +1357,14 @@ def stream_agent_loop(
 
     usage: dict = {}
 
-    def done_event() -> dict:
-        """Build one stable completion event for every normal exit path."""
+    def done_event(*, completed: bool = True) -> dict:
+        """Build one stable completion event for every exit path."""
         return {
             "type": "done",
             "usage": dict(usage),
             "selected_skills": list(runner_selected),
             "evidence": runner_evidence,
+            "completed": completed,
         }
     turn_count = 0
 
@@ -1420,7 +1422,7 @@ def stream_agent_loop(
                 )
             except Exception as e:
                 yield {"type": "text", "content": f"LLM error: {_friendly_error(model, e)}"}
-                yield done_event()
+                yield done_event(completed=False)
                 return
 
             content_parts: list[str] = []
@@ -1500,7 +1502,7 @@ def stream_agent_loop(
                         "Please start a new chat session to continue."
                     ),
                 }
-                yield done_event()
+                yield done_event(completed=False)
                 return
 
             full_content = "".join(content_parts).strip() if content_parts else ""
@@ -1658,7 +1660,7 @@ def stream_agent_loop(
                         grounding_failure or "a tool call was invalid or failed"
                     ),
                 }
-                yield done_event()
+                yield done_event(completed=False)
                 return
             elif turn_grounding_succeeded:
                 evidence_ready = True

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -1947,12 +1947,62 @@ def _cmd_chat(args, _profile):
             "\"<question>\"' for a single non-interactive answer."
         )
 
+    from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
+
+    location = resolve_session_location(
+        getattr(args, "session", None), root=DEFAULT_SESSION_ROOT
+    )
+    profile_path = _resolve_chat_profile(args, location)
+
+    if location is not None:
+        from nsys_ai.profile_runner import build_local_profile_reference
+        from nsys_ai.session_store import SessionExistsError, SessionStore
+
+        before_ref = build_local_profile_reference(profile_path)
+        store = SessionStore(location.root)
+        try:
+            store.create(location.session_id, before_profile=before_ref)
+        except SessionExistsError:
+            pass
+
     try:
         from nsys_ai.tui_textual import run_chat_tui
     except ImportError:
         print("Error: 'textual' package is required. Install with: pip install 'textual>=0.80.0'")
         return
-    run_chat_tui(args.profile)
+    if location is None:
+        run_chat_tui(profile_path)
+    else:
+        run_chat_tui(
+            profile_path,
+            session_id=location.session_id,
+            session_root=str(location.root),
+        )
+
+
+def _resolve_chat_profile(args, location) -> str:
+    """Resolve chat's profile from an explicit path or session handoff."""
+    profile_path = getattr(args, "profile", None)
+    if profile_path:
+        return profile_path
+    if location is None:
+        print(
+            "Error: chat requires a profile, or --session <dir> with a recorded before profile",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    from nsys_ai.session_store import SessionStore
+
+    snapshot = SessionStore(location.root).load(location.session_id)
+    before = snapshot.state.before_profile
+    if before is None:
+        print(
+            f"Error: session {location.session_id} has no before profile",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    return before.path
 
 
 def _cmd_evidence(args, _profile):

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -844,7 +844,23 @@ def _build_parser():
     p.set_defaults(handler=_cmd_loop)
 
     p = sub.add_parser("chat", help="AI chat TUI")
-    p.add_argument("profile", help="Path to profile (.sqlite or .nsys-rep)")
+    p.add_argument(
+        "profile",
+        nargs="?",
+        default=None,
+        help="Path to profile (.sqlite or .nsys-rep); omit when using --session",
+    )
+    p.add_argument(
+        "--session",
+        nargs="?",
+        const="",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Open or resume the SessionStore handoff. A profile is required "
+            "when creating a new session."
+        ),
+    )
     p.set_defaults(handler=_cmd_chat)
 
     p = sub.add_parser("ask", help="Ask AI a backend analysis question")

--- a/src/nsys_ai/tui_textual.py
+++ b/src/nsys_ai/tui_textual.py
@@ -2,7 +2,7 @@
 tui_textual.py — Textual AI chat TUI for nsys-ai (§11.3, §11.8).
 
 Usage (registered as CLI command):
-    nsys-ai chat <profile>
+    nsys-ai chat <profile> [--session <dir>]
 
 Layout:
     Left panel:  DataTable of top kernels by GPU time.
@@ -204,10 +204,18 @@ class NsysChatApp(App):
         Binding("escape", "quit", "Quit", show=True),
     ]
 
-    def __init__(self, profile_path: str) -> None:
+    def __init__(
+        self,
+        profile_path: str,
+        *,
+        session_id: str | None = None,
+        session_root: str = ".nsys-ai/sessions",
+    ) -> None:
         super().__init__()
         self.profile_path = profile_path
         self.profile_name = Path(profile_path).name
+        self.session_id = session_id
+        self.session_root = session_root
         # LLM conversation history (user + assistant turns only; system is built internally).
         self._chat_messages: list[dict] = []
         # Top kernels loaded from the profile DB.
@@ -510,6 +518,9 @@ class NsysChatApp(App):
         # Snapshot history so the worker sees a consistent view (read-only copy).
         messages = list(self._chat_messages)
         accumulated: list[str] = []
+        runner_evidence: dict[str, list[dict]] = {}
+        runner_selected: list[str] = []
+        completed = False
 
         stream = stream_agent_loop(
             model=model,
@@ -517,6 +528,8 @@ class NsysChatApp(App):
             ui_context=ui_context,
             profile_path=self.profile_path,
             max_turns=5,
+            session_id=self.session_id,
+            session_root=self.session_root,
             prefill_evidence=True,
         )
         try:
@@ -553,7 +566,11 @@ class NsysChatApp(App):
                             self._on_system_event,
                             f"🔍 Zoom: {start_s:.3f}s – {end_s:.3f}s",
                         )
-                # "done" type is handled by loop termination.
+                elif etype == "done":
+                    runner_evidence = event.get("evidence") or {}
+                    runner_selected = list(event.get("selected_skills") or [])
+                    completed = event.get("completed", True) is not False
+                    break
         except Exception as e:
             if not cancelled():
                 self.call_from_thread(
@@ -580,6 +597,33 @@ class NsysChatApp(App):
             return
 
         final_content = "".join(accumulated)
+        if completed and self.session_id:
+            try:
+                from .session_cli import append_ask_log
+
+                session_log = append_ask_log(
+                    self.session_id,
+                    self.session_root,
+                    question=user_msg,
+                    answer=final_content,
+                    selected_skills=runner_selected,
+                    evidence=runner_evidence,
+                    profile_path=self.profile_path,
+                    trim_kwargs={},
+                )
+                self.call_from_thread(
+                    self._ui_call,
+                    gen,
+                    self._on_system_event,
+                    f"Session handoff saved: {session_log}",
+                )
+            except Exception:
+                self.call_from_thread(
+                    self._ui_call,
+                    gen,
+                    self._on_system_event,
+                    "Session handoff failed; the chat response is still available.",
+                )
         self.call_from_thread(self._ui_call, gen, self._on_stream_done, final_content)
 
         # Distill history to compress tool call/result sequences for lean context (§11.7).
@@ -613,6 +657,15 @@ class NsysChatApp(App):
 # ---------------------------------------------------------------------------
 
 
-def run_chat_tui(profile_path: str) -> None:
-    """Launch the Textual AI chat TUI for the given profile path."""
-    NsysChatApp(profile_path).run()
+def run_chat_tui(
+    profile_path: str,
+    *,
+    session_id: str | None = None,
+    session_root: str = ".nsys-ai/sessions",
+) -> None:
+    """Launch the Textual AI chat TUI with an optional session handoff."""
+    NsysChatApp(
+        profile_path,
+        session_id=session_id,
+        session_root=session_root,
+    ).run()

--- a/tests/test_cli_usage_errors.py
+++ b/tests/test_cli_usage_errors.py
@@ -355,6 +355,44 @@ def test_chat_accepts_a_terminal_whose_stdout_is_redirected(monkeypatch, tmp_pat
     assert started == [str(PROFILE)]
 
 
+def test_chat_session_opens_handoff_and_passes_it_to_tui(monkeypatch, tmp_path: Path):
+    """The standalone chat entry point can create a portable session handoff."""
+    from argparse import Namespace
+
+    from nsys_ai import tui_textual
+    from nsys_ai.cli import handlers
+    from nsys_ai.session_store import SessionStore
+
+    started: list[tuple[str, dict]] = []
+    monkeypatch.setattr(
+        tui_textual,
+        "run_chat_tui",
+        lambda path, **kwargs: started.append((path, kwargs)),
+    )
+
+    class _Terminal:
+        @staticmethod
+        def isatty():
+            return True
+
+    monkeypatch.setattr(sys, "stdin", _Terminal())
+    session_dir = tmp_path / "chat-session"
+    handlers._cmd_chat(
+        Namespace(profile=str(PROFILE), session=str(session_dir)),
+        None,
+    )
+
+    assert started == [
+        (
+            str(PROFILE),
+            {"session_id": "chat-session", "session_root": str(tmp_path)},
+        )
+    ]
+    snapshot = SessionStore(tmp_path).load("chat-session")
+    assert snapshot.state.before_profile is not None
+    assert snapshot.state.before_profile.path == str(PROFILE)
+
+
 # ── a busy port ────────────────────────────────────────────────────────
 
 

--- a/tests/test_tui_chat_app.py
+++ b/tests/test_tui_chat_app.py
@@ -69,7 +69,11 @@ class _GatedStream:
             for i in range(1, 6):
                 self.produced.append(f"<{label}{i}>")
                 yield {"type": "text", "content": f"<{label}{i}>"}
-            yield {"type": "done"}
+            yield {
+                "type": "done",
+                "selected_skills": ["top_kernels"],
+                "evidence": {"top_kernels": [{"name": "fake_kernel", "total_ms": 1.0}]},
+            }
         finally:
             # Lets a test wait for the worker to be done with this stream instead
             # of sleeping. The worker's `finally: stream.close()` throws
@@ -176,6 +180,86 @@ async def test_cancelled_turn_stops_writing(profile_copy, fake_stream):
         assert [m["role"] for m in app._chat_messages] == ["user", "user", "assistant"], (
             f"unexpected history shape: {app._chat_messages}"
         )
+
+
+@pytest.mark.asyncio
+async def test_completed_session_turn_persists_canonical_handoff(profile_copy, fake_stream, tmp_path):
+    """A standalone chat turn writes the same handoff shape as other TUIs."""
+    import json
+
+    from nsys_ai.profile_runner import build_local_profile_reference
+    from nsys_ai.session_store import SessionStore
+    from nsys_ai.tui_textual import NsysChatApp
+
+    session_root = tmp_path / "sessions"
+    SessionStore(session_root).create(
+        "chat-session",
+        before_profile=build_local_profile_reference(profile_copy),
+    )
+    app = NsysChatApp(
+        profile_copy,
+        session_id="chat-session",
+        session_root=str(session_root),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        inp = app.query_one("#chat-input")
+        inp.focus()
+        inp.value = "What is the top kernel?"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: "<What is the top kernel?0>" in fake_stream.produced)
+        fake_stream.gate("What is the top kernel?").set()
+        assert await _until(pilot, lambda: app._is_generating is False)
+
+    log_path = session_root / "chat-session" / "logs" / "ask.jsonl"
+    records = [json.loads(line) for line in log_path.read_text().splitlines()]
+    assert len(records) == 1
+    assert records[0]["kind"] == "ask"
+    assert records[0]["question"] == "What is the top kernel?"
+    assert records[0]["answer"] == "<What is the top kernel?0><What is the top kernel?1><What is the top kernel?2><What is the top kernel?3><What is the top kernel?4><What is the top kernel?5>"
+    assert records[0]["selected_skills"] == ["top_kernels"]
+    assert records[0]["evidence"]["top_kernels"][0]["name"] == "fake_kernel"
+    assert records[0]["profile_path"] == profile_copy
+
+
+@pytest.mark.asyncio
+async def test_failed_session_turn_is_not_persisted(profile_copy, monkeypatch, tmp_path):
+    """An error completion is visible in the UI but never becomes handoff."""
+    from nsys_ai.profile_runner import build_local_profile_reference
+    from nsys_ai.session_store import SessionStore
+    from nsys_ai.tui_textual import NsysChatApp
+
+    def failed_stream(**_kwargs):
+        yield {"type": "text", "content": "Profile error: unavailable"}
+        yield {"type": "done", "completed": False}
+
+    import nsys_ai.chat as chat_mod
+
+    monkeypatch.setattr(chat_mod, "stream_agent_loop", failed_stream)
+    monkeypatch.setattr(
+        chat_mod,
+        "_get_model_and_key",
+        lambda *args, **kwargs: ("fake/model", "key"),
+    )
+    session_root = tmp_path / "sessions"
+    SessionStore(session_root).create(
+        "failed-session",
+        before_profile=build_local_profile_reference(profile_copy),
+    )
+    app = NsysChatApp(
+        profile_copy,
+        session_id="failed-session",
+        session_root=str(session_root),
+    )
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        inp = app.query_one("#chat-input")
+        inp.focus()
+        inp.value = "What failed?"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: app._is_generating is False)
+
+    assert not (session_root / "failed-session" / "logs" / "ask.jsonl").exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #512.

- add `nsys-ai chat [profile] --session <dir>` with the same SessionStore location rules as other transports;
- allow an existing session's recorded before profile to be used without repeating the profile path;
- pass session identity through the standalone Textual chat into `stream_agent_loop`;
- persist only completed turns to the canonical `logs/ask.jsonl`, including question, answer, selected skills, evidence, profile path, and trim metadata;
- add an explicit `completed` flag to stream completion events so failed/error turns are not persisted;
- preserve the legacy no-session invocation and existing Textual cancellation behavior.

## Verification

- `ruff check` and `git diff --check` pass;
- focused standalone chat/session/chat suite: **139 passed**;
- `python -m nsys_ai chat --help` shows the new optional session handoff;
- tests cover new session creation, session forwarding, completed handoff persistence, and failed-turn non-persistence.
