### PR TITLE
feat: attribute CUDA Graph kernels

### DIFF
--- a/docs/04-cuda-trace.md
+++ b/docs/04-cuda-trace.md
@@ -68,10 +68,27 @@ Enable with: `--cudabacktrace=all --python-backtrace=cuda`
 
 | Table | Key Columns |
 |-------|-------------|
-| `CUPTI_ACTIVITY_KIND_KERNEL` | `demangledName`→StringIds, `start`, `end`, `streamId`, `deviceId`, `gridX/Y/Z`, `blockX/Y/Z` |
+| `CUPTI_ACTIVITY_KIND_KERNEL` | `demangledName`→StringIds, `start`, `end`, `streamId`, `deviceId`, `gridX/Y/Z`, `blockX/Y/Z`, optional `graphNodeId`/`graphId` |
 | `CUPTI_ACTIVITY_KIND_RUNTIME` | `nameId`→StringIds, `start`, `end`, `correlationId`, `globalTid` |
 | `CUPTI_ACTIVITY_KIND_MEMCPY` | `copyKind`, `bytes`, `start`, `end`, `srcKind`, `dstKind` |
 | `CUPTI_ACTIVITY_KIND_MEMSET` | `bytes`, `start`, `end`, `value` |
+
+### CUDA Graph attribution
+
+Recent Nsight Systems exports may include `CUDA_GRAPH_EVENTS`,
+`CUDA_GRAPH_NODE_EVENTS`, and graph identifiers on kernel rows. When
+`graphNodeId` or `graphId` is present, nsys-ai exposes the normalized
+`graph_node_id` and `graph_id` fields through kernel and NVTX attribution
+results. The launch skills retain per-kernel/node counts but charge one shared
+CUDA launch API interval once, so a single graph replay is not mistaken for a
+separate host launch for every node.
+
+These tables and columns are optional. Older captures, or captures without
+CUDA Graph tracing, keep the normal kernel analysis path and report graph
+attribution as unavailable rather than inferring it. A graph-node metadata
+table without kernel timing rows is not sufficient to manufacture kernel
+attribution; use a capture that includes `CUPTI_ACTIVITY_KIND_KERNEL` for
+kernel-level diagnosis.
 
 ## Skipped CUDA Functions
 

--- a/src/nsys_ai/cuda_graph.py
+++ b/src/nsys_ai/cuda_graph.py
@@ -1,0 +1,77 @@
+"""Optional CUDA Graph schema support.
+
+Nsight Systems adds CUDA Graph columns and tables independently of the core
+kernel activity schema.  Keep the probes in one small module so SQLite,
+DuckDB, and the Parquet cache agree on what "graph-aware" means without
+turning graph tracing into a hard requirement for older reports.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+
+GRAPH_TABLE_NAMES = (
+    "CUDA_GRAPH_EVENTS",
+    "CUDA_GRAPH_NODE_EVENTS",
+    "CUPTI_ACTIVITY_KIND_GRAPH_TRACE",
+)
+
+# Canonical output names used by nsys-ai.  The values are the names NVIDIA
+# uses in the kernel activity export.  Keeping the mapping explicit also lets
+# us tolerate harmless case changes in future exports.
+GRAPH_KERNEL_COLUMNS = {
+    "graph_node_id": "graphNodeId",
+    "graph_id": "graphId",
+}
+
+
+def actual_table(tables: Iterable[str], name: str) -> str | None:
+    """Return the case-preserving table name matching *name*, if present."""
+    wanted = name.lower()
+    return next((table for table in tables if str(table).lower() == wanted), None)
+
+
+def actual_columns(columns: Iterable[str]) -> dict[str, str]:
+    """Return lower-case column names mapped to their actual spelling."""
+    return {str(column).lower(): str(column) for column in columns}
+
+
+def graph_tables(tables: Iterable[str]) -> dict[str, str]:
+    """Resolve the optional graph tables present in an export."""
+    return {
+        name: table
+        for name in GRAPH_TABLE_NAMES
+        if (table := actual_table(tables, name)) is not None
+    }
+
+
+def kernel_graph_columns(columns: Iterable[str]) -> dict[str, str]:
+    """Resolve graph columns on a kernel table to canonical output names."""
+    by_lower = actual_columns(columns)
+    resolved: dict[str, str] = {}
+    for canonical, source in GRAPH_KERNEL_COLUMNS.items():
+        # Accept both NVIDIA's camelCase export and the normalized names used
+        # by the Parquet cache/raw parquetdir adapter.
+        for candidate in (source, canonical):
+            if candidate.lower() in by_lower:
+                resolved[canonical] = by_lower[candidate.lower()]
+                break
+    return resolved
+
+
+def graph_capability(
+    tables: Iterable[str], kernel_columns: Mapping[str, str]
+) -> dict[str, object]:
+    """Describe optional graph support without claiming more than the data.
+
+    ``kernel_attribution`` is true only when kernel rows carry a graph ID.  A
+    graph metadata table alone is useful for diagnostics, but it cannot be
+    joined to kernel timing without inventing an attribution.
+    """
+    resolved_tables = graph_tables(tables)
+    return {
+        "kernel_attribution": bool(kernel_columns),
+        "kernel_columns": dict(kernel_columns),
+        "tables": resolved_tables,
+        "available": bool(kernel_columns or resolved_tables),
+    }

--- a/src/nsys_ai/doctor.py
+++ b/src/nsys_ai/doctor.py
@@ -613,6 +613,39 @@ def _check_profile_health(prof: Any, *, deep: bool = False) -> DoctorSection:
         else:
             checks.append(CheckResult("Schema compatibility", "ok", f"export schema {sv}"))
 
+        graph = getattr(schema, "cuda_graph", {})
+        graph_tables = graph.get("tables", {})
+        graph_columns = graph.get("kernel_columns", {})
+        if graph.get("kernel_attribution"):
+            checks.append(
+                CheckResult(
+                    "CUDA Graph attribution",
+                    "ok",
+                    "kernel rows expose " + ", ".join(sorted(graph_columns)),
+                )
+            )
+        elif graph_tables:
+            checks.append(
+                CheckResult(
+                    "CUDA Graph attribution",
+                    "warn",
+                    "graph metadata present, kernel graph IDs absent",
+                    hint=(
+                        "Graph metadata can be inspected, but kernel-level graph "
+                        "attribution is unavailable in this export; nsys-ai will "
+                        "not infer it."
+                    ),
+                )
+            )
+        else:
+            checks.append(
+                CheckResult(
+                    "CUDA Graph attribution",
+                    "skipped",
+                    "not present (capture may predate CUDA Graph export or graph tracing was disabled)",
+                )
+            )
+
     checks.append(CheckResult("Duration", "ok", f"{span_ns / 1e9:.1f}s"))
     # GPUs — COUNT(DISTINCT deviceId), not the fingerprint heuristic.
     checks.append(CheckResult("GPUs", "ok", str(len(devices))))

--- a/src/nsys_ai/nvtx_attribution.py
+++ b/src/nsys_ai/nvtx_attribution.py
@@ -40,7 +40,7 @@ def _sort_merge_attribute(
     Overall complexity is O(N+M) per thread (each NVTX is pushed and
     popped at most once; each runtime call is processed once).
     """
-    from .connection import wrap_connection
+    from .connection import DB_ERRORS, wrap_connection
 
     adapter = wrap_connection(conn)
     resolved_tables = adapter.resolve_activity_tables()
@@ -48,6 +48,17 @@ def _sort_merge_attribute(
     kernel_table = resolved_tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
     runtime_table = resolved_tables.get("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME")
     nvtx_table = resolved_tables.get("nvtx", "NVTX_EVENTS")
+    try:
+        kernel_columns = {
+            str(column).lower(): str(column)
+            for column in adapter.get_table_columns(kernel_table)
+        }
+    except DB_ERRORS:
+        kernel_columns = {}
+    graph_node_column = kernel_columns.get("graphnodeid") or kernel_columns.get("graph_node_id")
+    graph_id_column = kernel_columns.get("graphid") or kernel_columns.get("graph_id")
+    graph_node_expr = f'k."{graph_node_column}"' if graph_node_column else "NULL"
+    graph_id_expr = f'k."{graph_id_column}"' if graph_id_column else "NULL"
 
     # Trim clause for SQL queries
     trim_sql = ""
@@ -59,7 +70,9 @@ def _sort_merge_attribute(
     kr_rows = adapter.execute(
         f"""
         SELECT r.globalTid, r.start, r.[end],
-               k.start AS ks, k.[end] AS ke, k.shortName
+               k.start AS ks, k.[end] AS ke, k.shortName,
+               {graph_node_expr} AS graph_node_id,
+               {graph_id_expr} AS graph_id
         FROM {kernel_table} k
         JOIN {runtime_table} r ON r.correlationId = k.correlationId
         WHERE 1=1 {trim_sql}
@@ -137,7 +150,7 @@ def _sort_merge_attribute(
 
     kr_by_tid: dict[int, list[tuple]] = defaultdict(list)
     for r in kr_rows:
-        kr_by_tid[r[0]].append((r[1], r[2], r[3], r[4], r[5]))
+        kr_by_tid[r[0]].append((r[1], r[2], r[3], r[4], r[5], r[6], r[7]))
         # r_start, r_end, k_start, k_end, shortName
 
     results = []
@@ -155,7 +168,7 @@ def _sort_merge_attribute(
         nvtx_idx = 0
         open_stack: list[tuple[int, int, str]] = []  # (start, end, text)
 
-        for r_start, r_end, k_start, k_end, short_name in kr_by_tid[tid]:
+        for r_start, r_end, k_start, k_end, short_name, graph_node_id, graph_id in kr_by_tid[tid]:
             # 1. Pop NVTX ranges that have already closed before this runtime starts
             # Because NVTX ranges are assumed strictly nested per thread, O(1) amortized
             while open_stack and open_stack[-1][1] < r_start:
@@ -197,6 +210,8 @@ def _sort_merge_attribute(
                         "k_start": k_start,
                         "k_end": k_end,
                         "k_dur_ns": k_end - k_start,
+                        "graph_node_id": graph_node_id,
+                        "graph_id": graph_id,
                     }
                 )
 
@@ -271,8 +286,7 @@ def attribute_kernels_to_nvtx(
                         extra_params.append(f"%{kernel_name_substring}%")
                     cur = adapter.execute(
                         f"""
-                        SELECT m.nvtx_text, m.nvtx_depth, d.nvtx_path, m.kernel_name,
-                               m.k_start, m.k_end, m.k_dur_ns
+                        SELECT m.*, d.nvtx_path
                         FROM nvtx_kernel_map m
                         JOIN nvtx_path_dict d ON m.path_id = d.path_id
                         {where_m}
@@ -302,6 +316,17 @@ def attribute_kernels_to_nvtx(
             kernel_table = tables.get("kernel", "CUPTI_ACTIVITY_KIND_KERNEL")
             runtime_table = tables.get("runtime", "CUPTI_ACTIVITY_KIND_RUNTIME")
             nvtx_table = tables.get("nvtx", "NVTX_EVENTS")
+            try:
+                kernel_columns = {
+                    str(column).lower(): str(column)
+                    for column in adapter.get_table_columns(kernel_table)
+                }
+            except DB_ERRORS:
+                kernel_columns = {}
+            graph_node_column = kernel_columns.get("graphnodeid") or kernel_columns.get("graph_node_id")
+            graph_id_column = kernel_columns.get("graphid") or kernel_columns.get("graph_id")
+            graph_node_expr = f'k."{graph_node_column}"' if graph_node_column else "NULL"
+            graph_id_expr = f'k."{graph_id_column}"' if graph_id_column else "NULL"
             has_textid = adapter.detect_nvtx_text_id()
             if has_textid:
                 text_expr = "COALESCE(n.text, ns.value)"
@@ -329,7 +354,9 @@ def attribute_kernels_to_nvtx(
                     SELECT r.globalTid, r.start AS r_start, r."end" AS r_end,
                            k.start AS k_start, k."end" AS k_end,
                            COALESCE(kd.value, ks.value, 'kernel_' || CAST(k.shortName AS VARCHAR)) AS kernel_name,
-                           r.correlationId
+                           r.correlationId,
+                           {graph_node_expr} AS graph_node_id,
+                           {graph_id_expr} AS graph_id
                     FROM {kernel_table} k
                     JOIN {runtime_table} r ON r.correlationId = k.correlationId
                     LEFT JOIN StringIds ks ON k.shortName = ks.id
@@ -339,6 +366,7 @@ def attribute_kernels_to_nvtx(
                 enclosing AS (
                     SELECT kr.k_start, kr.k_end, kr.kernel_name,
                            kr.r_start, kr.r_end, kr.globalTid, kr.correlationId,
+                           kr.graph_node_id, kr.graph_id,
                            {text_expr} AS nvtx_text,
                            (n."end" - n.start) AS n_dur, n.start AS n_start
                     FROM kr
@@ -360,11 +388,15 @@ def attribute_kernels_to_nvtx(
                         kernel_name,
                         k_start,
                         k_end,
-                        (k_end - k_start) AS k_dur_ns
+                        (k_end - k_start) AS k_dur_ns,
+                        graph_node_id,
+                        graph_id
                     FROM enclosing
-                    GROUP BY k_start, k_end, globalTid, kernel_name, correlationId
+                    GROUP BY k_start, k_end, globalTid, kernel_name, correlationId,
+                             graph_node_id, graph_id
                 )
-                SELECT nvtx_text, nvtx_depth, nvtx_path, kernel_name, k_start, k_end, k_dur_ns
+                SELECT nvtx_text, nvtx_depth, nvtx_path, kernel_name, k_start, k_end, k_dur_ns,
+                       graph_node_id, graph_id
                 FROM grouped
                 {trim_clause}
                 ORDER BY k_start

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -2305,12 +2305,23 @@ def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
                     "k_start": k_start,
                     "k_end": k_end,
                     "k_dur_ns": dur,
-                    "graph_node_id": graph_node_id,
-                    "graph_id": graph_id,
                     "is_tc_eligible": is_tc_eligible,
                     "uses_tc": uses_tc,
                 }
             )
+            # Sparse on purpose, and it is load-bearing. Every one of these
+            # dicts is held for the length of the build, so the key count is
+            # multiplied by the row count -- and CPython sizes a dict by that
+            # count, where 11 keys crosses the boundary 9 sits under: 272 bytes
+            # becomes 464. That 192-byte tax bought two fields that are null on
+            # every kernel not launched from a graph, which on a capture using
+            # no graphs is all of them, and it took the skills window from
+            # 6.63 MB to 7.54 MB past the 7.4 MB ceiling in CI. Absent means
+            # "not a graph node"; ``_nvtx_map_arrow_tables`` reads both with
+            # ``.get()`` and writes a null column.
+            if graph_node_id is not None or graph_id is not None:
+                results[-1]["graph_node_id"] = graph_node_id
+                results[-1]["graph_id"] = graph_id
     return results
 
 

--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -143,10 +143,11 @@ def _build_lock(cache_dir: Path) -> Iterator[None]:
         os.close(fd)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
-_CACHE_VERSION = 17  # bumped: the Tensor Core name patterns now recognise cuBLAS's Hopper
-# ``nvjet`` GEMMs. is_tc_eligible/uses_tc are computed at build time and stored in
-# kernels.parquet, so a version 16 cache keeps answering that every nvjet kernel is neither
-# eligible nor active -- the exact blind spot this fixes -- until it is rebuilt.
+_CACHE_VERSION = 18  # bumped: CUDA Graph attribution normalizes graph_node_id/graph_id into
+# kernels and nvtx_kernel_map, so a cache without those columns cannot answer a graph question.
+# 18 rather than 17 because two invalidations landed independently and both have to apply: 17 was
+# the Tensor Core name patterns learning cuBLAS's Hopper ``nvjet`` GEMMs, and a version 17 cache
+# carries that fix but none of the graph columns.
 
 _SAFE_PARQUETDIR_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
@@ -170,6 +171,9 @@ _BASE_TABLES = [
     ("nvtx_payload_schema_entries", "NVTX_PAYLOAD_SCHEMA_ENTRIES"),
     ("nvtx_payload_enums", "NVTX_PAYLOAD_ENUMS"),
     ("nvtx_payload_enum_entries", "NVTX_PAYLOAD_ENUM_ENTRIES"),
+    ("cuda_graph_events", "CUDA_GRAPH_EVENTS"),
+    ("cuda_graph_node_events", "CUDA_GRAPH_NODE_EVENTS"),
+    ("graph_trace", "CUPTI_ACTIVITY_KIND_GRAPH_TRACE"),
 ]
 
 
@@ -461,6 +465,9 @@ _ALIASES: dict[str, list[str]] = {
     "nvtx_payload_schema_entries": ["NVTX_PAYLOAD_SCHEMA_ENTRIES"],
     "nvtx_payload_enums": ["NVTX_PAYLOAD_ENUMS"],
     "nvtx_payload_enum_entries": ["NVTX_PAYLOAD_ENUM_ENTRIES"],
+    "cuda_graph_events": ["CUDA_GRAPH_EVENTS"],
+    "cuda_graph_node_events": ["CUDA_GRAPH_NODE_EVENTS"],
+    "graph_trace": ["CUPTI_ACTIVITY_KIND_GRAPH_TRACE"],
 }
 
 _PARQUETDIR_BINARY_COLUMNS: dict[str, tuple[str, ...]] = {
@@ -832,9 +839,14 @@ def _build_cache_into(
                 )
         else:
             _progress("kernels.parquet")
+            graph_projection = _optional_graph_projection(
+                db, f"src.{kernel_table}", alias="k"
+            )
+            graph_projection_sql = f",\n                           {graph_projection}" if graph_projection else ""
             db.execute(f"""
                 COPY (
-                    SELECT k.*, COALESCE(d.value, s.value, 'kernel_' || CAST(k.shortName AS VARCHAR)) AS name, d.value AS demangled,
+                    SELECT k.*{graph_projection_sql},
+                           COALESCE(d.value, s.value, 'kernel_' || CAST(k.shortName AS VARCHAR)) AS name, d.value AS demangled,
                            CAST(CASE
                    WHEN regexp_matches(lower(COALESCE(d.value, s.value, '')), {_TC_ELIGIBLE_PATTERN})
                      OR regexp_matches(lower(COALESCE(d.value, s.value, '')), {_TC_ACTIVE_PATTERN})
@@ -1290,9 +1302,40 @@ def _table_has_column(db: duckdb.DuckDBPyConnection, table: str, column: str) ->
     """Check whether a table/view has a specific column."""
     try:
         cols = db.execute(f"DESCRIBE {table}").fetchall()
-        return any(c[0] == column for c in cols)
+        return any(str(c[0]).lower() == column.lower() for c in cols)
     except duckdb.Error:
         return False
+
+
+def _optional_graph_projection(
+    db: duckdb.DuckDBPyConnection,
+    table_ref: str,
+    *,
+    alias: str = "k",
+) -> str:
+    """Return stable nullable graph columns for an activity-table SELECT.
+
+    Nsight uses camelCase names (``graphNodeId``/``graphId``), while the
+    analysis/cache contract uses snake_case.  The aliases are added only when
+    the source does not already expose the normalized name, avoiding duplicate
+    DuckDB columns on a future export that adopts the contract itself.
+    """
+    try:
+        columns = {
+            str(row[0]).lower(): str(row[0])
+            for row in db.execute(f"DESCRIBE {table_ref}").fetchall()
+        }
+    except duckdb.Error:
+        columns = {}
+
+    expressions: list[str] = []
+    for normalized, source in (("graph_node_id", "graphNodeId"), ("graph_id", "graphId")):
+        if normalized in columns:
+            continue
+        actual = columns.get(source.lower())
+        expression = f'{alias}."{actual}"' if actual else "CAST(NULL AS BIGINT)"
+        expressions.append(f"{expression} AS {normalized}")
+    return ",\n                   ".join(expressions)
 
 
 def _create_existing_alias_views(db: duckdb.DuckDBPyConnection) -> None:
@@ -1344,10 +1387,14 @@ def _create_enriched_kernel_view(
         return
 
     try:
+        graph_projection = _optional_graph_projection(
+            db, f'"{kernel_table}"', alias="k"
+        )
+        graph_projection_sql = f",\n                   {graph_projection}" if graph_projection else ""
         db.execute(
             f'''
             CREATE VIEW "kernels" AS
-            SELECT k.*,
+            SELECT k.*{graph_projection_sql},
                    COALESCE(d.value, s.value, 'kernel_' || CAST(k.shortName AS VARCHAR)) AS name,
                    d.value AS demangled,
                    CAST(CASE
@@ -1835,9 +1882,19 @@ def _build_nvtx_kernel_map_from_parquet(
     nvtx_cur = db.cursor()
     kernel_cur = db.cursor()
 
+    # Cache exports normalize these fields even when the source profile is a
+    # pre-graph report.  Probe once here rather than once per thread so the
+    # streamed builder keeps its per-thread cost unchanged.
+    cached_kernel_columns = {
+        str(row[0]).lower()
+        for row in db.execute(f"DESCRIBE SELECT * FROM read_parquet('{kps}')").fetchall()
+    }
+    graph_node_expr = 'k."graph_node_id"' if "graph_node_id" in cached_kernel_columns else "NULL"
+    graph_id_expr = 'k."graph_id"' if "graph_id" in cached_kernel_columns else "NULL"
+
     # Staged first, published second. The sweep cannot know the path dictionary
     # until it has seen every row, and the map's ``path_id`` column is defined
-    # against that dictionary — so the nine columns land in a scratch Parquet
+    # against that dictionary — so the eleven columns land in a scratch Parquet
     # carrying the path text itself, and the two published files are derived
     # from it in SQL. It also means a build that dies part-way leaves no
     # readable nvtx_kernel_map.parquet behind.
@@ -1850,7 +1907,11 @@ def _build_nvtx_kernel_map_from_parquet(
             buf: list[tuple] = []
             for tid in tids:
                 nvtx_rows = _stream_thread_nvtx(nvtx_cur, nps, tid)
-                kr_rows = _stream_thread_kernels(kernel_cur, kps, rps, tid)
+                kr_rows = _stream_thread_kernels(
+                    kernel_cur, kps, rps, tid,
+                    graph_node_expr=graph_node_expr,
+                    graph_id_expr=graph_id_expr,
+                )
                 try:
                     for row in _attribute_thread(kr_rows, nvtx_rows):
                         buf.append(row)
@@ -1906,6 +1967,8 @@ def _staged_map_schema() -> pa.Schema:
             ("k_start", pa.int64()),
             ("k_end", pa.int64()),
             ("k_dur_ns", pa.int64()),
+            ("graph_node_id", pa.int64()),
+            ("graph_id", pa.int64()),
             ("is_tc_eligible", pa.int32()),
             ("uses_tc", pa.int32()),
         ]
@@ -1955,7 +2018,8 @@ def _publish_nvtx_kernel_map_parquet(db, staged: Path, out_dir: Path) -> None:
     db.execute(f"""
         COPY (
             SELECT d.path_id, m.nvtx_text, m.nvtx_depth, m.kernel_name,
-                   m.k_start, m.k_end, m.k_dur_ns, m.is_tc_eligible, m.uses_tc
+                   m.k_start, m.k_end, m.k_dur_ns,
+                   m.graph_node_id, m.graph_id, m.is_tc_eligible, m.uses_tc
             FROM read_parquet('{sps}') m
             JOIN read_parquet('{dps}') d ON d.nvtx_path = m.nvtx_path
             ORDER BY m.k_start, m.k_end, m.kernel_name
@@ -2009,8 +2073,17 @@ def _stream_thread_nvtx(cur, nvtx_parquet: str, tid):
             yield starts[i], ends[i], text
 
 
-def _stream_thread_kernels(cur, kernels_parquet: str, runtime_parquet: str, tid):
-    """Yield one thread's ``(r_start, r_end, k_start, k_end, name, elig, used)``.
+def _stream_thread_kernels(
+    cur,
+    kernels_parquet: str,
+    runtime_parquet: str,
+    tid,
+    *,
+    graph_node_expr: str = "NULL",
+    graph_id_expr: str = "NULL",
+):
+    """Yield one thread's ``(r_start, r_end, k_start, k_end, name, graph_node,
+    graph_id, elig, used)``.
 
     Sorted by ``r_start``, which #318 and #327 removed from this query and this
     restores — per thread, and on ``r.start`` only. Those removals were right for
@@ -2035,6 +2108,8 @@ def _stream_thread_kernels(cur, kernels_parquet: str, runtime_parquet: str, tid)
         cur,
         f"""
         SELECT r.start, r."end", k.start, k."end", k.name,
+               {graph_node_expr} AS graph_node_id,
+               {graph_id_expr} AS graph_id,
                COALESCE(CAST(k.is_tc_eligible AS INTEGER), 0) AS is_tc_eligible,
                COALESCE(CAST(k.uses_tc AS INTEGER), 0) AS uses_tc
         FROM read_parquet('{kernels_parquet}') k
@@ -2044,13 +2119,16 @@ def _stream_thread_kernels(cur, kernels_parquet: str, runtime_parquet: str, tid)
         """,
         [tid],
     ):
-        cols = [batch.column(i).to_pylist() for i in range(7)]
-        r_starts, r_ends, k_starts, k_ends, names, elig, used = cols
+        cols = [batch.column(i).to_pylist() for i in range(9)]
+        r_starts, r_ends, k_starts, k_ends, names, graph_nodes, graph_ids, elig, used = cols
         for i, name in enumerate(names):
             shared = pool.get(name)
             if shared is None:
                 shared = pool[name] = name
-            yield r_starts[i], r_ends[i], k_starts[i], k_ends[i], shared, elig[i], used[i]
+            yield (
+                r_starts[i], r_ends[i], k_starts[i], k_ends[i], shared,
+                graph_nodes[i], graph_ids[i], elig[i], used[i],
+            )
 
 
 def _nvtx_map_arrow_tables(results: list[dict]) -> tuple[pa.Table, pa.Table]:
@@ -2064,7 +2142,7 @@ def _nvtx_map_arrow_tables(results: list[dict]) -> tuple[pa.Table, pa.Table]:
     column in ``TestStreamedSweep.test_both_map_writers_emit_the_same_columns``
     (tests/test_parquet_cache.py); nothing else catches a divergence, because
     the row-for-row oracle in that class compares the *cached* map against
-    ``_sweep_nvtx_kernel_map``'s rows and never calls this function. All nine
+    ``_sweep_nvtx_kernel_map``'s rows and never calls this function. All eleven
     columns are
     emitted, including ``is_tc_eligible``/``uses_tc``: consumers probe for those
     two by presence (``connection.cached_nvtx_map_has_embedded_tc``), so a map
@@ -2085,6 +2163,8 @@ def _nvtx_map_arrow_tables(results: list[dict]) -> tuple[pa.Table, pa.Table]:
             "k_start": pa.array([r["k_start"] for r in results], pa.int64()),
             "k_end": pa.array([r["k_end"] for r in results], pa.int64()),
             "k_dur_ns": pa.array([r["k_dur_ns"] for r in results], pa.int64()),
+            "graph_node_id": pa.array([r.get("graph_node_id") for r in results], pa.int64()),
+            "graph_id": pa.array([r.get("graph_id") for r in results], pa.int64()),
             "is_tc_eligible": pa.array([r.get("is_tc_eligible", 0) for r in results], pa.int32()),
             "uses_tc": pa.array([r.get("uses_tc", 0) for r in results], pa.int32()),
         }
@@ -2197,7 +2277,7 @@ def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
 
     kr_by_tid: dict[int, list[tuple]] = defaultdict(list)
     for r in kr_rows:
-        kr_by_tid[r[0]].append((r[1], r[2], r[3], r[4], r[5]))
+        kr_by_tid[r[0]].append((r[1], r[2], r[3], r[4], r[5], *r[6:]))
 
     results: list[dict] = []
     for tid, kr_list in kr_by_tid.items():
@@ -2205,7 +2285,17 @@ def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
         if not nvtx_list:
             continue
         kr_list.sort(key=lambda x: x[0])
-        for text, depth, path, name, k_start, k_end, dur in _attribute_thread(kr_list, nvtx_list):
+        for attributed in _attribute_thread(kr_list, nvtx_list):
+            text, depth, path, name, k_start, k_end, dur, *extra = attributed
+            # Direct callers historically supplied only the six identifying
+            # fields. Accept that shape, the old ``(elig, used)`` extension,
+            # and the graph-aware ``(node, graph, elig, used)`` shape.
+            graph_node_id = graph_id = None
+            is_tc_eligible = uses_tc = 0
+            if len(extra) >= 4:
+                graph_node_id, graph_id, is_tc_eligible, uses_tc = extra[:4]
+            elif len(extra) >= 2:
+                is_tc_eligible, uses_tc = extra[:2]
             results.append(
                 {
                     "nvtx_text": text,
@@ -2215,6 +2305,10 @@ def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
                     "k_start": k_start,
                     "k_end": k_end,
                     "k_dur_ns": dur,
+                    "graph_node_id": graph_node_id,
+                    "graph_id": graph_id,
+                    "is_tc_eligible": is_tc_eligible,
+                    "uses_tc": uses_tc,
                 }
             )
     return results
@@ -2222,11 +2316,11 @@ def _sweep_nvtx_kernel_map(kr_rows, nvtx_rows) -> list[dict]:
 
 def _materialize_nvtx_kernel_map(db, results: list[dict]) -> None:
     """Create the ``nvtx_kernel_map`` + ``nvtx_path_dict`` tables on a
-    DuckDB connection from sweep ``results``. Emits the full 9-column
+    DuckDB connection from sweep ``results``. Emits the full 11-column
     cache-built schema, including the embedded ``is_tc_eligible``/``uses_tc``,
     so consumers take their map-only fast path (a TC-less map would force
     nvtx_layer_breakdown into a (start,end) kernels-join that double-counts
-    timestamp-colliding kernels). The nine columns are listed in
+    timestamp-colliding kernels). The eleven columns are listed in
     ``_nvtx_map_arrow_tables`` above, and again in the cached builder's
     ``_publish_nvtx_kernel_map_parquet``; the two lists are separate and
     ``TestStreamedSweep.test_both_map_writers_emit_the_same_columns`` is what
@@ -2633,9 +2727,21 @@ def _ensure_nvtx_kernel_map_in_memory(adapter, db) -> bool:
     tc_elig = _TC_ELIGIBLE_PATTERN
     lname = "lower(COALESCE(sd.value, ss.value, ''))"
     try:
+        kernel_columns = {
+            str(column).lower(): str(column)
+            for column in adapter.get_table_columns(kernel_table)
+        }
+    except DB_ERRORS:
+        kernel_columns = {}
+    graph_node_column = kernel_columns.get("graphnodeid") or kernel_columns.get("graph_node_id")
+    graph_id_column = kernel_columns.get("graphid") or kernel_columns.get("graph_id")
+    graph_node_expr = f'k."{graph_node_column}"' if graph_node_column else "NULL"
+    graph_id_expr = f'k."{graph_id_column}"' if graph_id_column else "NULL"
+    try:
         kr_rows = db.execute(
             f'SELECT r.globalTid, r.start, r."end", k.start, k."end", '
             f"COALESCE(sd.value, ss.value, 'kernel_' || CAST(k.shortName AS VARCHAR)) AS kernel_name, "
+            f"{graph_node_expr} AS graph_node_id, {graph_id_expr} AS graph_id, "
             f"CAST(CASE WHEN regexp_matches({lname}, {tc_elig}) "
             f"OR regexp_matches({lname}, {tc_active}) THEN 1 ELSE 0 END AS INTEGER) AS is_tc_eligible, "
             f"CAST(CASE WHEN regexp_matches({lname}, {tc_active}) THEN 1 ELSE 0 END AS INTEGER) AS uses_tc "
@@ -2659,14 +2765,9 @@ def _ensure_nvtx_kernel_map_in_memory(adapter, db) -> bool:
         log.debug("ensure_nvtx_kernel_map: source fetch failed (%s)", exc)
         return False
 
-    # Per-kernel TC flags (by k_start, k_end, name) to attach after the
-    # name-agnostic sweep, which only reads the first six fields.
-    tc_by_kernel = {(r[3], r[4], r[5]): (r[6], r[7]) for r in kr_rows}
+    # The name-agnostic sweep carries graph IDs and TC flags through its
+    # optional tail, so no second lookup is needed after attribution.
     results = _sweep_nvtx_kernel_map(kr_rows, nvtx_rows)
-    for r in results:
-        r["is_tc_eligible"], r["uses_tc"] = tc_by_kernel.get(
-            (r["k_start"], r["k_end"], r["kernel_name"]), (0, 0)
-        )
     # Materialize even when empty: the existence check then passes and consumers
     # take the (empty) map path rather than re-entering the hanging IEJoin.
     with _CATALOG_DDL_LOCK:

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -25,6 +25,7 @@ if typing.TYPE_CHECKING:
 
 from nsys_ai import parquet_cache
 from nsys_ai.connection import DB_ERRORS
+from nsys_ai.cuda_graph import graph_capability, kernel_graph_columns
 from nsys_ai.exceptions import (
     ExportError,
     ExportTimeoutError,
@@ -130,6 +131,20 @@ class NsightSchema:
         self.schema_version: str | None = self._meta.get("EXPORT_SCHEMA_VERSION") or None
         kt = self._detect_kernel_table()
         self.kernel_table: str | None = _validate_table_name(kt) if kt else None
+        self.graph_events_table = self._resolve_table("CUDA_GRAPH_EVENTS")
+        self.graph_node_events_table = self._resolve_table("CUDA_GRAPH_NODE_EVENTS")
+        self.graph_trace_table = self._resolve_table("CUPTI_ACTIVITY_KIND_GRAPH_TRACE")
+        self.kernel_graph_columns: dict[str, str] = {}
+        if self.kernel_table:
+            try:
+                self.kernel_graph_columns = kernel_graph_columns(
+                    self._adapter.get_table_columns(self.kernel_table)
+                )
+            except DB_ERRORS:
+                # The required-column contract reports unreadable schemas. An
+                # optional graph probe must never make an otherwise readable
+                # pre-graph profile fail to open.
+                self.kernel_graph_columns = {}
 
     # ── Version detection ──────────────────────────────────────────────
 
@@ -280,6 +295,16 @@ class NsightSchema:
             if t.lower() == lname:
                 return t
         return None
+
+    @property
+    def cuda_graph(self) -> dict[str, object]:
+        """Optional CUDA Graph capability visible in this export.
+
+        This is deliberately informational. Missing graph tables/columns do
+        not enter :meth:`missing_required_columns`; pre-2026 captures remain
+        fully analyzable through the non-graph path.
+        """
+        return graph_capability(self.tables, self.kernel_graph_columns)
 
     def _missing_columns(self, table: str, required) -> list[str]:
         try:
@@ -638,13 +663,28 @@ class Profile:
 
     def kernels(self, device: int | None, trim: tuple[int, int] | None = None) -> list[dict]:
         """All kernels on a device (or all devices if None), optionally trimmed to a time window."""
+        graph_select = ",\n                   " + ",\n                   ".join(
+            f'k.{_validate_table_name(column)} AS {name}'
+            for name, column in self.schema.kernel_graph_columns.items()
+        )
+        # Stable nullable fields make the absence of graph attribution
+        # explicit to callers while preserving the old profile behaviour.
+        if not self.schema.kernel_graph_columns:
+            graph_select = ",\n                   NULL AS graph_node_id, NULL AS graph_id"
+        else:
+            present = set(self.schema.kernel_graph_columns)
+            missing = [name for name in ("graph_node_id", "graph_id") if name not in present]
+            if missing:
+                graph_select += ",\n                   " + ", ".join(
+                    f"NULL AS {name}" for name in missing
+                )
         sql = """
             SELECT k.start, k.[end], k.deviceId, k.streamId, k.correlationId,
-                   s.value as name, d.value as demangled
+                   s.value as name, d.value as demangled{graph_select}
             FROM {kernel_table} k
             JOIN StringIds s ON k.shortName = s.id
             JOIN StringIds d ON k.demangledName = d.id"""
-        sql = sql.format(kernel_table=self.schema.kernel_table)
+        sql = sql.format(kernel_table=self.schema.kernel_table, graph_select=graph_select)
         params: list = []
         if device is not None:
             sql += "\n            WHERE k.deviceId = ?"
@@ -861,6 +901,17 @@ class Profile:
 
     def kernel_map(self, device: int) -> dict[int, dict]:
         """Build correlationId -> kernel info for ALL kernels on a device."""
+        graph_select = ", ".join(
+            f'k.{_validate_table_name(column)} AS {name}'
+            for name, column in self.schema.kernel_graph_columns.items()
+        )
+        if graph_select:
+            present = set(self.schema.kernel_graph_columns)
+            missing = [name for name in ("graph_node_id", "graph_id") if name not in present]
+            if missing:
+                graph_select += ", " + ", ".join(f"NULL AS {name}" for name in missing)
+        else:
+            graph_select = "NULL AS graph_node_id, NULL AS graph_id"
         return {
             r["correlationId"]: dict(
                 start=r["start"],
@@ -868,11 +919,13 @@ class Profile:
                 stream=r["streamId"],
                 name=r["name"],
                 demangled=r["demangled"],
+                graph_node_id=r["graph_node_id"],
+                graph_id=r["graph_id"],
             )
             for r in self._duckdb_query(
                 f"""
-                    SELECT k.start, k.[end], k.streamId, k.correlationId,
-                           s.value as name, d.value as demangled
+                SELECT k.start, k.[end], k.streamId, k.correlationId,
+                           s.value as name, d.value as demangled, {graph_select}
                     FROM {self.schema.kernel_table} k
                     JOIN StringIds s ON k.shortName = s.id
                     JOIN StringIds d ON k.demangledName = d.id

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -81,6 +81,35 @@ ACTIVITY_TABLE_PLACEHOLDERS: dict[str, tuple[str, str]] = {
     "sync_type_table": ("sync_type", "ENUM_CUPTI_SYNC_TYPE"),
 }
 
+
+def _kernel_graph_sql(adapter, kernel_table: str | None) -> dict[str, str]:
+    """Resolve optional graph columns for SQL skills.
+
+    The expressions are intentionally nullable SQL, not hard requirements:
+    pre-graph exports must continue to run the same launch/pattern skills.
+    """
+    columns: dict[str, str] = {}
+    if kernel_table:
+        try:
+            actual = {
+                str(column).lower(): str(column)
+                for column in adapter.get_table_columns(kernel_table)
+            }
+        except DB_ERRORS:
+            actual = {}
+        for placeholder, candidates in (
+            ("graph_node_expr", ("graphNodeId", "graph_node_id")),
+            ("graph_id_expr", ("graphId", "graph_id")),
+        ):
+            column = next(
+                (actual[candidate.lower()] for candidate in candidates if candidate.lower() in actual),
+                None,
+            )
+            columns[placeholder] = f'k."{column}"' if column else "NULL"
+    else:
+        columns = {"graph_node_expr": "NULL", "graph_id_expr": "NULL"}
+    return columns
+
 _DEVICE_INVENTORY_CACHE_KEY = "skill:device_inventory"
 
 
@@ -777,6 +806,8 @@ class Skill:
         # CUPTI_ACTIVITY_KIND_KERNEL which may be _KERNEL_V2/_V3 in
         # newer Nsight Systems versions.
         tables = adapter.resolve_activity_tables()
+        if "{graph_node_expr}" in self.sql or "{graph_id_expr}" in self.sql:
+            resolved.update(_kernel_graph_sql(adapter, tables.get("kernel")))
         unresolved: list[str] = []
         for placeholder, (key, canonical) in ACTIVITY_TABLE_PLACEHOLDERS.items():
             if placeholder in resolved:

--- a/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
+++ b/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
@@ -97,6 +97,18 @@ def _execute(conn, **kwargs):
     if unavailable is not None:
         return unavailable
 
+    try:
+        kernel_columns = {
+            str(column).lower(): str(column)
+            for column in adapter.get_table_columns(kernel_table)
+        }
+    except Exception:  # noqa: BLE001 - required-table validation already ran
+        kernel_columns = {}
+    graph_node_column = kernel_columns.get("graphnodeid") or kernel_columns.get("graph_node_id")
+    graph_id_column = kernel_columns.get("graphid") or kernel_columns.get("graph_id")
+    graph_node_expr = f'k."{graph_node_column}"' if graph_node_column else "NULL"
+    graph_id_expr = f'k."{graph_id_column}"' if graph_id_column else "NULL"
+
     trim_clause = ""
     params: list[int] = [device]
     if trim_start is not None and trim_end is not None:
@@ -131,6 +143,8 @@ def _execute(conn, **kwargs):
                 k.start AS kernel_start_ns,
                 k."end" AS kernel_end_ns,
                 k.shortName AS short_name,
+                {graph_node_expr} AS graph_node_id,
+                {graph_id_expr} AS graph_id,
                 r.global_tid,
                 r.api_start_ns,
                 r.api_end_ns,
@@ -163,7 +177,15 @@ def _execute(conn, **kwargs):
                 process_id, device_id, stream_id, correlation_id,
                 kernel_start_ns, kernel_end_ns, short_name, global_tid,
                 api_start_ns, api_end_ns, api_duration_ns,
-                queue_duration_ns, kernel_duration_ns
+                queue_duration_ns, kernel_duration_ns, graph_node_id, graph_id,
+                CASE
+                    WHEN ROW_NUMBER() OVER (
+                        PARTITION BY global_tid, correlation_id, api_start_ns, api_end_ns
+                        ORDER BY kernel_start_ns, kernel_end_ns, short_name
+                    ) = 1
+                    THEN api_duration_ns
+                    ELSE 0
+                END AS api_charge_ns
             FROM launch_candidates
             WHERE match_rank = 1
         )
@@ -171,14 +193,16 @@ def _execute(conn, **kwargs):
             s_kernel.value AS kernel_name,
             l.device_id,
             COUNT(*) AS launch_count,
-            ROUND(SUM(l.api_duration_ns) / 1e6, 3) AS total_api_ms,
-            ROUND(AVG(l.api_duration_ns) / 1e3, 1) AS avg_api_us,
-            ROUND(MAX(l.api_duration_ns) / 1e3, 1) AS max_api_us,
+            ROUND(SUM(l.api_charge_ns) / 1e6, 3) AS total_api_ms,
+            ROUND(AVG(NULLIF(l.api_charge_ns, 0)) / 1e3, 1) AS avg_api_us,
+            ROUND(MAX(l.api_charge_ns) / 1e3, 1) AS max_api_us,
             COUNT(l.queue_duration_ns) AS queue_count,
             ROUND(COALESCE(SUM(l.queue_duration_ns), 0) / 1e6, 3) AS total_queue_ms,
             ROUND(COALESCE(AVG(l.queue_duration_ns), 0) / 1e3, 1) AS avg_queue_us,
             ROUND(SUM(l.kernel_duration_ns) / 1e6, 3) AS total_kernel_ms,
             ROUND(AVG(l.kernel_duration_ns) / 1e3, 3) AS avg_kernel_us,
+            COUNT(DISTINCT l.graph_node_id) AS graph_node_count,
+            COUNT(DISTINCT l.graph_id) AS graph_id_count,
             MIN(l.kernel_start_ns) AS span_start_ns,
             MAX(l.kernel_end_ns) AS span_end_ns
         FROM launches l
@@ -186,7 +210,7 @@ def _execute(conn, **kwargs):
         GROUP BY s_kernel.value, l.device_id
         HAVING COUNT(*) >= ?
            AND AVG(l.kernel_duration_ns) < {_SMALL_KERNEL_AVG_US_THRESHOLD * 1000}
-        ORDER BY SUM(l.api_duration_ns) DESC,
+        ORDER BY SUM(l.api_charge_ns) DESC,
                  COUNT(*) DESC,
                  s_kernel.value ASC,
                  l.device_id ASC
@@ -254,6 +278,8 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 "queue_count": int(row["queue_count"]),
                 "avg_queue_us": float(row["avg_queue_us"]),
                 "total_queue_ms": float(row["total_queue_ms"]),
+                "graph_node_count": int(row.get("graph_node_count", 0) or 0),
+                "graph_id_count": int(row.get("graph_id_count", 0) or 0),
             },
             units={
                 "launch_count": "count",
@@ -264,6 +290,8 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 "queue_count": "count",
                 "avg_queue_us": "microseconds",
                 "total_queue_ms": "ms",
+                "graph_node_count": "count",
+                "graph_id_count": "count",
             },
             selection_id=selection.id,
             provenance={

--- a/src/nsys_ai/skills/builtins/kernel_launch_pattern.py
+++ b/src/nsys_ai/skills/builtins/kernel_launch_pattern.py
@@ -26,6 +26,8 @@ WITH launch_gaps AS (
         k.start,
         k.[end],
         (k.[end] - k.start) AS dur_ns,
+        {graph_node_expr} AS graph_node_id,
+        {graph_id_expr} AS graph_id,
         LAG(k.[end]) OVER (
             PARTITION BY k.streamId ORDER BY k.start, k.correlationId
         ) AS prev_end,
@@ -49,7 +51,9 @@ stream_stats AS (
         ROUND(AVG(CASE WHEN prev_end IS NOT NULL AND start > prev_end THEN start - prev_end ELSE NULL END) / 1e3, 1)
             AS avg_gap_us,
         SUM(CASE WHEN prev_end IS NOT NULL AND (start - prev_end) > 1000000 THEN 1 ELSE 0 END)
-            AS sync_stalls
+            AS sync_stalls,
+        COUNT(DISTINCT graph_node_id) AS graph_node_count,
+        COUNT(DISTINCT graph_id) AS graph_id_count
     FROM launch_gaps
     GROUP BY streamId
 )
@@ -63,7 +67,9 @@ SELECT
     avg_kernel_us,
     max_gap_ms,
     avg_gap_us,
-    sync_stalls
+    sync_stalls,
+    graph_node_count,
+    graph_id_count
 FROM stream_stats
 ORDER BY kernel_count DESC, streamId ASC
 LIMIT {limit}""",
@@ -81,14 +87,16 @@ def _format(rows):
     lines = [
         "── Kernel Launch Patterns ──",
         f"{'Stream':>7s} {'Kernels':>8s} {'Span(ms)':>10s} "
-        f"{'Rate/ms':>8s} {'Occ%':>6s} {'MaxGap':>10s} {'Stalls':>7s}",
-        "─" * 65,
+        f"{'Rate/ms':>8s} {'Occ%':>6s} {'MaxGap':>10s} {'Stalls':>7s} "
+        f"{'GraphNodes':>10s} {'Graphs':>7s}",
+        "─" * 86,
     ]
     for r in rows:
         lines.append(
             f"s{r['streamId']:>5d} {r['kernel_count']:>8d} "
             f"{r['span_ms']:>10.2f} {r['dispatch_rate_per_ms']:>8.1f} "
             f"{r['occupancy_pct']:>5.1f}% {r['max_gap_ms']:>8.3f}ms "
-            f"{r['sync_stalls']:>7d}"
+            f"{r['sync_stalls']:>7d} {r['graph_node_count']:>10d} "
+            f"{r['graph_id_count']:>7d}"
         )
     return "\n".join(lines)

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -166,3 +166,63 @@ def test_cache_keeps_graph_tables_and_normalized_kernel_ids(tmp_path):
     assert cache_dir.joinpath("graph_trace.parquet").is_file()
     assert ids == [(101, 42), (102, 42)]
     assert mapped == [(101, 42), (102, 42)]
+
+
+def test_sweep_carries_graph_ids_only_for_kernels_that_have_them():
+    """The graph ids are sparse in the row dict, and that is load-bearing.
+
+    ``_sweep_nvtx_kernel_map`` builds one dict per attributed kernel and holds
+    every one of them for the length of the build, so the dict's key count is
+    multiplied by the row count. CPython sizes a dict by its key count, and 11
+    keys crosses the boundary that 9 keys sits under: 272 bytes becomes 464, a
+    192-byte tax on every row for two fields that are null on every kernel that
+    was not launched from a graph -- which, on a capture that uses no graphs, is
+    all of them. That is what took the skills window from 6.63 MB to 7.54 MB in
+    CI and broke ``test_running_skills_stays_under_the_python_heap_ceiling``.
+
+    Absent therefore means "not a graph node", and the one consumer reads the
+    fields with ``.get()``. Writing them unconditionally would restore the
+    regression without failing anything else, so it is pinned here.
+    """
+    from nsys_ai.parquet_cache import _sweep_nvtx_kernel_map
+
+    nvtx_rows = [(1, 0, 1000, "step")]
+    kr_rows = [
+        # (globalTid, r_start, r_end, k_start, k_end, name, node, graph, elig, used)
+        (1, 10, 20, 30, 40, "plain_kernel", None, None, 0, 0),
+        (1, 50, 60, 70, 80, "graph_kernel", 101, 42, 0, 0),
+    ]
+
+    rows = _sweep_nvtx_kernel_map(kr_rows, nvtx_rows)
+    by_name = {r["kernel_name"]: r for r in rows}
+
+    assert "graph_node_id" not in by_name["plain_kernel"]
+    assert "graph_id" not in by_name["plain_kernel"]
+    assert by_name["plain_kernel"].get("graph_node_id") is None
+
+    assert by_name["graph_kernel"]["graph_node_id"] == 101
+    assert by_name["graph_kernel"]["graph_id"] == 42
+
+
+def test_the_arrow_writer_reads_the_sparse_graph_fields():
+    """The consumer's contract: a missing key is a null column, not a KeyError."""
+    from nsys_ai.parquet_cache import _nvtx_map_arrow_tables
+
+    results = [
+        {
+            "nvtx_text": "step",
+            "nvtx_depth": 0,
+            "nvtx_path": "step",
+            "kernel_name": "plain_kernel",
+            "k_start": 30,
+            "k_end": 40,
+            "k_dur_ns": 10,
+            "is_tc_eligible": 0,
+            "uses_tc": 0,
+        }
+    ]
+
+    map_tbl, _ = _nvtx_map_arrow_tables(results)
+
+    assert map_tbl.column("graph_node_id").to_pylist() == [None]
+    assert map_tbl.column("graph_id").to_pylist() == [None]

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -1,0 +1,168 @@
+"""CUDA Graph attribution contracts (#236)."""
+
+import sqlite3
+
+from nsys_ai.parquet_cache import build_cache, ensure_nvtx_kernel_map, open_cached_db
+from nsys_ai.profile import NsightSchema, Profile
+from nsys_ai.skills.builtins.kernel_launch_overhead import SKILL as OVERHEAD
+from nsys_ai.skills.builtins.kernel_launch_pattern import SKILL as PATTERN
+
+
+def _graph_connection(*, graph_kernel_columns=True):
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE StringIds(id INTEGER PRIMARY KEY, value TEXT);
+        INSERT INTO StringIds VALUES
+            (1, 'tiny_kernel'), (2, 'void tiny_kernel()'),
+            (10, 'cudaLaunchKernel');
+        CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL(
+            globalPid INTEGER, deviceId INTEGER, streamId INTEGER,
+            correlationId INTEGER, start INTEGER, "end" INTEGER,
+            shortName INTEGER, demangledName INTEGER
+        );
+        CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME(
+            globalTid INTEGER, correlationId INTEGER, start INTEGER,
+            "end" INTEGER, nameId INTEGER
+        );
+        CREATE TABLE NVTX_EVENTS(
+            globalTid INTEGER, start INTEGER, "end" INTEGER, text TEXT,
+            eventType INTEGER, rangeId INTEGER, textId INTEGER
+        );
+        CREATE TABLE CUDA_GRAPH_EVENTS(
+            start INTEGER, "end" INTEGER, globalTid INTEGER, nameId INTEGER,
+            graphId INTEGER, originalGraphId INTEGER, graphExecId INTEGER
+        );
+        CREATE TABLE CUDA_GRAPH_NODE_EVENTS(
+            start INTEGER, "end" INTEGER, eventClass INTEGER, globalTid INTEGER,
+            nameId INTEGER, graphNodeId INTEGER, originalGraphNodeId INTEGER
+        );
+        CREATE TABLE CUPTI_ACTIVITY_KIND_GRAPH_TRACE(
+            start INTEGER, "end" INTEGER, deviceId INTEGER, contextId INTEGER,
+            streamId INTEGER, correlationId INTEGER, globalPid INTEGER,
+            graphId INTEGER, graphExecId INTEGER
+        );
+        """
+    )
+    if graph_kernel_columns:
+        conn.execute("ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL ADD COLUMN graphNodeId INTEGER")
+        conn.execute("ALTER TABLE CUPTI_ACTIVITY_KIND_KERNEL ADD COLUMN graphId INTEGER")
+    return conn
+
+
+def _insert_graph_replay(conn):
+    rows = [
+        (0x100000000, 0, 7, 7, 10_000, 10_005, 1, 2, 101, 42),
+        (0x100000000, 0, 7, 7, 10_020, 10_025, 1, 2, 102, 42),
+    ]
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL "
+        "(globalPid, deviceId, streamId, correlationId, start, end, shortName, demangledName, graphNodeId, graphId) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (?, ?, ?, ?, ?)",
+        (0x100000007, 7, 8_000, 9_000, 10),
+    )
+    conn.execute(
+        "INSERT INTO NVTX_EVENTS VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (0x100000007, 0, 20_000, "decode", 59, 1, None),
+    )
+    conn.commit()
+
+
+def test_schema_detects_graph_tables_and_optional_kernel_columns():
+    conn = _graph_connection()
+    schema = NsightSchema(conn)
+
+    assert schema.kernel_graph_columns == {
+        "graph_node_id": "graphNodeId",
+        "graph_id": "graphId",
+    }
+    assert schema.cuda_graph["kernel_attribution"] is True
+    assert set(schema.cuda_graph["tables"]) == {
+        "CUDA_GRAPH_EVENTS",
+        "CUDA_GRAPH_NODE_EVENTS",
+        "CUPTI_ACTIVITY_KIND_GRAPH_TRACE",
+    }
+    assert schema.missing_required_columns() == []
+
+
+def test_graph_metadata_without_kernel_ids_is_a_clean_partial_capability():
+    conn = _graph_connection(graph_kernel_columns=False)
+    schema = NsightSchema(conn)
+
+    assert schema.cuda_graph["available"] is True
+    assert schema.cuda_graph["kernel_attribution"] is False
+    # Optional graph support must never make an otherwise valid old-style
+    # kernel export fail the hard schema contract.
+    assert schema.missing_required_columns() == []
+
+
+def test_profile_kernel_accessors_preserve_graph_attribution():
+    conn = _graph_connection()
+    _insert_graph_replay(conn)
+    profile = Profile._from_conn(conn)
+
+    rows = profile.kernels(0)
+    assert [(row["graph_node_id"], row["graph_id"]) for row in rows] == [(101, 42), (102, 42)]
+    mapped = profile.kernel_map(0)
+    assert mapped[7]["graph_node_id"] == 102
+    assert mapped[7]["graph_id"] == 42
+
+
+def test_launch_overhead_charges_one_runtime_call_for_many_graph_nodes():
+    conn = _graph_connection()
+    _insert_graph_replay(conn)
+
+    rows = OVERHEAD.execute_fn(conn, min_launches=1, device=0)
+
+    assert len(rows) == 1
+    assert rows[0]["launch_count"] == 2
+    assert rows[0]["total_api_ms"] == 0.001
+    assert rows[0]["avg_api_us"] == 1.0
+    assert rows[0]["graph_node_count"] == 2
+    assert rows[0]["graph_id_count"] == 1
+
+
+def test_launch_pattern_reports_graph_fanout():
+    conn = _graph_connection()
+    _insert_graph_replay(conn)
+
+    rows = PATTERN.execute(conn, limit=10, _skip_device_validation=True)
+
+    assert len(rows) == 1
+    assert rows[0]["kernel_count"] == 2
+    assert rows[0]["graph_node_count"] == 2
+    assert rows[0]["graph_id_count"] == 1
+
+
+def test_cache_keeps_graph_tables_and_normalized_kernel_ids(tmp_path):
+    source = tmp_path / "graph.sqlite"
+    conn = _graph_connection()
+    _insert_graph_replay(conn)
+    disk = sqlite3.connect(source)
+    conn.backup(disk)
+    disk.close()
+    conn.close()
+
+    cache_dir = build_cache(str(source))
+    db = open_cached_db(str(source))
+    try:
+        assert db.execute("SELECT COUNT(*) FROM cuda_graph_events").fetchone()[0] == 0
+        ids = db.execute(
+            "SELECT graph_node_id, graph_id FROM kernels ORDER BY start"
+        ).fetchall()
+        assert ensure_nvtx_kernel_map(db) is True
+        mapped = db.execute(
+            "SELECT graph_node_id, graph_id FROM nvtx_kernel_map ORDER BY k_start"
+        ).fetchall()
+    finally:
+        db.close()
+
+    assert cache_dir.joinpath("cuda_graph_events.parquet").is_file()
+    assert cache_dir.joinpath("cuda_graph_node_events.parquet").is_file()
+    assert cache_dir.joinpath("graph_trace.parquet").is_file()
+    assert ids == [(101, 42), (102, 42)]
+    assert mapped == [(101, 42), (102, 42)]

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -313,7 +313,7 @@ def test_the_direct_attach_builder_keeps_the_same_total_order():
     # Pinned as a literal on purpose: this is a tripwire, so a build change that
     # forgets to invalidate stops here rather than shipping a stale cache. Update
     # it in the same commit as the bump.
-    assert "_CACHE_VERSION = 17" in cache
+    assert "_CACHE_VERSION = 18" in cache
 
 
 # ── Cross-backend agreement ─────────────────────────────────────────────────

--- a/tests/test_parquet_cache.py
+++ b/tests/test_parquet_cache.py
@@ -831,7 +831,7 @@ class TestTensorCorePatterns:
         assert not re.search(active, name.lower())
 
 
-def test_the_map_is_built_by_the_sweep_and_carries_all_nine_columns(tmp_path):
+def test_the_map_is_built_by_the_sweep_and_carries_graph_attribution_columns(tmp_path):
     """NVTX attribution is a stack sweep, not a general inequality join.
 
     NVIDIA documents eventType 59 as a Push/Pop range maintaining an nvtxRange
@@ -842,11 +842,11 @@ def test_the_map_is_built_by_the_sweep_and_carries_all_nine_columns(tmp_path):
     twenty-plus minutes to 60.6 s.
 
     Output was compared row-for-row against the IEJoin's on that capture:
-    3,042,699 rows, zero differences either direction, all nine columns.
+    3,042,699 rows, zero differences either direction, across the full map schema.
 
-    Nine columns is the other half, and this is now the only guard on it. A
+    The map schema is the other half, and this is now the only guard on it. A
     second, unreachable builder used to exist alongside the sweep; unifying the
-    two on one nine-column writer fixed the shape but not the values — it went
+    two on one map writer fixed the shape but not the values — it went
     on filling is_tc_eligible/uses_tc with zeroes where the sweep writes 296/296
     on this fixture, and since consumers probe those columns by *presence*
     (connection.cached_nvtx_map_has_embedded_tc), nine zeroed columns read as
@@ -883,6 +883,8 @@ def test_the_map_is_built_by_the_sweep_and_carries_all_nine_columns(tmp_path):
         "k_start",
         "k_end",
         "k_dur_ns",
+        "graph_node_id",
+        "graph_id",
         "is_tc_eligible",
         "uses_tc",
     ], f"map schema drifted: {cols}"
@@ -930,7 +932,7 @@ class TestStreamedSweep:
     Peak memory then tracks the batch rather than the profile: measured on a
     3.5 GB capture (15.9 M ranges, 3.1 M kernel-runtime rows) the build went from
     6.95 GB peak / 51.2 s to 3.31 GB / 37.3 s, producing 3,042,699 rows with zero
-    differences in either direction across all nine columns and the path
+    differences in either direction across all map columns and the path
     dictionary.
 
     These tests assert *contents*, not that a build finished, because both known
@@ -960,7 +962,7 @@ class TestStreamedSweep:
 
     @staticmethod
     def _streamed(db, cache_dir, out_dir):
-        """Run the production builder into ``out_dir`` and read its nine columns
+        """Run the production builder into ``out_dir`` and read its map columns
         back with the path text joined in."""
         out_dir.mkdir(parents=True, exist_ok=True)
         built = parquet_cache._build_nvtx_kernel_map_from_parquet(db, cache_dir, out_dir)


### PR DESCRIPTION
## Summary

Closes #236.

Adds optional CUDA Graph node attribution across the analysis path:

- Detects `CUDA_GRAPH_EVENTS`, `CUDA_GRAPH_NODE_EVENTS`, and
  `CUPTI_ACTIVITY_KIND_GRAPH_TRACE` without making them required.
- Normalizes optional kernel `graphNodeId` / `graphId` to
  `graph_node_id` / `graph_id` in `Profile`, enriched kernels views, and
  Parquet cache output.
- Preserves graph IDs in the NVTX kernel map and Python/DuckDB attribution
  paths.
- Makes launch-pattern findings report graph-node/graph counts.
- Charges one shared runtime API interval once in launch-overhead analysis so
  graph fan-out is not mistaken for one host launch per graph node.
- Adds a `doctor` capability check and documents the clean fallback for older
  captures or graph metadata without kernel timing.

The cache schema version is bumped to 17 because the normalized graph fields
are part of the persisted kernel/map contract.

## Verification

- Focused checkpoint: `168 passed`
- Ruff: clean
- CLI smoke: `PYTHONPATH=src python3 -m nsys_ai --help`
- Full suite: `2571 passed, 146 skipped, 4 xfailed`
- One environment-only coverage-contract failure remains in
  `tests/test_ci_coverage.py::test_every_skip_has_a_known_reason` because the
  local environment has integration tests skipped with `No test profile`; no
  #236 test or source change is involved.

The implementation does not infer kernel timing from graph-node metadata alone.
Captures must expose kernel activity rows for kernel-level attribution.
