### PR TITLE
docs: finalize the 0.3.0 release boundary

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ Before raising a PR, verify:
 ## Key Design Decisions
 
 - **Internal module = `nsys_ai`**, external package = `nsys-ai` (historical rename)
+- **Installed entry points:** `nsys-ai` is the main CLI (including `tui` and `timeline` subcommands); `nsys-ai-mcp` is the optional stdio MCP transport. There is no packaged `nsys-tui` executable in 0.3.0.
 - **Core runtime deps**: `duckdb` + `pyarrow` (Parquet cache) and `rich` + `textual` (TUI). SQL analysis and the web server stay on the stdlib (`sqlite3`, `http.server`)
 - **Optional deps**: `litellm` (+ `anthropic`) for AI features (`pip install 'nsys-ai[agent]'`), `pytest` for dev
 - **Profiles are `.sqlite` files** exported from NVIDIA Nsight Systems (`.nsys-rep` → `.sqlite`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,9 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   evidence pack and the canonical diff. `diagnose` publishes findings to a
   session and prints the next command with its arguments filled in; `review`
   resumes a session and reports where its decision stands, or compares a pair
-  without owning a session. `review`'s pair output is byte-identical to
-  `diff --no-ai`.
+  without owning a session. Its pair report is rendered by the same canonical
+  diff path as `diff --no-ai`; the report on stdout is identical, while
+  `review` adds two next-step hints on stderr for an interactive shell.
 - `nsys-ai diff --session --accept/--reject --reason TEXT` records the decision
   on the session's own `diff.json`, so a session that has findings, a proposal
   and a diff can reach a decision without leaving the command line.
@@ -90,6 +91,11 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   ranks, and communicator IDs.
 - A labeled-profile evaluation harness under `tests/eval/` (expected and
   forbidden findings) to keep skill outputs honest as they change.
+- Memoized skill execution keyed by the profile identity and every
+  answer-affecting parameter, so repeated evidence requests can reuse results
+  without confusing a changed window or GPU selection with the old answer.
+- Candidate-anchored regression Findings from `diagnose --against`, giving the
+  proposal workflow a stable finding ID and evidence window to act on.
 
 ### Changed
 
@@ -102,6 +108,17 @@ and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
   leaf NVTX label, and ancestor-path containment is temporal, not lexical, so
   matching on a path substring can pick up kernels whose enclosing scope merely
   happened to still be open.
+- Idle findings calibrate their severity against the aggregate profile share,
+  while retaining conservative warning severity when the aggregate denominator
+  is unavailable.
+
+### Scope boundaries
+
+- The persisted pair-level `DiffIndex` memo remains deferred. The canonical diff
+  and session handoff are shipped; promotion of pair reuse requires a measured
+  checkpoint on real before/after captures.
+- Remote verification providers and a separate diagnostics artifact remain
+  follow-up work. The 0.3.0 session is the local, inspectable handoff boundary.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 nsys-ai is an AI-powered terminal UI for analyzing NVIDIA Nsight Systems GPU profiles (`.sqlite` files). It provides Textual-based TUI viewers, a local web timeline, HTML export, a skill-based analysis system, and an LLM agent for automated GPU performance diagnosis.
 
-**Naming:** The PyPI package is `nsys-ai`, but the internal Python module is `nsys_ai` (historical). The CLI command is `nsys-ai`; the older `nsys-tui` entry point was dropped in the rename.
+**Naming:** The PyPI package is `nsys-ai`, but the internal Python module is `nsys_ai` (historical). The wheel exposes two console entry points: `nsys-ai` for the main CLI and `nsys-ai-mcp` for the optional stdio MCP transport. `nsys-tui` is not a 0.3.0 entry point; tree and timeline TUIs are subcommands of `nsys-ai`.
 
 ## Build & Development Commands
 
@@ -39,7 +39,7 @@ Core runtime dependencies are `duckdb` + `pyarrow` (Parquet cache acceleration) 
 
 ### Entry Point
 
-`src/nsys_ai/__main__.py` delegates to `nsys_ai.cli.app:main`; the argparse CLI is built in `cli/parsers.py` (~30 subcommands) and dispatched to `cli/handlers.py`. One entry point is registered in pyproject.toml: `nsys-ai`, pointing at `nsys_ai.__main__:main`.
+`src/nsys_ai/__main__.py` delegates to `nsys_ai.cli.app:main`; the argparse CLI is built in `cli/parsers.py` (~30 subcommands) and dispatched to `cli/handlers.py`. `pyproject.toml` registers `nsys-ai` (the main CLI, pointing at `nsys_ai.__main__:main`) and `nsys-ai-mcp` (the stdio MCP server, pointing at `nsys_ai.mcp_server:main`). The MCP entry point is optional at runtime and requires the `mcp` extra when it is used.
 
 ### Core Data Model
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,27 @@ nsys-ai tui my_training.nsys-rep --gpu 0        # NVTX tree browser
 nsys-ai diff before.sqlite after.sqlite
 ```
 
+### 4. Keep the investigation in one session
+
+The 0.3.0 command surface is built around a session directory: findings,
+proposals, run specifications, diffs, and decisions can move between CLI, Web,
+TUI, and MCP without reconstructing state from terminal output.
+
+```bash
+SESSION=/tmp/nsys-ai/run-001
+
+nsys-ai doctor run-before/profile.sqlite --format json
+nsys-ai diagnose run-before/profile.sqlite --session "$SESSION"
+nsys-ai ask --session "$SESSION" "what is the main bottleneck?"
+nsys-ai diff run-before/profile.sqlite run-after/profile.sqlite \
+  --no-ai --session "$SESSION"
+nsys-ai review --session "$SESSION"
+```
+
+For a complete diagnose → propose → re-profile → diff → decision walkthrough,
+including the `RunSpec` required by `propose`, see the
+[user guide](https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md).
+
 ## Web timeline
 
 A browser-based multi-GPU viewer with progressive rendering — no `--trim`
@@ -247,6 +268,8 @@ via `--against` or as the `before` positional.
 | `tui` | NVTX tree TUI |
 | `web` | Web viewer server |
 | `info` | Profile metadata and GPU hardware |
+| `doctor` | Check environment, ingest, cache, and profile health |
+| `profile` | Capture a workload and write a reproducible RunSpec |
 | `warm` | Build the Parquet cache and NVTX kernel map up front |
 | `summary` | Top kernels and stream breakdown |
 | `analyze` | Full auto-report (`--format json` emits evidence findings) |
@@ -259,6 +282,10 @@ via `--against` or as the `before` positional.
 | `diff` | Before/after profile comparison |
 | `diff-web` | Side-by-side comparison web viewer |
 | `baseline` | Manage named baseline snapshots (`tag`, `list`, `show`) |
+| `diagnose` | Run the default evidence pack and publish findings |
+| `propose` | Turn one finding into a verifiable proposal |
+| `review` | Compare a pair or resume a session decision path |
+| `optimize` | Run diagnose → propose → re-profile → diff as one session |
 | `chat` | AI chat TUI for a profile |
 | `ask` | One-shot AI question about a profile |
 | `agent` | Agent auto-analysis (`analyze`, `ask`) |
@@ -426,6 +453,7 @@ interactive HTML explorer for the Nsight SQLite schema — open
 pip install nsys-ai              # core: CLI, TUIs, skills, web/diff viewers
 pip install 'nsys-ai[agent]'     # + LLM-backed agent (anthropic + litellm)
 pip install 'nsys-ai[chat]'      # + chat TUI
+pip install 'nsys-ai[mcp]'       # + stdio MCP transport (`nsys-ai-mcp`)
 pip install 'nsys-ai[cutracer]'  # + CUTracer instruction-level workflow
 pip install 'nsys-ai[all]'       # everything
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@ alongside them.
 | [dev/skill-memo-fingerprint.md](./dev/skill-memo-fingerprint.md) | How answer-affecting parameters define a skill memo identity |
 | [dev/diff-findings.md](./dev/diff-findings.md) | How baseline diffs seed candidate-owned findings and proposals |
 | [dev/testing.md](./dev/testing.md) | Test layers and subprocess-aware coverage |
+| [dev/architecture.md](./dev/architecture.md) | Layered architecture, shared runner, session contracts, and release checklist |
 | [support-matrix.md](./support-matrix.md) | Committed export schemas verified by CI |
 
 ## Nsight Systems reference

--- a/docs/dev/architecture.md
+++ b/docs/dev/architecture.md
@@ -1,0 +1,331 @@
+# Architecture and release-maintainer guide
+
+This page is the implementation map for nsys-ai 0.3.0. It describes the
+contracts that let CLI, TUI, Web, and MCP share one analysis path, then records
+the release boundary so a future change does not accidentally reopen the
+architecture migration.
+
+The short version is:
+
+> **Many entrances, one brain, one session for handoff.**
+
+This is a contract document, not a tour of every Python module. For input
+selection, start with [ingest policy](ingest-policy.md). For adding a skill,
+read the [skill contract](skill-contract.md). For surface-specific wiring, use
+[surface adapters](surface-adapters.md).
+
+## 1. Design goals
+
+The 0.3.0 architecture has four operational goals:
+
+1. **One analysis implementation.** A question asked in the CLI, browser,
+   TUI, or MCP must execute the same registered skills and the same grounding
+   policy.
+2. **Evidence before language.** SQL and deterministic heuristics produce the
+   evidence. An LLM may select skills or summarize rows, but it does not invent
+   profile SQL or replace a missing result.
+3. **A directory is the handoff.** A session contains inspectable artifacts,
+   not an opaque second database. Another process can resume it without parsing
+   the previous process's stdout.
+4. **Costs follow changed inputs.** Input-derived state is cached and keyed by
+   its source identity and answer-affecting parameters. Work that is not
+   invalidated should not be repeated merely because a different surface asked
+   the question.
+
+Non-goals for this release are a remote execution service, a second
+orchestrator package, and a new database hidden behind the session directory.
+
+## 2. Runtime layers
+
+The stack has five layers and two analysis engines. Dependencies flow downward;
+the transport layers do not implement analysis policy.
+
+| Layer | Responsibility | 0.3.0 boundary |
+| --- | --- | --- |
+| **L5 Transport** | CLI, TUI, Web, MCP input/output | Four verbs and session handoff; no surface-local SQL |
+| **L4 Agent core** | Shared runner and lifecycle | `agent/runner.py` owns the loop; legacy CLI loop is a thin adapter |
+| **L3 Engines** | Single-profile and pair analysis | `AnalysisKernel` runs packs/skills; `DiffIndex` is the pair-memo extension point |
+| **L2 Session** | Handoff artifacts and state | `findings`, `proposal`, `runspec`, `diff`, and indexes are inspectable files |
+| **L1 Ingest** | Turn profile inputs into queryable data | `.nsys-rep` defaults to Parquet; `.sqlite` remains a compatibility path |
+
+The two engines have different invalidation domains:
+
+- **AnalysisKernel** is invalidated by the profile identity, selected skill,
+  and every parameter that can change the answer (GPU, trim window, iteration,
+  schema mode, and relevant feature flags).
+- **DiffIndex** is invalidated by the ordered before/after identities and pair
+  options. Its persisted pair memo is deliberately deferred from the 0.3.0
+  release gate until a real-profile checkpoint proves the invalidation and
+  reconciliation costs.
+
+The current cache and memo rules are documented in
+[artifact layout](artifact-layout.md) and
+[skill memo identity](skill-memo-fingerprint.md).
+
+## 3. The transport contract
+
+Every transport should be explainable as one of four verbs:
+
+| Verb | Input | Engine | Primary output |
+| --- | --- | --- | --- |
+| `diagnose` | One profile | AnalysisKernel + default pack | `findings.json` |
+| `ask` | Question plus profile/session | Triage + AnalysisKernel | Evidence-first text or SSE |
+| `diff` | Ordered before/after profiles | DiffIndex/canonical diff | `diff.json` or rendered report |
+| `optimize_step` | Baseline plus RunSpec | Diagnose → propose → re-profile → diff | Complete session |
+
+The command names are product verbs, not four independent implementations.
+The Web and TUI may expose buttons and panels, but the action they invoke must
+map back to one of these verbs. MCP exposes the same handoff projection over
+stdio; it must not introduce an MCP-only session schema.
+
+### Session location
+
+`--session <dir>` is the portable form. A caller may pass a directory below a
+shared writable root, and a later caller may open that directory from a
+different working directory. A bare session value remains a compatibility
+shortcut for the local `.nsys-ai/sessions` root.
+
+The session directory is not a replacement for the profile cache. The profile
+cache is input-derived query state; the session is an invocation and decision
+handoff. Keep those ownership boundaries separate:
+
+```text
+profile.nsys-rep
+└── profile.parquetdir/       input-derived query state
+
+session/run-001/
+├── session.json              state, profile refs, artifact manifest
+├── findings.json             ranked evidence
+├── proposal.json             proposed change and verification
+├── runspec.json              reproducible capture specification
+├── diff.json                 pair result and optional decision
+├── indices/                  derived indexes when present
+└── logs/                     append-only transport records
+```
+
+See [artifact layout](artifact-layout.md) for the compatibility and atomic
+write rules. A new artifact must be versioned, hashed in the session manifest,
+and written atomically before a transport reports success.
+
+## 4. One runner, one lifecycle
+
+All four verbs use the same lifecycle. The planner chooses work; the engines do
+the work; the emitter translates the result into a surface response.
+
+```text
+Load → ORIENT → PLAN → INVESTIGATE → GROUND → SYNTHESIZE → EMIT
+```
+
+### Load
+
+Resolve the profile or session location, apply the ingest policy, and load the
+existing artifacts. If a session already contains a valid result, resume from
+that result instead of rebuilding it.
+
+### ORIENT
+
+Read profile metadata, health, available schema/features, and session state.
+This is where an absent NVTX table, an empty kernel side, or an out-of-range
+trim becomes an explicit limitation rather than a healthy-looking empty answer.
+
+### PLAN
+
+`diagnose` uses the fixed default pack. `ask` chooses at most four registered
+skills through keyword matching or optional LLM triage. `diff` ensures the pair
+inputs are resolved. `optimize_step` follows the recorded proposal RunSpec.
+
+### INVESTIGATE
+
+Execute `run_skill` through the registry. Grounding SQL belongs to the skill
+definition and its declared schema requirements. Chat code may request a skill,
+but must not assemble ad-hoc profile SQL.
+
+### GROUND
+
+The runner accepts an answer as grounded only when it has usable registry
+evidence. Abstention is preserved with its reason; an empty result means a
+check ran and found nothing, while an abstention means the check could not
+make a defensible claim. See [skill contract](skill-contract.md).
+
+### SYNTHESIZE
+
+The deterministic renderer formats findings and diffs. An LLM is optional and
+limited to planning/triage and language synthesis over already-returned rows.
+It cannot turn missing evidence into a diagnosis or silently change a metric's
+denominator.
+
+### EMIT
+
+Batch CLI commands write files and print a concise next action. Web/TUI use the
+same runner and emit `text`, `action`, and `done` SSE events where streaming is
+needed. MCP returns the same session projection and JSON-safe evidence.
+
+## 5. Dataflow by verb
+
+### Diagnose: one profile
+
+```text
+profile
+  → ingest policy
+  → run_pack(DIAGNOSE_DEFAULT)
+  → Finding[] + limitations
+  → findings.json
+  → CLI text / Web overlay / MCP JSON
+```
+
+The default pack is deterministic and does not require an LLM. A finding must
+retain its stable ID, category, severity, confidence, evidence, and time/GPU
+location when those values are available.
+
+### Ask: a question over evidence
+
+```text
+question
+  → root_cause_matcher
+  → ≤4 registered skills
+  → run_skill × N
+  → require registry evidence
+  → evidence-first answer
+  → stdout or SSE
+```
+
+If no profile is connected, profile-backed tools are removed from the tool set
+and the prompt must not require them. If a skill abstains, the answer should
+name that limitation rather than treating it as a clean profile.
+
+### Diff: an ordered pair
+
+```text
+before.ref ──┐
+             ├─ resolve identities → canonical diff → diff.json
+after.ref  ──┘                         ↓
+                              Web Decide / CLI --accept|--reject
+```
+
+The before/after order is part of the input. A self-diff is valid but should be
+reported as inconclusive when it cannot establish a change. A missing or empty
+side is not an improvement. Candidate-anchored findings from
+`diagnose --against` are described in [diff findings](diff-findings.md).
+
+### Optimize step: the composed path
+
+```text
+diagnose baseline
+  → propose one finding with a RunSpec
+  → capture candidate from that RunSpec
+  → diff baseline/candidate
+  → record accept/reject and reason
+```
+
+The session is the recovery boundary. If the process stops after capture, the
+next invocation reads the proposal and existing references rather than
+capturing a second candidate by accident. The composition must not duplicate
+the implementation of diagnose, propose, or diff.
+
+## 6. Extension boundaries
+
+### Add an analysis skill when
+
+The question can be answered from profile evidence and should be reusable by
+more than one surface. Define the SQL, schema requirements, parameters,
+formatter, abstention behavior, and tests in the skill contract. Register it;
+do not call it by importing a private module from chat or Web.
+
+### Add a transport adapter when
+
+The user needs a different interaction model, not a different analysis. The
+adapter should translate input into a verb, call the runner, and translate
+events/artifacts into its protocol. It should not add a fifth HTTP server or a
+second session database.
+
+### Add an artifact when
+
+The state is needed for a later process to inspect or resume. Define its schema,
+version, producer, consumer, hash/atomic-write behavior, and migration story.
+Do not put transient UI state into the session unless it affects the analysis
+or the handoff.
+
+### Keep LLMs at the edge
+
+Use an LLM to triage a natural-language question or summarize grounded rows.
+Keep skill selection bounded, validate every selected name through the
+registry, cap serialized evidence, and preserve abstention rows. A prompt is
+not a database API.
+
+## 7. What shipped in 0.3.0
+
+The required architecture migration is complete:
+
+- canonical skill packs and registry execution;
+- evidence-first chat tools backed by `run_skill`;
+- the shared agent runner and thin CLI/Web/TUI adapters;
+- Parquet-first `.nsys-rep` ingest with `.sqlite` compatibility;
+- session handoff for findings, proposals, RunSpecs, diffs, and decisions;
+- four-verb transport semantics across CLI, TUI, Web, and read-only MCP;
+- bounded Web NVTX tree slices and first-class health/abstention reporting;
+- deterministic diff findings and calibrated idle severity;
+- the `profile`, `doctor`, `diagnose`, `propose`, `review`, and `optimize`
+  command surfaces.
+
+The following are intentionally outside the 0.3.0 completion claim:
+
+- persisted pair-level `DiffIndex` memoization, pending a real delta-cost and
+  invalidation checkpoint;
+- remote verification providers and remote session storage;
+- a separate diagnostics artifact beyond the current findings/session records.
+
+These are follow-up roadmap items, not reasons to keep the shipped architecture
+in an unreleaseable state. The live roadmap records the promotion criteria.
+
+## 8. Release-maintainer checklist
+
+Run this sequence from a clean checkout of the release candidate. Do not place
+credentials or tokens in logs, release notes, or issue comments.
+
+### Candidate checks
+
+```console
+$ python -m nsys_ai --help
+$ python -m build
+$ python -m twine check dist/*
+$ python -m pip install --force-reinstall dist/nsys_ai-*.whl
+$ nsys-ai --help
+$ python -c 'from nsys_ai.mcp_server import main; print(main.__module__)'
+```
+
+Inspect the wheel before installing it: it must contain the templates, prompts,
+agent skill context, and documentation metadata required by the runtime. Verify
+the two console scripts from `pyproject.toml`; the MCP entry point starts a
+stdio server and intentionally has no standalone `--help` mode. Do not assume
+a source checkout proves the wheel is correct.
+
+### Four-verb smoke test
+
+Use a small committed fixture for the fast gate and a real `.nsys-rep` or
+`.sqlite` capture for the release checkpoint when available:
+
+```console
+$ nsys-ai doctor PROFILE --format json
+$ nsys-ai diagnose PROFILE --session SESSION_DIR --format json
+$ nsys-ai ask --session SESSION_DIR "what is the main bottleneck?"
+$ nsys-ai diff BEFORE AFTER --session SESSION_DIR --no-ai --format json
+$ nsys-ai review --session SESSION_DIR
+```
+
+Confirm that the session contains the expected artifacts and that a deliberate
+inconclusive or abstention result is visible as such. For the full test layers,
+see [testing](testing.md). For user-facing migration notes, see
+[migrating to 0.3.0](../user/migrating-to-0.3.0.md).
+
+### Publish and verify
+
+1. Confirm `pyproject.toml`, `CHANGELOG.md`, and the release tag agree on the
+   version and date.
+2. Build the wheel and source distribution from the intended commit.
+3. Create the Git tag and GitHub Release only after the candidate checks pass.
+4. Wait for the publish workflow, then install the released version in a clean
+   environment and repeat `--help`, `doctor`, and one deterministic diff.
+5. Record the PyPI/GitHub links and the known limitations in the release issue.
+
+The release is complete only when the artifact installed from the package index
+passes the same smoke test as the source checkout.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -319,6 +319,9 @@ coherent snapshot after an interrupted publication.
 
 - **A proposal needs a RunSpec to stand behind itself.** If you captured the baseline with plain
   `nsys`, there is no `runspec.json` and `propose` will abstain. Re-capture with `nsys-ai profile`.
+- **There are two installed entry points.** Use `nsys-ai` for the CLI and all TUI/Web subcommands;
+  use `nsys-ai-mcp` for the optional stdio MCP transport (`pip install 'nsys-ai[mcp]'`). There is no
+  separate `nsys-tui` executable in 0.3.0.
 - **The decision records your git `user.email`.** If you keep separate identities for separate work,
   check `git config user.email` in the directory you run from.
 - **`nsys-ai help` is a starting point, not the full command list.** `nsys-ai --help` is complete.

--- a/site/index.html
+++ b/site/index.html
@@ -566,10 +566,10 @@
         <div class="container">
             <div class="hero-layout">
                 <div class="hero-left">
-                    <div class="hero-badge">🌐 Web UI First · v0.2.1 on PyPI</div>
+                    <div class="hero-badge">🧠 Many entrances, one session · nsys-ai 0.3.0</div>
                     <h1>nsys-ai</h1>
-                    <p>Open Nsight Systems profiles directly in a browser-first timeline UI, then drill into terminal
-                        tools when you need them.</p>
+                    <p>Open Nsight Systems profiles in the browser, terminal, or MCP and keep one evidence-first
+                        diagnosis moving through a shared session.</p>
                     <div class="install-box"
                         onclick="navigator.clipboard.writeText('pip install nsys-ai').then(()=>this.querySelector('.copy').textContent='Copied!')">
                         <span class="dollar">$</span>
@@ -664,11 +664,12 @@
                     <span class="t-dim"># 3. Open the web viewer (default command)</span>
                     <span class="t-green">$</span> nsys-ai output/megatron_distca.nsys-rep
 
-                    <span class="t-dim"># 4. Optional: profile overview in terminal</span>
-                    <span class="t-green">$</span> nsys-ai info output/megatron_distca.sqlite
+                    <span class="t-dim"># 4. Check profile health before analysis</span>
+                    <span class="t-green">$</span> nsys-ai doctor output/megatron_distca.nsys-rep
 
-                    <span class="t-dim"># 5. Optional: terminal timeline TUI</span>
-                    <span class="t-green">$</span> nsys-ai timeline output/megatron_distca.sqlite --gpu 4 --trim 39 42
+                    <span class="t-dim"># 5. Publish deterministic findings to a handoff session</span>
+                    <span class="t-green">$</span> nsys-ai diagnose output/megatron_distca.nsys-rep \
+                        --session /tmp/nsys-ai/demo
                 </div>
             </div>
         </div>
@@ -703,8 +704,8 @@
                 <div class="feature-card">
                     <div class="feature-icon">🌐</div>
                     <h3>HTML Exports</h3>
-                    <p>Generate interactive HTML viewers, Perfetto JSON traces for ui.perfetto.dev, and flat CSV/JSON
-                        exports for scripting and sharing.</p>
+                    <p>Generate interactive HTML viewers, Chrome Trace Event JSON files for Perfetto, and flat
+                        CSV/JSON exports for scripting and sharing.</p>
                 </div>
                 <div class="feature-card">
                     <div class="feature-icon">🔍</div>
@@ -721,8 +722,14 @@
                 <div class="feature-card">
                     <div class="feature-icon">🤖</div>
                     <h3>AI Analysis</h3>
-                    <p>Optional AI module for auto-commentary on kernel distributions, NVTX annotation suggestions, and
-                        bottleneck detection.</p>
+                    <p>Optional planner and synthesizer over registered evidence: ask a question, inspect the skills
+                        that grounded it, and resume the answer from a shared session.</p>
+                </div>
+                <div class="feature-card">
+                    <div class="feature-icon">🔁</div>
+                    <h3>Session Handoff</h3>
+                    <p>Move findings, proposals, RunSpecs, diffs, and decisions between CLI, Web, TUI, and MCP with
+                        one inspectable directory.</p>
                 </div>
             </div>
         </div>
@@ -818,6 +825,9 @@
                 </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/testing.md" class="doc-link">
                     <span class="doc-num">dev</span><span class="doc-title">Testing &amp; coverage</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/dev/architecture.md" class="doc-link">
+                    <span class="doc-num">dev</span><span class="doc-title">Architecture &amp; release guide</span>
                 </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/01-cli-reference.md" class="doc-link">
                     <span class="doc-num">01</span><span class="doc-title">CLI Reference</span>

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -685,13 +685,12 @@ def _build_parser():
         ),
         description=(
             "Compare before/after profiles, or resume a session decision path. "
-            "The pair form is the canonical diff: stdout is byte-identical to "
-            "'nsys-ai diff <before> <after> --no-ai', including the per-GPU "
-            "overview and per-GPU regressions when --gpu is omitted. review "
-            "never calls an LLM, so the executive summary is the deterministic "
-            "one that --no-ai produces. Next-step hints are written to stderr, "
-            "so a redirected stdout holds exactly the diff report. review does "
-            "not create a session; --session resumes one."
+            "The pair form uses the canonical diff renderer: stdout is "
+            "byte-identical to 'nsys-ai diff <before> <after> --no-ai', including "
+            "the per-GPU overview and per-GPU regressions when --gpu is omitted. "
+            "review never calls an LLM, so the executive summary is the "
+            "deterministic one that --no-ai produces. It writes two next-step "
+            "hints to stderr, and does not create a session; --session resumes one."
         ),
     )
     p.add_argument(

--- a/src/nsys_ai/review_command.py
+++ b/src/nsys_ai/review_command.py
@@ -8,8 +8,9 @@ runs the canonical diff, prints the result to stdout and the next command to
 stderr, and leaves ``.nsys-ai/`` untouched. Diff analysis and the all-GPU shape
 stay in :func:`nsys_ai.diff.diff_profiles` /
 :func:`nsys_ai.diff.diff_profiles_all_gpus`; rendering stays in
-:mod:`nsys_ai.diff_render`. ``review <before> <after>`` stdout is byte-identical
-to ``diff <before> <after> --no-ai``.
+:mod:`nsys_ai.diff_render`. ``review <before> <after>`` uses the same canonical
+renderer as ``diff <before> <after> --no-ai``; stdout is byte-identical and the
+two next-step hints are deliberately written to stderr.
 """
 
 from __future__ import annotations
@@ -67,11 +68,12 @@ def run_review(
     ``nsys-ai optimize``.
     Internal diff uses the same limit=15 and sort=delta defaults as ``diff``.
 
-    The pair form prints the terminal report ``diff`` prints, with no LLM call:
-    stdout equals ``diff <before> <after> --no-ai`` byte for byte, including the
-    all-GPU shape (executive summary, per-GPU overview, per-GPU top regressions)
-    when ``gpu`` is ``None``. Next-step hints are written to ``stderr`` so a
-    redirected stdout is exactly that report.
+    The pair form prints the terminal report ``diff`` prints, with no LLM call.
+    Its stdout equals ``diff <before> <after> --no-ai`` byte for byte, including
+    the all-GPU shape (executive summary, per-GPU overview, per-GPU top
+    regressions) when ``gpu`` is ``None``. ``review`` also writes two next-step
+    hints to ``stderr``; a shell that combines both streams therefore shows
+    those hints after the report.
     """
     requested_session = session_id
     if session_id is not None:
@@ -126,11 +128,11 @@ def _compare_pair(
     stdout: TextIO,
     stderr: TextIO,
 ) -> int:
-    """Print the canonical diff report for a pair, byte-for-byte as ``diff --no-ai``.
+    """Print the canonical diff report and handoff hints for a pair.
 
     The profile paths are opened with the caller's spelling (as ``diff`` does)
     because that spelling is echoed in the report header. Next-step hints go to
-    ``stderr`` so redirected stdout stays exactly the diff report.
+    ``stderr`` so redirected stdout stays exactly the canonical diff report.
     """
     from .ai.diff_narrative import offline_diff_narrative
     from .diff import STEP_TIME_REGRESSION_PCT, diff_profiles, diff_profiles_all_gpus


### PR DESCRIPTION
## Summary

Finalize the documentation and release boundary for 0.3.0.

- refresh `CHANGELOG.md` with the final architecture checkpoint, memoized skills,
  candidate-anchored diff findings, calibrated idle severity, and explicit deferred scope;
- align README and the user guide with the session-based command surface;
- update the landing page for the 0.3.0 workflow and file-based Perfetto export;
- add the layered architecture and release-maintainer guide, indexed from repository docs and
  the landing page;
- correct the installed entry-point documentation for `nsys-ai` and `nsys-ai-mcp`;
- clarify that `review` keeps stdout byte-identical to canonical `diff --no-ai` while adding two
  interactive hints on stderr.

## Verification

- `pytest tests/test_docs_index.py` — 6 passed
- `pytest tests/test_diagnose_review.py` — 10 passed
- CLI focused tests — 17 passed, 53 deselected
- full suite with the CI fixture — 2533 passed, 140 skipped, 4 xfailed
- `ruff check src/nsys_ai/cli/parsers.py src/nsys_ai/review_command.py`
- `python -m build --sdist --wheel`
- installed the built wheel into a clean target and exercised `python -m nsys_ai --help`
- inspected wheel entry points and package data

Closes #531, #532, #533, #535, #536, #537.
