### PR TITLE
test(skills): pin thread_utilization's name resolution

### DIFF
--- a/tests/test_duckdb_path.py
+++ b/tests/test_duckdb_path.py
@@ -277,6 +277,11 @@ class TestDuckDBCompatibilityFixes:
 
         assert [row["tid"] for row in rows] == [100, 200]
         assert [float(row["cpu_pct"]) for row in rows] == [75.0, 25.0]
+        # The ranked-CTE rewrite replaced a correlated subquery, so the name it
+        # resolves is the half most likely to regress silently. 200 has no
+        # ThreadNames row, which is what the LEFT JOIN is for. The name itself is
+        # whatever string id 24 holds in the shared fixture.
+        assert [row["thread_name"] for row in rows] == ["cudaLaunchKernel", None]
 
     def test_thread_utilization_sqlite_compatibility(self):
         """The DuckDB fix must preserve the SQLite execution path."""
@@ -297,6 +302,30 @@ class TestDuckDBCompatibilityFixes:
 
             assert [row["tid"] for row in rows] == [100, 200]
             assert [float(row["cpu_pct"]) for row in rows] == [75.0, 25.0]
+            assert [row["thread_name"] for row in rows] == ["worker-a", "worker-b"]
+        finally:
+            conn.close()
+
+    def test_thread_utilization_picks_the_lowest_name_id_for_a_multi_named_thread(self):
+        """A thread can carry several names. The window function replaced an
+        explicit ORDER BY ... LIMIT 1, and nothing pinned which name wins."""
+        from nsys_ai.skills.registry import get_skill
+
+        conn = sqlite3.connect(":memory:")
+        try:
+            conn.executescript(
+                """
+                CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+                CREATE TABLE ThreadNames (globalTid INTEGER, nameId INTEGER);
+                INSERT INTO StringIds VALUES (2, 'chosen'), (5, 'later'), (9, 'latest');
+                INSERT INTO ThreadNames VALUES (100, 9), (100, 2), (100, 5);
+                """
+            )
+            self._seed_thread_utilization(conn)
+            rows = get_skill("thread_utilization").execute(conn)
+
+            assert rows[0]["tid"] == 100
+            assert rows[0]["thread_name"] == "chosen"
         finally:
             conn.close()
 


### PR DESCRIPTION
## Summary

- #568 rewrote `thread_utilization`'s name lookup from a correlated subquery into a ranked CTE with
  `ROW_NUMBER()`. That rewrite is roughly half the added SQL, and no test covers it.
- Both tests #568 added seed thread names — `worker-a` / `worker-b` — and then assert only `tid` and
  `cpu_pct`. The name column is never read.
- Adds three assertions. No source change.

## The gap, on `main` as it stands (`7222eba`)

Replace the resolved name with `NULL` in `thread_utilization.py` and nothing fails:

```
$ pytest tests/ -k "thread_utilization or thread"
22 passed

$ pytest tests/test_duckdb_path.py tests/test_skills.py tests/test_abstention.py
137 passed
```

So a change that silently stopped resolving thread names would ship green. `thread_name` is the
column that makes the skill's output legible — a CPU percentage against an unnamed tid does not tell
anyone which thread to look at.

## Changes

- `test_thread_utilization_duckdb_avoids_nested_aggregate` — asserts
  `["cudaLaunchKernel", None]`. The `None` is the point: tid 200 has no `ThreadNames` row, which is
  what the `LEFT JOIN` exists for. The name itself is whatever string id 24 holds in the shared
  DuckDB fixture, and the comment says so.
- `test_thread_utilization_sqlite_compatibility` — asserts `["worker-a", "worker-b"]`, the names the
  test already seeds.
- `test_thread_utilization_picks_the_lowest_name_id_for_a_multi_named_thread` — new. A thread with
  three names must resolve to the lowest `nameId`. The original code carried a comment explaining
  why that ordering matters ("A thread may carry several names; without an order the displayed one
  is whichever row the engine reaches first"); the rewrite moved it into a window `ORDER BY` and
  nothing pinned it.

## Reverse-verified

Each assertion fails when the behaviour it claims is removed, and passes when it is restored:

| mutation | result |
|---|---|
| `nt.thread_name` → `NULL AS thread_name` | all 3 fail |
| window `ORDER BY tn.nameId ASC` → `DESC` | the multi-name test fails; the other 2 pass, correctly — they have one name each |
| neither | all 3 pass |

## Backward compatibility

Yes. Tests only; `git diff --stat src/` is empty.

## Test plan

- [x] Tests added for behavior that had none
- [x] Each new assertion reverse-verified against a mutation of the code it covers
- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/` — 2573 passed, 140 skipped, 4 xfailed, 0 failed (8m57s); the
      one-test delta over `main`'s 2572 is the new multi-name test

## Out of scope

No change to `thread_utilization.py`. #568's SQL is correct — I compared it against the pre-#568
query on six shaped inputs (one name each, three names on one thread, no name row, a `nameId` with
no `StringIds` row, all-zero cycles, and a tid mask collision across processes) and the results are
identical in every case. This PR only pins that behaviour.

## Linked issues

Follows #568.
