### PR TITLE
docs: align CLAUDE release instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,25 @@ Skills are self-contained SQL-based analysis units that don't require an LLM. Ea
 
 ## Release Process
 
-1. Bump `version` in `pyproject.toml`
-2. Commit and tag: `git tag vX.Y.Z`
-3. Push: `git push origin main --tags`
-4. GitHub Actions auto-publishes to PyPI via trusted publisher (no tokens needed)
+Follow the complete [release guide](docs/dev/release.md) for scope/freeze,
+candidate verification, packaging, publishing, PyPI verification, and handoff.
+It is the source of truth for every release; do not replace its gates with a
+shorter tag-only procedure.
+
+For a quick orientation:
+
+1. Create the release tracking issue and record the exact candidate commit.
+2. Run the guide's source, full-suite, packaging, and product smoke checks.
+3. After review, push only the tested version tag to the canonical repository.
+4. Monitor the publish workflow and verify the package from a fresh PyPI
+   environment before closing the release issue.
+
+In the normal contributor checkout, `origin` is the fork and `upstream` is
+`GindaChen/nsys-ai`; verify that mapping with `git remote -v`. Push release
+branches and tags to the canonical remote (`upstream` in that setup), never
+by pushing the fork's `main` branch together with every tag. GitHub Actions
+publishes to PyPI through the trusted publisher; no package token belongs in
+the repository.
 
 ## Project Labels & Workflow
 

--- a/tests/test_documentation_contracts.py
+++ b/tests/test_documentation_contracts.py
@@ -95,3 +95,14 @@ def test_landing_page_has_a_keyboard_safe_install_action_and_workflow():
     for step in ("Diagnose", "Propose", "Re-profile", "Diff", "Decide"):
         assert f">{step}<" in site
     assert not re.search(r"[🚀📚🧠🌐🖥️🌲🔍📊🤖🔁]", site)
+
+
+def test_claude_release_process_points_to_the_canonical_release_guide():
+    claude = (ROOT / "CLAUDE.md").read_text(encoding="utf-8")
+    release = (ROOT / "docs/dev/release.md").read_text(encoding="utf-8")
+
+    assert "docs/dev/release.md" in claude
+    assert "git push origin main --tags" not in claude
+    assert "git push upstream v0.4.0" in release
+    assert re.search(r"`origin`\s+is\s+the\s+fork", release)
+    assert re.search(r"`upstream`\s+is\s+the\s+canonical", release)


### PR DESCRIPTION
## Summary

- make `docs/dev/release.md` the source of truth from `CLAUDE.md`
- replace the unsafe tag-and-branch release recipe with a concise orientation checklist
- document the `origin` fork / `upstream` canonical remote boundary
- add a documentation contract test preventing the two release procedures from drifting

Closes #555.

## Verification

- `python3 -m pytest tests/test_documentation_contracts.py tests/test_docs_index.py -q` (13 passed)
- `python3 -m ruff check tests/test_documentation_contracts.py`
- `git diff --check`
- `NSYS_TEST_PROFILE=tests/fixtures/h100_2gpu_1s.sqlite PYTHONPATH=... python3 -m pytest tests/ -q --tb=short` (2540 passed, 140 skipped, 4 xfailed)
