### PR TITLE
feat(diff): seed candidate findings from baseline comparisons

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ alongside them.
 | [dev/surface-adapters.md](./dev/surface-adapters.md) | How CLI, TUI, Web, MCP, and chat delegate shared policy and analysis |
 | [dev/artifact-layout.md](./dev/artifact-layout.md) | Where invocation artifacts and input-keyed profile caches live |
 | [dev/skill-memo-fingerprint.md](./dev/skill-memo-fingerprint.md) | How answer-affecting parameters define a skill memo identity |
+| [dev/diff-findings.md](./dev/diff-findings.md) | How baseline diffs seed candidate-owned findings and proposals |
 | [dev/testing.md](./dev/testing.md) | Test layers and subprocess-aware coverage |
 | [support-matrix.md](./support-matrix.md) | Committed export schemas verified by CI |
 

--- a/docs/dev/diff-findings.md
+++ b/docs/dev/diff-findings.md
@@ -1,0 +1,237 @@
+# Diff findings and the candidate handoff boundary
+
+This document defines how a deterministic profile diff becomes actionable
+evidence for the next optimization loop. It is an implementation contract for
+the CLI, SessionStore, proposal generator, and future Web/TUI consumers.
+
+The short version is:
+
+```text
+baseline + candidate
+        │
+        └── diff_profiles()
+              │
+              └── findings_from_diff()
+                    │
+                    └── candidate-seeded session
+```
+
+The diff is a pair computation. A Finding is a claim about one profile. The
+candidate is therefore the next session's `before_profile`, even though the
+Finding carries lineage back to the baseline that exposed the regression.
+
+## Scope
+
+This contract covers:
+
+- per-kernel regression Findings from `ProfileDiffSummary.top_regressions`;
+- the `diagnose --against REF` CLI path;
+- deterministic headroom and suggested actions;
+- proposal and SessionStore handoff semantics.
+
+It does not turn the overall step-time verdict, overlap delta, or category
+delta into a Finding. Those values remain diff-level measurements. A Proposal
+must point to a concrete candidate trace selection, so a whole-run Finding
+would be both hard to verify and unsafe to optimize.
+
+## User workflow
+
+The candidate profile is the positional argument. `--against` supplies the
+baseline:
+
+```console
+$ nsys-ai diagnose run-after/profile.sqlite \
+    --against run-before/profile.sqlite \
+    --format json \
+    --session artifacts/diagnose-regression
+```
+
+The baseline may also be a named snapshot:
+
+```console
+$ nsys-ai baseline tag main run-before/profile.sqlite \
+    --reason "last known good"
+$ nsys-ai diagnose run-after/profile.sqlite \
+    --against baseline:main
+```
+
+The resulting `findings.json` contains the ordinary default-pack findings
+plus any per-kernel regression Findings. Every diff Finding is anchored to the
+candidate profile. A user can select its id for the existing proposal flow:
+
+```console
+$ nsys-ai propose --session artifacts/diagnose-regression \
+    --finding-id finding_diff_regression_<id> \
+    --runspec runspec.json
+```
+
+If `--session` is omitted, normal diagnose derives a session id from the
+candidate profile id. `diagnose --against` derives one from the content-derived
+`diff_id` instead. This prevents a baseline comparison from silently replacing
+a normal diagnosis session for the same candidate.
+
+## Why the candidate owns the Finding
+
+Session publication has a deliberately strict invariant:
+
+```text
+session.state.before_profile.profile_id
+    == findings.json.profile_id
+    == finding.selection.profile_id
+```
+
+For an ordinary diagnosis, all three values identify the opened profile. For a
+baseline comparison, the opened profile is the candidate, so the invariant
+still holds. The baseline is retained in `finding.diff_lineage` rather than
+being made the Finding's profile identity.
+
+This gives the next loop a coherent state transition:
+
+```text
+baseline ──compare──> candidate
+                         │
+                         ├── findings.json (claims about candidate)
+                         ├── proposal.json (candidate selection)
+                         └── reprofile candidate ──> after profile
+```
+
+Publishing the Finding into a session owned by the baseline would violate the
+provenance check and would make the subsequent `propose → reprofile → diff`
+transition ambiguous. The implementation intentionally does not weaken that
+check.
+
+## Finding projection
+
+`findings_from_diff(summary)` is a pure function. It accepts an in-memory
+`ProfileDiffSummary` and performs no profile reads, cache writes, or session
+writes. For each item in `top_regressions` with a positive `delta_ns`, it
+creates one `Finding` with these fields:
+
+| Finding field | Source or rule |
+|---|---|
+| `type` | `region` |
+| `label` | `Regression: <kernel name>` |
+| `selection` | The diff's candidate-side `TraceSelection` |
+| `selection.profile_id` | `summary.after.profile_id` |
+| `selection.source` | `diff` |
+| `diff_lineage.diff_id` | `summary.diff_id` |
+| `diff_lineage.role` | `regression` |
+| `diff_lineage.rank` | Zero-based rank in `top_regressions` |
+| `diff_lineage.baseline_profile_id` | `summary.before.profile_id` |
+| `headroom_ms` | `kernel.delta_ns / 1e6` |
+| `headroom_basis` | `baseline_delta` |
+| `severity` | `warning` |
+| `category` | `compute` |
+
+The existing diff engine already computes a slowest-instance selection on the
+after profile. That selection is reused, including its time bounds and GPU
+filter. The pure projector has a deterministic fallback for hand-built
+summaries whose kernel row lacks a selection; it never opens a profile to
+invent one.
+
+The final list is passed through `rank_findings`, so the largest positive
+baseline delta is first. Finding ids are content-derived from the diff id,
+kernel key, and rank. They are stable for the same comparison and distinct for
+different ranked rows.
+
+## Headroom semantics
+
+`headroom_ms` is not a promise of realized speedup. It is the observed increase
+in aggregate GPU time relative to the selected baseline:
+
+```text
+headroom_ms = candidate_total_ns - baseline_total_ns
+               -----------------------------------
+                             1,000,000
+```
+
+The explicit basis `baseline_delta` is copied into `ExpectedImpact` when a
+Proposal is generated. This makes the proposal honest: it carries a measured
+opportunity, not a model prediction or a claim that all overlapping GPU time
+can be removed.
+
+Aggregate kernel time can overlap across streams and devices. The Finding's
+false-positive notes preserve that caveat for CLI, Web, and MCP consumers.
+The selection is the verification target; it is not a source-code location.
+
+## Suggested-action decision table
+
+Actions are deterministic projections of the count and average-time deltas.
+They are deliberately phrased as investigation steps, not automatic fixes.
+
+| Classification | Count delta | Average delta | Action focus |
+|---|---:|---:|---|
+| `new` | any | any | Identify what introduced the kernel; it is absent from baseline |
+| existing | `> 0` | `<= 0` | Call count rose; inspect loop and batching structure |
+| existing | `0` | `> 0` | Same count, slower calls; compare shapes, dtypes, and occupancy |
+| existing | non-zero | non-zero | Separate call-frequency cost from per-call cost |
+| existing | `0` | `<= 0` | Inspect the workload path and aggregate attribution |
+
+The second row is important. A regression caused by more launches should not
+be narrated as “the kernel got slower.” The decomposition tells the next
+investigation which dimension to measure.
+
+## Session and proposal lifecycle
+
+`diagnose --against` performs the expensive analysis before acquiring a
+SessionStore writer lease:
+
+1. Resolve and open the candidate.
+2. Run the normal `DIAGNOSE_DEFAULT` evidence pack.
+3. Resolve the baseline path or `baseline:<name>` snapshot.
+4. Run the deterministic baseline → candidate diff.
+5. Project candidate Findings and rank the combined report.
+6. Derive the session id from `diff_id` unless the caller supplied one.
+7. Publish one candidate-owned `findings.json` artifact.
+
+The proposal path is unchanged. A Finding with an id, candidate selection,
+suggested action, and a verification `RunSpec` produces a non-abstained
+Proposal. The normal SessionStore transition then remains:
+
+```text
+diagnose → propose → reprofile → diff → decide
+```
+
+No diff Finding is written to `diff.json`. That artifact has an exact diff
+schema and remains the representation of the pair comparison. The Finding is
+an additive member of `findings.json`, where the evidence and proposal
+contracts already live.
+
+## Compatibility and failure behavior
+
+- No schema version bump is needed. `Finding` already has optional selection,
+  lineage, headroom, and suggested-action fields.
+- A pair with no positive top regression returns no diff Findings. It does not
+  fabricate a healthy whole-run Finding.
+- A low-comparability pair may still expose per-kernel deltas, but the Finding
+  carries the diff's confidence and the baseline-relative caveat. Callers must
+  continue to respect the diff verdict and confidence before treating the
+  regression as causal.
+- An invalid profile or missing named baseline fails the diagnose command
+  before publication. No partial session artifact is created by this path.
+- An explicit `--session` remains authoritative. Only the default session id
+  changes for `--against`.
+
+## Test contract
+
+The implementation is covered at four levels:
+
+| Layer | Assertion |
+|---|---|
+| Pure projection | Reversed fixtures produce 15 ranked positive headrooms, stable ids, lineage, and candidate selections |
+| Action semantics | Count-only regressions mention call frequency, not kernel slowdown |
+| Proposal | A projected Finding plus `RunSpec(argv=("true",))` is non-abstained and uses `baseline_delta` |
+| Session | Candidate-owned findings accept a RunSpec and reach `propose` |
+| CLI | `diagnose --against` writes a diff-derived session id and candidate provenance |
+| No-regression path | Forward fixture pair on GPU 0 returns `[]` |
+
+When changing this contract, run the focused suite first:
+
+```console
+$ pytest -q tests/test_diff_findings.py tests/test_session_cli.py \
+    tests/test_diagnose_review.py tests/test_gpu_selection.py
+```
+
+Then run the full repository suite before merging. The fixture pair is small
+enough for deterministic tests; large captures should be reserved for the
+checkpoint E2E, not embedded in unit tests.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -264,6 +264,9 @@ definitions, metric bases, and the recovery path for an inconclusive comparison.
 Useful variants:
 
 - `--session` publishes the diff into the same session directory.
+- `diagnose run-after/profile.sqlite --against run-before/profile.sqlite`
+  publishes candidate-anchored regression Findings that can be sent directly
+  to `propose`; see [the diff findings contract](./dev/diff-findings.md).
 - `--gpu N` restricts to one device; the default compares all of them.
 - `--against baseline:<name>` diffs against a stored baseline instead of a path — see
   `nsys-ai baseline --help`.

--- a/site/index.html
+++ b/site/index.html
@@ -813,6 +813,9 @@
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/skill-memo-fingerprint.md" class="doc-link">
                     <span class="doc-num">dev</span><span class="doc-title">Skill memo identity</span>
                 </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/diff-findings.md" class="doc-link">
+                    <span class="doc-num">dev</span><span class="doc-title">Diff findings</span>
+                </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/testing.md" class="doc-link">
                     <span class="doc-num">dev</span><span class="doc-title">Testing &amp; coverage</span>
                 </a>

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -57,6 +57,7 @@ def _cmd_diagnose(args, _profile):
             open_browser=not bool(getattr(args, "no_browser", False)),
             output=getattr(args, "output", None),
             format=getattr(args, "format", "text"),
+            against=getattr(args, "against", None),
         )
     except DiagnoseCommandError as exc:
         print(f"Error: {exc}", file=sys.stderr)

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -632,6 +632,15 @@ def _build_parser():
         help="Time window in seconds",
     )
     p.add_argument(
+        "--against",
+        default=None,
+        metavar="REF",
+        help=(
+            "Baseline to diff against while diagnosing the candidate "
+            "(e.g. 'baseline:<name>' or a profile path)"
+        ),
+    )
+    p.add_argument(
         "--session",
         nargs="?",
         const="",

--- a/src/nsys_ai/diagnose_command.py
+++ b/src/nsys_ai/diagnose_command.py
@@ -12,6 +12,7 @@ import os
 import sys
 from typing import TextIO
 
+from .annotation import rank_findings
 from .exceptions import NsysAiError, ProfileError
 from .profile import Profile, resolve_profile_path, select_gpu_device
 from .profile_runner import build_local_profile_reference
@@ -42,6 +43,7 @@ def run_diagnose(
     open_browser: bool = True,
     output: str | os.PathLike[str] | None = None,
     format: str = "text",
+    against: str | os.PathLike[str] | None = None,
     session_root: str | os.PathLike[str] = ".nsys-ai/sessions",
     stdout: TextIO = sys.stdout,
     stderr: TextIO = sys.stderr,
@@ -60,6 +62,8 @@ def run_diagnose(
     re-running analysis.
     """
     if profile_path is None:
+        if against:
+            raise DiagnoseCommandError("diagnose --against requires a candidate profile")
         if not web or not session_id:
             raise DiagnoseCommandError(
                 "diagnose requires a profile, or --session <id> --web to reopen"
@@ -85,6 +89,7 @@ def run_diagnose(
 
     from .evidence_builder import EvidenceBuilder
 
+    diff_summary = None
     try:
         with Profile(sqlite_path) as prof:
             selected_gpu = select_gpu_device(prof, gpu)
@@ -92,6 +97,30 @@ def run_diagnose(
             # Analysis completes before any session writer lease is taken.
             report = builder.build()
             before = build_local_profile_reference(prof.path, trim_ns=trim)
+            if against:
+                from .baseline import parse_baseline_ref, resolve_baseline_ref
+                from .diff import diff_profiles
+                from .diff_findings import findings_from_diff
+
+                baseline_ref = os.fspath(against)
+                baseline_path = (
+                    resolve_baseline_ref(baseline_ref)
+                    if parse_baseline_ref(baseline_ref) is not None
+                    else baseline_ref
+                )
+                baseline_sqlite = resolve_profile_path(
+                    os.path.abspath(os.path.expanduser(baseline_path))
+                )
+                with Profile(baseline_sqlite) as baseline_prof:
+                    diff_summary = diff_profiles(
+                        baseline_prof,
+                        prof,
+                        gpu=gpu,
+                        trim=trim,
+                    )
+                report.findings = rank_findings(
+                    [*report.findings, *findings_from_diff(diff_summary)]
+                )
     except (OSError, ProfileError, TypeError, ValueError) as exc:
         raise DiagnoseCommandError(f"diagnose failed: {exc}") from exc
 
@@ -101,7 +130,11 @@ def run_diagnose(
         root=session_root,
     )
     if location is None:
-        resolved_id = resolve_session_id(None, before=before)
+        resolved_id = resolve_session_id(
+            None,
+            before=before,
+            diff_id=diff_summary.diff_id if diff_summary is not None else None,
+        )
     else:
         resolved_id = location.session_id
         session_root = location.root

--- a/src/nsys_ai/diff_findings.py
+++ b/src/nsys_ai/diff_findings.py
@@ -1,0 +1,131 @@
+"""Turn deterministic kernel regressions into candidate-profile findings.
+
+The diff engine answers a pair question. This module closes that comparison
+by projecting only the regressions onto the candidate profile as ordinary
+``Finding`` objects. It deliberately accepts an in-memory
+``ProfileDiffSummary`` and performs no profile or session I/O, so callers can
+keep the diff calculation and session publication as separate boundaries.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from .annotation import DiffLineage, Finding, TraceSelection, rank_findings
+from .diff import KernelDiff, ProfileDiffSummary
+
+
+def _finding_id(summary: ProfileDiffSummary, kernel: KernelDiff, rank: int) -> str:
+    payload = f"{summary.diff_id}\0{rank}\0{kernel.key}".encode()
+    return f"finding_diff_regression_{hashlib.sha256(payload).hexdigest()[:16]}"
+
+
+def _selection(summary: ProfileDiffSummary, kernel: KernelDiff, rank: int) -> TraceSelection:
+    """Return the diff selection, with a deterministic defensive fallback."""
+    if kernel.selection is not None:
+        return kernel.selection
+    payload = f"{summary.diff_id}\0{kernel.key}\0{rank}".encode()
+    digest = hashlib.sha256(payload).hexdigest()[:12]
+    return TraceSelection(
+        id=f"sel_diff_regression_{digest}",
+        profile_id=summary.after.profile_id,
+        source="diff",
+        gpu_ids=[summary.after.gpu] if summary.after.gpu is not None else None,
+        label=f"{kernel.name} {kernel.delta_ns / 1e6:+.2f}ms",
+    )
+
+
+def _suggested_action(kernel: KernelDiff) -> str:
+    """Explain the deterministic decomposition that a user can verify."""
+    if kernel.classification == "new":
+        return (
+            f"Identify what introduced {kernel.name!r}; it is absent from the "
+            "baseline and contributes new GPU work."
+        )
+    if kernel.delta_count > 0 and kernel.delta_avg_ns <= 0:
+        return (
+            f"Investigate why call count rose from {kernel.before_count} to "
+            f"{kernel.after_count} for {kernel.name!r}; per-call time did not "
+            "increase, so inspect loop or batching structure."
+        )
+    if kernel.delta_count == 0 and kernel.delta_avg_ns > 0:
+        return (
+            f"Compare shapes, dtypes, and occupancy for {kernel.name!r}; call "
+            f"count stayed at {kernel.after_count}, while per-call time rose by "
+            f"{kernel.delta_avg_ns / 1e3:.2f}us."
+        )
+    if kernel.delta_count != 0 and kernel.delta_avg_ns != 0:
+        return (
+            f"Separate call-frequency cost from per-call cost for {kernel.name!r}: "
+            f"count changed by {kernel.delta_count:+d} and average time changed by "
+            f"{kernel.delta_avg_ns / 1e3:+.2f}us before optimizing."
+        )
+    return (
+        f"Inspect the workload path for {kernel.name!r}; aggregate GPU time rose "
+        f"by {kernel.delta_ns / 1e6:.2f}ms without a distinct count or average-time shift."
+    )
+
+
+def _finding_note(kernel: KernelDiff) -> str:
+    return (
+        f"Candidate GPU time is {kernel.after_total_ns / 1e6:.3f}ms versus "
+        f"{kernel.before_total_ns / 1e6:.3f}ms in the baseline "
+        f"({kernel.delta_ns / 1e6:+.3f}ms); calls "
+        f"{kernel.before_count} -> {kernel.after_count}, average "
+        f"{kernel.before_avg_ns / 1e3:.3f}us -> {kernel.after_avg_ns / 1e3:.3f}us."
+    )
+
+
+def findings_from_diff(summary: ProfileDiffSummary) -> list[Finding]:
+    """Mint ranked, candidate-anchored findings from per-kernel regressions.
+
+    ``step_time_delta_ms`` and the diff verdict are intentionally not turned
+    into a whole-run finding. A proposal needs a concrete trace selection, so
+    only the already-ranked ``top_regressions`` are projected. An empty list
+    means that this pair surfaced no per-kernel regression.
+    """
+    findings: list[Finding] = []
+    for rank, kernel in enumerate(summary.top_regressions):
+        if kernel.delta_ns <= 0:
+            continue
+        selection = _selection(summary, kernel, rank)
+        findings.append(
+            Finding(
+                type="region",
+                label=f"Regression: {kernel.name}",
+                start_ns=selection.start_ns if selection.start_ns is not None else 0,
+                end_ns=selection.end_ns,
+                gpu_id=selection.gpu_ids[0] if selection.gpu_ids else None,
+                color="rgba(255, 170, 0, 0.30)",
+                severity="warning",
+                note=_finding_note(kernel),
+                id=_finding_id(summary, kernel, rank),
+                category="compute",
+                confidence=summary.comparability_confidence,
+                selection=selection,
+                explanation=(
+                    f"{kernel.name} regressed by {kernel.delta_ns / 1e6:.3f}ms "
+                    "relative to the selected baseline."
+                ),
+                suggested_actions=[_suggested_action(kernel)],
+                false_positive_notes=[
+                    "Aggregate kernel time can overlap across concurrent streams.",
+                    "The headroom is a baseline-relative delta, not a guaranteed gain.",
+                ],
+                provenance={
+                    "skill": "diff",
+                    "row_kind": "kernel_regression",
+                    "diff_id": summary.diff_id,
+                    "kernel_key": kernel.key,
+                },
+                diff_lineage=DiffLineage(
+                    diff_id=summary.diff_id,
+                    role="regression",
+                    rank=rank,
+                    baseline_profile_id=summary.before.profile_id,
+                ),
+                headroom_ms=kernel.delta_ns / 1e6,
+                headroom_basis="baseline_delta",
+            )
+        )
+    return rank_findings(findings)

--- a/src/nsys_ai/session_cli.py
+++ b/src/nsys_ai/session_cli.py
@@ -167,14 +167,37 @@ def session_id_from_profile_id(profile_id: str) -> str:
     return derived
 
 
+def session_id_from_diff_id(diff_id: str) -> str:
+    """Derive a SessionStore-safe id from a content ``diff_id``.
+
+    A diagnose seeded by ``--against`` is a new handoff boundary: its
+    findings describe the candidate profile, but the pair comparison is the
+    identity that makes the run reproducible. Prefixing the normalized diff
+    id also keeps it distinct from a normal profile-derived session.
+    """
+    if not isinstance(diff_id, str) or not diff_id:
+        raise ValueError("diff_id must be a non-empty string")
+    derived = f"diff_{diff_id.replace(':', '_')}"
+    SessionState(session_id=derived)
+    return derived
+
+
 def resolve_session_id(
     explicit: str | None,
     *,
     before: LocalProfileReference | None = None,
+    diff_id: str | None = None,
 ) -> str:
-    """Return a caller id, or derive one from the before profile content id."""
+    """Return a caller id, or derive one from a diff/profile content id.
+
+    ``diff_id`` takes precedence over ``before`` because a diagnose seeded by
+    a baseline comparison must not silently replace a normal diagnosis for
+    the candidate profile.
+    """
     if explicit:
         return explicit
+    if diff_id:
+        return session_id_from_diff_id(diff_id)
     if before is None:
         raise ValueError(
             "session id is required when no before profile is available to derive from"

--- a/tests/test_diff_findings.py
+++ b/tests/test_diff_findings.py
@@ -1,0 +1,140 @@
+"""Regression findings minted from a baseline diff."""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+from nsys_ai.annotation import EvidenceReport
+from nsys_ai.diagnose_command import run_diagnose
+from nsys_ai.diff import diff_profiles
+from nsys_ai.diff_findings import findings_from_diff
+from nsys_ai.profile import Profile
+from nsys_ai.profile_runner import build_local_profile_reference
+from nsys_ai.proposal import generate_proposal
+from nsys_ai.runspec import RunSpec
+from nsys_ai.session_cli import publish_session_findings, publish_session_proposal
+from nsys_ai.session_store import SessionStore
+
+ROOT = Path(__file__).resolve().parents[1]
+BEFORE = ROOT / "tests" / "fixtures" / "mfu_2gpu_before.sqlite"
+AFTER = ROOT / "tests" / "fixtures" / "mfu_2gpu_after.sqlite"
+
+
+def _summary(*, before: Path = AFTER, after: Path = BEFORE, gpu: int | None = None):
+    with Profile(before) as before_prof, Profile(after) as after_prof:
+        return diff_profiles(before_prof, after_prof, gpu=gpu)
+
+
+def test_reversed_pair_mints_ranked_candidate_findings():
+    summary = _summary()
+    findings = findings_from_diff(summary)
+
+    assert len(findings) == 15
+    assert [finding.headroom_ms for finding in findings] == sorted(
+        (finding.headroom_ms for finding in findings), reverse=True
+    )
+    assert all(finding.headroom_ms > 0 for finding in findings)
+    assert all(finding.selection.profile_id == summary.after.profile_id for finding in findings)
+    assert all(finding.diff_lineage.diff_id == summary.diff_id for finding in findings)
+    assert all(
+        finding.diff_lineage.baseline_profile_id == summary.before.profile_id
+        for finding in findings
+    )
+    assert [finding.diff_lineage.rank for finding in findings] == list(range(15))
+    assert len({finding.id for finding in findings}) == len(findings)
+    assert all(finding.suggested_actions for finding in findings)
+    assert all(finding.selection.source == "diff" for finding in findings)
+
+
+def test_call_count_regression_action_describes_frequency_not_slowdown():
+    findings = findings_from_diff(_summary())
+    count_only = next(
+        finding
+        for finding in findings
+        if "call count rose" in finding.suggested_actions[0]
+    )
+
+    assert "call count rose" in count_only.suggested_actions[0]
+    assert "got slower" not in count_only.suggested_actions[0]
+    proposal = generate_proposal(count_only, RunSpec(argv=("true",)))
+    assert proposal.abstained is False
+    assert proposal.expected_impact is not None
+    assert proposal.expected_impact.headroom_basis == "baseline_delta"
+
+
+def test_forward_gpu_pair_without_regression_returns_empty():
+    summary = _summary(before=BEFORE, after=AFTER, gpu=0)
+
+    assert summary.top_regressions == []
+    assert findings_from_diff(summary) == []
+
+
+def test_diff_findings_never_mint_a_whole_run_finding():
+    findings = findings_from_diff(_summary())
+
+    assert findings
+    assert all(finding.selection is not None for finding in findings)
+    assert all(finding.diff_lineage.role == "regression" for finding in findings)
+    assert all(finding.diff_lineage.rank >= 0 for finding in findings)
+    assert all(finding.headroom_basis == "baseline_delta" for finding in findings)
+    assert all(finding.end_ns is None or finding.end_ns >= finding.start_ns for finding in findings)
+
+
+def test_candidate_session_accepts_diff_finding_and_reaches_propose(tmp_path: Path):
+    summary = _summary()
+    finding = findings_from_diff(summary)[0]
+    candidate = build_local_profile_reference(summary.after.path)
+    report = EvidenceReport(
+        title="Diff-seeded diagnosis",
+        profile_path=candidate.path,
+        profile_id=candidate.profile_id,
+        findings=[finding],
+    )
+    sessions = tmp_path / "sessions"
+
+    state = publish_session_findings(
+        session_id="candidate-diff",
+        report=report,
+        before_profile=candidate,
+        root=sessions,
+    )
+    assert state.phase == "diagnose"
+
+    proposal = generate_proposal(finding, RunSpec(argv=("true",)))
+    state = publish_session_proposal(
+        session_id="candidate-diff",
+        proposal=proposal,
+        runspec=proposal.verification,
+        root=sessions,
+    )
+
+    assert state.phase == "propose"
+    snapshot = SessionStore(sessions).load("candidate-diff")
+    assert snapshot.state.before_profile == candidate
+    assert snapshot.findings is not None
+    assert snapshot.findings.findings[0].selection.profile_id == candidate.profile_id
+
+
+def test_diagnose_against_seeds_default_session_from_diff_id(tmp_path: Path):
+    stdout = io.StringIO()
+    result = run_diagnose(
+        profile_path=BEFORE,
+        against=AFTER,
+        session_root=tmp_path / "sessions",
+        format="json",
+        stdout=stdout,
+        open_browser=False,
+    )
+
+    assert result == 0
+    payload = json.loads(stdout.getvalue())
+    diff_findings = [item for item in payload["findings"] if "diff_lineage" in item]
+    assert diff_findings
+    diff_id = diff_findings[0]["diff_lineage"]["diff_id"]
+    session_id = f"diff_{diff_id.replace(':', '_')}"
+    session = SessionStore(tmp_path / "sessions").load(session_id)
+    assert session.state.before_profile.profile_id == payload["profile_id"]
+    assert session.findings is not None
+    assert session.findings.findings[0].selection.profile_id == payload["profile_id"]

--- a/tests/test_session_cli.py
+++ b/tests/test_session_cli.py
@@ -15,6 +15,7 @@ from nsys_ai.session_cli import (
     resolve_session_location,
     session_argument,
     session_dir,
+    session_id_from_diff_id,
     session_id_from_profile_id,
 )
 from nsys_ai.session_store import SessionStore
@@ -49,6 +50,13 @@ def test_session_location_supports_directory_handoff_and_legacy_ids(tmp_path: Pa
 
     spaced_handoff = tmp_path / "handoff dir" / "run-002"
     assert session_argument(spaced_handoff) == shlex.quote(str(spaced_handoff.resolve()))
+
+
+def test_diff_id_derivation_is_distinct_from_profile_id_derivation():
+    diff_id = "diff1:sha256:abc123"
+
+    assert session_id_from_diff_id(diff_id) == "diff_diff1_sha256_abc123"
+    assert session_id_from_diff_id(diff_id) != session_id_from_profile_id(diff_id)
 
 
 def test_session_directory_can_be_used_by_publish_facade(tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes #224.

Turn deterministic per-kernel regressions from a baseline diff into actionable
Findings owned by the candidate profile. Add the `diagnose --against REF`
front door so the candidate can enter the existing proposal/session loop
without weakening SessionStore provenance checks.

## What changed

- add pure `findings_from_diff(ProfileDiffSummary)` projection;
- mint one candidate-anchored Finding per positive top regression;
- preserve `diff_id`, baseline profile id, rank, candidate selection, and
  `headroom_basis=baseline_delta` in the existing Finding schema;
- derive deterministic suggested actions from kernel classification, count
  delta, and average-time delta;
- add `diagnose --against PATH|baseline:<name>`;
- derive the default diagnose session id from `diff_id` for baseline-backed
  diagnoses, keeping it distinct from a candidate-only diagnosis;
- document the candidate handoff boundary and proposal lifecycle;
- add pure, proposal, SessionStore, CLI, and no-regression tests.

## Handoff invariant

For `diagnose --against`, the candidate is the session's `before_profile`:

```text
session.before_profile.profile_id
  == findings.profile_id
  == finding.selection.profile_id
```

The baseline remains in `Finding.diff_lineage`. No diff-derived Finding is
written into `diff.json`, and no changes were made to proposal or session
schema validation.

## Verification

Focused:

```text
ruff check: passed
38 focused tests: passed
```

Full suite, with the committed real fixture supplied to the existing
integration-test gate:

```text
NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite pytest -q
2531 passed, 140 skipped, 4 xfailed in 452.27s
```

Checkpoint E2E with the reversed MFU fixture pair produced 15 candidate
regression Findings, positive descending headroom values, unique ids,
candidate selection profile ids, non-abstained proposal output, and a
diff-derived default session id.

`bandit` was not installed in the local development environment; the existing
GitHub security workflow remains the authoritative security check.
