### PR TITLE
fix(findings): calibrate idle severity by profile share

### DIFF
--- a/docs/user/known-limits.md
+++ b/docs/user/known-limits.md
@@ -118,6 +118,15 @@ underlying synchronization calls separately.
 when the sweep can compute it. A stream can be idle while another stream keeps the device busy, so
 the per-stream sum is not recoverable device time. Do not add per-stream percentages across streams.
 
+Severity also has an aggregate-share guard. A gap can be larger than the reporting floor and still
+be immaterial to the capture: for example, a 2 ms gap in a four-second run is evidence of an
+observation, not by itself a warning-level bottleneck. When the aggregate idle share is below the
+15% warning threshold, per-gap findings remain visible at `info`; the summary uses the same
+threshold. If the aggregate row is unavailable, the analyzer keeps the legacy warning severity
+because it has no denominator with which to make that demotion safely. This is a severity
+calibration rule, not a claim that the gap is recoverable; consult `headroom_ms` and the labelled
+percentage separately.
+
 ## 3. Device selection can change the population being analysed
 
 Multi-GPU profiles have two related but different choices:

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -344,6 +344,12 @@ _FALSE_POSITIVE_NOTES = [
     "Profiler overhead can inflate apparent idle time on very short profiles",
 ]
 
+# A per-gap duration can be operationally noticeable while still being
+# immaterial to the run as a whole. Keep the threshold shared by the summary
+# and per-gap findings so consumers do not see an informational summary paired
+# with warning-level children for the same small aggregate signal.
+_IDLE_WARNING_SHARE_PCT = 15.0
+
 
 def _gap_confidence(gap_ms: float) -> float:
     """Map a gap duration to a confidence in [0, 1].
@@ -372,6 +378,24 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
 
     profile_id = (context or {}).get("profile_id", "unknown")
     findings = []
+
+    # `_execute` appends one aggregate row after the per-gap rows. Read it
+    # before constructing findings so severity does not depend on row order.
+    # Direct callers may provide only gap rows; in that case retain the legacy
+    # warning because there is no aggregate denominator to justify demotion.
+    idle_share_pct = None
+    for row in rows:
+        if row.get("_summary"):
+            try:
+                idle_share_pct = float(row.get("pct_of_profile"))
+            except (TypeError, ValueError):
+                idle_share_pct = None
+            break
+    per_gap_severity = (
+        "info"
+        if idle_share_pct is not None and idle_share_pct < _IDLE_WARNING_SHARE_PCT
+        else "warning"
+    )
 
     for r in rows:
         if r.get("error"):
@@ -443,7 +467,9 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                         start_ns=profile_start_ns,
                         end_ns=profile_end_ns,
                         gpu_id=target_device,
-                        severity="info" if pct < 15 else "warning",
+                        severity=(
+                            "info" if pct < _IDLE_WARNING_SHARE_PCT else "warning"
+                        ),
                         # The gap sum is per stream, so on a multi-stream profile
                         # it exceeds the wall-clock the device lost and the
                         # headroom below is visibly smaller than the number
@@ -535,7 +561,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 end_ns=end_ns,
                 gpu_id=device_id,
                 stream=str(stream_id),
-                severity="warning",
+                severity=per_gap_severity,
                 note=note,
                 # v0.1 fields
                 id=finding_id,

--- a/tests/eval/labels/healthy_judged_1pct.json
+++ b/tests/eval/labels/healthy_judged_1pct.json
@@ -19,14 +19,9 @@
     },
     {
       "category": "idle",
-      "min_severity": "critical",
-      "note": "0.99% idle must never reach critical. Warning-level idle findings ARE currently emitted here \u2014 see known_gaps \u2014 so the gate is set at critical to assert the real boundary rather than encode behaviour we think is wrong."
+      "min_severity": "warning",
+      "note": "0.99% idle must not reach warning severity. The gaps remain visible as informational observations, but must not compete with material bottlenecks."
     }
   ],
-  "known_gaps": [
-    {
-      "observation": "This profile produces 5 warning-severity 'GPU Idle Gap (2.00ms)' findings while claiming 0ms recoverable time. Severity is judged per gap against min_gap_ns, with no reference to what share of the run the gaps represent. So a healthy pipeline at 0.94% idle emits five warnings, which is the noise that buries real signal elsewhere in the corpus. Headroom is correctly zero, so the ROI ranking is unaffected \u2014 this is a severity calibration question, not a wrong number.",
-      "ref": "#284"
-    }
-  ]
+  "known_gaps": []
 }

--- a/tests/test_abstention.py
+++ b/tests/test_abstention.py
@@ -555,14 +555,13 @@ def test_idle_the_pipeline_actually_sees_is_still_not_called_recoverable():
         "no idle findings at all — the gaps were filtered, not judged"
     )
 
-    # Documenting current behaviour rather than blessing it: severity is judged
-    # per gap with no reference to the share of the run, so a healthy profile
-    # still emits warnings. Tracked separately; pinned here so a change is
-    # deliberate rather than accidental.
+    # The gaps are visible, but their aggregate share is immaterial. They are
+    # observations rather than warning-level bottlenecks.
     idle_warnings = [
         f for f in report.findings if f.category == "idle" and f.severity == "warning"
     ]
-    assert len(idle_warnings) <= 5, f"idle warning noise grew to {len(idle_warnings)}"
+    assert not idle_warnings, f"immaterial idle share emitted warnings: {idle_warnings}"
+    assert [f for f in report.findings if f.category == "idle" and f.severity == "info"]
     assert not [f for f in report.findings if f.category == "idle" and f.severity == "critical"]
 
 

--- a/tests/test_gpu_idle_gaps_findings.py
+++ b/tests/test_gpu_idle_gaps_findings.py
@@ -75,6 +75,28 @@ class TestPerGapFinding:
         assert f.severity == "warning"
         assert "Stream 3" in f.note
 
+    def test_immaterial_aggregate_share_demotes_per_gap_to_info(self):
+        """A visible gap is an observation when idle is a small share of the run."""
+        findings = _to_findings(
+            [
+                _per_gap_row(gap_ns=2_000_000),
+                _summary_row(pct_of_profile=0.9),
+            ]
+        )
+        assert len(findings) == 1
+        assert findings[0].severity == "info"
+
+    def test_material_aggregate_share_keeps_per_gap_warning(self):
+        findings = _to_findings(
+            [
+                _per_gap_row(gap_ns=2_000_000),
+                _summary_row(pct_of_profile=20.0),
+            ]
+        )
+        per_gap = [f for f in findings if f.provenance["row_kind"] == "per_gap"]
+        assert len(per_gap) == 1
+        assert per_gap[0].severity == "warning"
+
     def test_v01_fields_populated(self):
         findings = _to_findings(
             [_per_gap_row(gap_ns=12_500_000, start_ns=500, stream_id=7)],


### PR DESCRIPTION
## Summary

Fixes #284.

Idle-gap findings now use the aggregate idle share when assigning severity:

- below the existing 15% warning threshold: keep per-gap observations at `info`;
- at or above the threshold: retain `warning` severity;
- without an aggregate row: retain the conservative legacy `warning` behavior.

The summary finding and per-gap findings now share one named threshold. The
negative `healthy_judged_1pct.sqlite` eval is tightened from `critical` to
`warning`, proving that visible 2 ms gaps covering less than 1% of the run do
not compete with material bottlenecks. The findings and zero headroom remain
visible, so this changes triage severity rather than hiding evidence.

Documentation now records the denominator and the fallback behavior in the
known-limits guide.

## Verification

- `ruff check` for the changed Python files
- focused idle/eval tests: `27 passed`
- docs index: `6 passed`
- real `/home/rich-wsl/fastvideo/profile_results/perf.sqlite`: 17.9% idle share, 21 sampled findings, all retained `warning`
- full suite with `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite`: `2533 passed, 140 skipped, 4 xfailed`
