### PR TITLE
perf(skills): memoize audited computation inputs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -37,6 +37,7 @@ alongside them.
 | [dev/skill-contract.md](./dev/skill-contract.md) | How to add a portable, deterministic, JSON-safe analysis skill |
 | [dev/surface-adapters.md](./dev/surface-adapters.md) | How CLI, TUI, Web, MCP, and chat delegate shared policy and analysis |
 | [dev/artifact-layout.md](./dev/artifact-layout.md) | Where invocation artifacts and input-keyed profile caches live |
+| [dev/skill-memo-fingerprint.md](./dev/skill-memo-fingerprint.md) | How answer-affecting parameters define a skill memo identity |
 | [dev/testing.md](./dev/testing.md) | Test layers and subprocess-aware coverage |
 | [support-matrix.md](./support-matrix.md) | Committed export schemas verified by CI |
 

--- a/docs/dev/skill-memo-fingerprint.md
+++ b/docs/dev/skill-memo-fingerprint.md
@@ -1,0 +1,84 @@
+# Skill memo computation identity
+
+This page records the memo-key contract for built-in analysis skills. It is a
+developer document: the source of truth remains `Skill.execute`, but the table
+below is the review checklist for changing a skill's memo identity.
+
+## Why this exists
+
+The per-connection memo from #295 is deliberately keyed by the skill name and
+resolved call parameters. That strict default protects correctness: a
+`gpu_idle_gaps(limit=1)` result cannot be returned to a caller that asked for
+`limit=5`, and a result for GPU 0 cannot be returned for GPU 1.
+
+One `EvidenceBuilder` pass also has composite callers. The health manifest and
+root-cause matcher forward context through the same `Skill.execute` boundary.
+Some of that context is not read by the leaf skill, so raw call signatures can
+make the same computation look different. The safe abstraction is therefore a
+computation fingerprint:
+
+```text
+skill identity + input/profile identity + answer-affecting parameters
+```
+
+The current implementation still scopes the memo to one connection. The
+profile/package identity part of the fingerprint is a future cross-run cache
+concern; this page only defines the parameter portion of the fingerprint.
+
+## Static audit for #350
+
+The following trace was collected from a warm `EvidenceBuilder` pass on the
+committed `h100_2gpu_1s.sqlite` fixture. It is a call-path inventory, not a
+performance claim about large captures.
+
+| Skill | Repeated call shapes | Parameters read by the skill | Parameters deliberately excluded |
+|---|---|---|---|
+| `sync_cost_analysis` | direct pipeline: `device=0`, trim, injected `overhead_ns`; manifest child: `_skip_device_validation` and no `device` | `device`, `trim_start_ns`, `trim_end_ns` | `overhead_ns`, `communicator_data`; `_skip_device_validation` is consumed before the skill runs |
+| `overlap_breakdown` | direct pipeline; manifest child; root-cause call carrying `communicator_data` | `device`, `trim_start_ns`, `trim_end_ns` | `overhead_ns`, `communicator_data`; the nested sync lookup has its own memo key |
+| `gpu_idle_gaps` | pipeline `limit=5`; manifest `limit=1`; root-cause default `limit=20` | `device`, trim, `min_gap_ns`, `limit` | `overhead_ns`, `communicator_data` |
+| `iteration_timing` | direct pipeline; manifest child with `_skip_device_validation` | `device`, `marker`, `trim_start_ns`, `trim_end_ns` | `overhead_ns`, `communicator_data` |
+
+### Parameter matrix
+
+| Parameter | Where it comes from | Read by these four `execute_fn`s? | Memo treatment |
+|---|---|---:|---|
+| `device` | `EvidenceBuilder`, manifest, root-cause matcher | Yes | Included |
+| `trim_start_ns`, `trim_end_ns` | shared runner and transport trim | Yes | Included |
+| `limit` | skill caller, especially `gpu_idle_gaps` | `gpu_idle_gaps` only | Included for `gpu_idle_gaps` |
+| `min_gap_ns` | `gpu_idle_gaps` caller/default | `gpu_idle_gaps` | Included |
+| `marker` | `iteration_timing` caller/default | `iteration_timing` | Included |
+| `overhead_ns` | injected by `Skill.execute` | No | Excluded for these four |
+| `communicator_data` | manifest → root-cause handoff | No | Excluded for these four |
+| `_skip_device_validation` | manifest child-call policy | No; popped before resolution | Excluded globally by consumption |
+
+The manifest's `sync_cost_analysis` call without `device` is intentionally
+not merged with `device=0`: omitted `device` means the sync implementation's
+all-device aggregate. This is the counterexample that makes a name-only key
+unsafe.
+
+## Implementation rule
+
+`Skill.memo_key_params` is an explicit opt-in allow-list. Skills without it
+retain the strict key over every resolved parameter. An allow-list must satisfy
+all of the following:
+
+1. Every parameter read by the skill's `execute_fn` is included.
+2. Parameters omitted from the list are forwarded context or presentation
+   inputs that cannot change returned rows.
+3. Defaults are resolved before key construction, so omitted and explicit
+   defaults share a computation identity.
+4. The skill has tests for both sides: ignored context reuses a result, while
+   each answer-affecting parameter still splits the memo.
+
+Do not add a skill to an allow-list because two calls happen to return the same
+rows on a small fixture. Read the implementation first, then add the narrowest
+safe set and a regression test.
+
+## What this does not claim
+
+This change does not claim that a large profile's warm pass saves a fixed
+number of seconds. The original #350 measurement used a 3.5 GB capture that is
+not committed here; the repository fixture is suitable for correctness tests,
+not for reproducing that wall-clock result. A large-profile benchmark remains
+the next verification step before expanding the allow-list or introducing a
+cross-process cache.

--- a/site/index.html
+++ b/site/index.html
@@ -810,6 +810,9 @@
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/artifact-layout.md" class="doc-link">
                     <span class="doc-num">dev</span><span class="doc-title">Artifact layout</span>
                 </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/skill-memo-fingerprint.md" class="doc-link">
+                    <span class="doc-num">dev</span><span class="doc-title">Skill memo identity</span>
+                </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/testing.md" class="doc-link">
                     <span class="doc-num">dev</span><span class="doc-title">Testing &amp; coverage</span>
                 </a>

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -553,6 +553,13 @@ class Skill:
         required_tables: Activity-table resolver keys required before execution.
                          Used for execute_fn skills whose SQL is not visible to
                          the generic template guard.
+        memo_key_params: Optional allow-list of resolved parameters that affect
+                         the computation. When omitted, every resolved
+                         parameter remains part of the per-connection memo key.
+                         This is intentionally opt-in: a parameter may be
+                         forwarded by a composite skill without being read by
+                         the leaf skill, but dropping an actually-read
+                         parameter would return incorrect evidence.
     """
 
     name: str
@@ -566,6 +573,21 @@ class Skill:
     execute_fn: Callable | None = None
     to_findings_fn: Callable | None = None
     required_tables: tuple[str, ...] = ()
+    memo_key_params: tuple[str, ...] | None = None
+
+    def _resolved_memo_params(self, resolved: dict[str, object]) -> dict[str, object]:
+        """Return the computation-bearing subset of resolved parameters.
+
+        The default remains the strict, backwards-compatible behaviour: every
+        resolved value participates in the key. A skill may opt in to a named
+        subset only after a source-level audit proves that the omitted values
+        are transport/context inputs rather than computation inputs. Missing
+        allow-listed values are represented as ``None`` so an omitted optional
+        argument and an explicit ``None`` have the same computation identity.
+        """
+        if self.memo_key_params is None:
+            return dict(resolved)
+        return {name: resolved.get(name) for name in self.memo_key_params}
 
     def execute(self, conn: sqlite3.Connection, **kwargs) -> list[dict]:
         """Run the skill against a connection.
@@ -668,13 +690,23 @@ class Skill:
         # both directly and through the health manifest / root-cause matcher,
         # which re-run some analyses already requested by the pipeline.
         #
-        # The key includes the resolved parameters, not just the name. The
-        # repeats are mostly NOT identical — gpu_idle_gaps is called at limit=1
-        # and limit=5 in the same build, and those legitimately differ — so a
-        # name-only key would hand one caller another's results and silently
-        # change findings. Resolved rather than raw kwargs so an explicit
-        # limit=5 and a defaulted limit=5 share an entry.
-        cache_key = f"skill:{self.name}:{_params_key(resolved)}"
+        # The strict default includes every resolved parameter, not just the
+        # name. A name-only key would hand one caller another caller's rows and
+        # silently change findings: gpu_idle_gaps is called at limit=1 and
+        # limit=5 in one build, and those legitimately differ. Resolved rather
+        # than raw kwargs also means an explicit default shares an entry with
+        # an omitted default.
+        #
+        # Four composite-facing skills have an audited allow-list. Their
+        # callers forward ``overhead_ns`` and/or ``communicator_data`` through
+        # the shared path, but their execute functions do not read either
+        # value. Keeping those transport values out of the key joins calls
+        # that compute the same rows while retaining every answer-affecting
+        # parameter (device, trim, and the skill-specific limit/threshold or
+        # marker). The allow-list is opt-in on Skill so a future skill cannot
+        # accidentally inherit this assumption.
+        memo_params = self._resolved_memo_params(resolved)
+        cache_key = f"skill:{self.name}:{_params_key(memo_params)}"
         cached = cached_skill_rows(conn, cache_key)
         if cached is not SKILL_CACHE_MISS:
             # Copy on the way out as well, so two readers never share the row

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -574,5 +574,15 @@ SKILL = Skill(
     ],
     format_fn=_format,
     to_findings_fn=_to_findings,
+    # Static audit for #350: device, trim, min_gap_ns, and limit all affect
+    # the returned rows or summary. Forwarded overhead_ns and
+    # communicator_data are not read by _execute.
+    memo_key_params=(
+        "device",
+        "trim_start_ns",
+        "trim_end_ns",
+        "min_gap_ns",
+        "limit",
+    ),
     tags=["bubble", "idle", "gap", "pipeline", "stall", "utilization", "attribution"],
 )

--- a/src/nsys_ai/skills/builtins/iteration_timing.py
+++ b/src/nsys_ai/skills/builtins/iteration_timing.py
@@ -165,5 +165,8 @@ SKILL = Skill(
         SkillParam("device", "GPU device ID", "int", False, 0),
         SkillParam("marker", "NVTX text pattern for iteration boundary", "str", False, "sample_0"),
     ],
+    # Static audit for #350: detect_iterations reads device, marker, and trim.
+    # overhead_ns and communicator_data are forwarded context, not inputs.
+    memo_key_params=("device", "trim_start_ns", "trim_end_ns", "marker"),
     tags=["iteration", "timing", "variance", "nvtx", "training"],
 )

--- a/src/nsys_ai/skills/builtins/overlap_breakdown.py
+++ b/src/nsys_ai/skills/builtins/overlap_breakdown.py
@@ -511,6 +511,10 @@ SKILL = Skill(
     to_findings_fn=_to_findings,
     required_tables=("kernel",),
     params=[SkillParam("device", "GPU device ID", "int", False, 0)],
+    # Static audit for #350: overlap_analysis and the same-stream/device
+    # enrichment read device and trim. Forwarded overhead_ns and
+    # communicator_data do not affect this skill's rows.
+    memo_key_params=("device", "trim_start_ns", "trim_end_ns"),
     tags=[
         "overlap", "nccl", "compute", "communication", "distributed",
         "multi-gpu", "same-stream", "stream-serialization",

--- a/src/nsys_ai/skills/builtins/sync_cost_analysis.py
+++ b/src/nsys_ai/skills/builtins/sync_cost_analysis.py
@@ -280,4 +280,8 @@ SKILL = Skill(
             None,
         ),
     ],
+    # Static audit for #350: the execute function reads device and the two
+    # trim bounds. ``overhead_ns`` is injected by Skill.execute but unused;
+    # composite callers may also forward communicator_data, which is unused.
+    memo_key_params=("device", "trim_start_ns", "trim_end_ns"),
 )

--- a/tests/test_skill_memo.py
+++ b/tests/test_skill_memo.py
@@ -94,6 +94,151 @@ def test_a_defaulted_parameter_shares_an_entry_with_an_explicit_one(fixture):
     assert len(calls) == 1, f"defaulted and explicit {default_limit} did not share an entry"
 
 
+@pytest.mark.parametrize(
+    ("skill_name", "expected"),
+    [
+        ("sync_cost_analysis", ("device", "trim_start_ns", "trim_end_ns")),
+        ("overlap_breakdown", ("device", "trim_start_ns", "trim_end_ns")),
+        (
+            "gpu_idle_gaps",
+            ("device", "trim_start_ns", "trim_end_ns", "min_gap_ns", "limit"),
+        ),
+        ("iteration_timing", ("device", "trim_start_ns", "trim_end_ns", "marker")),
+    ],
+)
+def test_composite_skill_memo_allowlist_is_explicit(skill_name, expected):
+    """The #350 audit is an allow-list, not an implicit name-only shortcut."""
+    skill = get_skill(skill_name)
+    assert skill.memo_key_params == expected
+
+    base = {
+        "device": 0,
+        "trim_start_ns": 100,
+        "trim_end_ns": 200,
+        "overhead_ns": 0,
+        "communicator_data": [{"_diagnostic": True}],
+    }
+    if skill_name == "gpu_idle_gaps":
+        base.update(min_gap_ns=1_000_000, limit=5)
+    if skill_name == "iteration_timing":
+        base["marker"] = "sample_0"
+
+    assert skill._resolved_memo_params(base) == {
+        name: base.get(name) for name in expected
+    }
+    changed_context = {**base, "overhead_ns": 123, "communicator_data": [{"rows": 99}]}
+    assert skill._resolved_memo_params(base) == skill._resolved_memo_params(changed_context)
+
+
+@pytest.mark.parametrize(
+    ("skill_name", "first", "second"),
+    [
+        (
+            "sync_cost_analysis",
+            {"device": 0, "trim_start_ns": 100, "trim_end_ns": 200},
+            {
+                "device": 0,
+                "trim_start_ns": 100,
+                "trim_end_ns": 200,
+                "overhead_ns": 123,
+                "communicator_data": [{"rows": 99}],
+            },
+        ),
+        (
+            "overlap_breakdown",
+            {"device": 0, "trim_start_ns": 100, "trim_end_ns": 200},
+            {
+                "device": 0,
+                "trim_start_ns": 100,
+                "trim_end_ns": 200,
+                "overhead_ns": 123,
+                "communicator_data": [{"rows": 99}],
+            },
+        ),
+        (
+            "gpu_idle_gaps",
+            {"device": 0, "trim_start_ns": 100, "trim_end_ns": 200, "limit": 5},
+            {
+                "device": 0,
+                "trim_start_ns": 100,
+                "trim_end_ns": 200,
+                "limit": 5,
+                "overhead_ns": 123,
+                "communicator_data": [{"rows": 99}],
+            },
+        ),
+        (
+            "iteration_timing",
+            {"device": 0, "trim_start_ns": 100, "trim_end_ns": 200},
+            {
+                "device": 0,
+                "trim_start_ns": 100,
+                "trim_end_ns": 200,
+                "marker": "sample_0",
+                "overhead_ns": 123,
+                "communicator_data": [{"rows": 99}],
+            },
+        ),
+    ],
+)
+def test_audited_skills_reuse_rows_when_only_forwarded_context_differs(
+    skill_name, first, second, fixture
+):
+    """The omitted context values cannot recreate #350's duplicate execution."""
+    skill = get_skill(skill_name)
+    original = skill.execute_fn
+    calls = []
+
+    def counting(conn, **kwargs):
+        calls.append(kwargs)
+        return [{"call": len(calls)}]
+
+    skill.execute_fn = counting
+    conn = sqlite3.connect(fixture)
+    try:
+        first_rows = skill.execute(conn, **first)
+        second_rows = skill.execute(conn, **second)
+    finally:
+        skill.execute_fn = original
+        conn.close()
+
+    assert len(calls) == 1
+    assert first_rows == second_rows == [{"call": 1}]
+
+
+@pytest.mark.parametrize(
+    ("skill_name", "first", "second"),
+    [
+        ("sync_cost_analysis", {"device": 0}, {"device": 1}),
+        ("overlap_breakdown", {"device": 0}, {"device": 1}),
+        ("gpu_idle_gaps", {"limit": 1}, {"limit": 5}),
+        ("iteration_timing", {"marker": "sample_0"}, {"marker": "other"}),
+    ],
+)
+def test_audited_skills_still_split_on_answer_affecting_parameters(
+    skill_name, first, second, fixture
+):
+    """The allow-list preserves the safety property of the original strict key."""
+    skill = get_skill(skill_name)
+    original = skill.execute_fn
+    calls = []
+
+    def counting(conn, **kwargs):
+        calls.append(kwargs)
+        return [{"call": len(calls)}]
+
+    skill.execute_fn = counting
+    conn = sqlite3.connect(fixture)
+    try:
+        skill.execute(conn, **first)
+        skill.execute(conn, **second)
+    finally:
+        skill.execute_fn = original
+        conn.close()
+
+    assert len(calls) == 2
+
+
 def test_a_cached_result_cannot_be_corrupted_by_its_consumer(fixture):
     """Rows are copied out, because consumers mutate them in place.
 


### PR DESCRIPTION
## Summary

Implements the safe part of #350: record which parameters affect the computation for the four skills that are repeated by the evidence pipeline, then exclude only audited transport context from their per-connection memo keys.

## What changed

- Adds `Skill.memo_key_params` as an opt-in allow-list; skills without it retain the strict resolved-parameter key.
- Audits and configures `sync_cost_analysis`, `overlap_breakdown`, `gpu_idle_gaps`, and `iteration_timing`.
- Keeps `device`, trim bounds, and each skill-specific result-affecting parameter in the key.
- Excludes only forwarded `overhead_ns` / `communicator_data` for these four skills.
- Preserves the important exception that manifest `sync_cost_analysis` without `device` is an all-device computation and must not share the `device=0` result.
- Adds a developer guide with the call-path inventory, parameter matrix, implementation rule, and future cross-run fingerprint boundary.
- Adds regression tests proving ignored context reuses results and answer-affecting parameters still split the memo.

## Verification

- `ruff check` passed.
- Focused memo/skill suites: **149 passed**.
- Broader affected suite: **307 passed**.
- Real `/home/rich-wsl/fastvideo/profile_results/perf.sqlite` `evidence build`: succeeded; session contained **42 findings, 0 skipped**.
- On `h100_2gpu_1s.sqlite`, base and this branch produced the same 23 findings; canonical findings hashes matched.
- Warm fixture execution now records `sync_cost_analysis=2`, `overlap_breakdown=1`, `iteration_timing=1`, while `gpu_idle_gaps` remains distinct at limits 1/5/20.

The original 3.5 GB wall-clock benchmark is not claimed here because that capture is not committed. A large-profile benchmark remains the follow-up for #350 before expanding the allow-list or introducing a cross-process cache.
