### PR TITLE
fix(cache): recognise cuBLAS's Hopper nvjet GEMMs as Tensor Core kernels

### DIFF
--- a/src/nsys_ai/parquet_cache.py
+++ b/src/nsys_ai/parquet_cache.py
@@ -143,10 +143,10 @@ def _build_lock(cache_dir: Path) -> Iterator[None]:
         os.close(fd)
 
 # Bump this when the cache schema changes (e.g., new columns, new tables).
-_CACHE_VERSION = 16  # bumped: nvtx_kernel_map is now built by the stack sweep. A cache from
-# version 15 holds the same rows for the SQL path, but one written by the old Python path carries
-# seven columns instead of nine (no is_tc_eligible/uses_tc), and reusing that silently reports
-# every kernel as non-Tensor-Core.
+_CACHE_VERSION = 17  # bumped: the Tensor Core name patterns now recognise cuBLAS's Hopper
+# ``nvjet`` GEMMs. is_tc_eligible/uses_tc are computed at build time and stored in
+# kernels.parquet, so a version 16 cache keeps answering that every nvjet kernel is neither
+# eligible nor active -- the exact blind spot this fixes -- until it is rebuilt.
 
 _SAFE_PARQUETDIR_NAME_RE = re.compile(r"^[A-Za-z0-9_]+$")
 
@@ -402,9 +402,18 @@ _TABLE_PROJECTIONS: dict[str, str] = {
     "ENUM_CUPTI_SYNC_TYPE": "id, name",
 }
 
-_TC_ELIGIBLE_PATTERN = "'(gemm|conv|linear|attention|matmul|flash)'"
+# Kernel-name heuristics, and they go stale whenever a vendor renames a family.
+# ``nvjet`` is what recent cuBLAS calls its Hopper GEMMs -- names like
+# ``nvjet_tst_128x128_64x4_1x2_h_bz_coopA`` and ``nvjet_sm90_hss_320x128``. It
+# matched neither pattern, so on an H100/H200 capture the family that dominates
+# the profile scored is_tc_eligible = 0 and was dropped by tensor_core_usage's
+# own ``WHERE is_tc_eligible = 1`` before any analysis saw it. It is in both
+# patterns rather than only the first because these are warpgroup (wgmma)
+# kernels: eligible-only would report every Hopper GEMM as a Tensor Core
+# fallback, which is a louder wrong answer than the silence it replaced.
+_TC_ELIGIBLE_PATTERN = "'(gemm|conv|linear|attention|matmul|flash|nvjet)'"
 _TC_ACTIVE_PATTERN = (
-    "'(xmma|mma_sync|16816|1688|884|ampere_bf16|sm80_tensor_op|tensorop|flash)'"
+    "'(xmma|mma_sync|16816|1688|884|ampere_bf16|sm80_tensor_op|tensorop|flash|nvjet)'"
 )
 
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -310,7 +310,10 @@ def test_the_direct_attach_builder_keeps_the_same_total_order():
 
     cache = (root / "parquet_cache.py").read_text()
     # The persisted map must not be reused across a change in how it is built.
-    assert "_CACHE_VERSION = 16" in cache
+    # Pinned as a literal on purpose: this is a tripwire, so a build change that
+    # forgets to invalidate stops here rather than shipping a stale cache. Update
+    # it in the same commit as the bump.
+    assert "_CACHE_VERSION = 17" in cache
 
 
 # ── Cross-backend agreement ─────────────────────────────────────────────────

--- a/tests/test_tensor_core_patterns.py
+++ b/tests/test_tensor_core_patterns.py
@@ -1,0 +1,94 @@
+"""The Tensor Core name heuristics, pinned against real kernel names.
+
+``is_tc_eligible`` and ``uses_tc`` are decided by two regexes over the kernel
+name, computed once at cache-build time and stored in ``kernels.parquet``. They
+had no test, and they went stale: ``nvjet`` is what recent cuBLAS calls its
+Hopper GEMMs, it matched neither pattern, and ``tensor_core_usage`` drops
+non-eligible kernels in its own ``WHERE`` — so on an H100/H200 capture the
+family that dominates the profile was invisible to the Tensor Core check. Had a
+GEMM there fallen back to CUDA cores, nothing would have reported it.
+
+A name-based heuristic will go stale again. These cases are the record of what
+it is currently expected to know, so the next rename is a failing test rather
+than a silent blind spot.
+"""
+
+import re
+
+import pytest
+
+from nsys_ai.parquet_cache import _TC_ACTIVE_PATTERN, _TC_ELIGIBLE_PATTERN
+
+
+def _matches(pattern: str, name: str) -> bool:
+    """Apply a pattern the way the DuckDB build does: unquoted, against lower()."""
+    return re.search(pattern.strip("'"), name.lower()) is not None
+
+
+def _stored_eligible(name: str) -> bool:
+    """What the build actually writes to ``is_tc_eligible``.
+
+    Not the eligibility regex alone: the build ORs the two patterns, so a name
+    the active pattern recognises is eligible whether or not the first pattern
+    also matches. Asserting the regex instead of the stored value would forbid
+    an active-only marker -- a bare ``s16816`` with no ``gemm`` in the name --
+    which production handles correctly today.
+    """
+    return _matches(_TC_ELIGIBLE_PATTERN, name) or _matches(_TC_ACTIVE_PATTERN, name)
+
+
+#: (kernel name, eligible, tc-active). Names are real, from vendor libraries.
+CASES = [
+    # cuBLAS on Hopper. The regression this file exists for.
+    ("nvjet_tst_128x128_64x4_1x2_h_bz_coopA", True, True),
+    ("nvjet_hsh_256x128_64x4_2x1_v_bz_TNN", True, True),
+    ("nvjet_sm90_hss_320x128", True, True),
+    # Older cuBLAS/CUTLASS naming, which already worked.
+    ("sm90_xmma_gemm_bf16bf16_bf16f32_f32_tn", True, True),
+    ("sm80_xmma_gemm_f32f32_f32f32_f32_tn_n_tilesize64x256x8", True, True),
+    ("void cutlass::Kernel2<cutlass_80_tensorop_bf16_s16816gemm>", True, True),
+    ("flash_fwd_splitkv_kernel", True, True),
+    # Eligible by shape, but the name carries no evidence of a TC path. These
+    # are the ones a fallback would show up as.
+    ("volta_sgemm_128x64_nn", True, False),
+    ("implicit_convolve_sgemm", True, False),
+    # Active-only: the name carries a TC instruction marker but none of the
+    # shape words. The build ORs the patterns, so this is stored eligible --
+    # asserting the eligibility regex directly would have forbidden it.
+    ("some_kernel_with_s16816_marker", True, True),
+    # Not GEMM-shaped at all.
+    ("vectorized_elementwise_kernel", False, False),
+    ("ncclDevKernel_AllReduce_Sum_f32_RING_LL", False, False),
+    ("at::native::reduce_kernel", False, False),
+]
+
+
+@pytest.mark.parametrize("name, eligible, active", CASES)
+def test_tensor_core_name_heuristics(name, eligible, active):
+    """``eligible`` is the stored column, which is the OR of the two patterns."""
+    assert _stored_eligible(name) is eligible
+    assert _matches(_TC_ACTIVE_PATTERN, name) is active
+
+
+@pytest.mark.parametrize("name, eligible, active", CASES)
+def test_tc_active_implies_stored_eligible(name, eligible, active):
+    """A kernel cannot be recorded as using Tensor Cores while ineligible for them.
+
+    This holds by construction — the build ORs the patterns — so it is here to
+    catch a future edit that computes the two columns independently, not to
+    constrain which pattern a name matches.
+    """
+    if _matches(_TC_ACTIVE_PATTERN, name):
+        assert _stored_eligible(name)
+
+
+def test_nvjet_is_active_not_merely_eligible():
+    """Stated as its own case because the alternative is a tempting mistake.
+
+    Adding ``nvjet`` to the eligibility pattern alone would make every Hopper
+    cuBLAS GEMM report 0% Tensor Core usage — reading as a total fallback on a
+    healthy profile, which is a louder wrong answer than the silence it replaces.
+    These are warpgroup (wgmma) kernels; ``nvjet_sm90_hss_320x128`` measures
+    around 77% of an H100's dense FP16 peak, which no CUDA-core path reaches.
+    """
+    assert _matches(_TC_ACTIVE_PATTERN, "nvjet_sm90_hss_320x128")


### PR DESCRIPTION
## Summary

- Tensor Core eligibility is decided by two regexes over the kernel name, and neither knew `nvjet` — what recent cuBLAS calls its Hopper GEMMs.
- On an H100/H200 capture the GEMM family that dominates the profile scored `is_tc_eligible = 0`, and `tensor_core_usage` drops non-eligible kernels in its own `WHERE`, so the analysis never saw it.
- Fixes #575.

## Changes

**`src/nsys_ai/parquet_cache.py`**

- `nvjet` added to `_TC_ELIGIBLE_PATTERN` **and** `_TC_ACTIVE_PATTERN`.
- `_CACHE_VERSION` 16 → 17.

Both choices are the reviewable part:

*Why both patterns.* These are warpgroup (wgmma) kernels — `nvjet_sm90_hss_320x128` reaches roughly 77% of an H100's dense FP16 peak, which no CUDA-core path does. Marking them eligible but not active would report every Hopper cuBLAS GEMM as a Tensor Core fallback: a louder wrong answer than the silence it replaces, and one that would fire on healthy profiles. The cost is that a genuine fallback *within* the nvjet family can't be spotted by name — the same limitation `xmma` and `tensorop` already carry.

*Why the version bump.* `is_tc_eligible`/`uses_tc` are computed at build time and stored in `kernels.parquet`. Without the bump, an existing cache keeps answering that no nvjet kernel is eligible or active — the blind spot itself — on every machine that has already analysed a profile.

**`tests/test_tensor_core_patterns.py`** (new)

The patterns had no test at all. 27 cases over real vendor kernel names, asserting the **stored** eligibility — the OR of the two patterns, as the build computes it — rather than either regex alone. Includes an active-only name (a bare `s16816` marker with no shape word), which is eligible through that OR and would have been rejected by a naiver assertion.

**`tests/test_determinism.py`**

The cache-version tripwire updated to 17, with a note that it is pinned as a literal on purpose and should be updated in the same commit as a bump.

## Backward compatibility

Yes, for anything already correct. Kernels that matched before still match identically — the change is purely additive to both alternations.

Caches are invalidated by the version bump and rebuild on next use. That is the intended cost: a stale cache would silently preserve the defect.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2603 passed, 7 failed, 141 skipped, 4 xfailed**. The 7 are pre-existing on clean `main` on this machine (`PermissionError: Operation not permitted` in the `profile_runner` process-tree kill path).
- Verified end to end through a real cache build, not only by regex. A kernel family in a fixture copy was renamed to `nvjet_tst_128x128_64x4_1x2_h_bz_coopA`, the cache rebuilt, and `tensor_core_usage --format json` compared:

  | | rows | nvjet rows |
  |---|---|---|
  | `main` patterns | 7 | **0** |
  | this branch | 8 | 1 — `calls=60 tc=100%` |

  Directly against the `kernels` view: `eligible=1 active=1 count=60`.

- The kernel-family claim was checked against published measurements rather than assumed: `nvjet_sm90_hss_320x128` is described as a Hopper-native warpgroup kernel dispatched by cuBLAS, at ~77% of H100's 989 TFLOPS FP16 dense peak, and CUTLASS 3.x wgmma is benchmarked at 85.5% of nvjet on H100.

## Out of scope

The issue also suggested a safety net that reports high-GPU-time kernels matching no eligibility pattern. That is a new output surface rather than a fix, and it deserves its own issue — but it is the durable answer here, because a name-based heuristic will go stale again. This PR's contribution to that problem is making the pattern table's expectations explicit in a test, so the next rename fails a test instead of going quiet.

## Linked issues

Closes #575
