### PR TITLE
test(profile-reference): build the invalid-field reference under tmp_path

### DIFF
--- a/tests/test_profile_reference.py
+++ b/tests/test_profile_reference.py
@@ -393,10 +393,15 @@ def test_profile_reference_factory_calls_shared_validator(
     ],
 )
 def test_shared_profile_reference_validator_rejects_invalid_fields(
-    field, value, message
+    field, value, message, tmp_path
 ):
+    # tmp_path, not a hardcoded /tmp: on macOS /tmp is a symlink to private/tmp,
+    # and the validator refuses to inspect a reference through one. That guard
+    # fired before any field was looked at, so five of these cases failed with
+    # "file parent cannot be inspected safely" on every Mac -- reporting the
+    # wrong reason for the right refusal, and only off Linux.
     reference = LocalProfileReference(
-        path="/tmp/profile.sqlite",
+        path=str(tmp_path / "profile.sqlite"),
         profile_id=VALID_PROFILE_ID,
         schema_version="3.25.0",
         product_version="2026.2.1.106",


### PR DESCRIPTION
## Summary

- Five cases in `test_shared_profile_reference_validator_rejects_invalid_fields` fail on macOS and pass in CI, because the test hardcodes `path="/tmp/profile.sqlite"` and `/tmp` is a symlink to `private/tmp` there.
- The validator refuses to inspect a reference whose parent is reached through a symlink, and that guard fires **before** any field is examined — so every case raised the same unrelated error instead of the one it asserts.
- Refs #585.

## Changes

**`tests/test_profile_reference.py`**

The test takes `tmp_path` and builds its reference under it, with a comment recording why the literal path was a trap. It was the only test in the file not already using the fixture; every other one does.

## Backward compatibility

Test-only. No source change — the guard's behaviour is correct and is not touched.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [ ] Manually exercised the changed CLI / GUI path — not applicable, no CLI path changed

Notes on the run:

- `tests/test_profile_reference.py` alone: **60 passed**, from 5 failed.
- Full suite on macOS / Python 3.13.9: **2676 passed, 2 failed** — down from 7 failed on the same machine before this change.

The diagnosis, since "it fails on macOS" was how these had been written off:

```
$ ls -ld /tmp
lrwxr-xr-x  1 root  wheel  11  /tmp -> private/tmp

# same reference, three parents
/tmp/profile.sqlite          -> ValueError('local profile reference file parent
                                cannot be inspected safely')
/private/tmp/profile.sqlite  -> reaches field validation
/Users/rich/profile.sqlite   -> reaches field validation
```

So the five failures were the right refusal reported for the wrong reason, and only off Linux.

## Out of scope

The other half of #585: `test_profile_runner`'s `PermissionError: [Errno 1] Operation not permitted` from the process-group kill at `profile_runner.py:946`, which is the remaining 2 failures. That is a genuine platform question — the same shape as #572's Linux-only `/proc/self/fd` assumption in the same file — and needs a decision about whether the control can work under macOS's restrictions or should skip with a registered reason. Left for that issue.

## Linked issues

Refs #585
