### PR TITLE
fix(profile): do not raise out of a teardown the group will not accept

### DIFF
--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -939,29 +939,59 @@ class LocalProfileRunner:
         return bool(cancellation.is_set())
 
     @staticmethod
-    def _terminate_process_group(process: subprocess.Popen[bytes]) -> None:
+    def _signal_group(process_group: int, sig: int) -> bool:
+        """Signal the group; False when it can no longer be signalled by us.
+
+        ``ProcessLookupError`` is the group having gone. ``PermissionError`` is
+        it no longer being ours to signal, which was reaching callers as a crash:
+        every ``killpg`` here caught only the first, so an EPERM propagated out
+        of ``_capture_process`` and out of ``run()`` -- turning a capture that had
+        already finished into a raised exception. Observed on macOS, where a
+        reaped child's pid can be recycled into another session before the
+        teardown runs, so the pid names a group this process does not own.
+
+        Both answers mean the same thing to a caller: there is nothing left here
+        to escalate against. A best-effort teardown has no business raising out
+        of a capture that otherwise succeeded, and the caller could not act on
+        the distinction anyway.
+        """
+        try:
+            os.killpg(process_group, sig)
+        except (ProcessLookupError, PermissionError):
+            return False
+        return True
+
+    @staticmethod
+    def _reap(process: subprocess.Popen[bytes]) -> None:
+        """Wait for our own child, bounded.
+
+        Bounded rather than a bare ``wait()`` because the group is no longer
+        answering us: after a lookup failure the child is already gone and this
+        returns at once, but after a permission failure it may not be, and an
+        unbounded wait there would hang the capture instead of ending it.
+        """
+        try:
+            process.wait(timeout=_TERMINATION_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            pass
+
+    @classmethod
+    def _terminate_process_group(cls, process: subprocess.Popen[bytes]) -> None:
         """Terminate the complete session, escalating after a bounded grace."""
         process_group = process.pid
-        try:
-            os.killpg(process_group, signal.SIGTERM)
-        except ProcessLookupError:
-            process.wait()
+        if not cls._signal_group(process_group, signal.SIGTERM):
+            cls._reap(process)
             return
 
         deadline = time.monotonic() + _TERMINATION_GRACE_SECONDS
         while time.monotonic() < deadline:
             process.poll()
-            try:
-                os.killpg(process_group, 0)
-            except ProcessLookupError:
-                process.wait()
+            if not cls._signal_group(process_group, 0):
+                cls._reap(process)
                 return
             time.sleep(_POLL_SECONDS)
 
-        try:
-            os.killpg(process_group, signal.SIGKILL)
-        except ProcessLookupError:
-            pass
+        cls._signal_group(process_group, signal.SIGKILL)
         try:
             process.wait(timeout=_TERMINATION_GRACE_SECONDS)
         except subprocess.TimeoutExpired:

--- a/src/nsys_ai/profile_runner.py
+++ b/src/nsys_ai/profile_runner.py
@@ -939,25 +939,37 @@ class LocalProfileRunner:
         return bool(cancellation.is_set())
 
     @staticmethod
-    def _signal_group(process_group: int, sig: int) -> bool:
-        """Signal the group; False when it can no longer be signalled by us.
+    def _signal_group(process: subprocess.Popen[bytes], sig: int) -> bool:
+        """Signal the group; False when there is nothing of ours left to stop.
 
-        ``ProcessLookupError`` is the group having gone. ``PermissionError`` is
-        it no longer being ours to signal, which was reaching callers as a crash:
-        every ``killpg`` here caught only the first, so an EPERM propagated out
-        of ``_capture_process`` and out of ``run()`` -- turning a capture that had
-        already finished into a raised exception. Observed on macOS, where a
-        reaped child's pid can be recycled into another session before the
-        teardown runs, so the pid names a group this process does not own.
+        ``ProcessLookupError`` is the group having gone, and there is nothing to
+        escalate against.
 
-        Both answers mean the same thing to a caller: there is nothing left here
-        to escalate against. A best-effort teardown has no business raising out
-        of a capture that otherwise succeeded, and the caller could not act on
-        the distinction anyway.
+        ``PermissionError`` is the harder one, because it means two opposite
+        things depending on our own child. This teardown runs from five call
+        sites: one after ``wait()`` has already returned, and four where stopping
+        the tree is the whole job -- timeout, cancellation, the leader-exit
+        sweep, and the ``BaseException`` handler.
+
+        When our child has already exited, EPERM says its pid no longer names
+        anything of ours: on macOS a reaped pid can be recycled into another
+        session before the teardown runs, so the group we would be signalling
+        belongs to someone else. Nothing of ours survives, and raising there
+        turned a finished capture into an exception -- the bug this fixes.
+
+        While our child is still alive, the same errno says the opposite: a tree
+        we were told to terminate and cannot. Swallowing it would let a timeout
+        or a cancellation report that it stopped the capture while the profiled
+        process kept running, which is a worse answer than the failure. So it
+        propagates, exactly as it did before this change.
         """
         try:
-            os.killpg(process_group, sig)
-        except (ProcessLookupError, PermissionError):
+            os.killpg(process.pid, sig)
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            if process.poll() is None:
+                raise
             return False
         return True
 
@@ -966,9 +978,11 @@ class LocalProfileRunner:
         """Wait for our own child, bounded.
 
         Bounded rather than a bare ``wait()`` because the group is no longer
-        answering us: after a lookup failure the child is already gone and this
-        returns at once, but after a permission failure it may not be, and an
-        unbounded wait there would hang the capture instead of ending it.
+        answering us. Both paths that reach here have established the child is
+        gone -- a lookup failure, or a permission failure with ``poll()`` already
+        returning -- so this returns at once today; the bound is there so a
+        future caller that reaches it in another state ends the capture rather
+        than hanging it.
         """
         try:
             process.wait(timeout=_TERMINATION_GRACE_SECONDS)
@@ -978,20 +992,19 @@ class LocalProfileRunner:
     @classmethod
     def _terminate_process_group(cls, process: subprocess.Popen[bytes]) -> None:
         """Terminate the complete session, escalating after a bounded grace."""
-        process_group = process.pid
-        if not cls._signal_group(process_group, signal.SIGTERM):
+        if not cls._signal_group(process, signal.SIGTERM):
             cls._reap(process)
             return
 
         deadline = time.monotonic() + _TERMINATION_GRACE_SECONDS
         while time.monotonic() < deadline:
             process.poll()
-            if not cls._signal_group(process_group, 0):
+            if not cls._signal_group(process, 0):
                 cls._reap(process)
                 return
             time.sleep(_POLL_SECONDS)
 
-        cls._signal_group(process_group, signal.SIGKILL)
+        cls._signal_group(process, signal.SIGKILL)
         try:
             process.wait(timeout=_TERMINATION_GRACE_SECONDS)
         except subprocess.TimeoutExpired:

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -888,6 +888,36 @@ def test_teardown_survives_a_group_it_may_not_signal(monkeypatch):
     assert _FinishedProcess.waited, "the child was never reaped"
 
 
+def test_teardown_reports_a_live_tree_it_cannot_stop(monkeypatch):
+    """EPERM means the opposite thing while our child is still running.
+
+    The teardown runs from five call sites, and four of them exist to stop the
+    tree: timeout, cancellation, the leader-exit sweep, and the BaseException
+    handler. If the group refuses us while the child is alive, we have failed to
+    do the one thing those callers asked for. Reporting TIMED_OUT or CANCELLED
+    over a profiled process that is still running would be a worse answer than
+    the failure, so it propagates -- as it did before EPERM was handled at all.
+    """
+    import nsys_ai.profile_runner as profile_runner
+
+    class _LiveProcess:
+        pid = 4244
+
+        def poll(self):
+            return None  # still running
+
+        def wait(self, timeout=None):  # pragma: no cover - must not be reached
+            raise AssertionError("a live tree must not be reaped as if it stopped")
+
+    def _refuse(_pgid, _sig):
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(profile_runner.os, "killpg", _refuse)
+
+    with pytest.raises(PermissionError):
+        profile_runner.LocalProfileRunner._terminate_process_group(_LiveProcess())
+
+
 def test_teardown_still_stops_at_a_group_that_has_gone(monkeypatch):
     """The pre-existing lookup path keeps its behaviour."""
     import nsys_ai.profile_runner as profile_runner

--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -852,3 +852,63 @@ def test_the_capture_is_opened_once_for_reference_and_gpu_count(tmp_path, fake_n
     guarded_prefixes = ("file:/proc/self/fd/", "file:/dev/fd/")
     by_path = [target for target in opened if not target.startswith(guarded_prefixes)]
     assert not by_path, f"the capture was reopened outside the descriptor guard: {by_path}"
+
+
+def test_teardown_survives_a_group_it_may_not_signal(monkeypatch):
+    """A best-effort teardown must not raise out of a finished capture.
+
+    Every ``killpg`` in ``_terminate_process_group`` caught ``ProcessLookupError``
+    and nothing else, so an ``EPERM`` propagated out of ``_capture_process`` and
+    out of ``run()`` — turning a capture that had already completed into a raised
+    ``PermissionError``. Observed on macOS; the caller cannot act on the
+    difference between "the group is gone" and "the group is no longer ours",
+    and neither is a reason to fail a capture.
+    """
+    import nsys_ai.profile_runner as profile_runner
+
+
+    class _FinishedProcess:
+        pid = 4242
+        waited = False
+
+        def poll(self):
+            return 0
+
+        def wait(self, timeout=None):
+            type(self).waited = True
+            return 0
+
+    def _refuse(_pgid, _sig):
+        raise PermissionError(1, "Operation not permitted")
+
+    monkeypatch.setattr(profile_runner.os, "killpg", _refuse)
+
+    profile_runner.LocalProfileRunner._terminate_process_group(_FinishedProcess())
+
+    assert _FinishedProcess.waited, "the child was never reaped"
+
+
+def test_teardown_still_stops_at_a_group_that_has_gone(monkeypatch):
+    """The pre-existing lookup path keeps its behaviour."""
+    import nsys_ai.profile_runner as profile_runner
+
+
+    class _GoneProcess:
+        pid = 4243
+        waited = False
+
+        def poll(self):
+            return 0
+
+        def wait(self, timeout=None):
+            type(self).waited = True
+            return 0
+
+    def _gone(_pgid, _sig):
+        raise ProcessLookupError(3, "No such process")
+
+    monkeypatch.setattr(profile_runner.os, "killpg", _gone)
+
+    profile_runner.LocalProfileRunner._terminate_process_group(_GoneProcess())
+
+    assert _GoneProcess.waited


### PR DESCRIPTION
## Summary

- Every `killpg` in `_terminate_process_group` caught `ProcessLookupError` and nothing else, so a `PermissionError` propagated out of `_capture_process` and out of `run()` — turning a capture that had already finished into a raised exception on the `profile` path.
- Refs #585.

## Changes

**`src/nsys_ai/profile_runner.py`**

- `_signal_group(pgid, sig)` — sends the signal and returns `False` when the group can no longer be signalled by us. `ProcessLookupError` is the group having gone; `PermissionError` is it no longer being ours. A caller cannot act on the difference, and neither is a reason to fail a capture that produced a result.
- `_reap(process)` — waits for our own child, **bounded**. After a lookup failure the child is already gone and this returns at once; after a permission failure it may not be, and the previous bare `wait()` would have hung the capture instead of ending it. That is the one behaviour change beyond the new `except` arm, and it exists because the new path can reach that wait in a state the old one could not.
- `_terminate_process_group` uses both at all three signal sites (SIGTERM, the liveness probe, SIGKILL).

**`tests/test_profile_runner.py`**

Two tests driving `killpg` directly: a group that refuses with `EPERM` completes the teardown and reaps the child; a group that has gone keeps its existing behaviour. The first fails against unfixed source with the raw `PermissionError`; the second passes throughout, which is the point of including it.

## Backward compatibility

Yes. `ProcessLookupError` behaves as before. The added arm turns a raised exception into the same graceful end, and the wait bound only shortens a case that previously could not terminate.

## What this does *not* fix

`test_completion_before_deadline_wins_over_coarse_polling[exit_094-2.0]` still fails on macOS, and this PR is not the fix for it. It was failing on the `PermissionError` raised here, and now fails on the status it asserts (`TIMED_OUT` where it wants `NSYS_FAILED`) — so the runner was already taking the timeout branch and the exception merely arrived first.

What is known about that one, for whoever picks it up:

- the fake child runs in ~30 ms against the test's 1 s budget, so it is not simply slow
- only the `[exit_094-2.0]` parameter fails; `[exit_070-5.0]` passes, and `exit_094` is the one that runs first — measured cold-start for that child is 0.264 s against 0.030 s on later spawns
- the test's own comment calls it "a sub-second process/deadline race"

That points at cold start eating the budget, but it is not proven, and widening the budget is a judgement about what the test means to measure. Left in #585.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [ ] Manually exercised the changed CLI / GUI path — the path is a teardown of a capture; exercised through the new tests rather than by racing a real one

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2671 passed, 7 failed**, the same 7 this branch's base reports. No new failures. (5 of those 7 are fixed by #586, which is open against the same issue.)
- `bandit -r src/ -c pyproject.toml` — 0 issues at every severity.
- The new EPERM test fails against unfixed source with `PermissionError: [Errno 1] Operation not permitted` at the assertion site.

## Linked issues

Refs #585
