### PR TITLE
test: include CLI subprocesses in coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 __pycache__/
+.coverage
+.coverage.*
+htmlcov/
 *.egg-info/
 dist/
 # `python -m build` leaves this beside dist/; only dist/ was ignored, so a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,6 +155,18 @@ skip conditions:
 python -m pytest tests/test_ci_coverage.py -v --tb=short
 ~~~
 
+To measure the full suite, including CLI subprocesses, use the repository's
+[subprocess-aware coverage guide](docs/dev/testing.md) and wrapper:
+
+~~~bash
+bash scripts/coverage.sh
+~~~
+
+The wrapper combines child-process data before reporting. A plain
+`pytest --cov` run from the repository root also gets the child startup hook;
+do not run it from another working directory because CLI tests intentionally
+use temporary child directories.
+
 ### Layer 4: lint and security
 
 These are required CI checks, not optional polish:
@@ -479,4 +491,3 @@ Before requesting review:
 - [ ] Committed fixtures are unchanged.
 - [ ] The PR body records commands, results, skips, and follow-ups.
 - [ ] No secret, private capture data, or machine-specific credential appears in the patch or PR.
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ alongside them.
 | [dev/ingest-policy.md](./dev/ingest-policy.md) | How a profile path becomes an open backend, and why call sites must not bypass it |
 | [dev/skill-contract.md](./dev/skill-contract.md) | How to add a portable, deterministic, JSON-safe analysis skill |
 | [dev/surface-adapters.md](./dev/surface-adapters.md) | How CLI, TUI, Web, MCP, and chat delegate shared policy and analysis |
+| [dev/testing.md](./dev/testing.md) | Test layers and subprocess-aware coverage |
 | [support-matrix.md](./support-matrix.md) | Committed export schemas verified by CI |
 
 ## Nsight Systems reference

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,0 +1,179 @@
+# Testing nsys-ai
+
+This page describes how to choose a test layer and how to measure coverage
+without losing the tests that launch `nsys-ai` as a child process.
+
+## The test boundary
+
+The repository has two kinds of Python process in a normal test run:
+
+```text
+pytest process
+├── unit and API tests      (measured by pytest-cov)
+└── python -m nsys_ai ...   (measured by sitecustomize)
+```
+
+That second branch is intentional. The CLI tests exercise the same public
+entry point a user runs, including argument parsing, profile resolution, exit
+codes, JSON serialization, and session files. Measuring only the parent would
+make those tests pass while reporting the CLI handlers as uncovered.
+
+## Fast layers
+
+Run the smallest useful layer first:
+
+```bash
+python -m nsys_ai --help
+python -m pytest tests/test_docs_index.py -q
+```
+
+For a code boundary, use a focused group:
+
+```bash
+# Skills and evidence
+python -m pytest tests/test_skills.py tests/test_abstention.py -q
+
+# CLI and shared loop
+python -m pytest tests/test_cli.py tests/test_loop_api.py tests/test_loop_state.py -q
+
+# Web and timeline transport
+python -m pytest tests/test_web_foundation.py tests/test_timeline_web_data.py -q
+```
+
+The complete correctness run remains:
+
+```bash
+python -m pytest tests/ -v --tb=short -rs
+```
+
+Run it from the repository root. Several CLI tests deliberately change their
+child's working directory to a temporary path; the root working directory is
+what makes relative fixture and package paths meaningful.
+
+## Coverage command
+
+Install the development extra once in the active environment:
+
+```bash
+python -m pip install -e '.[dev]'
+```
+
+Then use the checked-in wrapper:
+
+```bash
+bash scripts/coverage.sh
+```
+
+It accepts the same test selectors as pytest:
+
+```bash
+bash scripts/coverage.sh tests/test_cli.py
+bash scripts/coverage.sh tests/test_cli.py::test_doctor_json
+```
+
+The wrapper does four things:
+
+1. points `COVERAGE_FILE` at one checkout-local data file;
+2. starts `pytest --cov=src/nsys_ai` with parallel data enabled;
+3. combines `.coverage.*` files emitted by child interpreters; and
+4. prints one report with missing lines.
+
+The equivalent direct command is useful when the inline pytest-cov report is
+preferred:
+
+```bash
+COVERAGE_FILE="$PWD/.coverage" \
+  python -m pytest tests/ --cov=src/nsys_ai --cov-report=term-missing
+```
+
+`tests/conftest.py` detects the `pytest-cov` plugin and exports
+`COVERAGE_PROCESS_START`, `COVERAGE_SOURCE`, `COVERAGE_FILE`, and the checkout's
+`src/` directory to children. A normal `pytest` or `nsys-ai` invocation does
+not enable coverage.
+
+## Why `sitecustomize.py` exists
+
+Coverage cannot attach to a fresh `python -m nsys_ai` interpreter merely
+because its parent is being measured. Python imports the top-level
+`sitecustomize` module during startup, before `nsys_ai` is imported. The
+repository's [sitecustomize.py](../../src/sitecustomize.py) calls
+`coverage.process_startup()` when `COVERAGE_PROCESS_START` is present.
+
+The hook has one important detail: CLI tests often run with `cwd=tmp_path`.
+The normal coverage configuration names `src/nsys_ai` relative to the
+checkout, so the test hook also passes an absolute `COVERAGE_SOURCE`. Without
+that override, the child starts coverage successfully but silently records no
+application lines from a temporary working directory.
+
+`parallel = true` is required because multiple Python processes cannot safely
+write one SQLite coverage data file at the same time. Each process writes a
+sidecar, and `coverage combine` produces the reportable file.
+
+## Timing-sensitive tests
+
+`test_completion_before_deadline_wins_over_coarse_polling` tests a process
+completion/deadline race. Line tracing changes scheduling in both the pytest
+process and its fake `nsys` child, so the test is marked `no_cover` and removes
+the startup variables for that invocation. This is an explicit measurement
+boundary, not a skipped correctness test: the timing assertion still runs in
+the normal suite, just without instrumentation overhead.
+
+Do not add `no_cover` to a test merely because it is slow. Use it only when
+coverage itself changes the behavior under test, and record the reason beside
+the marker.
+
+## Reading the number
+
+The subprocess-aware number is the useful baseline for module-level gaps. It
+is expected to be higher than the old parent-only number for CLI-heavy modules
+such as `cli/handlers.py`; no test files or assertions need to be added just to
+make that percentage look larger.
+
+Coverage is a map of executed lines, not a quality score. It does not prove
+that a SQL result is correct, that a profile schema is complete, or that an
+end-to-end surface agrees with another surface. Keep the full suite,
+contract tests, real-profile checks, and skip-reason guard as separate signals.
+
+There is deliberately no coverage threshold in this change. First establish a
+trustworthy baseline, then decide whether a gate is appropriate. A threshold
+introduced before subprocess data is combined would gate the measurement
+harness rather than the product.
+
+## Troubleshooting
+
+### `cli/handlers.py` is still implausibly low
+
+Check all of the following:
+
+```bash
+python -m pip show coverage pytest-cov
+python -c 'import sys; print(sys.executable)'
+pwd
+```
+
+Run from the repository root and use `bash scripts/coverage.sh`. If you use a
+custom data path, make it absolute:
+
+```bash
+COVERAGE_FILE="$PWD/.coverage-local" bash scripts/coverage.sh tests/test_cli.py
+```
+
+### `No data collected`
+
+That warning can be legitimate for a test that only exercises code outside the
+configured source. It is not legitimate for a CLI test. Confirm that
+`COVERAGE_SOURCE` points to this checkout's `src/nsys_ai` and that `PYTHONPATH`
+contains this checkout's `src/`; both are set automatically by the test
+configuration when `--cov` is present.
+
+### Sidecars remain after a failed run
+
+They are disposable coverage data, ignored by Git. Re-run the wrapper; it
+starts with `coverage erase` and uses a fresh report.
+
+## Related contracts
+
+- [Contributing](../../CONTRIBUTING.md) — setup, test layers, and PR checks
+- [Skill contract](./skill-contract.md) — deterministic analysis behavior
+- [Surface adapters](./surface-adapters.md) — CLI/Web/TUI/MCP delegation
+- [Known limits](../user/known-limits.md) — what runtime analysis can and cannot prove

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,18 @@ ai = ["anthropic>=0.20.0", "litellm>=1.0.0"]  # backward compat alias
 tui = ["textual>=8.0.0"]                        # backward compat; textual is now core (tree + timeline)
 chat = ["litellm>=1.0.0", "nsys-ai[tui]"]       # AI chat TUI (tui extra kept for compat)
 cutracer = ["cutracer>=0.2.0"]                  # CUTracer CLI + instruction-level analysis
-dev = ["pytest>=8.2,<9", "ruff>=0.4.0", "pytest-textual-snapshot>=1.1.0", "pytest-asyncio>=0.25,<1"]
+dev = [
+    "pytest>=8.2,<9",
+    "pytest-asyncio>=0.25,<1",
+    "pytest-cov>=5.0",
+    "pytest-textual-snapshot>=1.1.0",
+    "coverage>=7.0",
+    "ruff>=0.4.0",
+]
 all = ["nsys-ai[agent,tui,chat,cutracer,mcp]"]
+
+[tool.setuptools]
+py-modules = ["sitecustomize"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
@@ -84,6 +94,17 @@ ignore = [
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "no_cover: exclude timing-sensitive tests from coverage instrumentation",
+]
+
+[tool.coverage.run]
+branch = true
+concurrency = ["multiprocessing", "thread"]
+disable_warnings = ["no-data-collected"]
+parallel = true
+sigterm = true
+source = ["src/nsys_ai"]
 
 [tool.bandit]
 # B110: try_except_pass; B608: SQL

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Run pytest with coverage for both the pytest process and CLI subprocesses.
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+python_cmd="${PYTHON:-python}"
+if ! command -v "$python_cmd" >/dev/null 2>&1; then
+    python_cmd=python3
+fi
+
+coverage_file="${COVERAGE_FILE:-$repo_root/.coverage}"
+export COVERAGE_FILE="$coverage_file"
+
+"$python_cmd" -m coverage erase
+
+if (($# == 0)); then
+    set -- tests/
+fi
+
+# pytest-cov reports the parent process and tests/conftest.py passes the
+# startup hook to every CLI child. Suppress its inline report so the explicit
+# combine/report below is the single final report.
+"$python_cmd" -m pytest "$@" --cov=src/nsys_ai --cov-report=
+
+# pytest-cov normally combines these itself. Keep the explicit step for
+# sidecars left by a child that exits after the plugin's reporting phase, and
+# make the script useful with older pytest-cov versions too.
+shopt -s nullglob
+parts=("${coverage_file}".*)
+if ((${#parts[@]})); then
+    "$python_cmd" -m coverage combine --data-file "$coverage_file" "$repo_root"
+fi
+
+"$python_cmd" -m coverage report --data-file "$coverage_file" --show-missing

--- a/site/index.html
+++ b/site/index.html
@@ -807,6 +807,9 @@
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/surface-adapters.md" class="doc-link">
                     <span class="doc-num">dev</span><span class="doc-title">Surface adapters</span>
                 </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/testing.md" class="doc-link">
+                    <span class="doc-num">dev</span><span class="doc-title">Testing &amp; coverage</span>
+                </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/01-cli-reference.md" class="doc-link">
                     <span class="doc-num">01</span><span class="doc-title">CLI Reference</span>
                 </a>

--- a/src/sitecustomize.py
+++ b/src/sitecustomize.py
@@ -1,0 +1,34 @@
+"""Start coverage in Python subprocesses when the test runner requests it.
+
+``pytest-cov`` measures the pytest process, but the nsys-ai CLI contract is
+tested mostly through ``subprocess.run``. Python imports ``sitecustomize``
+before application code, which gives those child interpreters a stable hook
+for ``coverage.process_startup()``. The environment variable is installed by
+``tests/conftest.py`` only for a ``pytest --cov`` run, so normal CLI invocations
+do not import or start coverage as a side effect.
+"""
+
+import os
+
+if os.environ.get("COVERAGE_PROCESS_START"):
+    try:
+        import coverage
+    except ImportError:
+        # A normal installed nsys-ai process may inherit the variable from a
+        # parent shell without having the development extra installed. It
+        # should still run; coverage is a test tool, not a runtime dependency.
+        pass
+    else:
+        source = os.environ.get("COVERAGE_SOURCE")
+        if source:
+            # The child may change cwd before it starts (many CLI tests use a
+            # temporary working directory). Override the config's relative
+            # source with the absolute checkout path so coverage does not
+            # silently record an empty run.
+            coverage.Coverage(
+                config_file=os.environ["COVERAGE_PROCESS_START"],
+                source=[source],
+                auto_data=True,
+            ).start()
+        else:
+            coverage.process_startup()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ All fixtures here are available to every test module without explicit imports.
 """
 
 import hashlib
+import os
 import shutil
 import sqlite3
 import subprocess
@@ -13,6 +14,32 @@ from pathlib import Path
 import pytest
 
 FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures"
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_COVERAGE_CONFIG = _REPO_ROOT / "pyproject.toml"
+_COVERAGE_SOURCE = _REPO_ROOT / "src"
+
+
+def pytest_configure(config):
+    """Pass pytest-cov's configuration to CLI subprocesses.
+
+    pytest-cov owns the parent process, but the suite exercises the public CLI
+    by launching fresh Python interpreters. Those interpreters need both the
+    coverage config path and the source directory on ``PYTHONPATH`` before
+    Python imports ``sitecustomize``. Keep this opt-in: an ordinary pytest run
+    must not enable coverage in every subprocess it launches.
+    """
+    if not config.pluginmanager.hasplugin("_cov"):
+        return
+
+    os.environ.setdefault("COVERAGE_PROCESS_START", str(_COVERAGE_CONFIG))
+    os.environ.setdefault("COVERAGE_FILE", str(_REPO_ROOT / ".coverage"))
+    os.environ.setdefault("COVERAGE_SOURCE", str(_REPO_ROOT / "src" / "nsys_ai"))
+
+    source = str(_COVERAGE_SOURCE)
+    paths = os.environ.get("PYTHONPATH", "").split(os.pathsep) if os.environ.get("PYTHONPATH") else []
+    if source not in paths:
+        paths.insert(0, source)
+        os.environ["PYTHONPATH"] = os.pathsep.join(paths)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -643,9 +643,17 @@ def test_leader_exit_always_cleans_surviving_process_group(
     ("mode", "poll_seconds"),
     [("exit_094", 2.0), ("exit_070", 5.0)],
 )
+@pytest.mark.no_cover
 def test_completion_before_deadline_wins_over_coarse_polling(
     tmp_path, fake_nsys, monkeypatch, mode, poll_seconds
 ):
+    # Coverage tracing is deliberately excluded here. This test verifies a
+    # sub-second process/deadline race, and tracing both this test and the fake
+    # nsys child changes the scheduling it is meant to measure. Keep the
+    # correctness check and the coverage report honest instead of making a
+    # timing assertion depend on instrumentation overhead.
+    monkeypatch.delenv("COVERAGE_PROCESS_START", raising=False)
+    monkeypatch.delenv("COVERAGE_SOURCE", raising=False)
     monkeypatch.setattr("nsys_ai.profile_runner._POLL_SECONDS", poll_seconds)
 
     result = _run(tmp_path, fake_nsys, mode, timeout_seconds=1)

--- a/tests/test_subprocess_coverage.py
+++ b/tests/test_subprocess_coverage.py
@@ -1,0 +1,68 @@
+"""Regression tests for coverage data written by CLI subprocesses."""
+
+import inspect
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import coverage
+
+from nsys_ai.cli.handlers import _cmd_doctor
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_cli_subprocess_writes_mergeable_coverage_data(tmp_path):
+    """A child launched from a temporary cwd contributes handler lines.
+
+    This is intentionally independent of whether the parent pytest invocation
+    uses ``--cov``. It exercises the same environment that conftest installs
+    for pytest-cov and catches the two easy regressions: the startup hook is no
+    longer importable, or relative ``source`` paths disappear when a CLI test
+    changes cwd.
+    """
+    data_file = tmp_path / ".coverage"
+    env = os.environ.copy()
+    env["COVERAGE_PROCESS_START"] = str(REPO_ROOT / "pyproject.toml")
+    env["COVERAGE_SOURCE"] = str(REPO_ROOT / "src" / "nsys_ai")
+    env["COVERAGE_FILE"] = str(data_file)
+    source_path = str(REPO_ROOT / "src")
+    pythonpath = env.get("PYTHONPATH", "").split(os.pathsep) if env.get("PYTHONPATH") else []
+    if source_path not in pythonpath:
+        pythonpath.insert(0, source_path)
+    env["PYTHONPATH"] = os.pathsep.join(pythonpath)
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "from argparse import Namespace; "
+                "from nsys_ai.cli.handlers import _cmd_doctor; "
+                "_cmd_doctor(Namespace(profile=None, deep=False, format='json', "
+                "verbose=False, strict=False), None)"
+            ),
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    sidecars = sorted(tmp_path.glob(".coverage.*"))
+    assert sidecars, "the CLI subprocess did not write a coverage sidecar"
+
+    combined = coverage.Coverage(data_file=str(data_file), config_file=False)
+    combined.combine(data_paths=[str(tmp_path)])
+    combined.load()
+    handlers = next(
+        path for path in combined.get_data().measured_files() if path.endswith("cli/handlers.py")
+    )
+    covered = set(combined.get_data().lines(handlers))
+    start = inspect.getsourcelines(_cmd_doctor)[1]
+    body_lines = range(start, start + len(inspect.getsource(_cmd_doctor).splitlines()))
+    assert set(body_lines).intersection(covered), (
+        "the child imported handlers but did not record the executed doctor path"
+    )


### PR DESCRIPTION
## Summary

Closes #502.

The test suite exercises the public CLI by starting fresh Python interpreters,
but the previous coverage configuration measured only the pytest parent. This
change makes those child processes contribute coverage data and documents the
test workflow.

## Changes

- add `pytest-cov` and `coverage` to the development extra;
- configure branch coverage, multiprocessing/thread concurrency, parallel
  data files, and SIGTERM handling in `pyproject.toml`;
- add the packaged `src/sitecustomize.py` startup hook for CLI children;
- pass an absolute source path, coverage config, data path, and repository
  `src/` path to subprocesses only when pytest-cov is active;
- add `scripts/coverage.sh` to erase, run, combine, and report coverage data;
- add a regression test that launches a CLI child from a temporary directory
  and verifies that `cli/handlers.py` lines are recorded;
- mark the process/deadline race test as an explicit `no_cover` measurement
  boundary because tracing changes the scheduling it verifies;
- document the process tree, fast/full test layers, coverage workflow,
  troubleshooting, and interpretation in `docs/dev/testing.md` and link it
  from the contributor guide, docs index, and site.

No coverage threshold is introduced in this PR. The first step is to make the
measurement trustworthy; a future threshold can be chosen from that baseline.

## Verification

- `ruff check src/ tests/`
- `git diff --check`
- `python -m pytest tests/test_subprocess_coverage.py tests/test_docs_index.py -q` — 7 passed
- `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite bash scripts/coverage.sh tests/ --ignore=tests/test_ci_coverage.py` — 2498 passed, 140 skipped, 4 xfailed; 76% total coverage
- `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite python -m pytest tests/test_ci_coverage.py -v --tb=short` — 7 passed
- `python -m build --wheel --no-isolation` — passed; wheel contains `sitecustomize.py`

The coverage run reports `src/nsys_ai/cli/handlers.py` at 55%, replacing the
previous parent-only result that understated CLI coverage.
