### PR TITLE
fix(skills): render a refusal centrally when a formatter cannot

### DIFF
--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -424,18 +424,35 @@ def _describe_event_type(adapter, event_type: int) -> str:
 def is_error_row(rows: list[dict] | None) -> bool:
     """True when *rows* is the single ``error`` row a skill returns to refuse.
 
-    Deliberately narrow. A skill's real results may well carry a per-row
-    ``error`` column, and truncating those to one rendered message would lose
-    the results — so only a lone row qualifies, which is the shape every
-    refusing skill in ``builtins/`` produces.
+    Deliberately narrow, in two ways. A skill's real results may well carry a
+    per-row ``error`` column, and truncating those to one rendered message would
+    lose the results — so only a lone row qualifies, which is the shape every
+    refusing skill in ``builtins/`` produces. And the column has to hold
+    something: a single data row with ``{"error": None}`` is a result whose error
+    column happens to be empty, not a refusal, which is the reading the agent
+    already takes when it tests ``row.get("error")`` for truth.
     """
     return (
         isinstance(rows, list)
         and len(rows) == 1
         and isinstance(rows[0], dict)
-        and "error" in rows[0]
+        and bool(rows[0].get("error"))
         and not is_abstention_row(rows[0])
     )
+
+
+def _error_signals(value) -> list[str]:
+    """Strings that identify *value* in rendered text.
+
+    An ``error`` is usually a sentence, but not always: ``region_mfu`` returns
+    ``{"code": ..., "message": ...}`` and its formatter renders the two fields
+    rather than the mapping. Matching on ``str(value)`` would miss that and
+    discard a better message than this module can write, so a mapping
+    contributes each of its scalar values instead of its repr.
+    """
+    if isinstance(value, dict):
+        return [str(v) for v in value.values() if isinstance(v, (str, int, float))]
+    return [str(value)]
 
 
 def _format_error(skill, row: dict) -> str:
@@ -445,7 +462,8 @@ def _format_error(skill, row: dict) -> str:
     the devices the profile does have, and that string never reached a reader
     while the formatters were crashing ahead of it.
     """
-    lines = [f"{skill.title}: {row['error']}"]
+    signals = [text for text in _error_signals(row["error"]) if text]
+    lines = [f"{skill.title}: {': '.join(signals) if signals else row['error']}"]
     hint = row.get("hint")
     if hint:
         lines += ["", str(hint)]
@@ -884,8 +902,10 @@ class Skill:
                 rendered = self.format_fn(rows)
             except (KeyError, IndexError, AttributeError, TypeError):
                 return _format_error(self, rows[0])
-            reason = str(rows[0].get("error", ""))
-            return rendered if reason and reason in rendered else _format_error(self, rows[0])
+            signals = [text for text in _error_signals(rows[0]["error"]) if text]
+            if any(text in rendered for text in signals):
+                return rendered
+            return _format_error(self, rows[0])
         return self.format_fn(rows)
 
     def run(self, conn: sqlite3.Connection, **kwargs) -> str:

--- a/src/nsys_ai/skills/base.py
+++ b/src/nsys_ai/skills/base.py
@@ -421,6 +421,37 @@ def _describe_event_type(adapter, event_type: int) -> str:
     return f"{event_type} ({row[0]})"
 
 
+def is_error_row(rows: list[dict] | None) -> bool:
+    """True when *rows* is the single ``error`` row a skill returns to refuse.
+
+    Deliberately narrow. A skill's real results may well carry a per-row
+    ``error`` column, and truncating those to one rendered message would lose
+    the results — so only a lone row qualifies, which is the shape every
+    refusing skill in ``builtins/`` produces.
+    """
+    return (
+        isinstance(rows, list)
+        and len(rows) == 1
+        and isinstance(rows[0], dict)
+        and "error" in rows[0]
+        and not is_abstention_row(rows[0])
+    )
+
+
+def _format_error(skill, row: dict) -> str:
+    """Render a refusal for a formatter that was not written for one.
+
+    ``hint`` is the field worth surfacing: the device-not-found row already names
+    the devices the profile does have, and that string never reached a reader
+    while the formatters were crashing ahead of it.
+    """
+    lines = [f"{skill.title}: {row['error']}"]
+    hint = row.get("hint")
+    if hint:
+        lines += ["", str(hint)]
+    return "\n".join(lines)
+
+
 def is_abstention(rows: list[dict] | None) -> bool:
     """True when ``rows`` is a skill saying it could not run.
 
@@ -813,12 +844,49 @@ class Skill:
         contract is defined in this module, so honouring it belongs here too —
         and a per-skill formatter that forgot would crash on the missing data
         columns instead of printing the reason.
+
+        The same argument covers an error row, and it was not being honoured. A
+        skill that cannot answer for the arguments it was given returns a single
+        ``{"error": ...}`` row — asking for a device the profile does not have
+        produces one carrying ``available_devices`` and a ``hint`` naming the
+        devices that do exist. That row has none of the data columns, so a
+        formatter that indexes them dies on it: handed that shape, 23 of the 37
+        builtins raise ``KeyError`` rather than printing the hint written for
+        exactly this case.
+
+        The central rendering is a *fallback*, not an interception. A formatter
+        written for its own error row renders it better than a generic message
+        can — ``code_attribution_candidates`` carries ``limitations`` that it
+        spells out, and ``tensor_core_usage`` explains which columns it needed.
+        So the skill's formatter is still tried first and only a formatter that
+        was never written for the shape, and says so by raising on a missing
+        column, falls through to the generic reason.
+
+        Raising is not the only way to mishandle the row, and it is not the worst
+        one. ``critical_path`` and ``profile_health_manifest`` render it without
+        complaint, as ``Bound class: None`` over a ``0.0ms`` critical path and a
+        manifest with a ``?`` for the GPU — a clean-looking report for a question
+        that was never answered, which beats a traceback only until someone reads
+        it. So a formatter has to say something about the refusal to keep it: its
+        output is used when it mentions the reason, and the generic rendering
+        takes over when it does not.
+
+        Swallowing an exception is worth naming: it is scoped to the error-row
+        branch, where there is no data to mis-render and the alternative on offer
+        is a traceback. A data row that raises still raises.
         """
         if is_abstention(rows):
             return f"{self.title}: not applicable to this profile.\n\n{rows[0]['reason']}"
-        if self.format_fn:
-            return self.format_fn(rows)
-        return _default_format(self, rows)
+        if not self.format_fn:
+            return _default_format(self, rows)
+        if is_error_row(rows):
+            try:
+                rendered = self.format_fn(rows)
+            except (KeyError, IndexError, AttributeError, TypeError):
+                return _format_error(self, rows[0])
+            reason = str(rows[0].get("error", ""))
+            return rendered if reason and reason in rendered else _format_error(self, rows[0])
+        return self.format_fn(rows)
 
     def run(self, conn: sqlite3.Connection, **kwargs) -> str:
         """Execute and format results as text."""

--- a/tests/test_skill_error_rows.py
+++ b/tests/test_skill_error_rows.py
@@ -171,3 +171,45 @@ def test_a_formatter_that_renders_defaults_over_an_error_does_not_get_to(name):
     assert "no kernels found" in text
     assert "Device 9 is not present in this profile" in text
     assert "0.0ms" not in text
+
+
+def test_a_lone_data_row_with_an_empty_error_column_is_not_a_refusal():
+    """The column holding nothing is a result, not a refusal.
+
+    A skill can return one row whose ``error`` column is simply empty. Testing
+    for the key alone called that a refusal and printed ``: None`` over the
+    formatter's real output. The agent already reads these by truth rather than
+    by presence, so this does too.
+    """
+    recorder = _Recorder()
+    skill = _skill_with(recorder)
+
+    assert skill.format_rows([{"error": None, "gap_ns": 1}]) == "formatted"
+    assert recorder.called_with == [{"error": None, "gap_ns": 1}]
+    assert skill.format_rows([{"error": "", "gap_ns": 1}]) == "formatted"
+
+
+def test_a_structured_error_keeps_the_formatter_that_understands_it():
+    """``error`` is not always a sentence.
+
+    ``region_mfu`` returns ``{"code": ..., "message": ...}`` and renders the two
+    fields. Looking for ``str(mapping)`` in that output finds nothing, so the
+    check used to decide the formatter had ignored the error and replace a good
+    message with a raw dict repr.
+    """
+    row = {"error": {"code": "KERNEL_NOT_FOUND", "message": "no kernels in the region"}}
+
+    text = get_skill("region_mfu").format_rows([row])
+
+    assert text == "(MFU error: KERNEL_NOT_FOUND: no kernels in the region)"
+
+
+def test_a_structured_error_still_renders_when_no_formatter_handles_it():
+    """The fallback spells the mapping out rather than printing its repr."""
+    row = {"error": {"code": "KERNEL_NOT_FOUND", "message": "no kernels in the region"}}
+
+    text = get_skill("gpu_idle_gaps").format_rows([row])
+
+    assert "KERNEL_NOT_FOUND" in text
+    assert "no kernels in the region" in text
+    assert "{'code'" not in text

--- a/tests/test_skill_error_rows.py
+++ b/tests/test_skill_error_rows.py
@@ -1,0 +1,173 @@
+"""A skill that refuses must say so, not crash the formatter it hands the row to.
+
+``Skill.execute`` has three documented outcomes -- no rows, an abstention row, or
+data -- and an undocumented fourth: a single ``{"error": ...}`` row returned when
+the skill cannot answer for the arguments it was given. Asking for a device the
+profile does not have produces one, and it is a good error, carrying
+``available_devices`` and a ``hint`` naming the devices that do exist.
+
+That row has none of the data columns. Formatters that index them died on it:
+eight of the thirty-seven builtins raised ``KeyError`` rather than printing the
+hint written for exactly this case, and ``arithmetic_intensity`` -- the skill
+usually cited as the one that handles it well -- was among them. The remaining
+twenty-nine were correct by luck, not by contract.
+
+``format_rows`` already renders abstention centrally for the same reason. These
+tests pin the error row to the same place.
+"""
+
+import pytest
+
+from nsys_ai.skills.base import abstain, is_error_row
+from nsys_ai.skills.registry import get_skill, list_skills
+
+#: The row the query layer produces for a device the profile does not have.
+DEVICE_ERROR_ROW = {
+    "error": "no kernels found",
+    "requested_device": 9,
+    "available_devices": {"0": 1721, "1": 1721},
+    "hint": "Device 9 is not present in this profile. Available devices: 0, 1.",
+}
+
+
+def _skill_names():
+    return sorted(list_skills())
+
+
+def test_there_are_skills_to_check():
+    """Guard the guard: an empty registry would make the sweep below vacuous."""
+    assert len(_skill_names()) > 10
+
+
+@pytest.mark.parametrize("name", _skill_names())
+def test_every_skill_formats_an_error_row_without_raising(name):
+    """The sweep that found the eight. It is the contract, so it covers all of them."""
+    text = get_skill(name).format_rows([dict(DEVICE_ERROR_ROW)])
+
+    assert isinstance(text, str) and text.strip()
+    assert "no kernels found" in text
+
+
+@pytest.mark.parametrize("name", ["gpu_idle_gaps", "arithmetic_intensity", "nccl_breakdown"])
+def test_the_hint_reaches_the_reader(name):
+    """The hint was always written; while the formatters crashed, nobody saw it."""
+    text = get_skill(name).format_rows([dict(DEVICE_ERROR_ROW)])
+
+    assert "Device 9 is not present in this profile" in text
+    assert "Available devices: 0, 1" in text
+
+
+def test_an_error_row_without_a_hint_still_renders():
+    """``hint`` is optional -- most refusals carry only ``error``."""
+    text = get_skill("gpu_idle_gaps").format_rows([{"error": "kernels table is absent"}])
+
+    assert "kernels table is absent" in text
+
+
+class _Recorder:
+    """Stands in for a format_fn so the tests can see whether it was reached."""
+
+    def __init__(self):
+        self.called_with = None
+
+    def __call__(self, rows):
+        self.called_with = rows
+        return "formatted"
+
+
+def _skill_with(format_fn):
+    skill = get_skill("gpu_idle_gaps")
+    import dataclasses
+
+    return dataclasses.replace(skill, format_fn=format_fn)
+
+
+def test_results_carrying_an_error_column_still_reach_the_formatter():
+    """The predicate is narrow on purpose.
+
+    A skill's real results may legitimately carry a per-row ``error`` column, and
+    collapsing those to one rendered message would throw the results away. Only a
+    lone row qualifies.
+    """
+    rows = [{"error": None, "gap_ns": 1}, {"error": "partial", "gap_ns": 2}]
+    recorder = _Recorder()
+
+    assert _skill_with(recorder).format_rows(rows) == "formatted"
+    assert recorder.called_with == rows
+
+
+def test_a_single_data_row_is_not_mistaken_for_an_error():
+    """One row with no ``error`` key is data, and goes where data goes."""
+    recorder = _Recorder()
+
+    assert _skill_with(recorder).format_rows([{"gap_ns": 1}]) == "formatted"
+    assert recorder.called_with == [{"gap_ns": 1}]
+
+
+def test_abstention_still_wins_over_the_error_branch():
+    """Abstention has its own rendering and its own meaning; it is checked first."""
+    text = get_skill("gpu_idle_gaps").format_rows(abstain("this profile has no NVTX"))
+
+    assert "not applicable to this profile" in text
+    assert "this profile has no NVTX" in text
+
+
+@pytest.mark.parametrize(
+    "rows, expected",
+    [
+        ([{"error": "x"}], True),
+        ([{"error": "x", "hint": "y"}], True),
+        ([], False),
+        (None, False),
+        ([{"gap_ns": 1}], False),
+        ([{"error": "x"}, {"error": "y"}], False),
+        (abstain("cannot run"), False),
+    ],
+)
+def test_is_error_row_predicate(rows, expected):
+    assert is_error_row(rows) is expected
+
+
+def test_a_skill_that_formats_its_own_error_row_keeps_doing_so():
+    """The central rendering is a fallback, not an interception.
+
+    ``code_attribution_candidates`` returns an error row carrying ``limitations``
+    and its formatter spells them out. A generic message would be a downgrade, so
+    the skill's own output is kept when it mentions the reason.
+    """
+    row = {
+        "error": "No overlapping NVTX ranges found for the selected window",
+        "selection": {"start_ns": 0, "end_ns": 1, "device_id": 0},
+        "limitations": ["NVTX ranges are a proxy for source location"],
+    }
+
+    text = get_skill("code_attribution_candidates").format_rows([row])
+
+    assert "No overlapping NVTX ranges found" in text
+    assert "Limitations:" in text
+    assert "NVTX ranges are a proxy for source location" in text
+
+
+def test_tensor_core_usage_keeps_its_own_explanation():
+    """The other formatter with a genuinely better message than a generic one."""
+    row = {"error": "Tensor Core analysis requires a database connection that exposes ..."}
+
+    text = get_skill("tensor_core_usage").format_rows([row])
+
+    assert "requires a database connection" in text
+
+
+@pytest.mark.parametrize("name", ["critical_path", "profile_health_manifest"])
+def test_a_formatter_that_renders_defaults_over_an_error_does_not_get_to(name):
+    """Not raising is not the same as handling it.
+
+    These two render an error row as an empty report -- ``Bound class: None`` over
+    a ``0.0ms`` critical path, a manifest with ``?`` for the GPU. That reads as a
+    clean bill of health for a question that was never answered, which is worse
+    than the crash this change replaced, so the reason wins.
+    """
+    text = get_skill(name).format_rows([dict(DEVICE_ERROR_ROW)])
+
+    assert "no kernels found" in text
+    assert "Device 9 is not present in this profile" in text
+    assert "0.0ms" not in text


### PR DESCRIPTION
## Summary

- `Skill.execute` has three documented outcomes — no rows, an abstention row, or data — and an undocumented fourth: a single `{"error": ...}` row returned when the skill cannot answer for the arguments it was given.
- That row has none of the data columns. Handed it, **23 of the 37 builtins raise `KeyError`** instead of printing the hint written for exactly this case, so `skill run ... -p device=9` showed a traceback where the answer was.
- Fixes #576.

## Changes

**`src/nsys_ai/skills/base.py`**

- `is_error_row(rows)` — a deliberately narrow predicate: a *lone* dict carrying `error` that is not an abstention. A skill's real results may legitimately have a per-row `error` column, and collapsing those would discard the results.
- `_format_error(skill, row)` — renders the reason and, when present, `hint`. The device row already names the devices that do exist; that string never reached a reader while the formatters were crashing ahead of it.
- `format_rows` handles the error row where it already handles abstention, on the argument its own docstring makes: the contract is defined in that module, so honouring it belongs there.

The central rendering is a **fallback, not an interception** — this is the part worth reviewing:

1. The skill's own formatter is tried first. One written for its own error row renders it better than a generic message can.
2. If it raises on a missing column, the generic reason is used.
3. If it returns without mentioning the reason, the generic reason is used as well.

Step 3 exists because raising is not the only way to mishandle the row, and it is not the worst. `critical_path` renders it as `Bound class: None` over a `0.0ms` critical path; `profile_health_manifest` renders a manifest with `?` for the GPU and a `0.0ms` span. Both read as a clean bill of health for a question that was never answered, which beats a traceback only until someone acts on it.

**`tests/test_skill_error_rows.py`** (new, 57 cases)

- every registered skill formats an error row without raising — the sweep, parametrised, so a new skill is covered on arrival
- the hint reaches the reader for three of the skills that were crashing
- `code_attribution_candidates` keeps its `Limitations:` block, and `tensor_core_usage` keeps its explanation — the preservation half
- `critical_path` and `profile_health_manifest` no longer render `0.0ms` over an error
- results carrying a per-row `error` column still reach the formatter; a lone data row is not mistaken for an error; abstention still wins
- the predicate itself, table-driven

## Backward compatibility

Yes for any skill whose formatter already handled its error row — output is unchanged, which the `tensor_core_usage` and `code_attribution_candidates` tests pin.

Changed for the rest: a traceback becomes a rendered reason, and two skills stop rendering an empty report over an error. Both are the fix.

`format_rows` no longer propagates `KeyError`/`IndexError`/`AttributeError`/`TypeError` **from the error-row branch only**. A data row that raises still raises — the swallow is scoped to the branch where there is no data to mis-render and the alternative on offer is a traceback.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2626 passed, 7 failed, 141 skipped, 4 xfailed**. The 7 are pre-existing on clean `main` on this machine (`PermissionError: Operation not permitted` in the `profile_runner` process-tree kill path), confirmed by stashing and re-running.
- Before/after on the exact assertion the sweep makes: **23 formatters raise → 0**.
- End to end, the reported command now answers instead of crashing:

  ```
  $ nsys-ai skill run gpu_idle_gaps PROFILE.sqlite -p device=9
  GPU Idle Gaps (Bubbles): no kernels found

  Device 9 is not present in this profile. Available devices: 0, 1. Try: -p device=0, -p device=1
  ```

- An earlier revision of this patch rendered centrally *before* the formatter. `tests/test_skills.py::test_tensor_core_usage_fallback` failed on it, and a Codex review flagged that `code_attribution_candidates` would lose its `limitations`. Both were right; the fallback ordering above is the result, and both cases now have tests.

## Out of scope

- Making these paths call `abstain()` instead of returning an `error` row. That is the better long-term shape — `docs/notes/cannot-answer.md` already tracks it as #345, with a matrix of the encodings in use — but it is a change to every producing skill, where this is a change to the one renderer.
- `_apply_max_rows_truncation` also special-cases error rows (#578, separate PR).

## Linked issues

Closes #576
