### PR TITLE
feat: relocate invocation artifacts with one root

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,10 @@ The wrapper combines child-process data before reporting. A plain
 do not run it from another working directory because CLI tests intentionally
 use temporary child directories.
 
+To keep local or CI runs from writing session and capture artifacts into the
+checkout, set `NSYS_AI_ARTIFACT_ROOT`; see the [artifact layout guide](docs/dev/artifact-layout.md)
+for the precedence rules and the separate input-keyed cache policy.
+
 ### Layer 4: lint and security
 
 These are required CI checks, not optional polish:

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,7 @@ alongside them.
 | [dev/ingest-policy.md](./dev/ingest-policy.md) | How a profile path becomes an open backend, and why call sites must not bypass it |
 | [dev/skill-contract.md](./dev/skill-contract.md) | How to add a portable, deterministic, JSON-safe analysis skill |
 | [dev/surface-adapters.md](./dev/surface-adapters.md) | How CLI, TUI, Web, MCP, and chat delegate shared policy and analysis |
+| [dev/artifact-layout.md](./dev/artifact-layout.md) | Where invocation artifacts and input-keyed profile caches live |
 | [dev/testing.md](./dev/testing.md) | Test layers and subprocess-aware coverage |
 | [support-matrix.md](./support-matrix.md) | Committed export schemas verified by CI |
 

--- a/docs/dev/artifact-layout.md
+++ b/docs/dev/artifact-layout.md
@@ -1,0 +1,115 @@
+# Artifact layout
+
+This document defines where `nsys-ai` writes files and why the locations are
+not all governed by the same root. It is intentionally explicit so a CI job
+can keep its checkout clean without moving profile-keyed caches to a shared
+namespace.
+
+## The two storage classes
+
+`nsys-ai` writes two kinds of local state:
+
+| Class | Identity | Default location | Relocatable by |
+|---|---|---|---|
+| Invocation artifacts | the command/session being executed | `.nsys-ai/` plus the historical standalone `diff.json` | `NSYS_AI_ARTIFACT_ROOT` |
+| Input-keyed caches | the immutable profile content/path | `<profile>.nsys-cache/` | no shared root; see below |
+
+The distinction is a correctness boundary. A cache beside `perf.sqlite` is
+invalidated and reused according to that profile; moving two unrelated
+`perf.sqlite` files into one directory would create a collision and change
+that identity model.
+
+## Default layout
+
+With no environment override, existing invocations keep their historical
+locations:
+
+```text
+checkout/
+├── .nsys-ai/
+│   ├── locks/                 # session writer/state locks
+│   ├── profiles/<timestamp>/  # default `nsys-ai profile` capture
+│   └── sessions/<id>/         # session.json and findings/proposal/diff artifacts
+└── diff.json                  # default standalone accepted/rejected decision
+```
+
+Explicit destinations continue to win:
+
+- `--session /path/to/handoff` uses that directory as the handoff location;
+- `-o PATH` keeps the existing command-specific output path;
+- `--decision-out PATH` keeps the standalone decision at `PATH`.
+
+## Relocating invocation artifacts
+
+Set `NSYS_AI_ARTIFACT_ROOT` to an absolute or working-directory-relative path:
+
+```bash
+export NSYS_AI_ARTIFACT_ROOT="$PWD/.nsys-ai-run"
+nsys-ai diagnose profile.sqlite --session training-001
+nsys-ai profile -- python train.py
+nsys-ai diff before.sqlite after.sqlite --accept --reason "verified"
+```
+
+The resulting layout is:
+
+```text
+.nsys-ai-run/
+├── locks/
+├── profiles/<timestamp>/
+├── sessions/training-001/
+└── decisions/diff.json
+```
+
+The variable is read at command/runtime resolution time, not import time.
+Relative values are resolved against the command's working directory. This is
+important for embedding callers and tests that pass a synthetic `cwd`.
+
+The precedence for the outputs covered by this policy is:
+
+1. an explicit command destination (`--session DIR`, `-o`, or
+   `--decision-out`);
+2. `NSYS_AI_ARTIFACT_ROOT`;
+3. the unchanged built-in defaults above.
+
+Project configuration can be layered above the environment in a future config
+issue; this resolver deliberately keeps that policy in one place.
+
+## Cache policy
+
+Parquet caches remain beside their source input:
+
+```text
+profile.sqlite
+profile.nsys-cache/
+├── *.parquet
+└── .cache_version
+```
+
+`nsys-ai doctor profile.sqlite` reports the actual registered cache path when
+one is open and the profile-support section states the policy even without a
+profile. `NSYS_AI_ARTIFACT_ROOT` does not move this directory. For a read-only
+input, use `--no-cache` where the command supports it or set
+`NSYS_AI_CACHE_MODE=direct`; disabling the cache is different from relocating
+it.
+
+## CI pattern
+
+Use a job-local directory and retain it as an artifact when debugging:
+
+```bash
+export NSYS_AI_ARTIFACT_ROOT="$RUNNER_TEMP/nsys-ai-artifacts"
+nsys-ai diagnose "$PROFILE" --session ci-diagnose
+nsys-ai diff "$BEFORE" "$AFTER" --accept --reason "CI baseline"
+test -f "$NSYS_AI_ARTIFACT_ROOT/decisions/diff.json"
+```
+
+The repository under test receives no default session, capture, lock, or
+decision files. The input profile's cache remains next to that input by design.
+
+## Implementation seam
+
+`src/nsys_ai/artifact_root.py` owns resolution. `SessionStore` and the
+transport-neutral `session_cli` facade use its session resolver; the profile
+wrapper uses its profile resolver; the diff CLI uses its decision resolver.
+This keeps CLI, TUI, Web, MCP, and embedding callers on the same session
+policy without introducing another storage database or server.

--- a/site/index.html
+++ b/site/index.html
@@ -807,6 +807,9 @@
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/surface-adapters.md" class="doc-link">
                     <span class="doc-num">dev</span><span class="doc-title">Surface adapters</span>
                 </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/artifact-layout.md" class="doc-link">
+                    <span class="doc-num">dev</span><span class="doc-title">Artifact layout</span>
+                </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/testing.md" class="doc-link">
                     <span class="doc-num">dev</span><span class="doc-title">Testing &amp; coverage</span>
                 </a>

--- a/src/nsys_ai/artifact_root.py
+++ b/src/nsys_ai/artifact_root.py
@@ -1,0 +1,105 @@
+"""Resolve the local root for invocation-owned nsys-ai artifacts.
+
+Input-keyed caches deliberately live beside their source profile.  This module
+only owns outputs of an invocation: sessions, locks, profile captures, and
+default decision records.  Keeping the distinction here prevents a shared
+artifact directory from accidentally changing cache identity or invalidation.
+
+The default is intentionally unchanged.  Set ``NSYS_AI_ARTIFACT_ROOT`` for a
+CI job or another caller that must keep the working directory clean::
+
+    NSYS_AI_ARTIFACT_ROOT=/tmp/nsys-artifacts nsys-ai diagnose profile.sqlite
+
+Relative roots are resolved against the command's working directory when one
+is supplied, which keeps ``run_profile_command(cwd=...)`` deterministic in
+tests and embedding callers.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+ARTIFACT_ROOT_ENV_VAR = "NSYS_AI_ARTIFACT_ROOT"
+DEFAULT_ARTIFACT_ROOT = ".nsys-ai"
+DEFAULT_SESSION_ROOT = f"{DEFAULT_ARTIFACT_ROOT}/sessions"
+
+
+def _base_directory(cwd: str | os.PathLike[str] | None = None) -> Path:
+    return Path.cwd() if cwd is None else Path(cwd).expanduser()
+
+
+def artifact_root(
+    root: str | os.PathLike[str] | None = None,
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+) -> Path:
+    """Return an absolute invocation-artifact root.
+
+    An explicit *root* wins over the environment.  ``None`` means read
+    ``NSYS_AI_ARTIFACT_ROOT`` and then use the historical ``.nsys-ai`` root.
+    The path is not created by this resolver.
+    """
+    selected = root
+    if selected is None:
+        selected = os.environ.get(ARTIFACT_ROOT_ENV_VAR) or DEFAULT_ARTIFACT_ROOT
+    path = Path(selected).expanduser()
+    if not path.is_absolute():
+        path = _base_directory(cwd) / path
+    return path.resolve(strict=False)
+
+
+def session_root(
+    root: str | os.PathLike[str] | None = None,
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+) -> Path:
+    """Return the SessionStore root under the configured artifact root."""
+    if root is None or _is_historical_session_root(root):
+        return artifact_root(cwd=cwd) / "sessions"
+    path = Path(root).expanduser()
+    if not path.is_absolute():
+        path = _base_directory(cwd) / path
+    return path.resolve(strict=False)
+
+
+def profile_root(*, cwd: str | os.PathLike[str] | None = None) -> Path:
+    """Return the default directory for ``nsys-ai profile`` captures."""
+    return artifact_root(cwd=cwd) / "profiles"
+
+
+def default_decision_path(*, cwd: str | os.PathLike[str] | None = None) -> Path:
+    """Return the default standalone decision path.
+
+    With no environment override the historical ``./diff.json`` remains the
+    default.  Once an artifact root is explicitly configured, the decision is
+    placed under ``<root>/decisions`` with the other invocation outputs.
+    An explicit ``--decision-out`` is handled by the caller and always wins.
+    """
+    configured = os.environ.get(ARTIFACT_ROOT_ENV_VAR)
+    if configured and configured.strip():
+        return artifact_root(cwd=cwd) / "decisions" / "diff.json"
+    if cwd is None:
+        # Preserve the historical spelling in CLI output and error messages;
+        # the process still writes this relative path in its current directory.
+        return Path("diff.json")
+    return _base_directory(cwd).resolve() / "diff.json"
+
+
+def _is_historical_session_root(root: str | os.PathLike[str]) -> bool:
+    try:
+        candidate = Path(root).expanduser()
+    except TypeError:
+        return False
+    return candidate == Path(DEFAULT_SESSION_ROOT)
+
+
+__all__ = [
+    "ARTIFACT_ROOT_ENV_VAR",
+    "DEFAULT_ARTIFACT_ROOT",
+    "DEFAULT_SESSION_ROOT",
+    "artifact_root",
+    "default_decision_path",
+    "profile_root",
+    "session_root",
+]

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -997,6 +997,7 @@ def _cmd_diff(args, _profile):
     elif getattr(args, "reject", False):
         decision = "rejected"
     reason = getattr(args, "reason", None)
+    from nsys_ai.artifact_root import default_decision_path
     from nsys_ai.session_cli import DEFAULT_SESSION_ROOT, resolve_session_location
 
     raw_session = getattr(args, "session", None)
@@ -1048,14 +1049,15 @@ def _cmd_diff(args, _profile):
     session_after_path = None
     before_ref = None
     after_ref = None
-    # Defaulted here rather than in the parser so the default stays visible next
-    # to the only code that writes it. A CI job runs in a checkout, so a record
-    # it cannot redirect is a record it cannot keep out of the repo under test.
+    # Resolve here rather than in the parser so the environment is read at
+    # command time. A CI job runs in a checkout, so a record it cannot redirect
+    # is a record it cannot keep out of the repo under test.
     # expanduser because the shell does not: CI invokes this without one, and a
     # literal "~/..." would be created as a directory named "~" in the checkout
     # this option exists to keep clean.
+    selected_decision_path = getattr(args, "decision_out", None)
     decision_out_path = os.path.expanduser(
-        getattr(args, "decision_out", None) or "diff.json"
+        selected_decision_path or str(default_decision_path())
     )
     if decision is not None:
         if getattr(args, "chat", False):

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -1049,8 +1049,9 @@ def _build_parser():
         default=None,
         metavar="PATH",
         help="Where --accept/--reject writes the decision record "
-        "(default: diff.json in the working directory). Distinct from -o, which "
-        "writes the rendered report in --format",
+        "(default: diff.json in the working directory, or "
+        "$NSYS_AI_ARTIFACT_ROOT/decisions/diff.json when configured). Distinct "
+        "from -o, which writes the rendered report in --format",
     )
     p.add_argument(
         "--reason",

--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -216,6 +216,19 @@ def _check_profile_support() -> DoctorSection:
             )
         )
 
+    checks.append(
+        CheckResult(
+            "Parquet cache location",
+            "ok",
+            "beside each input profile (<profile>.nsys-cache)",
+            hint=(
+                "The cache is input-keyed and is not moved by "
+                "NSYS_AI_ARTIFACT_ROOT. Use --no-cache or "
+                "NSYS_AI_CACHE_MODE=direct for read-only inputs."
+            ),
+        )
+    )
+
     return DoctorSection("Profile support", checks)
 
 
@@ -524,6 +537,29 @@ def _overhead_check(pct: float | None) -> CheckResult:
     return CheckResult("Profiler overhead", "ok", f"{pct:.1f}%")
 
 
+def _cache_location_check(prof: Any) -> CheckResult:
+    """Name the persisted cache behind an opened profile, if one exists."""
+    try:
+        from nsys_ai.connection import cache_dir_for_connection
+
+        cache_dir = cache_dir_for_connection(getattr(prof, "db", None))
+    except Exception:  # noqa: BLE001 — doctor must degrade to a useful report
+        cache_dir = None
+    if cache_dir:
+        return CheckResult(
+            "Parquet cache location",
+            "ok",
+            str(cache_dir),
+            hint="Input-keyed cache; it stays beside the profile rather than under the artifact root.",
+        )
+    return CheckResult(
+        "Parquet cache location",
+        "skipped",
+        "no persisted Parquet cache for this profile",
+        hint="The profile is using direct SQLite or an in-memory/parquetdir path.",
+    )
+
+
 def _runspec_check(profile_path: str | None) -> CheckResult:
     """Report whether this capture carries the RunSpec that lets the loop verify a change.
 
@@ -640,6 +676,7 @@ def _check_profile_health(prof: Any, *, deep: bool = False) -> DoctorSection:
         checks.append(CheckResult("NCCL events", "ok", "none"))
 
     checks.append(_overhead_check(_profiler_overhead_pct(prof, span_ns)))
+    checks.append(_cache_location_check(prof))
 
     checks.append(_runspec_check(getattr(prof, "path", None)))
 

--- a/src/nsys_ai/profile_command.py
+++ b/src/nsys_ai/profile_command.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, TextIO
 
+from .artifact_root import profile_root
 from .exceptions import NsysAiError
 from .profile_runner import LocalProfileRunner, RunProgress, RunStatus
 from .runspec import EnvironmentSpec, NsysTraceOptions, RunSpec, RunSpecError
@@ -301,7 +302,7 @@ def discover_git_provenance(
 def default_output_leaf(cwd: Path) -> Path:
     """Choose a fresh, sortable local artifact leaf without creating it."""
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S.%fZ")
-    return cwd / ".nsys-ai" / "profiles" / timestamp
+    return profile_root(cwd=cwd) / timestamp
 
 
 def _output_leaf(selected: str | None, cwd: Path) -> Path:

--- a/src/nsys_ai/session_cli.py
+++ b/src/nsys_ai/session_cli.py
@@ -15,6 +15,8 @@ from pathlib import Path
 from typing import Any
 
 from .annotation import EvidenceReport
+from .artifact_root import DEFAULT_SESSION_ROOT
+from .artifact_root import session_root as resolve_artifact_session_root
 from .profile_reference import LocalProfileReference
 from .proposal import Proposal
 from .runspec import RunSpec
@@ -24,8 +26,6 @@ from .session_store import (
     SessionState,
     SessionStore,
 )
-
-DEFAULT_SESSION_ROOT = ".nsys-ai/sessions"
 
 
 def append_ask_log(
@@ -111,7 +111,11 @@ def resolve_session_location(
             raise ValueError("session directory must have a session id basename")
         return SessionLocation(directory.name, directory.parent, explicit=True)
 
-    return SessionLocation(raw, Path(root).expanduser().resolve(strict=False), explicit=False)
+    return SessionLocation(
+        raw,
+        resolve_artifact_session_root(root),
+        explicit=False,
+    )
 
 
 def session_location(
@@ -133,7 +137,7 @@ def session_argument(
 ) -> str:
     """Return a re-runnable session argument for a user-facing hint."""
     location = session_location(session_id, root=root)
-    default_root = Path(DEFAULT_SESSION_ROOT).expanduser().resolve(strict=False)
+    default_root = resolve_artifact_session_root()
     if location.root == default_root and not location.explicit:
         return location.session_id
     return shlex.quote(str(location.directory))

--- a/src/nsys_ai/session_store.py
+++ b/src/nsys_ai/session_store.py
@@ -44,6 +44,7 @@ from .annotation import (
     SCHEMA_VERSION as EVIDENCE_SCHEMA_VERSION,
 )
 from .artifact_io import atomic_write_bytes, atomic_write_json, fsync_directory
+from .artifact_root import session_root as resolve_artifact_session_root
 from .diff_decision import (
     build_diff_decision_record_from_diff_dict,
     write_diff_json_from_diff_dict,
@@ -340,10 +341,10 @@ class SessionSnapshot:
 
 
 class SessionStore:
-    """Read and create sessions rooted at ``.nsys-ai/sessions``."""
+    """Read and create sessions under the configured artifact root."""
 
-    def __init__(self, root: str | os.PathLike[str] = ".nsys-ai/sessions"):
-        self.root = Path(root).expanduser().resolve(strict=False)
+    def __init__(self, root: str | os.PathLike[str] | None = None):
+        self.root = resolve_artifact_session_root(root)
         self.lock_root = self.root.parent / "locks"
 
     def create(

--- a/tests/test_artifact_root.py
+++ b/tests/test_artifact_root.py
@@ -1,0 +1,98 @@
+"""Tests for invocation-owned artifact placement (#430)."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from nsys_ai.artifact_root import (
+    ARTIFACT_ROOT_ENV_VAR,
+    artifact_root,
+    default_decision_path,
+    profile_root,
+    session_root,
+)
+from nsys_ai.profile_command import default_output_leaf
+from nsys_ai.session_cli import resolve_session_location
+from nsys_ai.session_store import SessionStore
+
+
+def test_default_layout_remains_under_dot_nsys_ai(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(ARTIFACT_ROOT_ENV_VAR, raising=False)
+
+    assert artifact_root() == tmp_path / ".nsys-ai"
+    assert session_root() == tmp_path / ".nsys-ai" / "sessions"
+    assert profile_root() == tmp_path / ".nsys-ai" / "profiles"
+    assert default_decision_path(cwd=tmp_path) == tmp_path / "diff.json"
+    assert default_output_leaf(tmp_path).parent == tmp_path / ".nsys-ai" / "profiles"
+
+
+def test_env_root_relocates_session_profile_and_decision_outputs(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.chdir(tmp_path)
+    configured = tmp_path / "ci-artifacts"
+    monkeypatch.setenv(ARTIFACT_ROOT_ENV_VAR, str(configured))
+
+    assert artifact_root() == configured
+    assert session_root() == configured / "sessions"
+    assert profile_root() == configured / "profiles"
+    assert default_decision_path() == configured / "decisions" / "diff.json"
+    assert default_output_leaf(tmp_path).parent == configured / "profiles"
+
+    location = resolve_session_location("run-001")
+    assert location is not None
+    assert location.root == configured / "sessions"
+
+    # The public default SessionStore must use the same resolver as the CLI
+    # facade; this is the guard against in-process surfaces silently diverging.
+    store = SessionStore()
+    store.create("run-001")
+    assert (configured / "sessions" / "run-001" / "session.json").is_file()
+    assert not (tmp_path / ".nsys-ai").exists()
+
+
+def test_explicit_session_directory_wins_over_artifact_root(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setenv(ARTIFACT_ROOT_ENV_VAR, str(tmp_path / "configured"))
+    explicit = tmp_path / "handoff" / "run-002"
+
+    location = resolve_session_location(explicit)
+
+    assert location is not None
+    assert location.explicit is True
+    assert location.directory == explicit
+    assert location.root == explicit.parent
+
+
+def test_diagnose_cli_keeps_working_directory_clean_with_artifact_root(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "ci-artifacts"
+    profile = Path(__file__).parent / "fixtures" / "mock.sqlite"
+    env = os.environ.copy()
+    env[ARTIFACT_ROOT_ENV_VAR] = str(artifact_root)
+    env["PYTHONPATH"] = str(Path(__file__).parents[1] / "src")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "nsys_ai",
+            "diagnose",
+            str(profile),
+            "--session",
+            "run-003",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (artifact_root / "sessions" / "run-003" / "findings.json").is_file()
+    assert not (tmp_path / ".nsys-ai").exists()

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -1313,6 +1313,33 @@ def test_diff_cli_decision_defaults_to_the_working_directory(tmp_path):
     assert (tmp_path / "diff.json").exists()
 
 
+def test_diff_cli_decision_uses_configured_artifact_root(tmp_path):
+    """The env override keeps a default decision out of the checkout."""
+    before = tmp_path / "before.sqlite"
+    after = tmp_path / "after.sqlite"
+    _make_profile(str(before), kernels=[(0, 10_000_000, 0, 7, 1, 1, 2)])
+    _make_profile(str(after), kernels=[(0, 9_000_000, 0, 7, 1, 1, 2)])
+    artifact_root = tmp_path / "artifacts"
+    env = _decision_cli_env(tmp_path)
+    env["NSYS_AI_ARTIFACT_ROOT"] = str(artifact_root)
+
+    result = _run_diff_cli(
+        before,
+        after,
+        "--accept",
+        "--reason",
+        "verified",
+        cwd=tmp_path,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    decision = artifact_root / "decisions" / "diff.json"
+    assert decision.is_file()
+    assert not (tmp_path / "diff.json").exists()
+    assert f"Diff decision written to {decision}" in result.stderr
+
+
 def test_diff_cli_unwritable_decision_path_is_a_configuration_error(tmp_path):
     """Exit 2, not 1: a CI job reads 1 as "the performance gate failed".
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -44,6 +44,9 @@ def test_env_checks_present():
     report = run_doctor()
     assert _check(report, "Python") is not None
     assert _check(report, "SQLite analysis").status == "ok"
+    cache_policy = _check(report, "Parquet cache location")
+    assert cache_policy is not None
+    assert "beside each input profile" in cache_policy.detail
     # AI provider + CUTracer are always reported (configured or not).
     assert _check(report, "AI provider (litellm)") is not None
     assert _check(report, "CUTracer") is not None
@@ -97,6 +100,22 @@ def test_health_section_on_minimal_profile(minimal_nsys_db_path):
     assert "Duration" in by_name
     assert "GPUs" in by_name
     assert "RunSpec attached" in by_name
+    assert "Parquet cache location" in by_name
+
+
+def test_cache_location_check_reports_the_registered_directory(tmp_path, monkeypatch):
+    from nsys_ai import doctor
+
+    cache = tmp_path / "profile.nsys-cache"
+    monkeypatch.setattr(
+        "nsys_ai.connection.cache_dir_for_connection", lambda _conn: str(cache)
+    )
+
+    check = doctor._cache_location_check(types.SimpleNamespace(db=object()))
+
+    assert check.status == "ok"
+    assert check.detail == str(cache)
+    assert "beside the profile" in (check.hint or "")
 
 
 def test_missing_profile_is_reported_as_failure(tmp_path):

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -331,6 +331,26 @@ def test_dry_run_is_structurally_redacted_and_does_not_create_output(
     assert not output.exists()
 
 
+def test_default_profile_output_uses_configured_artifact_root(tmp_path, fake_nsys, monkeypatch):
+    artifact_root = tmp_path / "ci-artifacts"
+    monkeypatch.setenv("NSYS_AI_ARTIFACT_ROOT", str(artifact_root))
+    args = _args(fake_nsys, tmp_path / "unused-output")
+    args.output = None
+
+    exit_code = run_profile_command(
+        args,
+        stdout=io.StringIO(),
+        stderr=io.StringIO(),
+        cwd=tmp_path,
+    )
+
+    assert exit_code == 0
+    profiles = list((artifact_root / "profiles").iterdir())
+    assert len(profiles) == 1
+    assert (profiles[0] / "profile.sqlite").is_file()
+    assert not (tmp_path / ".nsys-ai").exists()
+
+
 def test_fake_nsys_cli_preserves_tokens_python_shorthand_and_artifacts(
     tmp_path, fake_nsys
 ):


### PR DESCRIPTION
## Summary

Closes #430.

Add one runtime resolver for invocation-owned artifacts so CI and embedding
callers can keep their working directory clean without changing the identity
or invalidation policy of input-keyed Parquet caches.

## Storage policy

With no environment override, existing paths remain unchanged:

- `.nsys-ai/sessions/` and `.nsys-ai/locks/` for session handoffs;
- `.nsys-ai/profiles/<timestamp>/` for default `nsys-ai profile` captures;
- `./diff.json` for the default standalone accepted/rejected decision;
- `<profile>.nsys-cache/` for input-keyed Parquet data.

With `NSYS_AI_ARTIFACT_ROOT=/path/to/root`, the invocation-owned paths become
`root/sessions`, `root/locks`, `root/profiles`, and `root/decisions/diff.json`.
Explicit `--session DIR`, `-o`, and `--decision-out` destinations still win.
The profile cache intentionally stays beside its source profile; `doctor`
now reports that policy and the actual registered cache path when available.

## Changes

- add `src/nsys_ai/artifact_root.py` as the single resolver;
- make `SessionStore` and `session_cli` use the resolver, including direct
  in-process callers;
- route default profile capture and standalone diff decisions through it;
- keep historical default decision spelling/output when the variable is unset;
- add doctor cache-location policy and profile-specific reporting;
- add 115-line developer documentation covering storage classes, precedence,
  CI usage, cache boundaries, and implementation seams;
- add unit, subprocess CLI, profile, diff, doctor, and docs-index coverage.

## Verification

- `ruff check src/ tests/` — passed
- `git diff --check` — passed
- affected session/profile/diff/diagnose/review/propose/doctor suite — 270 passed
- session store + loop/Web/TUI handoff suite — 186 passed
- artifact-root/doctor/docs focused suite — 34 passed
- full CI-profile suite with nested skip guard — 2511 passed, 140 skipped, 4 xfailed
- real `perf.nsys-rep` doctor — passed; schema/profile health reported
- real `perf.sqlite` self-diff with `--trim 300 305 --accept` — passed; decision written to the configured `decisions/diff.json`
- wheel build — passed; wheel contains `nsys_ai/artifact_root.py`
- `python -m nsys_ai --help` — passed
