### PR TITLE
docs: cover the agent command family

### DIFF
--- a/docs/user/skills.md
+++ b/docs/user/skills.md
@@ -131,6 +131,45 @@ language question and want several registered skills selected for you. Use
 the optional chat/agent dependencies. In every case, the underlying evidence
 should remain visible in the session or JSON output.
 
+## Use the agent command family
+
+The `agent` commands are the CLI-facing analysis family. They use the same
+registered skills and evidence-first runner, but expose different levels of
+automation:
+
+```console
+# Full deterministic report; --trim uses seconds.
+$ nsys-ai agent analyze PROFILE.sqlite
+$ nsys-ai agent analyze PROFILE.sqlite --trim 10 20 --evidence -o findings.json
+
+# Question-driven evidence, from a profile or a session handoff.
+$ nsys-ai agent ask PROFILE.sqlite "why is the GPU idle?"
+$ nsys-ai agent ask --session /tmp/nsys-run-001 "what should I verify next?"
+
+# Print the onboarding guide for an external agent or automation.
+$ nsys-ai agent-guide > agent-guide.txt
+```
+
+`agent analyze` runs the fixed analysis pack and can emit a findings JSON file;
+it does not need an LLM. `agent ask` selects up to four registered skills and
+returns an evidence-first answer. Without model credentials it uses the
+deterministic keyword selector and local synthesis, so the command remains
+usable in a core installation. The profile form and the session form were
+both tested against the same fixture and produced the same evidence shape.
+
+For optional LLM triage or synthesis, install the extra and configure a
+provider credential in the environment:
+
+```console
+$ pip install 'nsys-ai[agent]'
+$ export ANTHROPIC_API_KEY=...  # or the key for another supported provider
+```
+
+`NSYS_AI_MODEL` can select a model when its matching provider key is present;
+see [environment variables](environment-variables.md). Never put provider
+keys in a session directory, findings file, or issue report. `agent-guide` is
+static output for external agents and requires neither a profile nor a key.
+
 For authoring a new skill, switch to the developer
 [skill contract](../dev/skill-contract.md); this page is intentionally about
 operating the existing registry.

--- a/tests/test_documentation_contracts.py
+++ b/tests/test_documentation_contracts.py
@@ -33,3 +33,17 @@ def test_every_runtime_nsis_ai_environment_variable_is_documented():
     assert not missing, "runtime environment variables missing from the reference: " + ", ".join(
         missing
     )
+
+
+def test_agent_command_family_is_documented_with_its_dependency_boundary():
+    docs = (ROOT / "docs/user/skills.md").read_text(encoding="utf-8")
+    required = (
+        "nsys-ai agent analyze",
+        "nsys-ai agent ask",
+        "nsys-ai agent-guide",
+        "nsys-ai[agent]",
+        "NSYS_AI_MODEL",
+        "provider credential",
+    )
+    missing = [target for target in required if target not in docs]
+    assert not missing, "agent command documentation is incomplete: " + ", ".join(missing)


### PR DESCRIPTION
## Summary

Closes #544

Document the remaining `agent` command family in the existing skills guide.
The page now shows runnable forms for `agent ask`, `agent analyze`, and
`agent-guide`, including profile/session handoff and findings output.

## Behavior verified before writing

Against current `main` (`365e364`):

- `nsys-ai agent ask --help` confirmed the positional profile/question form and
  `--session [DIR]` handoff.
- `nsys-ai agent analyze --help` confirmed `--trim START_S END_S`,
  `--evidence`, and `-o/--output`.
- `nsys-ai agent-guide --help` and the command itself succeeded and emitted the
  external-agent guide.
- With provider credentials unset, `agent ask` on
  `tests/fixtures/h100_2gpu_1s.sqlite` returned the evidence-first diagnosis.
- The same question through `diagnose --session ...` followed by
  `agent ask --session ...` succeeded and returned the same evidence shape.
- With provider credentials unset, `agent analyze --evidence -o ...` completed,
  printed the auto-analysis report, and wrote a 46 KB findings JSON file.

The documentation therefore distinguishes the core deterministic path from
the optional model-backed path: installing `nsys-ai[agent]` and configuring a
provider credential enables optional LLM triage/synthesis, but is not required
for the tested heuristic commands.

## Tests

- `pytest -q tests/test_documentation_contracts.py tests/test_docs_index.py tests/test_package_data.py tests/test_cli.py` — passed
- `ruff check tests/test_documentation_contracts.py` — passed
- `git diff --check` — passed
- `agent ask --help`, `agent analyze --help`, and `agent-guide` smoke checks — passed
