### PR TITLE
docs: complete 0.3.0 user documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@ nsys-ai/
 │   ├── skills/            # 🧩 Analysis skill system
 │   │   ├── base.py        # Skill dataclass + execution
 │   │   ├── registry.py    # Auto-discovery + lookup
-│   │   └── builtins/      # 37 built-in analysis skills
+│   │   └── builtins/      # built-in analysis skills (see `skill list`)
 │   ├── agent/             # 🤖 AI agent
 │   │   ├── persona.py     # System prompt + identity
 │   │   └── loop.py        # Analysis loop + skill selection

--- a/README.md
+++ b/README.md
@@ -348,9 +348,10 @@ still used, so delete the directory if you want the export read in place.
 
 ## Skills
 
-Skills are self-contained analysis units that run without an LLM. nsys-ai ships
-37 of them (kernels, memory, NCCL/communicators, NVTX, MFU, idle, root-cause,
-profile health, and more).
+Skills are self-contained analysis units that run without an LLM. The packaged
+registry covers kernels, memory, NCCL/communicators, NVTX, MFU, idle,
+root-cause, profile health, and more. Run `skill list` for the live catalog;
+the count is intentionally not a compatibility contract.
 
 ```bash
 nsys-ai skill list                                 # full catalog
@@ -425,6 +426,17 @@ and [docs/claude-plugin.md](https://github.com/GindaChen/nsys-ai/blob/main/docs/
 Start with the **[User guide](https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md)** — one workload from capture to a recorded
 decision, on the command line. To drive the same workflow in a browser instead, see
 [Guided loop setup](https://github.com/GindaChen/nsys-ai/blob/main/docs/guided-loop-setup.md).
+
+Useful entry points for the next question:
+
+- upgrading from 0.2.3 → [Migrating to 0.3.0](https://github.com/GindaChen/nsys-ai/blob/main/docs/user/migrating-to-0.3.0.md)
+- something is not working → [Troubleshooting](https://github.com/GindaChen/nsys-ai/blob/main/docs/user/troubleshooting.md)
+- checking an input before analysis → [Profile inputs](https://github.com/GindaChen/nsys-ai/blob/main/docs/user/profile-inputs.md)
+- choosing a browser surface → [Choosing a Web viewer](https://github.com/GindaChen/nsys-ai/blob/main/docs/user/viewers.md)
+- running a focused, no-LLM analysis → [Analysis skills](https://github.com/GindaChen/nsys-ai/blob/main/docs/user/skills.md)
+
+The complete, maintained documentation index is
+[docs/README.md](https://github.com/GindaChen/nsys-ai/blob/main/docs/README.md).
 
 The rest of the `docs/` directory mirrors the relevant NVIDIA Nsight Systems reference
 (capture, schema, NVTX, CUDA/NCCL trace) plus nsys-ai project guides:

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,6 +20,8 @@ Operating the tool.
 | [user/reading-a-diff.md](./user/reading-a-diff.md) | What a diff verdict means, how to recover from low comparability, and which metrics to trust |
 | [user/troubleshooting.md](./user/troubleshooting.md) | Symptoms, what they mean, and what to change |
 | [user/environment-variables.md](./user/environment-variables.md) | Every variable, its default, and when to change it |
+| [user/skills.md](./user/skills.md) | Discover and run deterministic analysis skills without an LLM |
+| [user/viewers.md](./user/viewers.md) | Choose between the Web, timeline-web, and diff-web surfaces |
 | [guided-loop-setup.md](./guided-loop-setup.md) | The same loop driven from the timeline web UI |
 | [doctor.md](./doctor.md) | Environment and profile health checks |
 | [ci-diff-gate.md](./ci-diff-gate.md) | Capture, compare, and gate performance regressions in CI |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -197,6 +197,40 @@ The NVTX tree viewer loads bounded slices from `GET /api/tree`. `depth` controls
 The optional MCP transport exposes the same read-only handoff as `get_session`; it returns the
 SessionStore projection rather than a second MCP-specific session schema.
 
+For an interactive terminal conversation instead of one question, use the chat TUI:
+
+```console
+$ nsys-ai chat run-before/profile.sqlite --session /tmp/nsys-run-001
+```
+
+`chat` needs a real terminal and the optional `[chat]` / `[agent]` dependencies. The one-shot
+`ask` path is easier to script; `agent ask` is the deterministic agent front door when you want a
+natural-language answer without opening a TUI. Both still ground their answer in registered skill
+evidence.
+
+For the three browser choices, see [Choosing a Web viewer](user/viewers.md). The short rule is:
+`web` for an NVTX tree, `timeline-web` for a progressive multi-GPU timeline and session, and
+`diff-web` for a before/after comparison.
+
+### Browse root-cause patterns
+
+The root-cause catalog is useful when you want the symptom, mechanism, detection skill, and fix
+guidance before asking the agent to summarize a profile:
+
+```console
+$ nsys-ai root-cause list
+$ nsys-ai root-cause show "GPU Bubbles"
+```
+
+To submit a personal markdown pattern, start from
+[`docs/root-causes/TEMPLATE.md`](root-causes/TEMPLATE.md) and pass the completed file:
+
+```console
+$ nsys-ai root-cause submit my-root-cause.md
+```
+
+The file is validated and copied to the user-local root; it does not modify the built-in catalog.
+
 Two lower-level entry points remain available when you want them: `nsys-ai evidence build <profile>`
 runs the same analyzers and writes findings JSON to stdout or `-o` (add `--session` to publish, and
 `--analyzers` to pick a subset), and `nsys-ai skill list` / `nsys-ai skill run <name> <profile>` run a
@@ -272,6 +306,44 @@ Useful variants:
   `nsys-ai baseline --help`.
 - `nsys-ai diff-web <before> <after>` opens the same comparison in a browser.
 
+### Named baselines
+
+If a profile is the reference for several comparisons, give it a stable local name instead of
+copying its path through every job:
+
+```console
+$ nsys-ai baseline tag main run-before/profile.sqlite --reason "green main"
+$ nsys-ai baseline list
+$ nsys-ai baseline show main
+$ nsys-ai diff --against baseline:main run-after/profile.sqlite --format json --no-ai
+```
+
+`baseline list` is the compact inventory; `baseline show NAME` includes the profile identity,
+source path, reason, timestamp, and any recorded RunSpec. The store is local. Set
+`NSYS_AI_BASELINE_ROOT` to an absolute shared directory when separate CI steps must see the same
+names.
+
+## 6a. Run the composed loop with `optimize`
+
+When the baseline was captured with `nsys-ai profile`, the complete loop can be composed into one
+command:
+
+```console
+$ nsys-ai optimize run-before/profile.sqlite \
+    --repo /path/to/your/checkout -- ./profile-workload.sh
+```
+
+The arguments after `--` are the verification workload. `--repo` is recorded in the RunSpec and
+must be a directory the capture can run from. The command diagnoses the baseline, proposes the top
+actionable finding, runs the recorded workload through the local `nsys` executable, diffs the new
+capture, and records an accept/reject decision in the session.
+
+The workload must actually produce a valid Nsight Systems profile. A command such as `true` is a
+useful smoke test for the failure path, but it stops at capture validation because it produces no
+profile; `optimize` reports that failure and leaves `findings.json`, `proposal.json`, `runspec.json`,
+and `session.json` so the attempted handoff is inspectable. If the proposal abstains because the
+baseline has no reproducible RunSpec, it stops before re-profiling instead.
+
 ## 7. Record the decision
 
 A comparison you do not act on is a comparison you will re-run next month. Record the outcome with
@@ -331,6 +403,8 @@ coherent snapshot after an interrupted publication.
 | Topic | Page |
 |-------|------|
 | Driving the same loop in a browser | [Guided loop setup](guided-loop-setup.md) |
+| Choosing between browser surfaces | [Choosing a Web viewer](user/viewers.md) |
+| Running one deterministic analysis | [Analysis skills](user/skills.md) |
 | What `doctor` checks, and why | [doctor](doctor.md) |
 | Annotating your code so iteration analysis works | [NVTX annotations](03-nvtx-annotations.md) |
 | Capturing a representative window of a long run | [Focused profiling](08-focused-profiling.md) |

--- a/docs/user/environment-variables.md
+++ b/docs/user/environment-variables.md
@@ -18,6 +18,7 @@ ignored rather than fatal — some warn, most are silent.
 
 | Variable | Default | Description |
 |---|---|---|
+| `NSYS_AI_ARTIFACT_ROOT` | `.nsys-ai` (relative to the working directory) | Root for invocation-owned artifacts: derived sessions, profile capture outputs, locks, and default decision files. Relative values resolve against the command working directory. It does not move input-keyed Parquet/SQLite caches; an explicit `--session` or `--decision-out` still wins. |
 | `NSYS_AI_INGEST` | `auto` | Which storage a profile is read from. `auto` converts `.nsys-rep` to a parquetdir and reads `.sqlite` in place; `parquetdir` refuses `.sqlite` inputs; `sqlite` converts `.nsys-rep` to `.sqlite`, refuses parquetdir inputs, and forces the cache mode to `direct` — see the note below. See [What to hand nsys-ai](./profile-inputs.md). |
 | `NSYS_AI_CACHE_MODE` | `auto` | Whether the SQLite path builds a Parquet query cache. `direct` queries the `.sqlite` in place with no cache; `parquet` forces the cache even when it is judged unaffordable; `auto` decides on free disk and profile size. Ignored once the parquetdir backend is in use, and overridden entirely by `NSYS_AI_INGEST=sqlite`. An unrecognised value warns and falls back to `auto`. |
 | `NSYS_AI_BASELINE_ROOT` | `.nsys-ai-baselines` (relative to the working directory) | Where the local baseline store lives. Point CI jobs at one absolute path so `baseline tag` and `diff --against baseline:X` agree regardless of which directory the job ran from. An explicit `--root` still wins. |
@@ -84,6 +85,12 @@ before concluding it does not work.
 is read; the second chooses whether the SQLite path builds a query cache. Setting the second has no
 effect once the first has selected a parquetdir. See [Ingest policy](../dev/ingest-policy.md) for
 where each is consumed.
+
+**`NSYS_AI_ARTIFACT_ROOT` and `NSYS_AI_BASELINE_ROOT` relocate different stores.** The artifact root
+holds invocation handoffs and default outputs; the baseline root holds named profile snapshots. Set
+both explicitly in CI when the job needs portable sessions and a shared baseline, or set only the
+one whose default location is unsuitable. A direct `--session` path is already an explicit handoff
+location and does not need the artifact-root default.
 
 ## Related
 

--- a/docs/user/skills.md
+++ b/docs/user/skills.md
@@ -1,0 +1,136 @@
+# Running deterministic analysis skills
+
+A skill is one registered, deterministic analysis unit. It reads profile
+evidence through the canonical ingest path and returns rows or an explicit
+abstention. Skills do not need an LLM, an API key, or a model subscription, so
+they are the lowest-cost way to answer a focused question and the easiest path
+to put in a script.
+
+The registry is the source of truth. It changes as skills are added; the
+0.3.0 release-candidate checkout used for this page returned 38 entries. Do not
+copy that number into automation or maintain a second catalog.
+
+## Discover the registry
+
+List the human-readable catalog:
+
+```console
+$ nsys-ai skill list
+Name                            Category         Description
+--------------------------------------------------------------------------------
+gpu_idle_gaps                   kernels          Finds idle gaps between kernels
+top_kernels                     kernels          Lists the heaviest GPU kernels
+...
+```
+
+For scripting, `--format json` returns a JSON array. Count or filter it with
+your JSON tool:
+
+```console
+$ nsys-ai skill list --format json | jq 'length'
+38
+$ nsys-ai skill list --format json | jq -r '.[] | [.name, .category] | @tsv'
+```
+
+The text catalog marks skills that require parameters with `*`. Inspect one
+skill before running it:
+
+```console
+$ nsys-ai skill info top_kernels
+{
+  "name": "top_kernels",
+  "parameters": {
+    "limit": {"type": "int", "default": 15, "required": false}
+  }
+}
+```
+
+`skill info` is the authoritative parameter spelling. Do not infer a
+parameter name from a different skill.
+
+## Run one skill
+
+The basic form is:
+
+```console
+$ nsys-ai skill run top_kernels PROFILE.sqlite
+```
+
+Use JSON when another program will consume the result, and cap the number of
+rows when the result will be passed into a prompt or log:
+
+```console
+$ nsys-ai skill run top_kernels PROFILE.sqlite \
+    --format json --max-rows 15
+```
+
+The JSON result is an array of rows. If the cap removed rows, the command adds
+a final metadata row with `_truncated`, `_total_rows`, and `_shown_rows`.
+`--trim START END` uses seconds on the profile's capture clock; `--iteration N`
+can derive a window from an iteration marker. Use `--no-cache` when a one-shot
+SQLite query should avoid creating a Parquet cache, accepting slower repeated
+queries.
+
+## Parameters are validated
+
+Pass parameters with repeated `--param` / `-p` flags:
+
+```console
+$ nsys-ai skill run region_mfu PROFILE.sqlite \
+    -p name=Attention \
+    -p theoretical_flops=1e12 \
+    -p peak_tflops=20 \
+    -p source=nvtx \
+    -p device_id=0
+```
+
+`region_mfu` uses `device_id`; `iteration_timing` uses `device`. The registry
+rejects an unknown parameter and prints the valid names, so this is an error:
+
+```console
+$ nsys-ai skill run region_mfu PROFILE.sqlite -p device=0
+Error: unknown parameter 'device' for skill 'region_mfu'.
+```
+
+Required values are checked before profile work starts. For example,
+`region_mfu` requires both `name` and `theoretical_flops`; provide
+`peak_tflops` when the profile does not contain a recognizable GPU model.
+
+## Match the skill to the question
+
+| Question | Start with | Useful follow-up |
+|---|---|---|
+| Which kernels dominate GPU time? | `top_kernels` | `kernel_instances`, `kernel_launch_overhead` |
+| Why is a stream idle? | `gpu_idle_gaps` | `cpu_gpu_pipeline`, `sync_cost_analysis` |
+| Is communication competing with compute? | `overlap_breakdown` | `nccl_breakdown`, `nccl_anomaly` |
+| Where is data movement happening? | `memory_transfers` | `h2d_distribution`, `memory_bandwidth` |
+| Are iterations repeating and stable? | `iteration_timing` | `iteration_detail` |
+| Is the capture healthy enough to trust? | `profile_health_manifest` | `schema_inspect` |
+| What likely root cause matches the evidence? | `root_cause_matcher` | the detection skill named in the result |
+
+This table is a starting map, not a replacement for the registry. A skill may
+abstain when its required table, marker, or denominator is absent.
+
+## Read abstention honestly
+
+An empty array means the skill ran and found no rows. An object/row carrying
+`_abstained: true` means it could not make a defensible claim and includes a
+`reason`. Do not convert the latter into “healthy”.
+
+For example, running `iteration_timing` against a profile with no NVTX table
+returns an abstention explaining that iteration detection needs NVTX
+annotations. Re-capture with `--trace=cuda,nvtx` or choose a skill whose inputs
+the profile actually contains.
+
+## When to use a higher-level command
+
+Use `diagnose` when you want the default pack, ranked findings, limitations,
+and a session artifact. Use `ask` or `agent ask` when you have a natural
+language question and want several registered skills selected for you. Use
+`chat` for an interactive terminal conversation; it needs a real terminal and
+the optional chat/agent dependencies. In every case, the underlying evidence
+should remain visible in the session or JSON output.
+
+For authoring a new skill, switch to the developer
+[skill contract](../dev/skill-contract.md); this page is intentionally about
+operating the existing registry.

--- a/docs/user/viewers.md
+++ b/docs/user/viewers.md
@@ -1,0 +1,90 @@
+# Choosing a Web viewer
+
+nsys-ai has three browser surfaces with similar names but different jobs. They
+all run locally and accept the same profile inputs; choose the surface that
+matches the question rather than starting every server.
+
+| Command | What it shows | Use it when |
+|---|---|---|
+| `nsys-ai web PROFILE` | NVTX tree viewer with lazy tree requests | You want to browse nested ranges and the kernels attributed to them |
+| `nsys-ai timeline-web PROFILE` | Progressive multi-GPU horizontal timeline | You want streams, kernels, NVTX lanes, search, and a session-backed workflow |
+| `nsys-ai diff-web BEFORE AFTER` | Before/after comparison shell with two timeline views | You want to inspect a change and its canonical diff side by side |
+
+The commands are separate transports over the same profile and diff contracts.
+The older `nsys-ai perfetto` server is not one of the choices; use
+`nsys-ai export` when you need a Chrome Trace Event JSON file instead.
+
+## NVTX tree: `web`
+
+Use this for hierarchy-first investigation:
+
+```console
+$ nsys-ai web PROFILE.sqlite --port 8142
+```
+
+The server prints the URL and builds the NVTX tree in the background. The root
+page is the interactive tree viewer; `GET /api/tree` returns a bounded tree
+slice. `depth`, `limit`, and `max_nodes` bound the response, and a truncated
+response carries `has_more` / `children_total` metadata rather than pretending
+that a high-fan-out node is complete.
+
+`web` selects one GPU when `--gpu` is omitted. Use this surface when the useful
+question is “which ranges contain this work?” rather than “how do all streams
+overlap over time?”.
+
+## Horizontal timeline: `timeline-web`
+
+Use this for a progressive, multi-GPU timeline:
+
+```console
+$ nsys-ai timeline-web PROFILE.sqlite --port 8144 --no-browser
+```
+
+The initial HTML shell is served while the NVTX data is prepared in the
+background. The client reads profile metadata from `/api/meta` and requests
+time tiles from `/api/data?start_s=START&end_s=END`. The query values are
+seconds on the Nsight capture clock, not indexes and not nanoseconds.
+
+This surface owns the browser loop UI and can open a session handoff:
+
+```console
+$ nsys-ai timeline-web PROFILE.sqlite --session /tmp/nsys-ai/run-001
+```
+
+Use `--findings FINDINGS.json` or `--auto-analyze` when you want evidence
+overlays. Use the [guided loop setup](../guided-loop-setup.md) for the full
+diagnose → propose → re-profile → diff → decide path.
+
+## Pair comparison: `diff-web`
+
+Use this after you have two captures:
+
+```console
+$ nsys-ai diff-web BEFORE.sqlite AFTER.sqlite --port 8145 --no-browser
+```
+
+The shell exposes the canonical pair metadata at `/api/diff/meta` and the
+deterministic summary at `/api/diff/summary`. The two embedded timeline views
+are read-only inspection surfaces; record a decision through the session-aware
+CLI or the session loop rather than treating a browser colour as the decision.
+
+`--gpu` restricts both sides to one device. Without it, the comparison remains
+all-GPU, matching `nsys-ai diff`.
+
+## Shared operational rules
+
+- `--no-browser` is useful on a remote host or in an automated smoke test; the
+  command still prints the local URL.
+- A requested port may be replaced with a free local port when it is already
+  occupied. Use the URL printed by the process, not a hard-coded port.
+- Use `nsys-ai doctor PROFILE` before a large `.nsys-rep` analysis. It reports
+  whether conversion, cache, and schema checks are ready.
+- For a trace file rather than an interactive service, run:
+
+  ```console
+  $ nsys-ai export PROFILE.sqlite --trim START_S END_S -o trace-export/
+  ```
+
+See [profile inputs](profile-inputs.md), [time windows](time-windows.md), and
+[known limits](known-limits.md) before interpreting a partial or incomparable
+view.

--- a/site/index.html
+++ b/site/index.html
@@ -793,6 +793,12 @@
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user/environment-variables.md" class="doc-link">
                     <span class="doc-num">→</span><span class="doc-title">Environment variables</span>
                 </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user/skills.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">Analysis skills</span>
+                </a>
+                <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user/viewers.md" class="doc-link">
+                    <span class="doc-num">→</span><span class="doc-title">Choosing a Web viewer</span>
+                </a>
                 <a href="https://github.com/GindaChen/nsys-ai/blob/main/docs/user-guide.md" class="doc-link">
                     <span class="doc-num">→</span><span class="doc-title">User guide</span>
                 </a>

--- a/src/nsys_ai/agent_skills/commands/skill.md
+++ b/src/nsys_ai/agent_skills/commands/skill.md
@@ -385,7 +385,8 @@ No required parameters. Supports `--trim`.
 | **Total** | **37** | |
 
 > **Note**: `memory_transfers.py` registers 2 skills (`memory_transfers` + `h2d_distribution`).
-> There are 37 registered builtin skills. Run `nsys-ai skill list` for the live catalog.
+> The registry is the live catalog. Run `nsys-ai skill list` to see the skills shipped by this
+> installation; the count is not a compatibility contract.
 
 ---
 

--- a/tests/test_documentation_contracts.py
+++ b/tests/test_documentation_contracts.py
@@ -1,0 +1,35 @@
+"""Small guards for the user-facing documentation front doors."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_readme_points_new_users_to_the_documentation_index_and_entry_pages():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    required = (
+        "docs/README.md",
+        "docs/user/migrating-to-0.3.0.md",
+        "docs/user/troubleshooting.md",
+        "docs/user/profile-inputs.md",
+        "docs/user-guide.md",
+    )
+    missing = [target for target in required if target not in readme]
+    assert not missing, "README front door is missing documentation links: " + ", ".join(missing)
+
+
+def test_every_runtime_nsis_ai_environment_variable_is_documented():
+    names: set[str] = set()
+    for path in (ROOT / "src").rglob("*.py"):
+        names.update(re.findall(r"\bNSYS_AI_[A-Z0-9_]+\b", path.read_text(encoding="utf-8")))
+
+    # This is an exception error-code prefix, not an environment variable.
+    names.discard("NSYS_AI_ERROR")
+    docs = (ROOT / "docs/user/environment-variables.md").read_text(encoding="utf-8")
+    missing = sorted(name for name in names if f"`{name}`" not in docs)
+    assert not missing, "runtime environment variables missing from the reference: " + ", ".join(
+        missing
+    )


### PR DESCRIPTION
## Summary

Closes #538
Closes #539
Closes #540
Closes #541

This documents the user-facing 0.3.0 analysis and web surfaces, adds the skill-system guide, connects the user documentation from the README and site, and documents `NSYS_AI_ARTIFACT_ROOT`.

## What changed

- Documented `optimize`, `web`, `timeline-web`, `diff-web`, `chat`, `agent ask`, baselines, and root-cause commands in the user guide.
- Added `docs/user/skills.md` covering registry discovery, `skill info`, `skill run`, parameters, JSON/truncation, and abstention semantics.
- Added `docs/user/viewers.md` with the three viewer surfaces, ports, endpoints, session/findings options, and bounded-tree behavior.
- Added README, docs index, and GitHub Pages links to the new user-facing pages.
- Documented `NSYS_AI_ARTIFACT_ROOT` and its distinction from the baseline root.
- Added documentation contract tests for README entry points and runtime `NSYS_AI_*` environment-variable coverage.
- Replaced the stale built-in-skill count in agent-facing documentation with the live registry guidance.

## Real verification

The command examples and claims were checked against the current `main` commit (`cb2d178`):

- `nsys-ai optimize --help`, `web --help`, `timeline-web --help`, `diff-web --help`, `agent ask --help`, and root-cause help/show/submit help.
- `skill list --format json` returned 38 entries; `skill run top_kernels` returned rows plus truncation metadata.
- `region_mfu` accepted `device_id`; an unknown `device` parameter returned a validation error.
- `iteration_timing` on a fixture without `NVTX_EVENTS` returned the canonical `_abstained` response.
- Baseline tag/list/show completed with an isolated temporary baseline root.
- `agent ask` produced an evidence-first answer on `tests/fixtures/h100_2gpu_1s.sqlite`.
- Live `web`, `timeline-web`, and `diff-web` servers served their documented pages/endpoints; timeline data was queried with `start_s`/`end_s` in seconds.
- `optimize` was exercised with a real fixture and `true` workload. It correctly stopped when the workload did not produce a valid Nsight profile and left `findings.json`, `proposal.json`, `runspec.json`, and `session.json`; the guide calls out that a real profiling workload is required for a successful run.
- `NSYS_AI_ARTIFACT_ROOT` was exercised with `diagnose`; it created the expected lock/session artifacts.

## Tests

- `PYTHONPATH=src .../pytest -q tests/test_docs_index.py tests/test_documentation_contracts.py tests/test_package_data.py` — 11 passed
- `ruff check tests/test_documentation_contracts.py` — passed
- `git diff --cached --check` — passed
- `python -m nsys_ai --help` — passed
