### PR TITLE
docs: add a code of conduct and a Community section

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ### Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the project maintainers by contacting [@GindaChen](https://github.com/GindaChen) on GitHub. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the project maintainers by contacting [@GindaChen](https://github.com/GindaChen) or [@rich7420](https://github.com/rich7420) on GitHub. All complaints will be reviewed and investigated promptly and fairly.
 
 All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,53 @@
+## Code of Conduct
+
+### Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+### Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+### Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the project maintainers by contacting [@GindaChen](https://github.com/GindaChen) on GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+### Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: https://www.contributor-covenant.org/version/2/1

--- a/README.md
+++ b/README.md
@@ -506,6 +506,16 @@ policy, and pull-request checklist.
 
 ---
 
+## Community
+
+Contributions are welcome through issues and pull requests. Please read the
+[Code of Conduct](https://github.com/GindaChen/nsys-ai/blob/main/CODE_OF_CONDUCT.md)
+before participating, and
+[CONTRIBUTING.md](https://github.com/GindaChen/nsys-ai/blob/main/CONTRIBUTING.md)
+for the workflow a change goes through.
+
+---
+
 ## License
 
 MIT — see [LICENSE](https://github.com/GindaChen/nsys-ai/blob/main/LICENSE).


### PR DESCRIPTION
## Summary

- The repository has no `CODE_OF_CONDUCT.md`, and the README has no section pointing at one — its last two headings are `## Development` and `## License`.
- Adds the file and a `## Community` section, so a reader arriving to contribute finds what conduct the project expects and where to report a problem, alongside the workflow already in `CONTRIBUTING.md`.

## Changes

**`CODE_OF_CONDUCT.md`** (new)

Adapted from the Contributor Covenant v2.1 **by way of [next.js's file](https://github.com/vercel/next.js/blob/canary/CODE_OF_CONDUCT.md)**, so the adaptation decisions are ones an established project already made rather than invented here:

- the four-tier Enforcement Guidelines ladder is dropped
- the actors are "project maintainers", not "community leaders"
- the note about maintainers who do not enforce in good faith is kept
- `###` headings, and the v2.1 attribution block

Diffed against the next.js file, it differs in exactly two lines:

```
24c24  apostrophe glyph — this uses the straight one from the canonical Covenant text
39c39  the enforcement contact
```

**`README.md`**

A `## Community` section before `## License`, linking the Code of Conduct and `CONTRIBUTING.md`. Both links are absolute: this file is the PyPI long description, where a relative link is dead, and `test_package_data.py::test_the_pypi_page_links_back_and_has_no_relative_links` enforces that.

## The one line worth a maintainer's decision

next.js routes reports to `coc@vercel.com`, a dedicated alias. This project has none, so the Enforcement section currently reads:

> reported privately to the project maintainers by contacting [@GindaChen](https://github.com/GindaChen) on GitHub

That commits no personal inbox and names the repository owner, which is publicly true — but it is a commitment made on the maintainer's behalf, so it is the line to change if an email address is preferred. Swapping it is a one-line edit and does not affect anything else here.

## Backward compatibility

Yes. One new file and one added README section; nothing removed or reworded.

## Test plan

- [ ] Tests added or updated for the new behavior — not applicable, no behaviour changes
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [ ] Manually exercised the changed CLI / GUI path — not applicable

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2683 passed, 2 failed**. The two are the process-runner races tracked in #585 and are unrelated to this change.
- The documentation contracts pass specifically: `test_package_data.py`, `test_documentation_contracts.py` and `test_docs_index.py` — 18 passed. The first of those is what would have caught a naive relative `CODE_OF_CONDUCT.md` link in the README.

## Out of scope

Whether an external programme requires this file. The motivation came from a screenshot of such a requirement, which is not something this PR verifies; what it does verify is that the file was genuinely absent and that most comparable projects ship one.

## Linked issues

None.
