### PR TITLE
fix(profile): open the guarded local read via the platform fd directory

### DIFF
--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -13,6 +13,7 @@ import signal
 import sqlite3
 import stat
 import subprocess  # nosec B404
+import sys
 import time
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, replace
@@ -189,6 +190,21 @@ def _assert_profile_descriptor_unchanged(
         raise ProfileError("local profile changed during validation")
 
 
+def _descriptor_uri(descriptor: int) -> str:
+    """SQLite URI that reopens an already-validated descriptor by identity.
+
+    ``read_local_profile_under_guard`` pins ``descriptor`` to the inode it
+    vetted; handing SQLite the raw path instead would let the file be swapped
+    between validation and the read. Every OS exposes a live descriptor as a
+    path under a per-process fd directory, but the mount point differs: Linux
+    uses ``/proc/self/fd``, while macOS and the BSDs use ``/dev/fd`` (and on
+    Linux ``/dev/fd`` is itself a symlink to ``/proc/self/fd``, so the two agree
+    there). The read stays bound to the vetted inode either way.
+    """
+    fd_dir = "/proc/self/fd" if sys.platform.startswith("linux") else "/dev/fd"
+    return f"file:{fd_dir}/{descriptor}?mode=ro&immutable=1"
+
+
 def read_local_profile_under_guard(
     path: str | os.PathLike[str],
     *,
@@ -285,7 +301,7 @@ def read_local_profile_under_guard(
     schema_version = None
     product_version = None
     try:
-        descriptor_uri = f"file:/proc/self/fd/{descriptor}?mode=ro&immutable=1"
+        descriptor_uri = _descriptor_uri(descriptor)
         connection = sqlite3.connect(
             descriptor_uri,
             uri=True,

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -210,6 +210,42 @@ def test_capture_environment_guard_allows_machine_metadata(tmp_path):
     )
 
 
+def test_descriptor_uri_targets_the_platform_fd_directory(monkeypatch):
+    """The guarded read reopens the vetted descriptor by identity, and the fd
+    directory that exposes it is Linux-only (``/proc/self/fd``) versus
+    ``/dev/fd`` on macOS/BSD. Pin both so the non-Linux branch cannot be
+    silently dropped by a refactor that only ever runs on Linux CI.
+    """
+    import nsys_ai.profile_runner as profile_runner
+
+    monkeypatch.setattr(profile_runner.sys, "platform", "linux")
+    assert (
+        profile_runner._descriptor_uri(7)
+        == "file:/proc/self/fd/7?mode=ro&immutable=1"
+    )
+    monkeypatch.setattr(profile_runner.sys, "platform", "darwin")
+    assert (
+        profile_runner._descriptor_uri(7) == "file:/dev/fd/7?mode=ro&immutable=1"
+    )
+
+
+def test_guarded_read_opens_the_capture_on_non_linux(
+    tmp_path, fake_nsys, monkeypatch
+):
+    """Forcing the non-Linux branch must open a real capture, not just format a
+    string. ``/dev/fd`` is a symlink to ``/proc/self/fd`` on Linux, so this
+    exercises the macOS descriptor path on Linux CI as well as on macOS.
+    """
+    import nsys_ai.profile_runner as profile_runner
+
+    monkeypatch.setattr(profile_runner.sys, "platform", "darwin")
+    result = _run(tmp_path, fake_nsys)
+
+    assert result.status is RunStatus.SUCCEEDED
+    assert result.profile is not None
+    assert result.profile.kernel_count == 1
+
+
 def test_success_returns_validated_reference_and_artifacts(tmp_path, fake_nsys):
     stages = []
     runner = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys))
@@ -810,5 +846,9 @@ def test_the_capture_is_opened_once_for_reference_and_gpu_count(tmp_path, fake_n
     monkeypatch.setattr(profile_runner.sqlite3, "connect", _record)
     profile_runner.read_local_profile_under_guard(result.sqlite_path)
 
-    by_path = [target for target in opened if not target.startswith("file:/proc/self/fd/")]
+    # The guard reopens the vetted descriptor through the platform's per-process
+    # fd directory: /proc/self/fd on Linux, /dev/fd on macOS/BSD. Anything else
+    # is a by-path reopen outside the swap guard.
+    guarded_prefixes = ("file:/proc/self/fd/", "file:/dev/fd/")
+    by_path = [target for target in opened if not target.startswith(guarded_prefixes)]
     assert not by_path, f"the capture was reopened outside the descriptor guard: {by_path}"


### PR DESCRIPTION
## Summary

- The guarded local-profile read reopens its vetted file descriptor by identity through `/proc/self/fd`, which only exists on Linux — so on macOS/BSD the open fails, the error is swallowed into a validation failure, and every caller (`diagnose`, `evidence build`, `propose`, `loop`, `review`, session/web workflows) reports a misleading `local profile is not a valid Nsight SQLite export`.
- Select the per-process fd directory by platform so the same TOCTOU swap guard works off Linux, keeping the Linux path byte-identical.

## Changes

- `src/nsys_ai/profile_runner.py`
  - Add `_descriptor_uri(descriptor)`: `/proc/self/fd` on Linux, `/dev/fd` on macOS/BSD. On Linux `/dev/fd` is a symlink to `/proc/self/fd`, so the Linux URI is unchanged and the read still binds to the vetted inode on both platforms.
  - Route the single existing call site through the helper.
- `tests/test_profile_runner.py`
  - `test_descriptor_uri_targets_the_platform_fd_directory`: pins the platform→path mapping so the non-Linux branch cannot be silently dropped by a Linux-only CI.
  - `test_guarded_read_opens_the_capture_on_non_linux`: forces the non-Linux branch through a real capture; exercises `/dev/fd` on Linux CI too (symlink) and on macOS.
  - Update `test_the_capture_is_opened_once_for_reference_and_gpu_count` to accept both guarded prefixes (`file:/proc/self/fd/`, `file:/dev/fd/`); a genuine by-path reopen is still rejected.

## Backward compatibility

Yes. On Linux the descriptor URI is byte-identical to before. The swap guard is preserved on both platforms (the read stays bound to the descriptor's inode; verified on macOS that `/dev/fd/N` survives an `os.replace` swap of the original path).

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally (macOS: 2559 passed; the 9 remaining failures are pre-existing macOS-environment issues unrelated to this change — `os.killpg` sandbox `PermissionError`, and skip-reason / error-string checks that pass on Linux CI — each confirmed still failing with this change stashed)
- [x] `ruff check src/ tests/` clean
- [x] `bandit -r src/nsys_ai/profile_runner.py -c pyproject.toml` clean (no new asserts in `src/`)
- [x] Manually exercised on macOS: `nsys-ai diagnose` / `skill run` now work against `tests/fixtures/h100_2gpu_1s.sqlite`

## Out of scope

- The pre-existing macOS-only test failures noted above (process-group signalling and a couple of error-string/skip-reason assertions). Separate platform issues; not touched here.

## Linked issues

Closes #571
