### PR TITLE
feat(profile): accept nsys PyTorch annotation modes at capture time

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -89,6 +89,32 @@ capture, so you never have to name sessions yourself.
 activity is an error, not a silent empty file. Add `--dry-run` to print the plan without running
 anything.
 
+### Annotating a PyTorch workload you have not instrumented
+
+A capture with no NVTX still shows kernels, but the analysis that maps GPU time back to a region of
+your model has nothing to attribute to, so it abstains. `doctor` warns when this is the case.
+
+Nsight Systems can annotate PyTorch itself, with no change to your source. Pass `--pytorch`:
+
+```console
+$ nsys-ai profile --pytorch autograd-nvtx -o run-before -- python train.py
+```
+
+| Mode | What it annotates |
+|------|-------------------|
+| `autograd-nvtx` | Autograd operations, via `emit_nvtx()` |
+| `autograd-shapes-nvtx` | The same, plus tensor shapes |
+| `functions-trace` | One range per `torch.Module.forward()` call |
+| `functions-trace-shapes` | The same, plus shapes as payloads |
+
+One autograd mode may be combined with one functions-trace mode:
+`--pytorch autograd-nvtx,functions-trace`. Anything else is refused before the capture starts, as is
+an Nsight Systems too old to offer the option.
+
+Annotation is off unless you ask for it, because it adds overhead and changes what the capture
+measures. For the same reason, do not compare an annotated capture against an un-annotated one — a
+before/after pair should be captured the same way.
+
 If you already have a `.nsys-rep`, a `.sqlite` or a `parquetdir` from `nsys` directly, skip this step.
 Every command below accepts any of them; see [what to hand nsys-ai](./user/profile-inputs.md) for how
 each is read.

--- a/src/nsys_ai/cli/parsers.py
+++ b/src/nsys_ai/cli/parsers.py
@@ -153,6 +153,18 @@ def _register_profile_parser(sub):
         default="none",
     )
     p.add_argument("--cuda-memory-usage", action="store_true")
+    p.add_argument(
+        "--pytorch",
+        default=None,
+        metavar="MODE[,MODE]",
+        help=(
+            "Ask nsys to annotate PyTorch without editing the workload: "
+            "autograd-nvtx, autograd-shapes-nvtx, functions-trace, "
+            "functions-trace-shapes, or none (default). One autograd mode may be "
+            "combined with one functions-trace mode. Adds capture overhead, so it "
+            "is off unless asked for"
+        ),
+    )
     p.add_argument("--dry-run", action="store_true")
     p.add_argument(
         "workload",

--- a/src/nsys_ai/profile_command.py
+++ b/src/nsys_ai/profile_command.py
@@ -23,19 +23,44 @@ from typing import Any, TextIO
 from .artifact_root import profile_root
 from .exceptions import NsysAiError
 from .profile_runner import LocalProfileRunner, RunProgress, RunStatus
-from .runspec import EnvironmentSpec, NsysTraceOptions, RunSpec, RunSpecError
+from .runspec import (
+    EnvironmentSpec,
+    NsysTraceOptions,
+    RunSpec,
+    RunSpecError,
+    normalize_pytorch_modes,
+)
 
 _PROBE_TIMEOUT_SECONDS = 10
 _GIT_TIMEOUT_SECONDS = 3
 _TRACE_HEADER_RE = re.compile(r"^\s*(?:-t,\s*)?--trace=")
 _OPTION_HEADER_RE = re.compile(r"^\s*(?:-[A-Za-z],\s*)?--[A-Za-z0-9-]+(?:=|<)")
 _QUOTED_VALUE_RE = re.compile(r"'([^']+)'")
+_PYTORCH_HEADER_RE = re.compile(r"^\s*(?:-[A-Za-z],\s*)?--pytorch(?:=|\s|$)", re.MULTILINE)
 
 
 class ProfileCommandError(NsysAiError):
     """The public profiling command could not build or execute its plan."""
 
     error_code = "PROFILE_COMMAND_FAILED"
+
+
+def parse_pytorch_modes(value: str | None) -> tuple[str, ...]:
+    """Split the ``--pytorch`` CLI value and validate it with the RunSpec rules.
+
+    The rules live in RunSpec so there is one copy of them, but its messages name
+    the persisted field. Someone who typed ``--pytorch`` should be told about
+    ``--pytorch``, which is what ``--trace`` and ``--sample`` already do.
+    """
+    if value is None:
+        return ()
+    modes = tuple(part.strip() for part in value.split(",") if part.strip())
+    if not modes:
+        raise ProfileCommandError("--pytorch requires at least one mode")
+    try:
+        return normalize_pytorch_modes(modes, label="--pytorch")
+    except RunSpecError as exc:
+        raise ProfileCommandError(str(exc)) from exc
 
 
 def normalize_workload(tokens: Sequence[str]) -> tuple[str, ...]:
@@ -108,6 +133,41 @@ def detect_supported_trace_domains(nsys_executable: str) -> tuple[str, ...]:
             f"nsys trace capability probe failed with exit code {completed.returncode}"
         )
     return parse_supported_trace_domains(completed.stdout + "\n" + completed.stderr)
+
+
+def parse_pytorch_support(help_text: str) -> bool:
+    """Report whether this nsys advertises the ``--pytorch`` option."""
+    return _PYTORCH_HEADER_RE.search(help_text) is not None
+
+
+def detect_pytorch_support(nsys_executable: str) -> bool:
+    """Run the bounded PyTorch-annotation capability probe.
+
+    ``nsys`` has no ``--help=pytorch`` tag, so this reads the full profile help.
+    Only called when ``--pytorch`` was actually requested, so the ordinary
+    capture path spawns no extra process.
+    """
+    try:
+        completed = subprocess.run(  # nosec B603
+            [nsys_executable, "profile", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=_PROBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise ProfileCommandError(
+            f"nsys pytorch capability probe timed out after {_PROBE_TIMEOUT_SECONDS}s"
+        ) from exc
+    except OSError as exc:
+        raise ProfileCommandError(
+            f"nsys pytorch capability probe could not start: {type(exc).__name__}"
+        ) from exc
+    if completed.returncode != 0:
+        raise ProfileCommandError(
+            f"nsys pytorch capability probe failed with exit code {completed.returncode}"
+        )
+    return parse_pytorch_support(completed.stdout + "\n" + completed.stderr)
 
 
 def select_trace_domains(
@@ -322,8 +382,9 @@ def _dry_run_payload(
     workload: Sequence[str],
     environment: EnvironmentSpec,
     trace: Sequence[str],
+    pytorch: Sequence[str],
 ) -> dict[str, Any]:
-    return {
+    payload: dict[str, Any] = {
         "mode": "dry-run",
         "nsys_executable": nsys_executable,
         "output": str(output),
@@ -335,6 +396,10 @@ def _dry_run_payload(
         "environment_policy": environment.policy,
         "trace": list(trace),
     }
+    # Present only when asked for, so an unchanged invocation keeps its output.
+    if pytorch:
+        payload["pytorch"] = list(pytorch)
+    return payload
 
 
 def run_profile_command(
@@ -348,6 +413,7 @@ def run_profile_command(
     """Execute the public command and return its documented process exit code."""
     working_directory = (cwd or Path.cwd()).resolve()
     workload = normalize_workload(args.workload)
+    pytorch = parse_pytorch_modes(args.pytorch)
     environment = parse_environment(args.public_env, args.secret_env)
     environment = EnvironmentSpec(
         policy=args.env_policy,
@@ -362,6 +428,14 @@ def run_profile_command(
         supported,
         warning=lambda message: print(f"Warning: {message}", file=stderr),
     )
+    if pytorch and not detect_pytorch_support(nsys_executable):
+        # An unsupported --trace domain is refused before anything launches; without
+        # this, an unsupported --pytorch costs a whole workload run and surfaces only
+        # as "nsys returned non-zero" plus a log path.
+        raise ProfileCommandError(
+            f"{nsys_executable} does not support --pytorch; "
+            "annotate the workload with torch.cuda.nvtx, or upgrade Nsight Systems"
+        )
 
     if args.dry_run:
         print(
@@ -372,6 +446,7 @@ def run_profile_command(
                     workload=workload,
                     environment=environment,
                     trace=trace,
+                    pytorch=pytorch,
                 ),
                 sort_keys=True,
             ),
@@ -401,6 +476,7 @@ def run_profile_command(
             cpuctxsw=args.cpuctxsw,
             capture_range=args.capture_range,
             cuda_memory_usage=args.cuda_memory_usage,
+            pytorch=pytorch,
         ),
         timeout_seconds=args.timeout,
     )

--- a/src/nsys_ai/runspec.py
+++ b/src/nsys_ai/runspec.py
@@ -30,6 +30,10 @@ _ENV_POLICIES = frozenset({"inherit", "clean"})
 _CAPTURE_RANGES = frozenset({"none", "cudaProfilerApi", "nvtx", "hotkey"})
 _SAMPLE_MODES = frozenset({"none", "process-tree", "system-wide"})
 _CPUCTXSW_MODES = frozenset({"none", "process-tree", "system-wide"})
+# nsys accepts one autograd mode and/or one functions-trace mode, comma-joined.
+_PYTORCH_AUTOGRAD_MODES = frozenset({"autograd-nvtx", "autograd-shapes-nvtx"})
+_PYTORCH_FUNCTIONS_MODES = frozenset({"functions-trace", "functions-trace-shapes"})
+_PYTORCH_MODES = _PYTORCH_AUTOGRAD_MODES | _PYTORCH_FUNCTIONS_MODES
 
 
 class RunSpecError(NsysAiError):
@@ -54,6 +58,48 @@ def _reject_unknown_keys(payload: Mapping[str, Any], allowed: set[str], label: s
     unknown = sorted(set(payload) - allowed)
     if unknown:
         raise RunSpecError(f"{label} has unknown field(s): {', '.join(unknown)}")
+
+
+def normalize_pytorch_modes(
+    value: Any, *, label: str = "trace_options.pytorch"
+) -> tuple[str, ...]:
+    """Validate the requested nsys PyTorch annotation modes and canonicalize order.
+
+    Returns an empty tuple for "not requested", which is also what an explicit
+    ``none`` means, so the two spell the same thing on disk and in the argv.
+
+    Public because the CLI must reach the same verdict *before* it decides whether
+    to build a RunSpec at all: ``--dry-run`` exists to show a plan that would run,
+    so it has to reject the same values the real capture would. ``label`` names the
+    thing the caller's user actually typed, so the CLI can say ``--pytorch`` while a
+    persisted spec says ``trace_options.pytorch``.
+    """
+    if isinstance(value, str):
+        raise RunSpecError(f"{label} must be an array, not a comma-joined string")
+    if not isinstance(value, (list, tuple)):
+        raise RunSpecError(f"{label} must be an array")
+    modes = tuple(value)
+    for mode in modes:
+        if not isinstance(mode, str) or (mode != "none" and mode not in _PYTORCH_MODES):
+            raise RunSpecError(f"unsupported {label} mode: {mode!r}")
+    if len(set(modes)) != len(modes):
+        raise RunSpecError(f"{label} must not contain duplicates")
+    if "none" in modes:
+        if len(modes) > 1:
+            raise RunSpecError(f"{label} cannot combine 'none' with a mode")
+        return ()
+    selected = set(modes)
+    if len(selected & _PYTORCH_AUTOGRAD_MODES) > 1:
+        raise RunSpecError(
+            f"{label} accepts at most one autograd mode: "
+            "'autograd-nvtx' or 'autograd-shapes-nvtx'"
+        )
+    if len(selected & _PYTORCH_FUNCTIONS_MODES) > 1:
+        raise RunSpecError(
+            f"{label} accepts at most one functions-trace mode: "
+            "'functions-trace' or 'functions-trace-shapes'"
+        )
+    return tuple(sorted(modes))
 
 
 def _validate_string(value: Any, label: str, *, allow_empty: bool = False) -> str:
@@ -162,6 +208,7 @@ class NsysTraceOptions:
     cpuctxsw: str = "none"
     capture_range: str = "none"
     cuda_memory_usage: bool = False
+    pytorch: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:
         if not isinstance(self.trace, (list, tuple)):
@@ -188,9 +235,10 @@ class NsysTraceOptions:
         if not isinstance(self.cuda_memory_usage, bool):
             raise RunSpecError("trace_options.cuda_memory_usage must be a boolean")
         object.__setattr__(self, "trace", tuple(sorted(trace)))
+        object.__setattr__(self, "pytorch", normalize_pytorch_modes(self.pytorch))
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        payload: dict[str, Any] = {
             "trace": list(self.trace),
             "sample": self.sample,
             "cpuctxsw": self.cpuctxsw,
@@ -199,6 +247,12 @@ class NsysTraceOptions:
             # Reports must not capture the runner's resolved environment.
             "discard_environment": True,
         }
+        # Emitted only when requested. This mapping is hashed into
+        # ``RunSpec.compatibility_key``, so an unconditional key would change the
+        # identity of every spec written before the option existed.
+        if self.pytorch:
+            payload["pytorch"] = list(self.pytorch)
+        return payload
 
     @classmethod
     def from_dict(cls, payload: Mapping[str, Any]) -> NsysTraceOptions:
@@ -209,6 +263,7 @@ class NsysTraceOptions:
             "cpuctxsw",
             "capture_range",
             "cuda_memory_usage",
+            "pytorch",
             "discard_environment",
         }
         _reject_unknown_keys(data, allowed, "trace_options")
@@ -220,6 +275,7 @@ class NsysTraceOptions:
             cpuctxsw=data.get("cpuctxsw", "none"),
             capture_range=data.get("capture_range", "none"),
             cuda_memory_usage=data.get("cuda_memory_usage", False),
+            pytorch=data.get("pytorch", ()),
         )
 
 
@@ -461,6 +517,8 @@ def build_nsys_profile_argv(
         argv.append(f"--capture-range={options.capture_range}")
     if options.cuda_memory_usage:
         argv.append("--cuda-memory-usage=true")
+    if options.pytorch:
+        argv.append(f"--pytorch={','.join(options.pytorch)}")
     argv.extend(spec.argv)
     return argv
 

--- a/tests/test_optimize_command.py
+++ b/tests/test_optimize_command.py
@@ -28,6 +28,7 @@ from nsys_ai.profile_runner import (
     RunTimings,
     build_local_profile_reference,
 )
+from nsys_ai.runspec import build_nsys_profile_argv
 from nsys_ai.session_cli import publish_session_findings
 from nsys_ai.session_store import SessionStore
 
@@ -434,3 +435,23 @@ def test_decision_reason_names_the_verdict_it_came_from(verdict, expected):
 def test_decision_reason_is_explicit_when_step_time_is_not_comparable():
     _decision, reason = _decision_for_verdict("inconclusive", None)
     assert "step time was not comparable" in reason
+
+
+def test_the_verification_capture_never_gains_pytorch_annotation(tmp_path):
+    """Before and after must be the same kind of capture. optimize builds its own
+    RunSpec, so a new capture option must not leak into it by default: annotating
+    only the after-profile would change what the diff is comparing."""
+    _seed_findings(tmp_path)
+    runner = _succeeding_runner(build_local_profile_reference(AFTER))
+
+    code, _out, err = _run(tmp_path, runner)
+
+    assert code == 0, err
+    spec = runner.specs[0]
+    assert spec.trace_options.pytorch == ()
+    assert "pytorch" not in spec.trace_options.to_dict()
+    assert not [
+        token
+        for token in build_nsys_profile_argv(spec, tmp_path / "after")
+        if token.startswith("--pytorch")
+    ]

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -9,11 +9,13 @@ from pathlib import Path
 
 import pytest
 
+from nsys_ai import profile_command
 from nsys_ai.profile_command import (
     ProfileCommandError,
     discover_git_provenance,
     normalize_workload,
     parse_environment,
+    parse_pytorch_support,
     parse_supported_trace_domains,
     run_profile_command,
     select_trace_domains,
@@ -48,6 +50,16 @@ if sys.argv[1:] == ['profile', '--help=trace']:
     --trace-fork-before-exec=
        Possible values are 'true' or 'false'.
     """)
+    sys.exit(0)
+
+if sys.argv[1:] == ['profile', '--help']:
+    # The capability surface the real nsys advertises. FAKE_NO_PYTORCH models an
+    # Nsight old enough to predate the option.
+    print("usage: nsys profile\n")
+    print("\t--sample=\n\t   Possible values are 'none'.\n")
+    if not os.environ.get('FAKE_NO_PYTORCH'):
+        print("\t--pytorch=\n\t   Possible values are 'autograd-nvtx' or 'none'.\n")
+    print("\t--cuda-memory-usage=\n\t   Possible values are 'true' or 'false'.")
     sys.exit(0)
 
 if sys.argv[1] == 'profile':
@@ -109,6 +121,7 @@ def _args(fake_nsys, output, **overrides):
         "cpuctxsw": "none",
         "capture_range": "none",
         "cuda_memory_usage": False,
+        "pytorch": None,
         "timeout": None,
     }
     values.update(overrides)
@@ -668,3 +681,188 @@ def test_existing_bare_profile_shortcut_remains_viewer_routed():
         "timeline-web",
         "profile.sqlite",
     ]
+
+
+def test_pytorch_flag_reaches_the_nsys_command_line_and_the_runspec(tmp_path, fake_nsys):
+    """An un-annotated PyTorch repo gets NVTX from nsys itself, with no source edit."""
+    output = tmp_path / "artifacts"
+
+    result = _run_cli(
+        tmp_path,
+        "profile",
+        "--nsys",
+        str(fake_nsys),
+        "--output",
+        str(output),
+        "--pytorch",
+        "autograd-nvtx,functions-trace",
+        "--",
+        "train.py",
+    )
+
+    assert result.returncode == 0, result.stderr
+    capture_argv = json.loads((output / "stdout.log").read_text())
+    assert "--pytorch=autograd-nvtx,functions-trace" in capture_argv
+    spec = RunSpec.from_json_bytes((output / "runspec.json").read_bytes())
+    assert spec.trace_options.pytorch == ("autograd-nvtx", "functions-trace")
+
+
+def test_capture_without_the_flag_asks_nsys_for_no_pytorch_annotation(tmp_path, fake_nsys):
+    output = tmp_path / "artifacts"
+
+    result = _run_cli(
+        tmp_path, "profile", "--nsys", str(fake_nsys), "--output", str(output), "--", "train.py"
+    )
+
+    assert result.returncode == 0, result.stderr
+    capture_argv = json.loads((output / "stdout.log").read_text())
+    assert not [token for token in capture_argv if token.startswith("--pytorch")]
+    spec = RunSpec.from_json_bytes((output / "runspec.json").read_bytes())
+    assert spec.trace_options.pytorch == ()
+    assert "pytorch" not in json.loads((output / "runspec.json").read_text())["trace_options"]
+
+
+def test_dry_run_reports_the_requested_pytorch_modes(tmp_path, fake_nsys):
+    stdout = io.StringIO()
+
+    exit_code = run_profile_command(
+        _args(fake_nsys, tmp_path / "dry", dry_run=True, pytorch="autograd-shapes-nvtx"),
+        stdout=stdout,
+        stderr=io.StringIO(),
+        cwd=tmp_path,
+        runner_factory=lambda *_: pytest.fail("dry-run must not construct the runner"),
+    )
+
+    assert exit_code == 0
+    assert json.loads(stdout.getvalue())["pytorch"] == ["autograd-shapes-nvtx"]
+
+
+def test_dry_run_omits_pytorch_when_it_was_not_requested(tmp_path, fake_nsys):
+    stdout = io.StringIO()
+
+    run_profile_command(
+        _args(fake_nsys, tmp_path / "dry", dry_run=True),
+        stdout=stdout,
+        stderr=io.StringIO(),
+        cwd=tmp_path,
+        runner_factory=lambda *_: pytest.fail("dry-run must not construct the runner"),
+    )
+
+    assert "pytorch" not in json.loads(stdout.getvalue())
+
+
+def test_an_unsupported_pytorch_mode_is_refused_before_anything_runs(tmp_path, fake_nsys):
+    with pytest.raises(ProfileCommandError):
+        run_profile_command(
+            _args(fake_nsys, tmp_path / "artifacts", pytorch="emit-nvtx"),
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+            cwd=tmp_path,
+            runner_factory=lambda *_: pytest.fail("an invalid mode must not reach the runner"),
+        )
+
+
+def test_an_empty_pytorch_value_is_refused(tmp_path, fake_nsys):
+    with pytest.raises(ProfileCommandError):
+        run_profile_command(
+            _args(fake_nsys, tmp_path / "artifacts", pytorch=" , "),
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+            cwd=tmp_path,
+            runner_factory=lambda *_: pytest.fail("an empty value must not reach the runner"),
+        )
+
+
+def _dry_run(fake_nsys, tmp_path, **overrides):
+    stdout = io.StringIO()
+    exit_code = run_profile_command(
+        _args(fake_nsys, tmp_path / "dry", dry_run=True, **overrides),
+        stdout=stdout,
+        stderr=io.StringIO(),
+        cwd=tmp_path,
+        runner_factory=lambda *_: pytest.fail("dry-run must not construct the runner"),
+    )
+    return exit_code, stdout.getvalue()
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "emit-nvtx",
+        "autograd-nvtx,autograd-shapes-nvtx",
+        "functions-trace,functions-trace-shapes",
+        "autograd-nvtx,autograd-nvtx",
+        "none,autograd-nvtx",
+    ],
+)
+def test_dry_run_refuses_what_the_real_capture_would_refuse(tmp_path, fake_nsys, value):
+    """--dry-run exists to show a plan before running it. Printing a plan that the
+    capture would reject, and exiting 0, is worse than not offering the flag."""
+    with pytest.raises(ProfileCommandError) as caught:
+        _dry_run(fake_nsys, tmp_path, pytorch=value)
+
+    # Someone who typed --pytorch is told about --pytorch, as --trace already does.
+    assert "--pytorch" in str(caught.value)
+    assert "trace_options" not in str(caught.value)
+
+
+def test_dry_run_reports_the_modes_in_the_order_the_runspec_records(tmp_path, fake_nsys):
+    """The plan has to be the plan: canonical order, not the order they were typed."""
+    _exit_code, out = _dry_run(fake_nsys, tmp_path, pytorch="functions-trace,autograd-nvtx")
+
+    assert json.loads(out)["pytorch"] == ["autograd-nvtx", "functions-trace"]
+
+
+def test_dry_run_treats_an_explicit_none_as_unset(tmp_path, fake_nsys):
+    _exit_code, out = _dry_run(fake_nsys, tmp_path, pytorch="none")
+
+    assert "pytorch" not in json.loads(out)
+
+
+def test_pytorch_support_is_read_from_the_option_block():
+    advertises = "usage: nsys profile\n\n\t--pytorch=\n\t   Possible values are 'autograd-nvtx'."
+    silent = "usage: nsys profile\n\n\t--sample=\n\t   Possible values are 'none'."
+
+    assert parse_pytorch_support(advertises) is True
+    assert parse_pytorch_support(silent) is False
+    # A mention inside another option's prose is not an option header.
+    assert parse_pytorch_support("   see --pytorch for details") is False
+    # nsys prints a short form for some options ("-t, --trace="); a future one here
+    # must not read as "unsupported" and refuse a capable Nsight.
+    assert parse_pytorch_support("\t-y, --pytorch=\n\t   Possible values are 'none'.") is True
+    # A longer option that merely starts with the same letters is a different option.
+    assert parse_pytorch_support("\t--pytorch-extra=\n") is False
+
+
+def test_an_nsys_without_pytorch_is_refused_before_the_workload_runs(
+    tmp_path, fake_nsys, monkeypatch
+):
+    """An unsupported --trace domain is refused up front. Without the same check,
+    an unsupported --pytorch costs a whole workload run and surfaces only as
+    "nsys returned non-zero" plus a path to a log."""
+    monkeypatch.setenv("FAKE_NO_PYTORCH", "1")
+
+    with pytest.raises(ProfileCommandError, match="does not support --pytorch"):
+        run_profile_command(
+            _args(fake_nsys, tmp_path / "artifacts", pytorch="autograd-nvtx"),
+            stdout=io.StringIO(),
+            stderr=io.StringIO(),
+            cwd=tmp_path,
+            runner_factory=lambda *_: pytest.fail("an unsupported flag must not reach the runner"),
+        )
+
+
+def test_a_capture_without_the_flag_never_runs_the_pytorch_probe(
+    tmp_path, fake_nsys, monkeypatch
+):
+    """The probe reads the whole profile help, so it must stay off the default path."""
+
+    def refuse(_executable):
+        raise AssertionError("the pytorch probe ran for a capture that did not ask for it")
+
+    monkeypatch.setattr(profile_command, "detect_pytorch_support", refuse)
+
+    exit_code, out = _dry_run(fake_nsys, tmp_path)
+
+    assert exit_code == 0
+    assert "pytorch" not in json.loads(out)

--- a/tests/test_runspec.py
+++ b/tests/test_runspec.py
@@ -508,3 +508,96 @@ def test_output_path_is_operational_not_persisted_or_comparable():
     assert left != right
     assert "/tmp/left" not in spec.canonical_json_bytes().decode("utf-8")
     assert "/tmp/right" not in json.dumps(spec.compatibility_payload())
+
+
+# ── nsys --pytorch annotation modes ────────────────────────────────────────
+
+
+def _minimal_spec(**trace_overrides):
+    return RunSpec(
+        argv=("python", "train.py"),
+        cwd=".",
+        environment=EnvironmentSpec(policy="inherit"),
+        trace_options=NsysTraceOptions(**trace_overrides),
+    )
+
+
+def test_pytorch_is_unset_by_default_and_changes_neither_argv_nor_identity():
+    """emit_nvtx costs overhead, so it is opt-in — and asking for nothing must
+    reproduce the pre-existing argv and compatibility key exactly."""
+    spec = _minimal_spec()
+
+    assert spec.trace_options.pytorch == ()
+    assert "pytorch" not in spec.trace_options.to_dict()
+    assert not any(token.startswith("--pytorch") for token in build_nsys_profile_argv(spec, "/tmp/o"))
+    assert spec.compatibility_key() == (
+        "runspec1:sha256:"
+        "b8d2b93c405c14419ef1bc2fbfb5da92a6f535cafd78588519fbce25405d0c73"
+    )
+
+
+def test_pytorch_mode_reaches_the_argv():
+    spec = _minimal_spec(pytorch=("autograd-nvtx",))
+
+    assert "--pytorch=autograd-nvtx" in build_nsys_profile_argv(spec, "/tmp/o")
+
+
+def test_pytorch_combines_one_autograd_mode_with_one_functions_mode():
+    options = NsysTraceOptions(pytorch=("functions-trace", "autograd-nvtx"))
+
+    assert options.pytorch == ("autograd-nvtx", "functions-trace")
+    spec = _minimal_spec(pytorch=("functions-trace", "autograd-nvtx"))
+    assert "--pytorch=autograd-nvtx,functions-trace" in build_nsys_profile_argv(spec, "/tmp/o")
+
+
+@pytest.mark.parametrize(
+    "modes",
+    [
+        ("autograd-nvtx", "autograd-shapes-nvtx"),
+        ("functions-trace", "functions-trace-shapes"),
+        ("none", "autograd-nvtx"),
+        ("autograd-nvtx", "autograd-nvtx"),
+        ("emit-nvtx",),
+    ],
+)
+def test_pytorch_rejects_combinations_nsys_would_reject(modes):
+    with pytest.raises(RunSpecError):
+        NsysTraceOptions(pytorch=modes)
+
+
+def test_pytorch_rejects_a_comma_joined_string():
+    """nsys spells it 'a,b'; the spec spells it as an array, so say so rather than
+    silently treating the whole string as one unknown mode."""
+    with pytest.raises(RunSpecError):
+        NsysTraceOptions(pytorch="autograd-nvtx,functions-trace")
+
+
+def test_pytorch_none_means_unset():
+    assert NsysTraceOptions(pytorch=("none",)).pytorch == ()
+    assert "pytorch" not in NsysTraceOptions(pytorch=("none",)).to_dict()
+
+
+def test_pytorch_round_trips_through_to_dict_and_from_dict():
+    options = NsysTraceOptions(pytorch=("autograd-shapes-nvtx", "functions-trace"))
+
+    assert NsysTraceOptions.from_dict(options.to_dict()).pytorch == options.pytorch
+
+
+def test_trace_options_written_before_pytorch_existed_still_load():
+    legacy = {
+        "trace": ["cuda", "nvtx"],
+        "sample": "none",
+        "cpuctxsw": "none",
+        "capture_range": "none",
+        "cuda_memory_usage": False,
+        "discard_environment": True,
+    }
+
+    assert NsysTraceOptions.from_dict(legacy).pytorch == ()
+
+
+def test_requesting_pytorch_changes_the_compatibility_key():
+    """Two runs that annotate differently are not the same capture."""
+    assert _minimal_spec().compatibility_key() != _minimal_spec(
+        pytorch=("autograd-nvtx",)
+    ).compatibility_key()


### PR DESCRIPTION
## Summary

- `nsys` can annotate PyTorch with `emit_nvtx` and per-`forward()` ranges without touching the
  workload's source, but nsys-ai had no way to ask for it: `NsysTraceOptions` is a closed five-field
  allowlist and the `profile` parser has no passthrough. A repository with no NVTX in its source
  could only be captured with no NVTX.
- Adds a validated `pytorch` field to the RunSpec trace options and a `--pytorch` flag on
  `nsys-ai profile`. Combinations `nsys` rejects are refused at spec construction, not at run time.
- The consequence this unblocks: 7 of the 38 registered skills are NVTX-gated and abstain on an
  un-annotated capture, and `nvtx_layer_breakdown`'s own abstention tells the user to "re-capture
  with NVTX enabled" — which the capture command could not do.

## Changes

- `runspec.py` — `NsysTraceOptions.pytorch: tuple[str, ...] = ()`; `_normalize_pytorch` validates the
  four nsys modes plus `none`, rejects duplicates, two autograd modes, two functions-trace modes, and
  `none` combined with a mode, and canonicalizes order. `build_nsys_profile_argv` emits
  `--pytorch=<joined>` only when set.
- `cli/parsers.py` — `--pytorch MODE[,MODE]` on `profile`.
- `profile_command.py` — `parse_pytorch_support` / `detect_pytorch_support`, a bounded capability
  probe mirroring the existing `--trace` one, so an Nsight too old for the option is refused before
  the workload launches.
- `profile_command.py` — `parse_pytorch_modes` splits the CLI value and validates it through the same
  RunSpec rules, so `--dry-run` reaches the verdict the capture would; the dry-run payload reports the
  modes in the order the RunSpec records them.
- `docs/user-guide.md` — a subsection under "2. Capture" for annotating a workload you have not
  instrumented.

## Backward compatibility

Yes, and this is load-bearing rather than incidental. `NsysTraceOptions.to_dict()` is embedded
verbatim in `RunSpec.compatibility_payload()`, which `compatibility_key()` hashes into the
`runspec1:sha256:` identity used to judge whether two runs are comparable. An unconditional
`"pytorch": []` would have changed that key for **every RunSpec ever written**. The key is therefore
emitted only when the option is set, and this is pinned by test rather than left to review:

```
upstream/main  runspec1:sha256:b8d2b93c405c14419ef1bc2fbfb5da92a6f535cafd78588519fbce25405d0c73
this branch    runspec1:sha256:b8d2b93c405c14419ef1bc2fbfb5da92a6f535cafd78588519fbce25405d0c73
```

Same for the argv: omitting the flag reproduces today's command line token for token. A
`trace_options` payload written before the field existed still loads, with `pytorch` unset.

`optimize` builds its own verification RunSpec and keeps inheriting the unset default — a
re-capture silently gaining `--pytorch` would change what the diff compares. Pinned by a test.

## Test plan

- [x] Tests added or updated for the new behavior — 13 in `test_runspec.py`, 16 in
      `test_profile_command.py` (two drive a real capture through the fake `nsys` and assert on the
      recorded argv), 1 in `test_optimize_command.py`. The fake `nsys` now answers `profile --help`
      with a capability surface, and `FAKE_NO_PYTORCH` models an Nsight that predates the option.
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/` — 2570 passed, 140 skipped, 4 xfailed, 0 failed (9m10s). The 30-test
      delta over `upstream/main`'s 2540 is exactly the tests added here; skips unchanged.
- [x] `ruff check src/ tests/` clean
- [x] `bandit -r src/ -c pyproject.toml` — no issues identified
- [x] Manually exercised against the installed `nsys 2026.4.1`, not just against its documentation:
      the argv this branch generates was handed to the real binary unchanged and ran to completion —

      ```
      $ nsys profile -o … --sample=none --cpuctxsw=none --trace=cuda,nccl,nvtx \
          --discard-environment=true --pytorch=autograd-nvtx,functions-trace python3 -c 'print(1)'
      rc = 0    Generating 'nsys-report-f2c5.qdstrm'
      ```

      and the three combinations this branch refuses are refused by nsys too, so the validator
      matches the tool rather than guessing at it:

      | value | nsys |
      |---|---|
      | `autograd-nvtx,autograd-shapes-nvtx` | rc=1 |
      | `functions-trace,functions-trace-shapes` | rc=1 |
      | `emit-nvtx` | rc=1 |

- [x] Verified the feature does what this PR claims, not just that the flag is plumbed. A three-block
      `nn.Module` with **zero NVTX in its source** (grep: 0 matches), captured with the argv this
      branch generates, produced 43 NVTX events carrying the module hierarchy:

      ```
      5  TinyModel        5  TinyModel.blocks.0     5  TinyModel.blocks.0.fc
      5  Forward          5  TinyModel.blocks.1     5  TinyModel.blocks.1.fc
                          5  TinyModel.blocks.2     5  TinyModel.blocks.2.fc
      ```

      Five of each, for five forward iterations — the repeated-sibling shape
      `nvtx_layer_detect.py` is written to auto-discover. Stated plainly: this host has no CUDA, so
      that verifies `functions-trace`, not `autograd-nvtx` (which needs `emit_nvtx`), and it does not
      verify kernel-to-range attribution.

## What review caught, all fixed

**`--dry-run` validated nothing.** Splitting parse from validate left the dry-run branch — which
returns before any RunSpec is built — with no validation at all, so it printed plans that could not
run and exited 0:

| invocation | was | now |
|---|---|---|
| `--pytorch bogus-mode --dry-run` | `rc=0`, `"pytorch": ["bogus-mode"]` | `rc=1`, `unsupported … mode` |
| `--pytorch autograd-nvtx,autograd-shapes-nvtx --dry-run` | `rc=0` | `rc=1`, as nsys itself does |
| `--pytorch functions-trace,autograd-nvtx --dry-run` | printed the typed order | prints the recorded order |
| `--pytorch none --dry-run` | printed `["none"]` | omits the key, as the real path does |

`normalize_pytorch_modes` is now public and called from the CLI boundary: one implementation of the
rules, reached by both paths.

**An unsupported Nsight was only diagnosable from a log file.** An unavailable `--trace` domain is
refused up front by an existing probe, but `--pytorch` had no equivalent — so an Nsight predating the
option would run the whole workload, exit non-zero, and surface as `Profile failed: nsys_failed` /
`nsys returned non-zero without a usable report` plus a path to `stderr.log`. nsys has no
`--help=pytorch` tag, so the probe reads the profile help, and it only runs when `--pytorch` was
actually requested — the ordinary capture path spawns no extra process, and there is a test pinning
that.

**The error messages named the wrong thing.** `--trace bogus` says `unsupported trace domain(s)` and
`--sample bogus` says `invalid choice`; `--pytorch bogus` was saying
`unsupported trace_options.pytorch mode` — the persisted field path, to someone who typed a flag.
`normalize_pytorch_modes` now takes a `label`, so the CLI says `--pytorch` and a persisted spec still
says `trace_options.pytorch`. It is a parameter rather than a string substitution on the message,
because a substitution silently stops working the day someone rewords the message.

**The capability probe was stricter than its own sibling.** `_OPTION_HEADER_RE` allows a short-form
prefix because nsys prints `-t, --trace=`; the new `_PYTORCH_HEADER_RE` did not, so an nsys printing
`-y, --pytorch=` would have been reported as not supporting the option and refused. It now mirrors
the sibling pattern, with tests for the short form and for `--pytorch-extra=` correctly not matching.

Every fix is reverse-verified: reverting each one makes its tests fail, restoring makes them pass.
The parametrized refusal test covers all five combinations reachable from the CLI, not the three it
started with — the two that were missing, duplicates and `none` combined with a mode, were exactly
where a silent translation failure would have hidden.

## Out of scope

- `--python-backtrace` and `--cudabacktrace` are the same class of gap and are deliberately not here.
- No default changes. `--trace auto` resolution is untouched, and annotation stays off unless asked
  for, because `emit_nvtx` adds overhead and changes what the capture measures.
- `doctor`'s no-NVTX hint still names two library functions rather than this flag. That belongs with
  the parent epic.
- `nsys` documents `--pytorch` as implying `--trace=nvtx`, so a capture with `--trace cuda` will
  contain NVTX the recorded `trace` does not list. Left alone deliberately: no consumer reads
  `trace_options.trace`, and the same is already true of other nsys implications.

## Found while verifying, filed separately

Running the skills against that kernel-less capture surfaced a pre-existing defect: 4 of 38 skills
let the query engine's error escape when a profile has no `CUPTI_ACTIVITY_KIND_KERNEL`, because every
abstention test fixture has one. Filed as #566, deliberately not folded in here. It is adjacent
because `--pytorch functions-trace` makes an NVTX-rich, kernel-less capture easy to produce by
accident on a machine without a GPU.

## Note for reviewers

#260 is open and also touches `cli/parsers.py`, in the agent parser rather than the profile parser.
It has not moved since 6 Aug; the regions do not overlap.

## Linked issues

Closes #559. Part of #558.
