### PR TITLE
test: add reproducible checkpoint manifests

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -20,6 +20,13 @@ python download_data.py
 nsys-ai timeline output/fastvideo-wan21-1.3b-4gpu.sqlite --gpu 0
 ```
 
+## Real-project checkpoints
+
+The [checkpoint manifest guide](checkpoints/README.md) explains how to record
+project provenance, capture checksums, expected signals, and the shared
+`doctor → diagnose → ask → diff → review` contract. Large captures stay outside
+the repository.
+
 ## Adding New Examples
 
 Follow the convention:

--- a/examples/checkpoints/README.md
+++ b/examples/checkpoints/README.md
@@ -1,0 +1,63 @@
+# Real-project checkpoints
+
+Checkpoint manifests make a profile run auditable. They are deliberately
+metadata-first: the repository stores the recipe and checksum, not a large
+`.nsys-rep` capture or model weights.
+
+## Validate the contract fixture
+
+From the repository root:
+
+```bash
+python3 scripts/checkpoint.py validate \
+  examples/checkpoints/b0-contract/manifest.json \
+  --repo-root .
+```
+
+To verify the committed fixture bytes as well:
+
+```bash
+python3 scripts/checkpoint.py validate \
+  examples/checkpoints/b0-contract/manifest.json \
+  --repo-root . \
+  --require-profile
+```
+
+Print the exact analysis commands without executing them:
+
+```bash
+python3 scripts/checkpoint.py plan \
+  examples/checkpoints/b0-contract/manifest.json \
+  --repo-root .
+```
+
+Run the five analysis steps and write per-step stdout/stderr logs outside the
+repository:
+
+```bash
+python3 scripts/checkpoint.py run \
+  examples/checkpoints/b0-contract/manifest.json \
+  --repo-root . \
+  --output /tmp/nsys-ai-checkpoint-b0
+```
+
+## Moving from B0 to a real project
+
+Copy the manifest shape for vLLM or SGLang and replace every contract fixture
+value with a pinned project revision, model/artifact revision, workload trace,
+capture environment, and profile checksum. Use `--profile` to point at a local
+capture during a manual checkpoint; do not commit the capture itself.
+
+The five analysis steps are intentionally explicit:
+
+```text
+doctor → diagnose → ask → diff → review
+```
+
+An exit code of zero is not sufficient for adoption. The `expected_signals`
+entries must name an independently checkable observation, and a missing
+RunSpec, provider, or worker profile must be recorded as an abstention/stop.
+
+The first external recipe after this contract fixture is vLLM single-GPU
+offline latency. SGLang follows with its own recipe. Ray is a separate ladder:
+Core actors/tasks, Compiled Graph, Serve, Train, and Data are not one checkbox.

--- a/examples/checkpoints/b0-contract/manifest.json
+++ b/examples/checkpoints/b0-contract/manifest.json
@@ -1,0 +1,129 @@
+{
+  "analysis": {
+    "session_dir": ".nsys-ai/checkpoints/b0-contract-session",
+    "steps": [
+      {
+        "command": [
+          "python3",
+          "-m",
+          "nsys_ai",
+          "doctor",
+          "--format",
+          "json",
+          "{profile}"
+        ],
+        "expected_exit_codes": [
+          0
+        ],
+        "name": "doctor"
+      },
+      {
+        "command": [
+          "python3",
+          "-m",
+          "nsys_ai",
+          "diagnose",
+          "{profile}",
+          "--format",
+          "json",
+          "--session",
+          "{session}"
+        ],
+        "expected_exit_codes": [
+          0
+        ],
+        "name": "diagnose"
+      },
+      {
+        "command": [
+          "python3",
+          "-m",
+          "nsys_ai",
+          "ask",
+          "--session",
+          "{session}",
+          "What GPU activity is present in this profile?"
+        ],
+        "expected_exit_codes": [
+          0
+        ],
+        "name": "ask"
+      },
+      {
+        "command": [
+          "python3",
+          "-m",
+          "nsys_ai",
+          "diff",
+          "{profile}",
+          "{profile}",
+          "--format",
+          "json",
+          "--no-ai"
+        ],
+        "expected_exit_codes": [
+          0
+        ],
+        "name": "diff"
+      },
+      {
+        "command": [
+          "python3",
+          "-m",
+          "nsys_ai",
+          "review",
+          "{profile}",
+          "{profile}"
+        ],
+        "expected_exit_codes": [
+          0
+        ],
+        "name": "review"
+      }
+    ]
+  },
+  "capture": {
+    "captured_at": "2026-08-02T15:53:57+08:00",
+    "format": "sqlite",
+    "output_paths": [
+      "tests/fixtures/h100_2gpu_1s.sqlite"
+    ],
+    "profile_path": "tests/fixtures/h100_2gpu_1s.sqlite",
+    "sha256": "36ad440e71a33725a672638da32d16e8dcab61e27fbc886b217f9d388fb02975"
+  },
+  "checkpoint": "B0-contract",
+  "environment": {
+    "cuda": "fixture metadata; capture host CUDA is not asserted",
+    "driver": "fixture metadata; capture host driver is not asserted",
+    "gpu": "H100 x2 fixture",
+    "nsys": "fixture metadata; no capture command is rerun in CI",
+    "python": ">=3.10"
+  },
+  "project": {
+    "name": "nsys-ai",
+    "repository": "https://github.com/GindaChen/nsys-ai",
+    "revision": "f0eecf4",
+    "revision_kind": "git_commit"
+  },
+  "schema_version": "checkpoint-v1",
+  "workload": {
+    "artifact": "tests/fixtures/h100_2gpu_1s.sqlite",
+    "capture_command": [
+      "fixture",
+      "tests/fixtures/h100_2gpu_1s.sqlite"
+    ],
+    "expected_signals": [
+      {
+        "description": "The profile contains GPU kernel activity and is not an empty capture.",
+        "id": "gpu-kernel-activity",
+        "verification": "Run doctor and inspect the profile health/kernel checks; compare with the SQLite fixture directly."
+      }
+    ],
+    "name": "h100_2gpu_1s contract fixture",
+    "parameters": {
+      "duration_seconds": 1,
+      "gpu_count": 2,
+      "source": "committed test fixture"
+    }
+  }
+}

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,21 @@ Developer utilities for local workflows. Some scripts under this directory are u
 (see `.github/workflows/plugin-smoke.yml` for `smoke_test.sh` and `build_fixture.py`).
 The CUDA axpy workload below is not.
 
+## Checkpoint manifests
+
+`checkpoint.py` validates and runs the versioned real-profile checkpoint
+recipes under `examples/checkpoints/`:
+
+```bash
+python3 scripts/checkpoint.py validate examples/checkpoints/b0-contract/manifest.json
+python3 scripts/checkpoint.py plan examples/checkpoints/b0-contract/manifest.json
+```
+
+Use `run ... --output /tmp/...` only after reviewing the manifest. The runner
+uses argv arrays and never invokes a shell; each step's stdout and stderr are
+written separately. GPU capture remains a manual or scheduled operation, while
+manifest structure and checksums can run in ordinary CI.
+
 ## CUDA axpy workload (`axpy.cu`)
 
 A tiny CUDA program that launches the same `axpy` kernel N times. It exists so a developer

--- a/scripts/checkpoint.py
+++ b/scripts/checkpoint.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Validate or run a reproducible nsys-ai checkpoint manifest.
+
+Examples:
+    python3 scripts/checkpoint.py validate examples/checkpoints/b0-fixture/manifest.json
+    python3 scripts/checkpoint.py plan examples/checkpoints/b0-fixture/manifest.json
+    python3 scripts/checkpoint.py run examples/checkpoints/b0-fixture/manifest.json \
+        --output /tmp/nsys-ai-checkpoint
+
+The runner executes argv arrays from the manifest without a shell. A manifest
+is a reviewed recipe, not an arbitrary command channel; inspect it before
+running a profile on a machine with credentials or a GPU.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from nsys_ai.checkpoint import (
+    CheckpointManifestError,
+    expand_command,
+    load_manifest,
+    resolve_profile_path,
+    run_steps,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="action", required=True)
+
+    validate = sub.add_parser("validate", help="validate manifest metadata")
+    _add_manifest_options(validate)
+    validate.add_argument(
+        "--require-profile",
+        action="store_true",
+        help="also verify the referenced profile exists and matches its SHA-256",
+    )
+    validate.add_argument("--profile", help="override capture.profile_path for checksum verification")
+
+    plan = sub.add_parser("plan", help="print the expanded analysis commands")
+    _add_manifest_options(plan)
+    plan.add_argument("--profile", help="override capture.profile_path")
+    plan.add_argument("--session", help="session directory used by command templates")
+
+    run = sub.add_parser("run", help="run the manifest analysis steps")
+    _add_manifest_options(run)
+    run.add_argument("--profile", help="override capture.profile_path")
+    run.add_argument("--session", help="session directory used by command templates")
+    run.add_argument("--output", required=True, help="directory for stdout/stderr step logs")
+    run.add_argument("--timeout", type=float, default=300.0, help="per-step timeout in seconds")
+    return parser
+
+
+def _add_manifest_options(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("manifest", type=Path, help="path to a checkpoint JSON manifest")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="repository root used for relative paths (default: current directory)",
+    )
+
+
+def _load(args: argparse.Namespace, *, require_profile: bool = False) -> dict:
+    return load_manifest(
+        args.manifest,
+        profile_root=args.repo_root,
+        profile_override=getattr(args, "profile", None),
+        require_profile=require_profile,
+    )
+
+
+def _profile(args: argparse.Namespace, manifest: dict) -> Path:
+    return resolve_profile_path(
+        manifest,
+        repo_root=args.repo_root,
+        profile_override=getattr(args, "profile", None),
+    )
+
+
+def _session(args: argparse.Namespace, manifest: dict) -> Path:
+    if getattr(args, "session", None):
+        return Path(args.session).expanduser().resolve()
+    return (args.repo_root / manifest["analysis"]["session_dir"]).resolve()
+
+
+def _print_error(exc: CheckpointManifestError) -> int:
+    print(f"error: {exc}", file=sys.stderr)
+    return 2
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        if args.action == "validate":
+            manifest = _load(args, require_profile=args.require_profile)
+            print(
+                f"valid checkpoint manifest: {args.manifest} "
+                f"({manifest['checkpoint']}, {manifest['schema_version']})"
+            )
+            return 0
+
+        manifest = _load(args)
+        profile = _profile(args, manifest)
+        session = _session(args, manifest)
+        if args.action == "plan":
+            for step in manifest["analysis"]["steps"]:
+                command = expand_command(
+                    step["command"], profile=profile, repo=args.repo_root, session=session
+                )
+                print(f"{step['name']}: {json.dumps(command, ensure_ascii=False)}")
+            return 0
+
+        results = run_steps(
+            manifest,
+            repo_root=args.repo_root,
+            profile=profile,
+            session=session,
+            output_dir=args.output,
+            timeout=args.timeout,
+        )
+        print(json.dumps({"steps": [result.to_dict() for result in results]}, indent=2))
+        return 0 if all(result.passed for result in results) else 1
+    except CheckpointManifestError as exc:
+        return _print_error(exc)
+    except (OSError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/nsys_ai/checkpoint.py
+++ b/src/nsys_ai/checkpoint.py
@@ -1,0 +1,386 @@
+"""Versioned manifests for reproducible real-profile checkpoints.
+
+The checkpoint harness deliberately lives outside the product CLI. It records
+the provenance and commands needed to prove that a real workload went through
+the same analysis contract, without making a GPU capture a per-commit CI
+dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CHECKPOINT_MANIFEST_SCHEMA = "checkpoint-v1"
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_REVISION_KINDS = {"git_commit", "git_tag", "dataset_revision"}
+_CAPTURE_FORMATS = {"nsys-rep", "sqlite", "parquetdir"}
+_STEP_NAMES = {"doctor", "diagnose", "ask", "diff", "review"}
+_PLACEHOLDER_VALUES = {
+    "",
+    "head",
+    "latest",
+    "main",
+    "master",
+    "none",
+    "n/a",
+    "todo",
+    "tbd",
+    "unknown",
+}
+_TEMPLATE_RE = re.compile(r"\{([a-z_][a-z0-9_]*)\}")
+_ALLOWED_TEMPLATES = {"profile", "repo", "session"}
+
+
+class CheckpointManifestError(ValueError):
+    """The manifest cannot be used as a reproducible checkpoint."""
+
+
+def _fail(errors: list[str], path: str, message: str) -> None:
+    errors.append(f"{path}: {message}")
+
+
+def _mapping(value: Any, path: str, errors: list[str]) -> Mapping[str, Any] | None:
+    if not isinstance(value, Mapping):
+        _fail(errors, path, "must be an object")
+        return None
+    return value
+
+
+def _required_string(
+    value: Any,
+    path: str,
+    errors: list[str],
+    *,
+    reject_placeholders: bool = False,
+) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        _fail(errors, path, "must be a non-empty string")
+        return None
+    normalized = value.strip()
+    if reject_placeholders and normalized.lower() in _PLACEHOLDER_VALUES:
+        _fail(errors, path, "must be pinned; placeholder values are not accepted")
+        return None
+    return normalized
+
+
+def _relative_path(value: Any, path: str, errors: list[str]) -> str | None:
+    text = _required_string(value, path, errors)
+    if text is None:
+        return None
+    candidate = Path(text)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        _fail(errors, path, "must be a relative path without '..'")
+    return text
+
+
+def _argv(value: Any, path: str, errors: list[str]) -> list[str] | None:
+    if not isinstance(value, list) or not value or not all(isinstance(item, str) for item in value):
+        _fail(errors, path, "must be a non-empty argv array of strings")
+        return None
+    for index, item in enumerate(value):
+        for name in _TEMPLATE_RE.findall(item):
+            if name not in _ALLOWED_TEMPLATES:
+                _fail(errors, f"{path}[{index}]", f"unknown template {{{name}}}")
+    return list(value)
+
+
+def validate_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    profile_root: str | os.PathLike[str] | None = None,
+    profile_override: str | os.PathLike[str] | None = None,
+    require_profile: bool = False,
+) -> dict[str, Any]:
+    """Validate and return a checkpoint manifest as a plain dictionary.
+
+    Structural validation is always performed. ``require_profile`` additionally
+    checks that the referenced/overridden profile exists, is non-empty, and has
+    the recorded SHA-256. A manifest can therefore be checked in CI without a
+    capture, while a real checkpoint run fails closed when the artifact differs.
+    """
+
+    if not isinstance(manifest, Mapping):
+        raise CheckpointManifestError("manifest must be a JSON object")
+
+    errors: list[str] = []
+    schema = _required_string(manifest.get("schema_version"), "schema_version", errors)
+    if schema is not None and schema != CHECKPOINT_MANIFEST_SCHEMA:
+        _fail(errors, "schema_version", f"must be {CHECKPOINT_MANIFEST_SCHEMA!r}")
+    _required_string(manifest.get("checkpoint"), "checkpoint", errors, reject_placeholders=True)
+
+    project = _mapping(manifest.get("project"), "project", errors)
+    if project is not None:
+        _required_string(project.get("name"), "project.name", errors, reject_placeholders=True)
+        _required_string(project.get("repository"), "project.repository", errors)
+        revision_kind = _required_string(
+            project.get("revision_kind"), "project.revision_kind", errors
+        )
+        if revision_kind is not None and revision_kind not in _REVISION_KINDS:
+            _fail(errors, "project.revision_kind", "must be git_commit, git_tag, or dataset_revision")
+        _required_string(
+            project.get("revision"), "project.revision", errors, reject_placeholders=True
+        )
+
+    workload = _mapping(manifest.get("workload"), "workload", errors)
+    if workload is not None:
+        _required_string(workload.get("name"), "workload.name", errors, reject_placeholders=True)
+        _required_string(workload.get("artifact"), "workload.artifact", errors)
+        parameters = workload.get("parameters")
+        if not isinstance(parameters, Mapping):
+            _fail(errors, "workload.parameters", "must be an object")
+        _argv(workload.get("capture_command"), "workload.capture_command", errors)
+        signals = workload.get("expected_signals")
+        if not isinstance(signals, list) or not signals:
+            _fail(errors, "workload.expected_signals", "must contain at least one signal")
+        else:
+            signal_ids: set[str] = set()
+            for index, signal in enumerate(signals):
+                item = _mapping(signal, f"workload.expected_signals[{index}]", errors)
+                if item is None:
+                    continue
+                signal_id = _required_string(
+                    item.get("id"), f"workload.expected_signals[{index}].id", errors
+                )
+                if signal_id is not None and signal_id in signal_ids:
+                    _fail(errors, f"workload.expected_signals[{index}].id", "must be unique")
+                if signal_id is not None:
+                    signal_ids.add(signal_id)
+                _required_string(
+                    item.get("description"),
+                    f"workload.expected_signals[{index}].description",
+                    errors,
+                )
+                _required_string(
+                    item.get("verification"),
+                    f"workload.expected_signals[{index}].verification",
+                    errors,
+                )
+
+    environment = _mapping(manifest.get("environment"), "environment", errors)
+    if environment is not None:
+        for key in ("python", "cuda", "driver", "gpu", "nsys"):
+            _required_string(
+                environment.get(key), f"environment.{key}", errors, reject_placeholders=True
+            )
+
+    capture = _mapping(manifest.get("capture"), "capture", errors)
+    profile_path: str | None = None
+    if capture is not None:
+        profile_path = _relative_path(capture.get("profile_path"), "capture.profile_path", errors)
+        capture_format = _required_string(capture.get("format"), "capture.format", errors)
+        if capture_format is not None and capture_format not in _CAPTURE_FORMATS:
+            _fail(errors, "capture.format", "must be nsys-rep, sqlite, or parquetdir")
+        digest = _required_string(capture.get("sha256"), "capture.sha256", errors)
+        if digest is not None and not _SHA256_RE.fullmatch(digest):
+            _fail(errors, "capture.sha256", "must be 64 lowercase hexadecimal characters")
+        output_paths = capture.get("output_paths")
+        if not isinstance(output_paths, list) or not output_paths:
+            _fail(errors, "capture.output_paths", "must contain at least one path")
+        else:
+            for index, output_path in enumerate(output_paths):
+                _relative_path(output_path, f"capture.output_paths[{index}]", errors)
+        _required_string(capture.get("captured_at"), "capture.captured_at", errors)
+
+    analysis = _mapping(manifest.get("analysis"), "analysis", errors)
+    if analysis is not None:
+        _relative_path(analysis.get("session_dir"), "analysis.session_dir", errors)
+        steps = analysis.get("steps")
+        if not isinstance(steps, list) or not steps:
+            _fail(errors, "analysis.steps", "must contain at least one step")
+        else:
+            names: set[str] = set()
+            for index, step in enumerate(steps):
+                item = _mapping(step, f"analysis.steps[{index}]", errors)
+                if item is None:
+                    continue
+                name = _required_string(item.get("name"), f"analysis.steps[{index}].name", errors)
+                if name is not None:
+                    if name not in _STEP_NAMES:
+                        _fail(errors, f"analysis.steps[{index}].name", "is not a supported analysis step")
+                    if name in names:
+                        _fail(errors, f"analysis.steps[{index}].name", "must be unique")
+                    names.add(name)
+                _argv(item.get("command"), f"analysis.steps[{index}].command", errors)
+                expected = item.get("expected_exit_codes", [0])
+                if (
+                    not isinstance(expected, list)
+                    or not expected
+                    or not all(isinstance(code, int) for code in expected)
+                ):
+                    _fail(
+                        errors,
+                        f"analysis.steps[{index}].expected_exit_codes",
+                        "must be a non-empty array of integers",
+                    )
+            missing_steps = _STEP_NAMES - names
+            if missing_steps:
+                _fail(errors, "analysis.steps", "missing required steps: " + ", ".join(sorted(missing_steps)))
+
+    if errors:
+        raise CheckpointManifestError("invalid checkpoint manifest:\n- " + "\n- ".join(errors))
+
+    result = json.loads(json.dumps(manifest))
+    if require_profile:
+        if profile_override is not None:
+            profile = Path(profile_override)
+        else:
+            if profile_path is None:
+                raise CheckpointManifestError("capture.profile_path is required to verify a profile")
+            root = Path(profile_root or ".").resolve()
+            profile = root / profile_path
+        _verify_profile(profile, str(capture["sha256"]))
+    return result
+
+
+def _verify_profile(path: Path, expected_sha256: str) -> None:
+    if not path.is_file():
+        raise CheckpointManifestError(f"capture profile does not exist: {path}")
+    if path.stat().st_size <= 0:
+        raise CheckpointManifestError(f"capture profile is empty: {path}")
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    actual = digest.hexdigest()
+    if actual != expected_sha256:
+        raise CheckpointManifestError(
+            f"capture checksum mismatch for {path}: expected {expected_sha256}, got {actual}"
+        )
+
+
+def load_manifest(path: str | os.PathLike[str], **kwargs: Any) -> dict[str, Any]:
+    """Load and validate one JSON manifest."""
+    manifest_path = Path(path)
+    try:
+        payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as exc:
+        raise CheckpointManifestError(f"could not read manifest {manifest_path}: {exc}") from exc
+    return validate_manifest(payload, **kwargs)
+
+
+def canonical_manifest_bytes(manifest: Mapping[str, Any]) -> bytes:
+    """Return stable JSON bytes for review, hashing, and change detection."""
+    validate_manifest(manifest)
+    return (json.dumps(manifest, allow_nan=False, indent=2, sort_keys=True) + "\n").encode("utf-8")
+
+
+def resolve_profile_path(
+    manifest: Mapping[str, Any],
+    *,
+    repo_root: str | os.PathLike[str],
+    profile_override: str | os.PathLike[str] | None = None,
+) -> Path:
+    """Resolve the manifest profile or an explicit real-profile override."""
+    if profile_override is not None:
+        return Path(profile_override).expanduser().resolve()
+    return (Path(repo_root).resolve() / str(manifest["capture"]["profile_path"])).resolve()
+
+
+def expand_command(
+    command: Sequence[str],
+    *,
+    profile: str | os.PathLike[str],
+    repo: str | os.PathLike[str],
+    session: str | os.PathLike[str],
+) -> list[str]:
+    """Expand the three safe path placeholders in one argv array."""
+    values = {"profile": os.fspath(profile), "repo": os.fspath(repo), "session": os.fspath(session)}
+    expanded: list[str] = []
+    for argument in command:
+        names = _TEMPLATE_RE.findall(argument)
+        unknown = [name for name in names if name not in _ALLOWED_TEMPLATES]
+        if unknown:
+            raise CheckpointManifestError(f"unsupported command template: {{{unknown[0]}}}")
+        expanded.append(argument.format_map(values))
+    return expanded
+
+
+@dataclass(frozen=True)
+class CheckpointStepResult:
+    """Machine-readable result of one analysis step."""
+
+    name: str
+    command: tuple[str, ...]
+    returncode: int
+    expected_exit_codes: tuple[int, ...]
+    elapsed_seconds: float
+
+    @property
+    def passed(self) -> bool:
+        return self.returncode in self.expected_exit_codes
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "command": list(self.command),
+            "returncode": self.returncode,
+            "expected_exit_codes": list(self.expected_exit_codes),
+            "elapsed_seconds": round(self.elapsed_seconds, 3),
+            "passed": self.passed,
+        }
+
+
+def run_steps(
+    manifest: Mapping[str, Any],
+    *,
+    repo_root: str | os.PathLike[str],
+    profile: str | os.PathLike[str],
+    session: str | os.PathLike[str],
+    output_dir: str | os.PathLike[str],
+    timeout: float = 300.0,
+) -> list[CheckpointStepResult]:
+    """Run manifest analysis steps without a shell and write per-step logs."""
+    validate_manifest(manifest, require_profile=True, profile_override=profile)
+    root = Path(repo_root).resolve()
+    destination = Path(output_dir).resolve()
+    destination.mkdir(parents=True, exist_ok=True)
+    results: list[CheckpointStepResult] = []
+    for index, raw_step in enumerate(manifest["analysis"]["steps"]):
+        step = dict(raw_step)
+        command = expand_command(
+            step["command"], profile=profile, repo=root, session=session
+        )
+        expected = tuple(step.get("expected_exit_codes", [0]))
+        started = time.monotonic()
+        try:
+            completed = subprocess.run(
+                command,
+                cwd=root,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+            )
+            returncode = completed.returncode
+            stdout = completed.stdout
+            stderr = completed.stderr
+        except subprocess.TimeoutExpired as exc:
+            returncode = 124
+            stdout = _decode_output(exc.stdout)
+            stderr = _decode_output(exc.stderr) + f"\ncheckpoint step timed out after {timeout}s\n"
+        elapsed = time.monotonic() - started
+        name = str(step["name"])
+        safe_name = re.sub(r"[^a-z0-9_-]+", "-", name.lower()).strip("-") or f"step-{index}"
+        (destination / f"{index:02d}-{safe_name}.stdout").write_text(stdout, encoding="utf-8")
+        (destination / f"{index:02d}-{safe_name}.stderr").write_text(stderr, encoding="utf-8")
+        results.append(
+            CheckpointStepResult(name, tuple(command), returncode, expected, elapsed)
+        )
+    return results
+
+
+def _decode_output(value: str | bytes | None) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value

--- a/tests/test_checkpoint_manifest.py
+++ b/tests/test_checkpoint_manifest.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nsys_ai.checkpoint import (
+    CHECKPOINT_MANIFEST_SCHEMA,
+    CheckpointManifestError,
+    canonical_manifest_bytes,
+    expand_command,
+    load_manifest,
+    run_steps,
+    validate_manifest,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+MANIFEST = ROOT / "examples/checkpoints/b0-contract/manifest.json"
+
+
+def _manifest(*, profile_path: str = "profile.sqlite", sha256: str | None = None) -> dict:
+    return {
+        "schema_version": CHECKPOINT_MANIFEST_SCHEMA,
+        "checkpoint": "B0-test",
+        "project": {
+            "name": "test-project",
+            "repository": "https://example.test/project",
+            "revision_kind": "git_commit",
+            "revision": "0123456789abcdef",
+        },
+        "workload": {
+            "name": "small-gpu-workload",
+            "artifact": "model@0123456",
+            "parameters": {"batch": 1},
+            "capture_command": ["nsys", "profile", "workload"],
+            "expected_signals": [
+                {
+                    "id": "kernel-activity",
+                    "description": "The workload launches a CUDA kernel.",
+                    "verification": "Check the kernel table independently.",
+                }
+            ],
+        },
+        "environment": {
+            "python": "3.12.1",
+            "cuda": "12.8",
+            "driver": "580.95",
+            "gpu": "H100",
+            "nsys": "2026.1",
+        },
+        "capture": {
+            "profile_path": profile_path,
+            "format": "sqlite",
+            "sha256": sha256 or "a" * 64,
+            "output_paths": [profile_path],
+            "captured_at": "2026-08-23T00:00:00Z",
+        },
+        "analysis": {
+            "session_dir": ".nsys-ai/checkpoints/test",
+            "steps": [
+                {
+                    "name": name,
+                    "command": [sys.executable, "-c", "print('ok')"],
+                    "expected_exit_codes": [0],
+                }
+                for name in ("doctor", "diagnose", "ask", "diff", "review")
+            ],
+        },
+    }
+
+
+def test_committed_contract_manifest_validates_and_matches_fixture():
+    manifest = load_manifest(
+        MANIFEST,
+        profile_root=ROOT,
+        require_profile=True,
+    )
+    assert manifest["checkpoint"] == "B0-contract"
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        ("project.revision", "main"),
+        ("environment.driver", "unknown"),
+        ("capture.profile_path", "/tmp/profile.sqlite"),
+    ],
+)
+def test_validation_rejects_unpinned_or_machine_local_metadata(path, value):
+    manifest = _manifest()
+    target = manifest
+    parts = path.split(".")
+    for part in parts[:-1]:
+        target = target[part]
+    target[parts[-1]] = value
+
+    with pytest.raises(CheckpointManifestError, match=path.replace(".", r"\.")):
+        validate_manifest(manifest)
+
+
+def test_validation_rejects_duplicate_expected_signals_and_missing_step():
+    manifest = _manifest()
+    signals = manifest["workload"]["expected_signals"]
+    signals.append(dict(signals[0]))
+    manifest["analysis"]["steps"] = manifest["analysis"]["steps"][:-1]
+
+    with pytest.raises(CheckpointManifestError) as error:
+        validate_manifest(manifest)
+    message = str(error.value)
+    assert "must be unique" in message
+    assert "missing required steps: review" in message
+
+
+def test_checksum_validation_fails_closed(tmp_path):
+    profile = tmp_path / "profile.sqlite"
+    profile.write_bytes(b"profile")
+    manifest = _manifest(
+        profile_path=profile.name,
+        sha256=hashlib.sha256(b"different").hexdigest(),
+    )
+
+    with pytest.raises(CheckpointManifestError, match="checksum mismatch"):
+        validate_manifest(manifest, profile_root=tmp_path, require_profile=True)
+
+
+def test_canonical_manifest_bytes_are_stable_and_newline_terminated():
+    manifest = _manifest()
+    first = canonical_manifest_bytes(manifest)
+    reordered = json.loads(json.dumps(manifest, sort_keys=False))
+    second = canonical_manifest_bytes(reordered)
+    assert first == second
+    assert first.endswith(b"\n")
+    assert first.index(b'"analysis"') < first.index(b'"capture"')
+
+
+def test_command_expansion_only_accepts_known_paths():
+    expanded = expand_command(
+        ["tool", "{profile}", "{repo}", "{session}"],
+        profile="/tmp/profile.sqlite",
+        repo="/repo",
+        session="/tmp/session",
+    )
+    assert expanded == ["tool", "/tmp/profile.sqlite", "/repo", "/tmp/session"]
+
+    with pytest.raises(CheckpointManifestError, match="unsupported command template"):
+        expand_command(
+            ["tool", "{shell}"],
+            profile="/tmp/profile.sqlite",
+            repo="/repo",
+            session="/tmp/session",
+        )
+
+
+def test_run_steps_writes_logs_and_reports_expected_exit_codes(tmp_path):
+    manifest = _manifest()
+    profile = tmp_path / "profile.sqlite"
+    profile.write_bytes(b"profile")
+    manifest["capture"]["sha256"] = hashlib.sha256(b"profile").hexdigest()
+    for step in manifest["analysis"]["steps"]:
+        step["command"] = [sys.executable, "-c", "print('step output')"]
+
+    results = run_steps(
+        manifest,
+        repo_root=tmp_path,
+        profile=profile,
+        session=tmp_path / "session",
+        output_dir=tmp_path / "logs",
+    )
+    assert len(results) == 5
+    assert all(result.passed for result in results)
+    assert (tmp_path / "logs/00-doctor.stdout").read_text() == "step output\n"
+    assert (tmp_path / "logs/04-review.stderr").read_text() == ""
+
+
+def test_documented_cli_validate_and_plan(tmp_path):
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(ROOT / "src")
+    validate = subprocess.run(
+        [
+            sys.executable,
+            "scripts/checkpoint.py",
+            "validate",
+            str(MANIFEST),
+            "--repo-root",
+            str(ROOT),
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert validate.returncode == 0, validate.stderr
+    assert "valid checkpoint manifest" in validate.stdout
+
+    plan = subprocess.run(
+        [
+            sys.executable,
+            "scripts/checkpoint.py",
+            "plan",
+            str(MANIFEST),
+            "--repo-root",
+            str(ROOT),
+        ],
+        cwd=ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert plan.returncode == 0, plan.stderr
+    assert "doctor:" in plan.stdout
+    assert "review:" in plan.stdout


### PR DESCRIPTION
## Summary

Add the first reproducible checkpoint harness for real-profile adoption.

This PR establishes the B0 contract; it does not claim that vLLM, SGLang, or
Ray have been validated yet. Those external workloads will use this manifest
and runner in follow-up checkpoints.

## What changed

- Add `nsys_ai.checkpoint` with strict `checkpoint-v1` JSON validation.
- Require pinned project revision, workload parameters, environment metadata,
  capture path/format/checksum, expected signals, and all five analysis steps.
- Verify profile bytes with streaming SHA-256 before a real run.
- Add `scripts/checkpoint.py validate|plan|run`.
- Execute manifest commands as argv arrays without a shell and write separate
  stdout/stderr logs for each step.
- Add a committed B0 contract manifest and documentation. Large captures remain
  outside Git.
- Add tests for invalid provenance, duplicate signals, checksum mismatch,
  deterministic JSON, safe template expansion, runner logs, and the documented
  CLI.

## Verification

- `ruff check .` — passed
- targeted docs/CLI/checkpoint suite — `93 passed`
- full suite with the CI fixture profile — `2550 passed, 140 skipped, 4 xfailed`
- B0 manifest run — `doctor`, `diagnose`, `ask`, `diff`, and `review` all passed
- real FastVideo `perf.nsys-rep` — `doctor` passed; `diagnose` produced 42
  findings and parquetdir session artifacts; `ask` selected
  `root_cause_matcher`, `top_kernels`, and `gpu_idle_gaps` with evidence
- FastVideo valid-window self-diff — honest `inconclusive` with identical-profile
  warning; out-of-range trim returned `TRIM_OUT_OF_RANGE`
- FastVideo optimize boundary — invalid `true` verification output stopped before
  after profile/diff instead of claiming completion

## Scope boundary

The current FastVideo capture has no attached RunSpec and its capture provenance
is not complete enough to check in as a verified upstream-project manifest. The
real vLLM recipe is the next checkpoint, using this harness with a pinned model,
request trace, capture environment, and independently checked expected signal.

Relates to #557.
