### PR TITLE
fix(tui): preserve chat handoff completion state

### DIFF
--- a/src/nsys_ai/tree/chat.py
+++ b/src/nsys_ai/tree/chat.py
@@ -14,6 +14,7 @@ Usage:
 
 from __future__ import annotations
 
+import logging
 import threading
 from collections.abc import Callable
 
@@ -21,6 +22,8 @@ from textual.app import ComposeResult
 from textual.reactive import reactive
 from textual.widget import Widget
 from textual.widgets import Input, RichLog, Static
+
+_log = logging.getLogger(__name__)
 
 
 class ChatPanel(Widget):
@@ -228,32 +231,41 @@ class ChatPanel(Widget):
                 elif t == "done":
                     runner_evidence = ev.get("evidence") or {}
                     runner_selected = list(ev.get("selected_skills") or [])
-                    completed = True
+                    completed = ev.get("completed", True) is not False
                     break
         except Exception as e:
             content = f"Error: {e}"
 
-        if completed and self._session_id and self._db_path and runner_evidence:
-            try:
-                session_log = chat_mod._record_session_ask(
-                    self._session_id,
-                    self._session_root,
-                    question=user_msg,
-                    answer=content,
-                    selected_skills=runner_selected,
-                    evidence=runner_evidence,
-                    profile_path=self._db_path,
-                    trim_kwargs={},
-                )
+        if completed and self._session_id and self._db_path:
+            if not runner_evidence:
+                # A UI-context or action-only turn is a valid answer, but it is
+                # not grounded evidence and must not masquerade as an ask log.
                 self.app.call_from_thread(
                     self._on_system_event,
-                    f"Session handoff saved: {session_log}",
+                    "Session handoff skipped: this answer had no grounded evidence.",
                 )
-            except Exception:
-                self.app.call_from_thread(
-                    self._on_system_event,
-                    "Session handoff failed; the chat response is still available.",
-                )
+            else:
+                try:
+                    session_log = chat_mod._record_session_ask(
+                        self._session_id,
+                        self._session_root,
+                        question=user_msg,
+                        answer=content,
+                        selected_skills=runner_selected,
+                        evidence=runner_evidence,
+                        profile_path=self._db_path,
+                        trim_kwargs={},
+                    )
+                    self.app.call_from_thread(
+                        self._on_system_event,
+                        f"Session handoff saved: {session_log}",
+                    )
+                except Exception:
+                    _log.exception("Session handoff failed for %s", self._session_id)
+                    self.app.call_from_thread(
+                        self._on_system_event,
+                        "Session handoff failed; the chat response is still available.",
+                    )
 
         # Distill history
         try:

--- a/tests/test_tui_chat_panel.py
+++ b/tests/test_tui_chat_panel.py
@@ -118,3 +118,126 @@ async def test_chat_panel_does_not_persist_incomplete_turn(tmp_path, monkeypatch
         assert await _until(pilot, lambda: not panel.is_running)
 
     assert not (session_root / "tui-chat-002" / "logs" / "ask.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_chat_panel_does_not_persist_failed_turn_with_evidence(tmp_path, monkeypatch):
+    """The done completion flag keeps a failed grounded turn out of the log."""
+    from nsys_ai import chat as chat_mod
+
+    session_root = tmp_path / "sessions"
+    SessionStore(session_root).create(
+        "tui-chat-003",
+        before_profile=build_local_profile_reference(str(PROFILE.absolute())),
+    )
+
+    def failed_stream(**_kwargs):
+        yield {"type": "text", "content": "partial answer before failure"}
+        yield {
+            "type": "done",
+            "selected_skills": ["top_kernels"],
+            "evidence": {"top_kernels": [{"name": "gemm"}]},
+            "completed": False,
+        }
+
+    monkeypatch.setattr(chat_mod, "get_default_model", lambda: "test/model")
+    monkeypatch.setattr(chat_mod, "stream_agent_loop", failed_stream)
+
+    panel = ChatPanel(
+        db_path=str(PROFILE.absolute()),
+        session_id="tui-chat-003",
+        session_root=str(session_root),
+    )
+    app = _ChatHost(panel)
+
+    async with app.run_test(size=(100, 20)) as pilot:
+        field = panel.query_one("#chat-input")
+        field.focus()
+        field.value = "why is this partial?"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: not panel.is_running)
+
+    assert not (session_root / "tui-chat-003" / "logs" / "ask.jsonl").exists()
+
+
+@pytest.mark.asyncio
+async def test_chat_panel_reports_completed_turn_without_evidence(tmp_path, monkeypatch):
+    """A successful but ungrounded turn is explicitly explained, not silently skipped."""
+    from nsys_ai import chat as chat_mod
+
+    session_root = tmp_path / "sessions"
+    SessionStore(session_root).create(
+        "tui-chat-004",
+        before_profile=build_local_profile_reference(str(PROFILE.absolute())),
+    )
+
+    def ungrounded_stream(**_kwargs):
+        yield {"type": "text", "content": "UI-context answer"}
+        yield {"type": "done", "selected_skills": [], "evidence": {}}
+
+    monkeypatch.setattr(chat_mod, "get_default_model", lambda: "test/model")
+    monkeypatch.setattr(chat_mod, "stream_agent_loop", ungrounded_stream)
+
+    events: list[str] = []
+    panel = ChatPanel(
+        db_path=str(PROFILE.absolute()),
+        session_id="tui-chat-004",
+        session_root=str(session_root),
+    )
+    panel._on_system_event = events.append
+    app = _ChatHost(panel)
+
+    async with app.run_test(size=(100, 20)) as pilot:
+        field = panel.query_one("#chat-input")
+        field.focus()
+        field.value = "what does the UI show?"
+        await pilot.press("enter")
+        assert await _until(pilot, lambda: not panel.is_running)
+
+    assert not (session_root / "tui-chat-004" / "logs" / "ask.jsonl").exists()
+    assert events == ["Session handoff skipped: this answer had no grounded evidence."]
+
+
+@pytest.mark.asyncio
+async def test_chat_panel_logs_failed_handoff(tmp_path, monkeypatch, caplog):
+    """A failed handoff keeps the user message and traceback for maintainers."""
+    from nsys_ai import chat as chat_mod
+
+    session_root = tmp_path / "sessions"
+    SessionStore(session_root).create(
+        "tui-chat-005",
+        before_profile=build_local_profile_reference(str(PROFILE.absolute())),
+    )
+
+    def grounded_stream(**_kwargs):
+        yield {"type": "text", "content": "Grounded answer"}
+        yield {
+            "type": "done",
+            "selected_skills": ["top_kernels"],
+            "evidence": {"top_kernels": [{"name": "gemm"}]},
+        }
+
+    def fail_handoff(*_args, **_kwargs):
+        raise OSError("session root is read-only")
+
+    monkeypatch.setattr(chat_mod, "get_default_model", lambda: "test/model")
+    monkeypatch.setattr(chat_mod, "stream_agent_loop", grounded_stream)
+    monkeypatch.setattr(chat_mod, "_record_session_ask", fail_handoff)
+
+    panel = ChatPanel(
+        db_path=str(PROFILE.absolute()),
+        session_id="tui-chat-005",
+        session_root=str(session_root),
+    )
+    app = _ChatHost(panel)
+
+    with caplog.at_level("ERROR", logger="nsys_ai.tree.chat"):
+        async with app.run_test(size=(100, 20)) as pilot:
+            field = panel.query_one("#chat-input")
+            field.focus()
+            field.value = "why is this slow?"
+            await pilot.press("enter")
+            assert await _until(pilot, lambda: not panel.is_running)
+
+    assert "Session handoff failed for tui-chat-005" in caplog.text
+    assert "OSError: session root is read-only" in caplog.text


### PR DESCRIPTION
## Summary

Closes #514, #515, and #516.

- consume the shared streaming `done.completed` flag in the tree/timeline `ChatPanel`, so failed turns carrying evidence are not persisted as successful asks;
- make the deliberate no-evidence exclusion explicit with a user-visible system event;
- add a module logger and traceback for session handoff failures while preserving the existing non-blocking UI message;
- cover failed-with-evidence, completed-without-evidence, and handoff-exception paths.

## Verification

- `ruff check` and `git diff --check` pass;
- related chat/TUI/session/Web suite: **140 passed**;
- focused `tests/test_tui_chat_panel.py`: **5 passed**.
