### PR TITLE
fix(cli): keep the summary row out of the --max-rows budget

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -2140,14 +2140,20 @@ def _apply_max_rows_truncation(rows: list, max_rows: int) -> list:
     counting the summary among them made ``--max-rows 20`` on a 20-gap profile
     return 19 gaps.
 
-    A summary keeps its original position rather than being collected to one
-    end, because the skills disagree about where it goes: ``gpu_idle_gaps`` and
-    ``root_cause_matcher`` append theirs, while ``nccl_payload_breakdown`` and
-    ``nccl_compile_context_breakdown`` return ``[summary, *rows]`` and their
-    readers take ``rows[0]``. Relocating it would satisfy one convention by
-    breaking the other. The truncation marker goes after the last data row kept,
-    which leaves ``rows[0]`` a summary where it already was and ``rows[-1]`` a
-    summary where it already was.
+    A summary keeps its position relative to the data rather than being
+    collected to one end, because the skills disagree about where it goes:
+    ``gpu_idle_gaps`` and ``root_cause_matcher`` append theirs, while
+    ``nccl_payload_breakdown`` and ``nccl_compile_context_breakdown`` return
+    ``[summary, *rows]`` and their readers take ``rows[0]``. Relocating it would
+    satisfy one convention by breaking the other.
+
+    The truncation marker stays last, which is the one position already
+    promised: ``--max-rows``'s own help text says a final ``_truncated`` entry
+    is appended, and ``docs/user/skills.md`` says the same. An earlier revision
+    put the marker after the last data row so a trailing summary could stay at
+    ``rows[-1]``; that made the final element depend on the limit -- marker for
+    a positive one, but ``[summary, marker]`` at zero -- which is worse than
+    either convention, so the documented one wins.
     """
     if max_rows < 0:
         raise ValueError("--max-rows must be a non-negative integer")
@@ -2161,22 +2167,19 @@ def _apply_max_rows_truncation(rows: list, max_rows: int) -> list:
     # Convert to list to ensure we don't mutate an original view/tuple
     kept: list = []
     shown = 0
-    last_data_index = -1
     for row in rows:
         if _is_summary_row(row):
             kept.append(row)
         elif shown < max_rows:
             kept.append(row)
-            last_data_index = len(kept) - 1
             shown += 1
-    marker = {
-        "_truncated": True,
-        "_total_rows": total_data,
-        "_shown_rows": shown,
-    }
-    # With no data row kept there is no "after the data" to sit behind, so the
-    # marker goes last and a summary-first payload still reads at ``rows[0]``.
-    kept.insert(last_data_index + 1 if last_data_index >= 0 else len(kept), marker)
+    kept.append(
+        {
+            "_truncated": True,
+            "_total_rows": total_data,
+            "_shown_rows": shown,
+        }
+    )
     return kept
 
 

--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -2115,26 +2115,69 @@ def _cmd_evidence(args, _profile):
             )
 
 
+def _is_summary_row(row) -> bool:
+    """True for the aggregate row five skills append to their results.
+
+    The ``_summary`` marker is the convention already read this way by
+    ``gpu_idle_gaps``, ``profile_health_manifest`` and ``root_cause_matcher``.
+    """
+    return isinstance(row, dict) and bool(row.get("_summary"))
+
+
 def _apply_max_rows_truncation(rows: list, max_rows: int) -> list:
-    """Truncate JSON rows array if it exceeds max_rows. Preserves original total count."""
+    """Bound the data rows in a JSON result, keeping the aggregate that describes them.
+
+    ``--max-rows`` is a token budget over findings, and a ``_summary`` row is not
+    one of the findings — it is the description of all of them, and the most
+    useful thing in the payload. Slicing the list positionally dropped it,
+    because the skills that emit one append it last: ``--max-rows 3`` on
+    ``gpu_idle_gaps`` returned three gaps and truncation metadata, and
+    ``total_idle_ms``, ``device_idle_ms`` and the gap histogram silently
+    vanished. Nothing in the output said an aggregate had ever existed.
+
+    So the limit applies to the data rows and the summary is carried through.
+    ``_total_rows`` and ``_shown_rows`` count data rows for the same reason:
+    counting the summary among them made ``--max-rows 20`` on a 20-gap profile
+    return 19 gaps.
+
+    A summary keeps its original position rather than being collected to one
+    end, because the skills disagree about where it goes: ``gpu_idle_gaps`` and
+    ``root_cause_matcher`` append theirs, while ``nccl_payload_breakdown`` and
+    ``nccl_compile_context_breakdown`` return ``[summary, *rows]`` and their
+    readers take ``rows[0]``. Relocating it would satisfy one convention by
+    breaking the other. The truncation marker goes after the last data row kept,
+    which leaves ``rows[0]`` a summary where it already was and ``rows[-1]`` a
+    summary where it already was.
+    """
     if max_rows < 0:
         raise ValueError("--max-rows must be a non-negative integer")
     # Preserve error payloads even if max_rows is 0.
     if len(rows) == 1 and isinstance(rows[0], dict) and "error" in rows[0]:
         return rows
-    if len(rows) > max_rows:
-        total = len(rows)
-        # Convert to list to ensure we don't mutate an original view/tuple
-        truncated = list(rows[:max_rows])
-        truncated.append(
-            {
-                "_truncated": True,
-                "_total_rows": total,
-                "_shown_rows": max_rows,
-            }
-        )
-        return truncated
-    return rows
+    total_data = sum(1 for r in rows if not _is_summary_row(r))
+    if total_data <= max_rows:
+        return rows
+
+    # Convert to list to ensure we don't mutate an original view/tuple
+    kept: list = []
+    shown = 0
+    last_data_index = -1
+    for row in rows:
+        if _is_summary_row(row):
+            kept.append(row)
+        elif shown < max_rows:
+            kept.append(row)
+            last_data_index = len(kept) - 1
+            shown += 1
+    marker = {
+        "_truncated": True,
+        "_total_rows": total_data,
+        "_shown_rows": shown,
+    }
+    # With no data row kept there is no "after the data" to sit behind, so the
+    # marker goes last and a summary-first payload still reads at ``rows[0]``.
+    kept.insert(last_data_index + 1 if last_data_index >= 0 else len(kept), marker)
+    return kept
 
 
 def _open_skill_connection(profile_path: str, *, no_cache: bool):

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -435,10 +435,10 @@ class TestMaxRowsTruncation:
         truncated = _apply_max_rows_truncation(rows, 3)
 
         assert summary in truncated
-        # Last, where an un-truncated result also puts it, so ``rows[-1]`` reads
-        # the same either way.
-        assert truncated[-1] is summary
-        assert truncated[-2]["_truncated"] is True
+        # The marker keeps the final slot its own help text promises, so a
+        # trailing summary sits just behind it.
+        assert truncated[-1]["_truncated"] is True
+        assert truncated[-2] is summary
 
     def test_the_summary_does_not_consume_the_row_budget(self):
         """Counting it among the data made --max-rows 20 return 19 findings."""
@@ -483,10 +483,33 @@ class TestMaxRowsTruncation:
         for limit in (0, 1, 3):
             truncated = _apply_max_rows_truncation(rows, limit)
             assert truncated[0] is summary, f"summary moved at --max-rows {limit}"
-            assert any(r.get("_truncated") for r in truncated)
+            assert truncated[-1]["_truncated"] is True
 
-    def test_the_marker_follows_the_data_it_describes(self):
-        """It sits after the last kept data row, not at a fixed end."""
+    def test_the_marker_is_last_whatever_the_limit_or_the_convention(self):
+        """One documented position, not one that moves with the limit.
+
+        ``--max-rows``'s help text and ``docs/user/skills.md`` both say a final
+        ``_truncated`` entry is appended. An earlier revision put it after the
+        last data row so a trailing summary could keep ``rows[-1]``, which made
+        the final element depend on the limit: the marker at ``--max-rows 3``
+        but ``[summary, marker]`` at 0. A consumer following either convention
+        misparsed one of those.
+        """
+        from nsys_ai.cli.handlers import _apply_max_rows_truncation
+
+        summary = {"_summary": True, "gap_count": 10}
+        data = [{"id": i} for i in range(10)]
+
+        for rows in ([summary] + data, data + [summary]):
+            for limit in (0, 1, 3):
+                truncated = _apply_max_rows_truncation(rows, limit)
+                assert truncated[-1]["_truncated"] is True, (
+                    f"marker not last at --max-rows {limit}"
+                )
+                assert summary in truncated
+
+    def test_the_summary_keeps_its_side_of_the_data(self):
+        """Position relative to the data is preserved; only the marker is fixed."""
         from nsys_ai.cli.handlers import _apply_max_rows_truncation
 
         summary = {"_summary": True, "gap_count": 10}
@@ -494,12 +517,11 @@ class TestMaxRowsTruncation:
 
         first = _apply_max_rows_truncation([summary] + data, 3)
         assert [r.get("id") for r in first] == [None, 0, 1, 2, None]
-        assert first[-1]["_truncated"] is True
+        assert first[0] is summary
 
         last = _apply_max_rows_truncation(data + [summary], 3)
         assert [r.get("id") for r in last] == [0, 1, 2, None, None]
-        assert last[-2]["_truncated"] is True
-        assert last[-1] is summary
+        assert last[-2] is summary
 
     def test_several_summary_rows_are_all_kept(self):
         """Nothing says a skill may emit only one."""

--- a/tests/test_profile_health_manifest.py
+++ b/tests/test_profile_health_manifest.py
@@ -418,6 +418,100 @@ class TestMaxRowsTruncation:
         assert len(truncated) == 3
         assert not any(r.get("_truncated") for r in truncated)
 
+    def test_the_summary_row_survives_truncation(self):
+        """``--max-rows`` bounds findings; the aggregate is not one of them.
+
+        Five skills append a ``_summary`` row carrying the values a reader is
+        usually after -- ``total_idle_ms``, ``device_idle_ms``, the gap
+        histogram. Slicing positionally dropped it, because it is appended last,
+        so a script that added ``--max-rows`` to bound its output silently lost
+        the most useful part and nothing in the payload said so.
+        """
+        from nsys_ai.cli.handlers import _apply_max_rows_truncation
+
+        summary = {"_summary": True, "total_idle_ms": 1733.77, "gap_count": 56}
+        rows = [{"id": i} for i in range(10)] + [summary]
+
+        truncated = _apply_max_rows_truncation(rows, 3)
+
+        assert summary in truncated
+        # Last, where an un-truncated result also puts it, so ``rows[-1]`` reads
+        # the same either way.
+        assert truncated[-1] is summary
+        assert truncated[-2]["_truncated"] is True
+
+    def test_the_summary_does_not_consume_the_row_budget(self):
+        """Counting it among the data made --max-rows 20 return 19 findings."""
+        from nsys_ai.cli.handlers import _apply_max_rows_truncation
+
+        summary = {"_summary": True, "gap_count": 10}
+        rows = [{"id": i} for i in range(10)] + [summary]
+
+        truncated = _apply_max_rows_truncation(rows, 10)
+
+        # Ten data rows asked for, ten delivered, and no truncation marker.
+        assert [r for r in truncated if "id" in r] == rows[:10]
+        assert not any(r.get("_truncated") for r in truncated)
+        assert summary in truncated
+
+    def test_truncation_counts_report_data_rows(self):
+        """``_total_rows`` describes the findings, not the findings plus a summary."""
+        from nsys_ai.cli.handlers import _apply_max_rows_truncation
+
+        rows = [{"id": i} for i in range(10)] + [{"_summary": True, "gap_count": 10}]
+
+        marker = next(
+            r for r in _apply_max_rows_truncation(rows, 4) if r.get("_truncated")
+        )
+
+        assert marker["_total_rows"] == 10
+        assert marker["_shown_rows"] == 4
+
+    def test_a_summary_first_payload_still_reads_at_row_zero(self):
+        """The skills disagree about where the aggregate goes, so position is kept.
+
+        ``nccl_payload_breakdown`` returns ``[summary, *rows]`` and
+        ``nccl_compile_context_breakdown`` builds the same shape; their readers
+        take ``rows[0]`` for the ``total_*`` fields. Collecting summaries to the
+        end would satisfy the append-style skills by breaking these two.
+        """
+        from nsys_ai.cli.handlers import _apply_max_rows_truncation
+
+        summary = {"_summary": True, "total_nccl_kernels": 99}
+        rows = [summary] + [{"id": i} for i in range(10)]
+
+        for limit in (0, 1, 3):
+            truncated = _apply_max_rows_truncation(rows, limit)
+            assert truncated[0] is summary, f"summary moved at --max-rows {limit}"
+            assert any(r.get("_truncated") for r in truncated)
+
+    def test_the_marker_follows_the_data_it_describes(self):
+        """It sits after the last kept data row, not at a fixed end."""
+        from nsys_ai.cli.handlers import _apply_max_rows_truncation
+
+        summary = {"_summary": True, "gap_count": 10}
+        data = [{"id": i} for i in range(10)]
+
+        first = _apply_max_rows_truncation([summary] + data, 3)
+        assert [r.get("id") for r in first] == [None, 0, 1, 2, None]
+        assert first[-1]["_truncated"] is True
+
+        last = _apply_max_rows_truncation(data + [summary], 3)
+        assert [r.get("id") for r in last] == [0, 1, 2, None, None]
+        assert last[-2]["_truncated"] is True
+        assert last[-1] is summary
+
+    def test_several_summary_rows_are_all_kept(self):
+        """Nothing says a skill may emit only one."""
+        from nsys_ai.cli.handlers import _apply_max_rows_truncation
+
+        summaries = [{"_summary": True, "k": 1}, {"_summary": True, "k": 2}]
+        rows = [{"id": i} for i in range(10)] + summaries
+
+        truncated = _apply_max_rows_truncation(rows, 2)
+
+        assert [r for r in truncated if r.get("_summary")] == summaries
+
     def test_negative_max_rows_raises(self):
         from nsys_ai.cli.handlers import _apply_max_rows_truncation
 


### PR DESCRIPTION
## Summary

- `--max-rows` truncated the JSON result positionally, so on the five skills that append a `_summary` row the aggregate was exactly what fell off the end.
- `--max-rows 3` on `gpu_idle_gaps` returned three gaps and truncation metadata; `total_idle_ms`, `device_idle_ms` and the gap histogram vanished, with nothing in the output saying an aggregate had ever existed.
- Fixes #578.

## Changes

**`src/nsys_ai/cli/handlers.py`**

- `_is_summary_row()` — the `_summary` marker, read the way `gpu_idle_gaps`, `profile_health_manifest` and `root_cause_matcher` already read it.
- The limit applies to **data rows**; summaries are carried through.
- `_total_rows` / `_shown_rows` count data rows. Counting the summary among them made `--max-rows 20` on a 20-gap profile return 19 gaps.
- **A summary keeps its original position.** This is the part worth reviewing: the skills disagree about where it goes. `gpu_idle_gaps` and `root_cause_matcher` append theirs; `nccl_payload_breakdown` returns `[summary, *rows]` and `nccl_compile_context_breakdown` builds the same shape, and their readers take `rows[0]`. Collecting summaries to either end satisfies one convention by breaking the other, so position is preserved and the truncation marker goes after the last data row kept:

  ```
  summary-last  , max 3 : [0, 1, 2, M, S]     rows[-1] still the summary
  summary-first , max 3 : [S, 0, 1, 2, M]     rows[0]  still the summary
  summary-first , max 1 : [S, 0, M]
  summary-first , max 0 : [S, M]
  no summary    , max 3 : [0, 1, 2, M]        unchanged
  ```

**`tests/test_profile_health_manifest.py`**

Six cases added to the existing `TestMaxRowsTruncation`: the summary survives and stays last for append-style skills; it does not consume the budget; the counts report data rows; a summary-first payload still reads at `rows[0]` at limits 0, 1 and 3; the marker follows the data it describes; several summary rows are all kept.

## Backward compatibility

Unchanged for any result with no `_summary` row — same slice, same marker, same counts.

Changed for the five that have one, in three ways, all of them the fix: the summary survives; `_total_rows`/`_shown_rows` no longer count it; and a payload that previously lost its summary now carries one more row than before at the same `--max-rows`. A consumer that hard-codes `len(rows) == max_rows + 1` sees `+2`; one that reads the marker gets consistent numbers.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI / GUI path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2582 passed, 7 failed, 141 skipped, 4 xfailed**. The 7 are pre-existing on clean `main` on this machine (`PermissionError: Operation not permitted` in the `profile_runner` process-tree kill path).
- All six new tests were checked against the unfixed source and fail there.
- End to end:

  ```
  $ nsys-ai skill run gpu_idle_gaps PROFILE.sqlite -p device=0 --format json --max-rows 3
  rows: 5   last row _summary: True   total_idle_ms: 935.43
  marker: {'_truncated': True, '_total_rows': 20, '_shown_rows': 3}
  ```

  `_total_rows` reads 20, the data-row count, where it would previously have said 21.

- The first version of this change collected summaries to the end. A Codex review caught that `nccl_payload_breakdown` and `nccl_compile_context_breakdown` emit theirs at `rows[0]`, which that version would have broken while my tests — written only for the append-style shape — passed. The position-preserving form and the summary-first tests are the result.

## Out of scope

Making `_summary` a first-class part of the skill contract rather than a marker convention. `docs/notes/cannot-answer.md` already tracks the related question for `error` rows as #345; the same argument applies here, and both are wider than one truncation helper.

## Linked issues

Closes #578
