### PR TITLE
fix(skills): resolve GPU specs by name before falling back to the chip name

### DIFF
--- a/src/nsys_ai/hardware.py
+++ b/src/nsys_ai/hardware.py
@@ -37,7 +37,10 @@ GPU_SPECS: dict[str, tuple[float, float]] = {
     "H100 PCIe": (756.0, 2039),  # H100 PCIe — BF16 dense, 2TB/s HBM2e
     "H100 NVL": (835.0, 3900),  # H100 NVL — BF16 dense, 3.9TB/s HBM3
     "H800": (989.0, 3350),  # H800 (China variant, same die)
-    "GH100": (989.0, 3350),  # ASIC code
+    # Die codes, not parts. One die ships as several SKUs with different memory
+    # (GH100 is both H100 and H200), so these are a last-resort fallback: callers
+    # must try the GPU name first or they will hand an H200 H100's bandwidth.
+    "GH100": (989.0, 3350),  # ASIC code — also the H200 die; H200 is 4800 GB/s
     # === Ada Lovelace (2022-2023) ===
     "L40S": (362.0, 864),  # L40S — BF16/FP16 dense, GDDR6
     "L40": (181.0, 864),  # L40 — BF16/FP16 dense, GDDR6
@@ -63,7 +66,7 @@ GPU_SPECS: dict[str, tuple[float, float]] = {
     "A100 80GB": (312.0, 2039),  # A100 80GB (SXM or PCIe) — BF16 dense
     "A100 PCIe": (312.0, 1555),
     "A100": (312.0, 2039),
-    "GA100": (312.0, 2039),  # ASIC code
+    "GA100": (312.0, 2039),  # ASIC code — spans A100 40GB (1555) and 80GB (2039)
     "A30": (165.0, 933),
     "A10G": (125.0, 600),
     "A10": (125.0, 600),

--- a/src/nsys_ai/skills/builtins/arithmetic_intensity.py
+++ b/src/nsys_ai/skills/builtins/arithmetic_intensity.py
@@ -67,17 +67,30 @@ def _execute(conn, **kwargs):
         else "from this package's hardware spec table"
     )
 
+    # The GPU name is tried before the chip name, and the order is the whole of
+    # this block. A die is not a part: H100 and H200 are the same GH100 die with
+    # different memory, so a die code cannot settle bandwidth. When chipName won,
+    # an H200 was given H100's 3350 GB/s -- the peak is identical across that
+    # pair, so only the bandwidth was wrong and only the ridge point showed it,
+    # 295.2 instead of 206.0 FLOP/Byte. The name is the specific end of the two,
+    # so it goes first and the die code stays as the fallback for exports that
+    # carry no name this table recognises.
+    spec_source = None
     if peak_tflops is None or hbm_bw_gbps is None:
-        if "error" not in spec1:
-            peak_tflops = peak_tflops if peak_tflops is not None else spec1.get("peak_tflops")
-            hbm_bw_gbps = hbm_bw_gbps if hbm_bw_gbps is not None else spec1.get("hbm_bw_gbps")
-        elif "error" not in spec2:
-            peak_tflops = peak_tflops if peak_tflops is not None else spec2.get("peak_tflops")
-            hbm_bw_gbps = hbm_bw_gbps if hbm_bw_gbps is not None else spec2.get("hbm_bw_gbps")
+        for spec, source in ((spec2, "gpu name"), (spec1, f"chip name {chip_name}")):
+            if "error" in spec:
+                continue
+            if peak_tflops is None:
+                peak_tflops = spec.get("peak_tflops")
+            if hbm_bw_gbps is None:
+                hbm_bw_gbps = spec.get("hbm_bw_gbps")
+                spec_source = source
+            break
 
     # If hbm_bw_gbps is still missing, attempt DB fallback
     if hbm_bw_gbps is None and hbm_bw_raw > 0:
         hbm_bw_gbps = hbm_bw_raw / 1e9
+        spec_source = "profile metadata"
 
     # No peak, no roofline: this is the "cannot run" case, so it abstains rather
     # than returning a row with an ``error`` key. Consumers distinguish the two —
@@ -343,6 +356,9 @@ def _execute(conn, **kwargs):
         {
             "gpu_name": gpu_name,
             "chip_name": chip_name,
+            # Which lookup supplied the bandwidth, so a die-code fallback is
+            # visible rather than silent. None when the caller passed it in.
+            "hbm_bw_source": spec_source,
             "peak_fp16_tflops": round(peak_tflops, 1),
             "hbm_bw_gbps": round(hbm_bw_gbps, 1),
             "ridge_point_flop_per_byte": round(ridge_point, 1),
@@ -372,7 +388,12 @@ def _format(rows):
         "── Arithmetic Intensity Assessment (Roofline) ──",
         f"  GPU:              {r['gpu_name']}",
         f"  Peak FP16:        {r['peak_fp16_tflops']} TFLOPS",
-        f"  HBM Bandwidth:    {r['hbm_bw_gbps']} GB/s",
+        f"  HBM Bandwidth:    {r['hbm_bw_gbps']} GB/s"
+        + (
+            f"  (matched on {r['hbm_bw_source']})"
+            if (r.get("hbm_bw_source") or "").startswith("chip name")
+            else ""
+        ),
         f"  Ridge Point:      {r['ridge_point_flop_per_byte']} FLOP/Byte",
         "",
         f"  Kernel Union Time:  {r['kernel_union_ms']:.2f} ms  ({r['kernel_count']} kernels)",

--- a/tests/test_skills_benchmarks.py
+++ b/tests/test_skills_benchmarks.py
@@ -114,7 +114,7 @@ def test_pipeline_bubble_metrics_no_tables_graceful(minimal_nsys_conn):
 
 
 def _use_a100(conn):
-    """Point the fixture's GPU row at an A100 so the chipName lookup resolves.
+    """Point the fixture's GPU row at an A100 so the spec lookup resolves.
 
     TARGET_INFO_GPU already has id=0 from the fixture with chipName='TestChip',
     which is in no spec table.
@@ -150,6 +150,75 @@ def test_arithmetic_intensity_execute(minimal_nsys_conn):
     assert "achieved_tflops" in r
     assert "mfu_pct" in r
     assert r["peak_fp16_tflops"] == 312.0  # GA100 lookup
+
+
+def _use_h200(conn):
+    """An H200 as Nsight reports one: the marketing name, and the shared die.
+
+    H200 is the same GH100 die as H100, and GH100 is itself a spec-table key
+    carrying H100's 3350 GB/s. That is the whole trap -- both parts have the
+    same 989 TFLOPS peak, so a die-code match looks right until the bandwidth
+    is read.
+    """
+    conn.execute(
+        "UPDATE TARGET_INFO_GPU SET name='NVIDIA H200', "
+        "chipName='GH100', memoryBandwidth=0 WHERE id=0"
+    )
+
+
+def test_h200_gets_its_own_bandwidth_not_the_shared_die_s(minimal_nsys_conn):
+    """The GPU name is more specific than the die code, so it decides."""
+    from nsys_ai.skills.registry import get_skill
+
+    _use_h200(minimal_nsys_conn)
+
+    rows = get_skill("arithmetic_intensity").execute(
+        minimal_nsys_conn, theoretical_flops=200e12 * _FIXTURE_KERNEL_S
+    )
+
+    r = rows[0]
+    assert r["hbm_bw_gbps"] == 4800.0, "H200 is HBM3e at 4.8 TB/s, not H100's 3.35 TB/s"
+    assert r["ridge_point_flop_per_byte"] == 206.0  # 989e12 / 4800e9
+    assert r["peak_fp16_tflops"] == 989.0  # identical across the pair, and correct
+    assert r["hbm_bw_source"] == "gpu name"
+
+
+def test_the_die_code_still_answers_when_the_name_is_unknown(minimal_nsys_conn):
+    """The fallback is kept -- some exports carry no name this table recognises."""
+    from nsys_ai.skills.registry import get_skill
+
+    minimal_nsys_conn.execute(
+        "UPDATE TARGET_INFO_GPU SET name='Graphics Device', "
+        "chipName='GH100', memoryBandwidth=0 WHERE id=0"
+    )
+
+    rows = get_skill("arithmetic_intensity").execute(
+        minimal_nsys_conn, theoretical_flops=200e12 * _FIXTURE_KERNEL_S
+    )
+
+    r = rows[0]
+    assert r["peak_fp16_tflops"] == 989.0
+    assert r["hbm_bw_gbps"] == 3350.0
+    # Named in the row, and rendered, so a die-code match is not silent.
+    assert r["hbm_bw_source"] == "chip name GH100"
+    assert "matched on chip name GH100" in get_skill("arithmetic_intensity").format_rows(rows)
+
+
+def test_a_caller_supplied_bandwidth_outranks_both_lookups(minimal_nsys_conn):
+    """The documented override still wins, and is not labelled as a lookup."""
+    from nsys_ai.skills.registry import get_skill
+
+    _use_h200(minimal_nsys_conn)
+
+    rows = get_skill("arithmetic_intensity").execute(
+        minimal_nsys_conn,
+        theoretical_flops=200e12 * _FIXTURE_KERNEL_S,
+        hbm_bw_gbps=1234,
+    )
+
+    r = rows[0]
+    assert r["hbm_bw_gbps"] == 1234.0
+    assert r["hbm_bw_source"] is None
 
 
 def test_arithmetic_intensity_no_gpu_table(minimal_nsys_conn):


### PR DESCRIPTION
## Summary

- The roofline looked up `TARGET_INFO_GPU.chipName` **before** the GPU name. H100 and H200 are the same GH100 die, and `GH100` is itself a spec-table key carrying H100's 3350 GB/s — so an H200 was classified against H100 bandwidth.
- Both parts share a 989 TFLOPS peak, so the header looked correct and only the ridge point showed it: **295.2 FLOP/Byte instead of 206.0**, 43% high, which moves the memory-bound / compute-bound boundary for every kernel classified.
- Fixes #577.

## Changes

**`src/nsys_ai/skills/builtins/arithmetic_intensity.py`**

- The GPU name is resolved first; the chip name stays as the fallback for exports carrying no name the table recognises. The `if/elif` became a short ordered loop so the precedence is the readable part.
- The result row gains `hbm_bw_source` — `"gpu name"`, `"chip name GH100"`, `"profile metadata"`, or `None` when the caller supplied the value.
- `_format` appends `(matched on chip name GH100)` to the bandwidth line when a die code supplied it, so a fallback is visible rather than silent.

**`src/nsys_ai/hardware.py`**

- Comments only. `GH100` and `GA100` are marked as die codes that span SKUs with different memory, with the values they are wrong for, so the next person adding a die-code key sees the trap.

**`tests/test_skills_benchmarks.py`**

Three tests beside the existing `arithmetic_intensity` ones, using a `_use_h200` helper that sets the marketing name and the shared die exactly as Nsight reports them:

- an H200 resolves to 4800 GB/s and a 206.0 ridge point, with `hbm_bw_source == "gpu name"`
- an unrecognised name still falls back to the die code, and both the row and the rendered text say so
- a caller-supplied `hbm_bw_gbps` outranks both lookups and is not labelled as one

The `_use_a100` docstring said "so the chipName lookup resolves", which this change makes stale; it now says "spec lookup". That helper's GPU resolves identically either way, which is why the existing tests are untouched.

## Backward compatibility

Yes, with the intended value change: a GPU whose name and chip name disagree on bandwidth now takes the name's value. That is the bug. Where the two agree — every entry that is not a shared die — nothing moves.

`hbm_bw_source` is an added key; none is removed.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2572 passed, 7 failed, 141 skipped, 4 xfailed**. The 7 are pre-existing on clean `main` on this machine (`PermissionError: Operation not permitted` in the `profile_runner` process-tree kill path), confirmed by stashing and re-running. Passing count is +3, the new tests.
- The three new tests were checked in both directions: against the unfixed source they fail with `AssertionError: H200 is HBM3e at 4.8 TB/s, not H100's 3.35 TB/s` and two `KeyError: 'hbm_bw_source'`; with the fix all 22 tests in the file pass.
- Spec values were checked against vendor documentation rather than assumed: H200 SXM is HBM3e at 4.8 TB/s against H100 SXM5's 3.35 TB/s — the same 43% the ridge point was off by.

## Out of scope

- Whether a die-code key should be allowed to supply bandwidth at all. Kept, because some exports carry no usable name and a wrong-but-labelled figure beats refusing to classify — but it is now labelled, so the decision can be revisited with evidence.
- One residual uncertainty, recorded rather than papered over: that an H200 export's `chipName` is literally `GH100` was not confirmed against an H200 capture on this machine. The conclusion does not rest on it — `get_peak_tflops("NVIDIA H200")` returns 4800, and the header prints the same string it passes to that lookup, so 3350 can only have come from the chip-name branch. `tests/test_parquetdir_backend.py:102` already uses `GH100` for Hopper.

## Linked issues

Closes #577
