### PR TITLE
fix(skills): make thread utilization DuckDB compatible

### DIFF
--- a/src/nsys_ai/skills/builtins/thread_utilization.py
+++ b/src/nsys_ai/skills/builtins/thread_utilization.py
@@ -25,19 +25,30 @@ def _execute(conn: Any, *, limit: int = 10, **_kwargs):
         )
 
     sql = f"""\
+WITH total_cycles AS (
+    SELECT CASE
+               WHEN COALESCE(SUM(cpuCycles), 0) < 1 THEN 1
+               ELSE SUM(cpuCycles)
+           END AS total_cpu_cycles
+    FROM COMPOSITE_EVENTS
+), named_threads AS (
+    SELECT tn.globalTid,
+           s.value AS thread_name,
+           ROW_NUMBER() OVER (
+               PARTITION BY tn.globalTid ORDER BY tn.nameId ASC
+           ) AS name_rank
+    FROM ThreadNames tn
+    LEFT JOIN StringIds s ON s.id = tn.nameId
+)
 SELECT ce.globalTid % 0x1000000 AS tid,
-       (SELECT s.value FROM StringIds s
-        WHERE s.id = (SELECT tn.nameId FROM ThreadNames tn
-                      WHERE tn.globalTid = ce.globalTid
-                      -- A thread may carry several names; without an order the
-                      -- displayed one is whichever row the engine reaches first.
-                      ORDER BY tn.nameId ASC LIMIT 1)
-       ) AS thread_name,
-       ROUND(100.0 * SUM(ce.cpuCycles) / (
-           SELECT MAX(1, SUM(cpuCycles)) FROM COMPOSITE_EVENTS
-       ), 2) AS cpu_pct
+       nt.thread_name,
+       ROUND(100.0 * SUM(ce.cpuCycles) / total_cycles.total_cpu_cycles, 2)
+           AS cpu_pct
 FROM COMPOSITE_EVENTS ce
-GROUP BY ce.globalTid
+CROSS JOIN total_cycles
+LEFT JOIN named_threads nt
+       ON nt.globalTid = ce.globalTid AND nt.name_rank = 1
+GROUP BY ce.globalTid, nt.thread_name, total_cycles.total_cpu_cycles
 -- globalTid, not the masked tid: the mask can collide across processes.
 ORDER BY cpu_pct DESC, ce.globalTid ASC
 LIMIT {int(limit)}"""

--- a/tests/test_duckdb_path.py
+++ b/tests/test_duckdb_path.py
@@ -6,6 +6,7 @@ Profile-like object with ``db=duckdb_conn`` and ``conn=None``.  Any code path
 that accidentally touches ``self.conn`` will crash here — which is the point.
 """
 
+import sqlite3
 import threading
 
 import duckdb
@@ -255,6 +256,49 @@ class TestDuckDBCompatibilityFixes:
         rows = skill.execute(bad_conn)
         assert is_abstention(rows)
         assert "CUPTI_ACTIVITY_KIND_MEMCPY" in rows[0]["reason"]
+
+    @staticmethod
+    def _seed_thread_utilization(conn):
+        """Create the sampled CPU table used by ``thread_utilization``."""
+        conn.execute(
+            "CREATE TABLE COMPOSITE_EVENTS (globalTid INTEGER, cpuCycles INTEGER)"
+        )
+        conn.executemany(
+            "INSERT INTO COMPOSITE_EVENTS VALUES (?, ?)",
+            [(100, 3), (200, 1)],
+        )
+
+    def test_thread_utilization_duckdb_avoids_nested_aggregate(self, duckdb_conn):
+        """The CPU percentage query must bind on DuckDB's aggregate rules."""
+        from nsys_ai.skills.registry import get_skill
+
+        self._seed_thread_utilization(duckdb_conn)
+        rows = get_skill("thread_utilization").execute(duckdb_conn)
+
+        assert [row["tid"] for row in rows] == [100, 200]
+        assert [float(row["cpu_pct"]) for row in rows] == [75.0, 25.0]
+
+    def test_thread_utilization_sqlite_compatibility(self):
+        """The DuckDB fix must preserve the SQLite execution path."""
+        from nsys_ai.skills.registry import get_skill
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+                CREATE TABLE ThreadNames (globalTid INTEGER, nameId INTEGER);
+                INSERT INTO StringIds VALUES (1, 'worker-a'), (2, 'worker-b');
+                INSERT INTO ThreadNames VALUES (100, 1), (200, 2);
+                """
+            )
+            self._seed_thread_utilization(conn)
+            rows = get_skill("thread_utilization").execute(conn)
+
+            assert [row["tid"] for row in rows] == [100, 200]
+            assert [float(row["cpu_pct"]) for row in rows] == [75.0, 25.0]
+        finally:
+            conn.close()
 
     def _make_textid_db(self, nvtx_rows: list[tuple], string_rows: list[tuple]):
         """Return a minimal DuckDB connection with textId-based NVTX schema."""


### PR DESCRIPTION
## Summary

Fixes #567.

`thread_utilization` used `MAX(1, SUM(cpuCycles))` in the denominator. DuckDB treats that as an invalid nested aggregate, so real `.nsys-rep` profiles with `COMPOSITE_EVENTS` failed instead of returning CPU thread utilization.

This change:

- computes the total CPU cycles in a separate aggregate CTE with portable `CASE`/`COALESCE` logic;
- resolves the first thread name through a ranked CTE and `LEFT JOIN`, avoiding the DuckDB binder issue from the correlated subquery plus aggregate;
- preserves the existing missing-`COMPOSITE_EVENTS` abstention behavior.

## Verification

- `tests/test_duckdb_path.py tests/test_abstention.py tests/test_skills.py`: 137 passed
- DuckDB regression: 75% / 25% CPU percentages
- SQLite compatibility regression: 75% / 25% CPU percentages
- Real vLLM CPU-sampled profile: `thread_utilization` now returns rows successfully; top EngineCore thread 62.55% instead of a DuckDB Binder Error
- `ruff check` clean

The full local suite reached 2,535 passed, 146 skipped, and 4 xfailed; the only failure was the repository's existing `test_every_skip_has_a_known_reason` check because this checkout has no optional `tests/integration.py` test profile (`No test profile`).
