### PR TITLE
docs: align documented commands with the shipped CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ use a Parquet cache by default; `.sqlite` remains the compatibility path.
 ![nsys-ai timeline viewer](https://raw.githubusercontent.com/GindaChen/nsys-ai/main/docs/images/timeline-web.png)
 
 The screenshot is captured from the committed H100 fixture; the other browser
-surfaces are shown in [Choosing a Web viewer](https://github.com/GindaChen/nsys-ai/blob/main/docs/user/viewers.md).
+surfaces are shown in [Choosing a viewer](https://github.com/GindaChen/nsys-ai/blob/main/docs/user/viewers.md).
 
 ## Installation
 
@@ -97,11 +97,13 @@ nsys-ai info my_training.nsys-rep
 nsys-ai summary my_training.nsys-rep --gpu 0
 ```
 
-Prefer the terminal? The TUIs work the same way:
+Prefer the terminal? `open --viewer tui` needs no window; the dedicated TUI
+commands render one window at a time, so they require `--trim`:
 
 ```bash
-nsys-ai timeline my_training.nsys-rep --gpu 0   # Perfetto-style horizontal timeline
-nsys-ai tui my_training.nsys-rep --gpu 0        # NVTX tree browser
+nsys-ai open my_training.nsys-rep --viewer tui              # NVTX tree browser, full span
+nsys-ai timeline my_training.nsys-rep --gpu 0 --trim 0 5    # Perfetto-style horizontal timeline
+nsys-ai tui my_training.nsys-rep --gpu 0 --trim 0 5         # NVTX tree browser, explicit window
 ```
 
 ### 3. Compare two runs
@@ -138,8 +140,12 @@ required. This is the default view when you run `nsys-ai <profile>`.
 
 ```bash
 nsys-ai my_training.nsys-rep                       # opens in your browser
-nsys-ai timeline-web my_training.nsys-rep --gpu 0 1 2 3
+nsys-ai timeline-web my_training.nsys-rep          # every GPU in the capture
+nsys-ai timeline-web my_training.nsys-rep --gpu 0  # restrict to one device
 ```
+
+`--gpu` takes a single device id. The stacked multi-GPU view is what you get by
+omitting it, not by listing several.
 
 - Multi-GPU stacked view with color-coded separators
 - Progressive rendering — pre-builds the NVTX tree at startup, then serves tiles
@@ -305,10 +311,14 @@ Run `nsys-ai <command> --help` for flags.
 
 ## Analysis cache
 
-The first command run against a profile builds a `<profile>.nsys-cache` directory
-next to it: the tables analysis needs, exported to Parquet and queried through
-DuckDB. Later commands reuse it and open in well under a second. The cache is
-rebuilt automatically when the profile changes; deleting the directory is safe.
+The first command run against a profile builds a Parquet working set next to it:
+the tables analysis needs, queried through DuckDB. Which directory appears
+depends on what you handed in — a `.sqlite` gets a `<profile>.nsys-cache` query
+cache beside it, while a `.nsys-rep` is converted once into `<profile>.parquetdir`
+and read from there. Later commands reuse either and open in well under a second.
+Both are rebuilt automatically when the profile changes; deleting the directory
+is safe. See [profile inputs](https://github.com/GindaChen/nsys-ai/blob/main/docs/user/profile-inputs.md)
+for the full table.
 
 Measured on the reference captures (12 cores, 15 GB RAM), running eight skills:
 `top_kernels`, `gpu_idle_gaps`, `overlap_breakdown`, `memory_transfers`,

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Operating the tool.
 | [user/troubleshooting.md](./user/troubleshooting.md) | Symptoms, what they mean, and what to change |
 | [user/environment-variables.md](./user/environment-variables.md) | Every variable, its default, and when to change it |
 | [user/skills.md](./user/skills.md) | Discover and run deterministic analysis skills without an LLM |
-| [user/viewers.md](./user/viewers.md) | Choose between the Web, timeline-web, and diff-web surfaces |
+| [user/viewers.md](./user/viewers.md) | Choose between `open`, the Web surfaces, and the terminal viewers |
 | [guided-loop-setup.md](./guided-loop-setup.md) | The same loop driven from the timeline web UI |
 | [doctor.md](./doctor.md) | Environment and profile health checks |
 | [ci-diff-gate.md](./ci-diff-gate.md) | Capture, compare, and gate performance regressions in CI |

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -259,9 +259,13 @@ Check the result, not only the exit code:
 For a release that changes the optimization workflow, add the guided path:
 
 ```bash
-nsys-ai propose PROFILE --session SESSION_DIR --format json
-nsys-ai optimize PROFILE --session SESSION_DIR --format json
+nsys-ai propose --session SESSION_DIR --finding-id FINDING_ID
+nsys-ai optimize PROFILE --session SESSION_DIR --repo REPO_PATH
 ```
+
+Take `FINDING_ID` from the `diagnose` run above; `propose` selects one finding
+by its stable id and has no `--format` flag. `optimize` needs the repository it
+is allowed to change.
 
 ### 2.4 Surface and documentation checks
 

--- a/docs/user/migrating-to-0.3.0.md
+++ b/docs/user/migrating-to-0.3.0.md
@@ -243,14 +243,18 @@ session and analysis contracts.
 Replace the executable in scripts and documentation:
 
 ```console
-$ nsys-ai tui PROFILE
+$ nsys-ai tui PROFILE --gpu 0 --trim START_S END_S
 ```
 
 For the horizontal timeline mode, use:
 
 ```console
-$ nsys-ai timeline PROFILE
+$ nsys-ai timeline PROFILE --trim START_S END_S
 ```
+
+Both render one window rather than streaming tiles, so `--trim` is required on each and `--gpu` is
+required on `tui`. When you do not have a window in mind, `nsys-ai open PROFILE --viewer tui`
+resolves the full span and the first GPU for you.
 
 For browser automation or a remote workstation, use `timeline-web` instead. `nsys-ai open PROFILE`
 still opens the default Web viewer.

--- a/docs/user/viewers.md
+++ b/docs/user/viewers.md
@@ -1,14 +1,25 @@
-# Choosing a Web viewer
+# Choosing a viewer
 
-nsys-ai has three browser surfaces with similar names but different jobs. They
-all run locally and accept the same profile inputs; choose the surface that
-matches the question rather than starting every server.
+nsys-ai has one entry point and five surfaces behind it. They all run locally
+and accept the same profile inputs; choose the surface that matches the question
+rather than starting every server.
+
+Start with `open` when you do not yet know which surface you want:
+
+| Command | What it shows | Use it when |
+|---|---|---|
+| `nsys-ai open PROFILE` | The `web` viewer, browser launched for you | You just want to look at a capture and have no reason to pick |
+| `nsys-ai open PROFILE --viewer tui` | The NVTX tree TUI over the full span | You are on a remote shell, or a browser is not worth starting |
+
+The named surfaces, when the question is already specific:
 
 | Command | What it shows | Use it when |
 |---|---|---|
 | `nsys-ai web PROFILE` | NVTX tree viewer with lazy tree requests | You want to browse nested ranges and the kernels attributed to them |
 | `nsys-ai timeline-web PROFILE` | Progressive multi-GPU horizontal timeline | You want streams, kernels, NVTX lanes, search, and a session-backed workflow |
 | `nsys-ai diff-web BEFORE AFTER` | Before/after comparison shell with two timeline views | You want to inspect a change and its canonical diff side by side |
+| `nsys-ai tui PROFILE --gpu N --trim START_S END_S` | NVTX tree TUI | You want the tree in the terminal and already know the window |
+| `nsys-ai timeline PROFILE --trim START_S END_S` | Horizontal timeline TUI | You want the timeline in the terminal and already know the window |
 
 The commands are separate transports over the same profile and diff contracts.
 The older `nsys-ai perfetto` server is not one of the choices; use
@@ -90,6 +101,23 @@ CLI or the session loop rather than treating a browser colour as the decision.
 
 `--gpu` restricts both sides to one device. Without it, the comparison remains
 all-GPU, matching `nsys-ai diff`.
+
+## Terminal viewers: `tui` and `timeline`
+
+Both render one window at a time rather than streaming tiles, so both require
+`--trim`; `tui` also requires `--gpu`. They do not appear in the `nsys-ai --help`
+command table — they are listed under its `also available:` footer, along with
+the other text-report commands.
+
+```console
+$ nsys-ai tui PROFILE.sqlite --gpu 0 --trim 39 42
+$ nsys-ai timeline PROFILE.sqlite --gpu 0 --trim 39 42
+```
+
+`nsys-ai open PROFILE --viewer tui` is the same tree browser without the window
+arguments: it resolves the full profile span and the first GPU for you. Reach for
+the explicit commands when you want a specific window, and for `timeline-web`
+when the capture spans more GPUs than one terminal can usefully show.
 
 ## Shared operational rules
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,14 +11,21 @@ Hands-on examples for getting started with nsys-ai. Each example includes a down
 | 10 | [FastVideo Inference](example-10-fastvideo-inference/) | Inference (video generation) | 4× H100 | ⭐⭐ Intermediate |
 | 20 | [Megatron-LM DistCA](example-20-megatron-distca/) | Training (Transformer Engine) | 8× H200 | ⭐⭐⭐ Advanced |
 
-## Quick Start (Example 10)
+## Quick Start (Example 20)
+
+Example 20 is the one whose capture is published, so it runs end to end today.
+It downloads a `.nsys-rep`, so Nsight Systems must be on your `PATH` — nsys-ai
+converts the capture by shelling out to `nsys export`:
 
 ```bash
 pip install nsys-ai
-cd example-10-fastvideo-inference
+cd example-20-megatron-distca
 python download_data.py
-nsys-ai timeline output/fastvideo-wan21-1.3b-4gpu.sqlite --gpu 0
+nsys-ai open output/megatron_distca.nsys-rep
 ```
+
+Example 10 has no profile on HuggingFace yet; its download step fails until one
+is uploaded, or until you capture your own with the Modal script it documents.
 
 ## Adding New Examples
 

--- a/examples/example-10-fastvideo-inference/README.md
+++ b/examples/example-10-fastvideo-inference/README.md
@@ -18,8 +18,10 @@ pip install nsys-ai
 python download_data.py
 ```
 
-> **Note:** This example requires a pre-captured profile. If none is available on HuggingFace yet,
-> you can capture your own using the Modal profiling script (requires Modal account + GPU access).
+> **Note:** This example requires a pre-captured profile, and one is not published on HuggingFace
+> yet — `download_data.py` will report the failure rather than produce a file. Capture your own with
+> the Modal profiling script below (requires a Modal account + GPU access), or start with
+> [example 20](../example-20-megatron-distca/), whose capture does download.
 
 ### Step 3: Explore the profile
 
@@ -30,11 +32,11 @@ nsys-ai info output/fastvideo_inference.sqlite
 # Kernel summary — see which kernels dominate inference
 nsys-ai summary output/fastvideo_inference.sqlite --gpu 0
 
-# NVTX tree — hierarchical view of the inference pipeline
-nsys-ai tree output/fastvideo_inference.sqlite --gpu 0
+# NVTX tree — hierarchical view of the inference pipeline (--gpu and --trim required)
+nsys-ai tree output/fastvideo_inference.sqlite --gpu 0 --trim 0 5
 
-# Interactive timeline TUI
-nsys-ai timeline output/fastvideo_inference.sqlite --gpu 0
+# Interactive timeline TUI (--trim required)
+nsys-ai timeline output/fastvideo_inference.sqlite --gpu 0 --trim 0 5
 ```
 
 ### Step 4: Web UI & Exports
@@ -43,8 +45,8 @@ nsys-ai timeline output/fastvideo_inference.sqlite --gpu 0
 # Web viewer
 nsys-ai web output/fastvideo_inference.sqlite --gpu 0
 
-# Perfetto trace
-nsys-ai perfetto output/fastvideo_inference.sqlite --gpu 0
+# Chrome Trace Event JSON — open the written file in ui.perfetto.dev
+nsys-ai export output/fastvideo_inference.sqlite --gpu 0 --trim 0 5 -o output/trace-export/
 ```
 
 ---

--- a/examples/example-10-fastvideo-inference/download_data.py
+++ b/examples/example-10-fastvideo-inference/download_data.py
@@ -66,7 +66,7 @@ def main():
         print()
         print("Next steps:")
         print(f"  nsys-ai info output/{SQLITE_FILE}")
-        print(f"  nsys-ai timeline output/{SQLITE_FILE} --gpu 0")
+        print(f"  nsys-ai timeline output/{SQLITE_FILE} --gpu 0 --trim 0 5")
     except Exception as e:
         print(f"✗ Download failed: {e}")
         print()

--- a/examples/example-20-megatron-distca/README.md
+++ b/examples/example-20-megatron-distca/README.md
@@ -20,7 +20,16 @@ pip install nsys-ai
 python download_data.py
 ```
 
-This downloads the `.sqlite` profile (~700 MB) from HuggingFace into `output/megatron_distca.sqlite`.
+The dataset publishes the 11 MB `.nsys-rep` capture, which the script saves as
+`output/megatron_distca.nsys-rep`. A pre-converted `.sqlite` is not uploaded yet, so
+the script's SQLite path falls through to this one.
+
+**Nsight Systems has to be on your `PATH` for the steps below.** The first nsys-ai
+command converts the capture once into `output/megatron_distca.parquetdir` beside it,
+and that conversion shells out to `nsys export`; every later command reuses the
+directory. See [profile inputs](../../docs/user/profile-inputs.md). If you would
+rather work from SQLite, run `nsys export --type sqlite output/megatron_distca.nsys-rep`
+yourself and substitute the `.sqlite` path throughout.
 
 ### Step 3: Explore the profile
 
@@ -28,16 +37,16 @@ Run these commands in order to explore the profile:
 
 ```bash
 # 3a. Profile overview — see GPUs, tables, time range
-nsys-ai info output/megatron_distca.sqlite
+nsys-ai info output/megatron_distca.nsys-rep
 
 # 3b. Kernel summary — top kernels by GPU time
-nsys-ai summary output/megatron_distca.sqlite --gpu 4
+nsys-ai summary output/megatron_distca.nsys-rep --gpu 4
 
 # 3c. NVTX tree — hierarchical view of one training iteration
-nsys-ai tree output/megatron_distca.sqlite --gpu 4 --trim 39 42
+nsys-ai tree output/megatron_distca.nsys-rep --gpu 4 --trim 39 42
 
 # 3d. Compute / NCCL overlap analysis
-nsys-ai overlap output/megatron_distca.sqlite --gpu 4 --trim 39 42
+nsys-ai overlap output/megatron_distca.nsys-rep --gpu 4 --trim 39 42
 ```
 
 ### Step 4: Interactive TUIs
@@ -45,30 +54,30 @@ nsys-ai overlap output/megatron_distca.sqlite --gpu 4 --trim 39 42
 ```bash
 # 4a. Timeline TUI — Perfetto-style horizontal timeline
 #     Keys: ←→ pan, ↑↓ select stream, +/- zoom, Tab snap to kernel
-nsys-ai timeline output/megatron_distca.sqlite --gpu 4 --trim 39 42
+nsys-ai timeline output/megatron_distca.nsys-rep --gpu 4 --trim 39 42
 
 # 4b. Tree TUI — interactive NVTX hierarchy browser
 #     Keys: ↑↓ navigate, Enter expand, / search, q quit
-nsys-ai tui output/megatron_distca.sqlite --gpu 4 --trim 39 42
+nsys-ai tui output/megatron_distca.nsys-rep --gpu 4 --trim 39 42
 ```
 
 ### Step 5: Web UI & Exports
 
 ```bash
 # 5a. Web viewer — opens interactive HTML in browser
-nsys-ai web output/megatron_distca.sqlite --gpu 4 --trim 39 42
+nsys-ai web output/megatron_distca.nsys-rep --gpu 4 --trim 39 42
 
 # 5b. Timeline web viewer
-nsys-ai timeline-web output/megatron_distca.sqlite --gpu 4 --trim 39 42
+nsys-ai timeline-web output/megatron_distca.nsys-rep --gpu 4 --trim 39 42
 
-# 5c. Perfetto trace — opens in ui.perfetto.dev
-nsys-ai perfetto output/megatron_distca.sqlite --gpu 4 --trim 39 42
+# 5c. Chrome Trace Event JSON — open the written file in ui.perfetto.dev
+nsys-ai export output/megatron_distca.nsys-rep --gpu 4 --trim 39 42 -o output/trace-export/
 
 # 5d. Export HTML report
-nsys-ai viewer output/megatron_distca.sqlite --gpu 4 --trim 39 42 -o output/report.html
+nsys-ai viewer output/megatron_distca.nsys-rep --gpu 4 --trim 39 42 -o output/report.html
 
 # 5e. Export CSV for scripting
-nsys-ai export-csv output/megatron_distca.sqlite --gpu 4 --trim 39 42 -o output/kernels.csv
+nsys-ai export-csv output/megatron_distca.nsys-rep --gpu 4 --trim 39 42 -o output/kernels.csv
 ```
 
 ---
@@ -94,7 +103,7 @@ This profile contains a Megatron-LM training run with Transformer Engine on 8 GP
 
 | File | Purpose |
 |------|---------|
-| `download_data.py` | Downloads `.sqlite` from HuggingFace |
+| `download_data.py` | Downloads the `.nsys-rep` capture from HuggingFace |
 | `benchmark_timeline_web.py` | Benchmarks timeline-web cache/tile phases |
 | `timeline_web_perf_budget.json` | Performance budget for regression checks |
 | `.gitignore` | Ignores `output/` directory |

--- a/examples/example-20-megatron-distca/download_data.py
+++ b/examples/example-20-megatron-distca/download_data.py
@@ -3,11 +3,13 @@
 Download the Megatron-LM DistCA profile from HuggingFace.
 
 Dataset: https://huggingface.co/datasets/GindaChen/nsys-hero
-Profile: distca-0/baseline.t128k.host-fs-mbz-gpu-899.sqlite
-         → saved locally as output/megatron_distca.sqlite
+Profile: distca-0/baseline.t128k.host-fs-mbz-gpu-899.nsys-rep
+         → saved locally as output/megatron_distca.nsys-rep
 
-Downloads the pre-converted .sqlite file so you can immediately use nsys-ai
-without needing nsys or Modal installed.
+Prefers a pre-converted .sqlite when the dataset carries one, and falls back to
+the .nsys-rep otherwise. The dataset currently publishes only the .nsys-rep, so
+the fallback is the normal path -- which means Nsight Systems has to be on PATH,
+because nsys-ai converts a .nsys-rep by shelling out to `nsys export`.
 """
 
 import os

--- a/tests/test_documentation_contracts.py
+++ b/tests/test_documentation_contracts.py
@@ -106,3 +106,94 @@ def test_claude_release_process_points_to_the_canonical_release_guide():
     assert "git push upstream v0.4.0" in release
     assert re.search(r"`origin`\s+is\s+the\s+fork", release)
     assert re.search(r"`upstream`\s+is\s+the\s+canonical", release)
+
+
+#: Documentation placeholders that stand in for a real value. The parser only has to
+#: accept the shape of the line, so these are substituted with something well-typed.
+DOCUMENTATION_PLACEHOLDERS = {"START_S": "0", "END_S": "5", "N": "0"}
+
+
+def _documented_command_lines() -> list[tuple[Path, int, str]]:
+    """Every fenced `nsys-ai ...` invocation across the documentation tree.
+
+    Only fenced blocks count. A sentence that happens to open with the program name is
+    prose, and a line carrying shell syntax (a continuation, a redirect, a pipe) is not
+    a single argv this can hand to argparse.
+    """
+    lines: list[tuple[Path, int, str]] = []
+    roots = (ROOT.glob("*.md"), ROOT.glob("docs/**/*.md"), ROOT.glob("examples/**/*.md"))
+    for path in sorted({p for root in roots for p in root}):
+        inside_fence = False
+        for number, raw in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if raw.lstrip().startswith("```"):
+                inside_fence = not inside_fence
+                continue
+            if not inside_fence:
+                continue
+            line = raw.strip().removeprefix("$ ").strip()
+            if not line.startswith("nsys-ai ") or "`" in line or "](" in line:
+                continue
+            if line.rstrip().endswith((".", ",", ":", ";")):
+                continue
+            if any(token in line for token in ("\\", ">", "|")):
+                continue
+            lines.append((path.relative_to(ROOT), number, line))
+    return lines
+
+
+def test_there_are_documented_commands_to_check():
+    """Guard the guard: an empty sweep would make the assertion below vacuous."""
+    assert _documented_command_lines(), "no fenced nsys-ai commands found in the docs tree"
+
+
+def test_every_documented_command_line_is_accepted_by_the_cli():
+    """A copy-pasted documentation command must not die on argparse.
+
+    This is the failure the docs keep shipping: the command exists, the reader copies
+    the line, and it stops at `error: the following arguments are required: --trim`, or
+    at a subcommand that was removed a release ago. Nothing connected the documented
+    examples to the parser that has to accept them, so the drift was invisible until a
+    reader hit it. Parsing is deliberately all this asserts -- running the commands
+    would need real profiles -- but argparse is where every one of those failures was.
+    """
+    import contextlib
+    import io
+    import shlex
+    import sys
+
+    saved_argv = sys.argv
+    sys.argv = ["nsys-ai"]
+    try:
+        from nsys_ai.cli.app import (
+            _normalize_default_profile_command,
+            _normalize_optimize_command,
+        )
+        from nsys_ai.cli.parsers import (
+            LEGACY_ROUTED_COMMANDS,
+            _build_legacy_parser,
+            _build_parser,
+        )
+    finally:
+        sys.argv = saved_argv
+
+    rejected = []
+    for path, number, line in _documented_command_lines():
+        try:
+            argv = shlex.split(line.split(" #")[0])
+        except ValueError:
+            continue
+        argv = [DOCUMENTATION_PLACEHOLDERS.get(token, token) for token in argv]
+        # main() rewrites the bare `nsys-ai PROFILE` form before it reaches a parser.
+        argv = _normalize_optimize_command(_normalize_default_profile_command(argv))
+        command = argv[1] if len(argv) > 1 else ""
+        parser = _build_legacy_parser() if command in LEGACY_ROUTED_COMMANDS else _build_parser()
+        stdout, stderr = io.StringIO(), io.StringIO()
+        try:
+            with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(stderr):
+                parser.parse_args(argv[1:])
+        except SystemExit as exit_status:
+            if exit_status.code:
+                reason = (stderr.getvalue().strip().splitlines() or ["rejected"])[-1]
+                rejected.append(f"{path}:{number}: {line}\n    {reason}")
+
+    assert not rejected, "documented commands the CLI rejects:\n" + "\n".join(rejected)


### PR DESCRIPTION
## Summary

- Documented `nsys-ai` commands had drifted from the parser that has to accept them, so a reader who copied a line from the README hit argparse rather than a profile. Found while testing the released `nsys-ai==0.3.0` wheel on macOS / Python 3.13.
- Fixes every documented command line that the CLI rejects, plus two claims about what a profile download and a cache build actually produce.
- Adds a documentation contract so this class of drift fails a test instead of reaching a reader.

## Changes

**Commands the CLI rejected**

- `README.md` — `timeline` / `tui` quickstart examples omitted `--trim`, which both require; added it and pointed at `open --viewer tui` as the no-window path.
- `README.md` — the Web-timeline section passed four device ids to `--gpu`, which takes a single `int` (`_add_gpu_trim`, `cli/handlers.py:448`). The stacked multi-GPU view is what you get by *omitting* `--gpu`.
- `docs/user/migrating-to-0.3.0.md` — `nsys-ai tui PROFILE` / `nsys-ai timeline PROFILE` were missing `--gpu` / `--trim`.
- `examples/example-10-...`, `examples/example-20-...` — `nsys-ai perfetto` was removed a release ago (the migration guide already documents this); replaced with `nsys-ai export`. `tree` / `timeline` examples were missing `--trim`.
- `docs/dev/release.md` — the guided-path smoke commands were missing `propose --finding-id` and `optimize --repo`, and passed a `--format` flag `propose` does not have.

**Claims that were not true**

- `examples/example-20-megatron-distca/` — the guide promised a `~700 MB .sqlite` from HuggingFace. The dataset publishes only an 11 MB `.nsys-rep`, so every command in the guide named a file the download never produces. Rewritten around the `.nsys-rep`, and the "no nsys install needed" claim corrected: converting a `.nsys-rep` shells out to `nsys export`, so Nsight Systems must be on `PATH`.
- `examples/README.md` — the quick start pointed at example 10, whose profile is not on HuggingFace at all (`fastvideo/` 404s). Points at example 20, which downloads; example 10 now says plainly that its download fails until a capture is uploaded.
- `README.md` — the cache section described `<profile>.nsys-cache` as what every input produces. That holds for a `.sqlite`; a `.nsys-rep` is converted to `<profile>.parquetdir` instead.

**Viewer documentation**

- `docs/user/viewers.md` — covered only the three browser surfaces, leaving `open` (the default entry point) and both terminal viewers undocumented. Retitled "Choosing a viewer", added `open` and the two TUI surfaces, and a section noting that `tui` / `timeline` live under the `also available:` footer of `--help` rather than in its command table.

**Regression guard**

- `tests/test_documentation_contracts.py` — parses every fenced `nsys-ai` command across `*.md`, `docs/**`, and `examples/**` through the real parser (including `main()`'s bare-profile normalisation and the legacy routing set). Parsing is all it asserts; running the commands would need real profiles, but argparse is where every one of these failures was.

## Backward compatibility

Yes. Documentation and one test only; no runtime code changes.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path (if applicable)

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2569 passed, 7 failed, 141 skipped, 4 xfailed**. The 7 failures are pre-existing on clean `main` on this machine (`PermissionError: Operation not permitted` in the `profile_runner` process-tree kill path); confirmed by stashing the change and re-running. They are macOS-local and do not appear related to this PR.
- `bandit -r src/ -c pyproject.toml` — 0 issues at every severity.
- The new contract test was checked in both directions: it fails against the unfixed docs (10 rejected command lines) and passes against the fixed ones (80 command lines parsed).
- Command shapes were verified against both the released `nsys-ai==0.3.0` wheel and this branch, using the committed `tests/fixtures/h100_2gpu_1s.sqlite`.

## Out of scope

Two product issues surfaced during the same test pass; neither is a documentation defect and neither is touched here:

- `nsys-ai --version` is not supported (`unrecognized arguments: --version`); the version is only reachable through `pip`.
- `nsys-ai info` prints empty hardware fields verbatim on a profile that lacks them — `GPU 0:  | PCI= | SMs=0 | Mem=0GB`, which reads as broken rather than as absent data.

Also out of scope: the `.sqlite` upload for `example-20` and the missing `example-10` capture. The guides now describe what the dataset actually holds; uploading the converted caches is a separate task.

Separately, the macOS `local profile is not a valid Nsight SQLite export` failure seen on the 0.3.0 wheel is already fixed on `main` by #572 and awaits a release.
