### PR TITLE
fix(summary): measure GPU utilization against the union, not the kernel sum

### DIFF
--- a/src/nsys_ai/report.py
+++ b/src/nsys_ai/report.py
@@ -179,8 +179,12 @@ def format_report_markdown(data: dict, profile_path: str, trim: tuple[int, int])
         )
         lines.append("")
         lines.append(
-            f"Span: {t['span_ms']:.1f}ms | Compute: {t['compute_ms']:.1f}ms | Idle: {t['idle_ms']:.1f}ms | Util: {t['utilization_pct']}%"
+            f"Span: {t['span_ms']:.1f}ms | Busy: {t['busy_ms']:.1f}ms | Idle: {t['idle_ms']:.1f}ms | Util: {t['utilization_pct']}%"
         )
+        lines.append("")
+        # Both numbers, named for what they are. The sum exceeds the span when
+        # streams overlap, and the gap between the two is the overlap itself.
+        lines.append(f"Kernel time summed over streams: {t['compute_ms']:.1f}ms")
         lines.append("")
         lines.append("| % | Total ms | Count | Kernel |")
         lines.append("|---|----------|-------|-------|")

--- a/src/nsys_ai/summary.py
+++ b/src/nsys_ai/summary.py
@@ -54,7 +54,15 @@ def gpu_summary(prof: Profile, device: int, trim: tuple[int, int] | None = None)
             idle_ns += k["start"] - max_end
         max_end = max(max_end, k["end"])
 
+    # Two different quantities, and conflating them is how utilization used to
+    # exceed 100%. The sum counts every kernel's duration, so two kernels running
+    # concurrently on different streams contribute twice -- on a capture where
+    # compute and NCCL overlap, the sum can exceed the wall span it is measured
+    # against. ``busy_ns`` is the union: the sweep above already computed the
+    # device-level idle time, so span minus idle is the time at least one kernel
+    # was resident, which is what a fraction of wall time has to be built from.
     total_compute_ns = sum(k["end"] - k["start"] for k in kernels)
+    busy_ns = span_ns - idle_ns
 
     # NCCL vs compute split across ALL kernels (not just top 10)
     nccl_ms_total = 0.0
@@ -75,9 +83,14 @@ def gpu_summary(prof: Profile, device: int, trim: tuple[int, int] | None = None)
         },
         "timing": {
             "span_ms": round(span_ns / 1e6, 2),
+            # Kept under its published name and its original meaning -- a sum over
+            # kernels, which may exceed span_ms -- because export-json ships it as
+            # part of a versioned payload. busy_ms is the union alongside it, and
+            # span_ms == busy_ms + idle_ms holds where compute_ms cannot.
             "compute_ms": round(total_compute_ns / 1e6, 2),
+            "busy_ms": round(busy_ns / 1e6, 2),
             "idle_ms": round(idle_ns / 1e6, 2),
-            "utilization_pct": round(100 * total_compute_ns / span_ns, 1) if span_ns else 0,
+            "utilization_pct": round(100 * busy_ns / span_ns, 1) if span_ns else 0,
         },
         "kernel_count": len(kernels),
         "top_kernels": [
@@ -107,7 +120,8 @@ def format_text(summary: dict) -> str:
     t = summary["timing"]
     lines = [
         f"{format_gpu_label(summary['device'], hw)}:",
-        f"  Span: {t['span_ms']:.1f}ms | Compute: {t['compute_ms']:.1f}ms | Idle: {t['idle_ms']:.1f}ms | Util: {t['utilization_pct']}%",
+        f"  Span: {t['span_ms']:.1f}ms | Busy: {t['busy_ms']:.1f}ms | Idle: {t['idle_ms']:.1f}ms | Util: {t['utilization_pct']}%",
+        f"  Kernel time (sum over streams): {t['compute_ms']:.1f}ms",
         f"  Kernels: {summary['kernel_count']}",
         "",
         "  Top kernels:",

--- a/tests/test_summary_timing.py
+++ b/tests/test_summary_timing.py
@@ -1,0 +1,107 @@
+"""GPU utilization is a fraction of wall time, so it cannot exceed 100%.
+
+It used to. ``compute_ms`` is a sum over kernels, and two kernels resident at the
+same instant on different streams each contribute their full duration to it -- so
+on any capture where compute and communication overlap, the sum outruns the wall
+span it was being divided by. A Megatron capture reported ``Util: 112.5%``, and
+the narrative summary repeated the number in prose.
+
+The union was already in the same function: the idle sweep advances a watermark
+over sorted kernels and only counts a gap when the next kernel starts after it, so
+``span - idle`` is the time at least one kernel was resident. These tests pin the
+identity that makes the difference visible -- ``span_ms == busy_ms + idle_ms`` --
+because it is what ``compute_ms`` cannot satisfy.
+"""
+
+from nsys_ai.summary import gpu_summary
+
+
+class _Meta:
+    def __init__(self):
+        self.gpu_info = {}
+
+
+class _StubProfile:
+    """The two attributes ``gpu_summary`` reads, and nothing else."""
+
+    def __init__(self, kernels):
+        self._kernels = kernels
+        self.meta = _Meta()
+        self.path = "stub.sqlite"
+
+    def kernels(self, device, trim=None):
+        return self._kernels
+
+
+def _kernel(name, stream, start_ms, end_ms):
+    return {
+        "name": name,
+        "streamId": stream,
+        "start": int(start_ms * 1e6),
+        "end": int(end_ms * 1e6),
+    }
+
+
+def test_fully_overlapped_streams_do_not_exceed_one_hundred_percent():
+    """Two streams busy for the same 100ms: the device is 100% busy, not 200%."""
+    prof = _StubProfile(
+        [
+            _kernel("gemm", 7, 0, 100),
+            _kernel("nccl_allreduce", 15, 0, 100),
+        ]
+    )
+
+    timing = gpu_summary(prof, device=0)["timing"]
+
+    assert timing["utilization_pct"] == 100.0
+    assert timing["busy_ms"] == 100.0
+    assert timing["idle_ms"] == 0.0
+    # The sum is still reported, still means what it always meant, and is exactly
+    # the quantity that would have produced 200%.
+    assert timing["compute_ms"] == 200.0
+
+
+def test_partial_overlap_is_measured_against_the_union_not_the_sum():
+    """60ms of union work in a 100ms span is 60%, whatever the per-stream sum says."""
+    prof = _StubProfile(
+        [
+            _kernel("gemm", 7, 0, 50),
+            _kernel("nccl_allreduce", 15, 10, 60),
+            _kernel("gemm", 7, 90, 100),
+        ]
+    )
+
+    timing = gpu_summary(prof, device=0)["timing"]
+
+    assert timing["span_ms"] == 100.0
+    assert timing["busy_ms"] == 70.0  # [0,60) and [90,100)
+    assert timing["idle_ms"] == 30.0  # [60,90)
+    assert timing["utilization_pct"] == 70.0
+    assert timing["compute_ms"] == 110.0  # 50 + 50 + 10, overlap counted twice
+
+
+def test_span_reconciles_with_busy_and_idle():
+    """The identity a reader checks by eye, on a shape with several overlaps."""
+    prof = _StubProfile(
+        [
+            _kernel("a", 7, 0, 30),
+            _kernel("b", 15, 20, 45),
+            _kernel("c", 7, 70, 90),
+            _kernel("d", 23, 80, 120),
+        ]
+    )
+
+    timing = gpu_summary(prof, device=0)["timing"]
+
+    assert timing["span_ms"] == timing["busy_ms"] + timing["idle_ms"]
+    assert 0.0 <= timing["utilization_pct"] <= 100.0
+
+
+def test_a_single_stream_is_unaffected():
+    """No overlap, so sum and union agree -- the old number was right here."""
+    prof = _StubProfile([_kernel("a", 7, 0, 40), _kernel("b", 7, 60, 100)])
+
+    timing = gpu_summary(prof, device=0)["timing"]
+
+    assert timing["compute_ms"] == timing["busy_ms"] == 80.0
+    assert timing["utilization_pct"] == 80.0


### PR DESCRIPTION
## Summary

- `utilization_pct` divided a **sum over kernels** by the **wall span**, so any capture with overlapping streams reported utilization above 100% — a Megatron capture showed `Util: 112.5%`, and the narrative repeated it in prose.
- The correct denominator was already computed a few lines above: the idle sweep is a device-level union, so `span - idle` is the time at least one kernel was resident.
- Fixes #574.

## Changes

**`src/nsys_ai/summary.py`**

- `busy_ns = span_ns - idle_ns`, published as `timing.busy_ms`.
- `utilization_pct` is now `100 * busy_ns / span_ns` — bounded by 100% by construction.
- `compute_ms` keeps its name and its value. It is a sum, it is meaningful, and `export-json --summary` ships it inside a `format_version: 1` payload, so renaming it would break a published key for no correctness gain.
- `format_text` prints `Busy:` on the timing line and moves the sum to its own line, `Kernel time (sum over streams)`, so it can no longer be read as a wall-clock quantity.

**`src/nsys_ai/report.py`**

- Same split in the markdown report: `Busy:` on the timing line, the sum on its own labelled line.

**`tests/test_summary_timing.py`** (new)

Four tests, driven through a stub profile exposing only the two attributes `gpu_summary` reads:

- two streams fully overlapping for 100 ms → 100%, not 200% (this is the defect, minimised)
- partial overlap → measured against the union; the sum is asserted separately at its double-counted value
- `span_ms == busy_ms + idle_ms` on a shape with several overlaps
- a single-stream profile → sum and union agree, and the number is unchanged

## Backward compatibility

Yes, with one deliberate value change: `timing.utilization_pct` now returns the union measure. That is the bug being fixed — the previous value was wrong whenever streams overlapped, and identical whenever they did not.

`timing.compute_ms` is unchanged in both name and value. `timing.busy_ms` is added. No key is removed, so `export-json --summary` consumers keep parsing.

The displayed label `Compute:` became `Busy:` on the text and markdown timing lines. Anything scraping that text — rather than the JSON — sees a different word.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2573 passed, 7 failed, 141 skipped, 4 xfailed**. The 7 failures are pre-existing on clean `main` on this machine (`PermissionError: Operation not permitted` in the `profile_runner` process-tree kill path), confirmed by stashing and re-running; they are unrelated to this change. Passing count is +4, the new tests.
- Exercised on the committed fixture: `Span: 960.5ms | Busy: 22.4ms | Idle: 938.1ms | Util: 2.3%`, with `Kernel time (sum over streams): 22.4ms`. That profile is single-stream, so sum and union agree and the reported number is unchanged — which is the non-regression case.
- `nsys-ai report --gpu 0 --trim 155.4 156.3` renders the same split.

## Out of scope

- `overlap.py` and `iteration_timing.py` have their own `compute_ms` keys in different dicts. They were checked and are unrelated to this one.
- The `_summary`/aggregate handling in #578, the device-error formatters in #576, and the `nvjet` eligibility gap in #575 are separate issues with separate PRs.

## Linked issues

Closes #574
