### PR TITLE
fix(cutracer): diagnose an unusable CUTracer instead of crashing on it, and build v0.3.0

### DIFF
--- a/src/nsys_ai/cli/handlers.py
+++ b/src/nsys_ai/cli/handlers.py
@@ -172,18 +172,51 @@ def _cutracer_check():
     """Verify CUTracer Python package and .so availability."""
     import importlib.util
 
+    from nsys_ai.cutracer.installer import CUTRACER_TAG
+
     ok = True
 
-    # Python package
-    if importlib.util.find_spec("cutracer") is not None:
-        import cutracer as _ct  # type: ignore[import]
-
-        version = getattr(_ct, "__version__", "unknown")
-        print(f"  cutracer Python package : OK (v{version})")
-    else:
+    # Python package. find_spec only proves the module can be *located*; the
+    # import itself can still fail, and a check that crashes on the condition it
+    # exists to report is worse than no check. cutracer 0.2.1 and 0.3.0 both
+    # import importlib_resources without declaring it, so on an environment
+    # without that backport this raised ModuleNotFoundError straight out of
+    # `nsys-ai cutracer check`.
+    version = None
+    if importlib.util.find_spec("cutracer") is None:
         print("  cutracer Python package : NOT FOUND")
         print("    Install: pip install cutracer")
         ok = False
+    else:
+        try:
+            import cutracer as _ct  # type: ignore[import]
+        except Exception as exc:  # noqa: BLE001 - any import failure is a finding
+            print("  cutracer Python package : FOUND but not importable")
+            print(f"    {type(exc).__name__}: {exc}")
+            print(
+                "    The package is installed and its own import failed, which is a "
+                "problem in that package or its environment rather than in nsys-ai."
+            )
+            if isinstance(exc, ModuleNotFoundError) and exc.name:
+                print(f"    Try: pip install {exc.name}")
+            ok = False
+        else:
+            version = getattr(_ct, "__version__", None)
+            print(f"  cutracer Python package : OK (v{version or 'unknown'})")
+
+    # The pip package and the .so are versioned separately: the `cutracer` extra
+    # is unpinned above 0.2.0, so pip installs whatever is current, while the
+    # bundled installer builds one tag. They can differ by a minor version with
+    # nothing saying so, and the traces the .so writes are what the parser reads.
+    if version and version != CUTRACER_TAG.lstrip("v"):
+        print(
+            f"  version alignment       : package v{version}, "
+            f"but `nsys-ai cutracer install` builds {CUTRACER_TAG}"
+        )
+        print(
+            "    A .so built by this installer does not match the installed package. "
+            "Pin the package to match, or set CUTRACER_SO to a .so you built yourself."
+        )
 
     # .so instrumentation library
     so_path = _find_cutracer_so()

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -41,8 +41,12 @@ NVBIT_REPO = "https://github.com/NVlabs/NVBit/releases/download"
 NVBIT_VERSION = "1.7.1"
 # The CUTracer repo migrated from the facebookresearch org to facebookexperimental.
 CUTRACER_GITHUB = "https://github.com/facebookexperimental/CUTracer"
-# Pinned release tag for reproducible builds (clone --branch). Bump on upstream releases.
-CUTRACER_TAG = "v0.2.1"
+# Pinned release tag for reproducible builds (clone --branch). Bump on upstream
+# releases, and keep it aligned with what the ``cutracer`` extra installs: the
+# extra is unpinned above 0.2.0, so pip takes the newest release, and a .so built
+# from a different tag writes traces this parser was not written against.
+# ``nsys-ai cutracer check`` compares the two and says so when they diverge.
+CUTRACER_TAG = "v0.3.0"
 
 # CUDA major.minor → NVBit release asset name pattern
 # NVBit ships separate builds for each CUDA toolkit version.

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -479,9 +479,26 @@ def _clone_and_build(
             )
 
     # ── install_third_party.sh — downloads NVBit + nlohmann/json ────────────
+    # Keyed on the tag, not just on nvbit's presence. What the script fetches
+    # changes between releases: v0.3.0 added src/trace_rapidjson.cpp and a
+    # RapidJSON download to go with it, which v0.2.1 neither built nor fetched.
+    # Testing only for third_party/nvbit meant an existing v0.2.1 tree checked
+    # out to v0.3.0 skipped the download it now needs, and the build failed on
+    # missing RapidJSON headers unless the host happened to have them. The stamp
+    # records which tag the tree was provisioned for, so any future bump
+    # re-provisions rather than compiling against a stale dependency set.
     third_party_nvbit = clone_dir / "third_party" / "nvbit"
-    if not third_party_nvbit.exists():
+    third_party_stamp = clone_dir / "third_party" / ".nsys-ai-provisioned-tag"
+    provisioned_tag = (
+        third_party_stamp.read_text().strip() if third_party_stamp.is_file() else None
+    )
+    if not third_party_nvbit.exists() or provisioned_tag != CUTRACER_TAG:
         if progress:
+            if provisioned_tag and provisioned_tag != CUTRACER_TAG:
+                print(
+                    f"  third_party was provisioned for {provisioned_tag}, "
+                    f"now building {CUTRACER_TAG} — re-running install_third_party.sh"
+                )
             print("  Running install_third_party.sh (downloads NVBit …)")
         r = subprocess.run(  # nosec B603 B607
             ["bash", "install_third_party.sh"],
@@ -494,9 +511,13 @@ def _clone_and_build(
                 f"install_third_party.sh failed (exit {r.returncode}):\n"
                 f"{getattr(r, 'stderr', '')}"
             )
+        third_party_stamp.parent.mkdir(parents=True, exist_ok=True)
+        third_party_stamp.write_text(f"{CUTRACER_TAG}\n")
     else:
         if progress:
-            print("  third_party/nvbit already present — skipping download")
+            print(
+                f"  third_party already provisioned for {CUTRACER_TAG} — skipping download"
+            )
 
     # ── make ─────────────────────────────────────────────────────────────────
     if so_dest.exists():

--- a/src/nsys_ai/cutracer/runner.py
+++ b/src/nsys_ai/cutracer/runner.py
@@ -48,7 +48,10 @@ class RunConfig:
     """Local directory where histogram CSVs will land."""
 
     kernel_filter: list[str] = field(default_factory=list)
-    """Normalised kernel name tokens for ``CUTRACER_KERNEL_FILTER``."""
+    """Normalised kernel name tokens, passed as ``--kernel-filters``.
+
+    Not an environment variable: no ``CUTRACER_KERNEL_FILTER`` exists upstream at
+    v0.2.1 or v0.3.0, and this is sent on the command line."""
 
     so_path: Path | None = None
     """Path to ``cutracer.so``.  ``None`` → auto-detect at runtime."""

--- a/tests/test_cutracer_check.py
+++ b/tests/test_cutracer_check.py
@@ -1,0 +1,137 @@
+"""`cutracer check` must diagnose the environment, not fall over in it.
+
+The command's whole job is to say why instrumentation is not ready. It used to
+crash on one of the conditions it exists to report: ``importlib.util.find_spec``
+proves a module can be *located*, not that it *imports*, and the ``import`` on
+the next line was unguarded. cutracer 0.2.1 and 0.3.0 both import
+``importlib_resources`` without declaring it, so on an environment lacking that
+backport ``nsys-ai cutracer check`` exited with a ModuleNotFoundError traceback
+pointing into handlers.py.
+
+The second case here is a mismatch rather than a failure: the ``cutracer`` extra
+is unpinned above 0.2.0, so pip installs whatever is current, while the bundled
+installer builds one tag. Nothing compared them, and the .so is what writes the
+traces the parser reads.
+"""
+
+import sys
+import types
+
+import pytest
+
+from nsys_ai.cli import handlers
+from nsys_ai.cutracer.installer import CUTRACER_TAG
+
+
+@pytest.fixture
+def fake_cutracer(monkeypatch):
+    """Install a stand-in ``cutracer``, importable or not.
+
+    ``find_spec`` consults ``sys.modules`` first and rejects a module with no
+    ``__spec__``, so the importable stand-in needs a real one. The unimportable
+    case cannot live in ``sys.modules`` at all -- that is the point of it -- so
+    it patches the lookup and the import separately, which is exactly the split
+    the bug lived in.
+    """
+    import builtins
+    import importlib.machinery
+    import importlib.util
+
+    def _install(*, version=None, raises=None):
+        if raises is not None:
+            monkeypatch.setattr(
+                importlib.util,
+                "find_spec",
+                lambda name, *a, **k: (
+                    importlib.machinery.ModuleSpec("cutracer", loader=None)
+                    if name == "cutracer"
+                    else None
+                ),
+            )
+            real_import = builtins.__import__
+
+            def _fake_import(name, *args, **kwargs):
+                if name == "cutracer":
+                    raise raises
+                return real_import(name, *args, **kwargs)
+
+            monkeypatch.setattr(builtins, "__import__", _fake_import)
+            return
+
+        module = types.ModuleType("cutracer")
+        module.__spec__ = importlib.machinery.ModuleSpec("cutracer", loader=None)
+        if version is not None:
+            module.__version__ = version
+        monkeypatch.setitem(sys.modules, "cutracer", module)
+
+    return _install
+
+
+def _run_check(capsys):
+    """Run the check, returning (stdout, exited_nonzero)."""
+    try:
+        handlers._cutracer_check()
+    except SystemExit as exit_status:
+        return capsys.readouterr().out, bool(exit_status.code)
+    return capsys.readouterr().out, False
+
+
+def test_an_unimportable_package_is_reported_not_raised(fake_cutracer, capsys, monkeypatch):
+    """The reported B200 failure: installed, locatable, and its import raises."""
+    monkeypatch.setattr(handlers, "_find_cutracer_so", lambda: None)
+    fake_cutracer(raises=ModuleNotFoundError("No module named 'importlib_resources'", name="importlib_resources"))
+
+    out, failed = _run_check(capsys)
+
+    assert "FOUND but not importable" in out
+    assert "importlib_resources" in out
+    # Actionable, not just descriptive.
+    assert "pip install importlib_resources" in out
+    assert failed, "an unusable cutracer must still be a failing check"
+
+
+def test_a_missing_package_still_reads_as_missing(fake_cutracer, capsys, monkeypatch):
+    """The pre-existing path keeps its wording; absent is not the same as broken."""
+    import importlib.util
+
+    monkeypatch.setattr(handlers, "_find_cutracer_so", lambda: None)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name, *a, **k: None)
+
+    out, failed = _run_check(capsys)
+
+    assert "NOT FOUND" in out
+    assert "not importable" not in out
+    assert failed
+
+
+def test_a_package_newer_than_the_installer_tag_is_flagged(fake_cutracer, capsys, monkeypatch):
+    """pip takes the newest release; the installer builds one tag."""
+    monkeypatch.setattr(handlers, "_find_cutracer_so", lambda: None)
+    fake_cutracer(version="0.9.9")
+
+    out, _ = _run_check(capsys)
+
+    assert "version alignment" in out
+    assert "0.9.9" in out and CUTRACER_TAG in out
+
+
+def test_a_matching_version_says_nothing(fake_cutracer, capsys, monkeypatch):
+    """The warning is for a real mismatch, not noise on every run."""
+    monkeypatch.setattr(handlers, "_find_cutracer_so", lambda: None)
+    fake_cutracer(version=CUTRACER_TAG.lstrip("v"))
+
+    out, _ = _run_check(capsys)
+
+    assert "version alignment" not in out
+    assert f"OK (v{CUTRACER_TAG.lstrip('v')})" in out
+
+
+def test_an_unknown_version_does_not_claim_a_mismatch(fake_cutracer, capsys, monkeypatch):
+    """A package without __version__ is unknown, which is not evidence of drift."""
+    monkeypatch.setattr(handlers, "_find_cutracer_so", lambda: None)
+    fake_cutracer(version=None)
+
+    out, _ = _run_check(capsys)
+
+    assert "OK (vunknown)" in out
+    assert "version alignment" not in out

--- a/tests/test_cutracer_installer.py
+++ b/tests/test_cutracer_installer.py
@@ -524,3 +524,77 @@ class TestInstall:
 
         assert not result.success
         assert any("git clone" in e or "clone" in e.lower() for e in result.errors)
+
+
+class TestThirdPartyProvisioning:
+    """`install_third_party.sh` is keyed on the tag, not on nvbit's presence.
+
+    What that script fetches changes between releases: v0.3.0 added
+    ``src/trace_rapidjson.cpp`` and a RapidJSON download to go with it, and
+    v0.2.1 had neither. A tree provisioned under the old tag and checked out to
+    the new one therefore has nvbit but no RapidJSON, and testing only for
+    ``third_party/nvbit`` skipped the download the build now depends on.
+    """
+
+    @staticmethod
+    def _clone(tmp_path, *, provisioned_for=None):
+        clone = tmp_path / "cutracer"
+        (clone / "third_party" / "nvbit").mkdir(parents=True)
+        (clone / "Makefile").write_text("all:\n\techo built\n")
+        (clone / "install_third_party.sh").write_text("#!/bin/bash\nexit 0\n")
+        if provisioned_for is not None:
+            (clone / "third_party" / ".nsys-ai-provisioned-tag").write_text(
+                provisioned_for + "\n"
+            )
+        return clone
+
+    def _ran_third_party(self, monkeypatch, clone):
+        """Run the build far enough to see whether the script was invoked."""
+        import subprocess as _sp
+
+        from nsys_ai.cutracer import installer
+
+        calls = []
+        real_run = _sp.run
+
+        def _fake_run(cmd, *args, **kwargs):
+            calls.append(cmd)
+            if cmd and cmd[0] == "bash":
+                (clone / "third_party" / "rapidjson").mkdir(exist_ok=True)
+            return real_run(["true"], *args, **kwargs)
+
+        monkeypatch.setattr(installer.subprocess, "run", _fake_run)
+        # Stop before the compile; only the provisioning decision is under test.
+        (clone / "lib").mkdir(exist_ok=True)
+        (clone / "lib" / "cutracer.so").write_text("")
+        installer._clone_and_build(clone_dir=clone, progress=False)
+        return any(c and c[0] == "bash" for c in calls)
+
+    def test_a_tree_provisioned_for_an_older_tag_is_reprovisioned(
+        self, tmp_path, monkeypatch
+    ):
+        from nsys_ai.cutracer.installer import CUTRACER_TAG
+
+        clone = self._clone(tmp_path, provisioned_for="v0.2.1")
+        assert CUTRACER_TAG != "v0.2.1", "this test needs the tag to have moved"
+
+        assert self._ran_third_party(monkeypatch, clone), (
+            "a stale dependency set must be re-provisioned, not built against"
+        )
+
+    def test_a_tree_provisioned_for_the_current_tag_is_left_alone(
+        self, tmp_path, monkeypatch
+    ):
+        from nsys_ai.cutracer.installer import CUTRACER_TAG
+
+        clone = self._clone(tmp_path, provisioned_for=CUTRACER_TAG)
+
+        assert not self._ran_third_party(monkeypatch, clone), (
+            "re-downloading on every install would be a needless cost"
+        )
+
+    def test_an_unstamped_tree_is_reprovisioned(self, tmp_path, monkeypatch):
+        """Every clone made before this change has nvbit and no stamp."""
+        clone = self._clone(tmp_path, provisioned_for=None)
+
+        assert self._ran_third_party(monkeypatch, clone)


### PR DESCRIPTION
## Summary

Two failures hit on a B200 run, both nsys-ai's rather than the GPU's or upstream's.

- `nsys-ai cutracer check` exited with a `ModuleNotFoundError` traceback — from the command whose entire job is to report why instrumentation is not ready.
- The pip package and the compiled `.so` were versioned independently and could differ by a minor release with nothing saying so.

## Changes

**`src/nsys_ai/cli/handlers.py` — the traceback**

`importlib.util.find_spec` proves a module can be *located*, not that it *imports*, and the `import cutracer` on the next line was unguarded:

```python
if importlib.util.find_spec("cutracer") is not None:
    import cutracer as _ct          # <- raises straight out of the command
```

cutracer 0.2.1 and 0.3.0 both import `importlib_resources` without declaring it (checked against both releases' `requires_dist`), so any environment without that backport hit this. Now:

```
cutracer Python package : FOUND but not importable
  ModuleNotFoundError: No module named 'importlib_resources'
  The package is installed and its own import failed, which is a problem in
  that package or its environment rather than in nsys-ai.
  Try: pip install importlib_resources
```

It stays a failing check — unusable is not OK — and the missing-package path keeps its existing wording, because absent and broken are different answers.

**`src/nsys_ai/cutracer/installer.py` — the version split**

The `cutracer` extra is `cutracer>=0.2.0`, so pip installs the newest release (0.3.0 today), while the installer built `v0.2.1`. `CUTRACER_TAG` is now `v0.3.0`, and `check` reports a divergence when the extra moves ahead again.

Verified before bumping, on everything reachable without a GPU:

| Check | Result |
|---|---|
| `v0.3.0` exists upstream | yes — `dde45fd` |
| Tree vs `v0.2.1` | identical but for an added `docs/`; top-level `Makefile` in both |
| Environment variable surface | **purely additive** — 22 → 26, nothing removed |
| `--kernel-filters` (used by the runner) | present at both tags |
| `CUTRACER_MAX_ITERS` absent | still true, so the runner's no-op note holds |

**`src/nsys_ai/cutracer/runner.py` — a docstring that was wrong**

`kernel_filter` was documented as feeding a `CUTRACER_KERNEL_FILTER` environment variable. No such variable exists at either tag; the filter is passed as `--kernel-filters` on the command line. The code was right, the comment was not.

**`tests/test_cutracer_check.py`** (new, 5 cases)

Installed-but-unimportable is reported and still fails; missing still reads as missing; a package ahead of the tag is flagged; a matching version says nothing; an unknown version does not claim a mismatch. Two of the five fail against unfixed source.

## Backward compatibility

Yes for the check's existing outputs — a working install prints what it printed before. The new lines appear only in states that previously crashed or were silent.

The tag bump changes what `nsys-ai cutracer install` builds. That is the point: it now matches what `pip install nsys-ai[cutracer]` installs. Anyone who wants the old tool can set `CUTRACER_SO`.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed CLI path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2691 passed, 2 failed** — the two `test_profile_runner` races tracked in #585, unrelated to this change.
- `cutracer check` exercised directly against a stand-in package in all three states: unimportable, version-matched, and version-ahead.

## Out of scope

The undeclared `importlib_resources` dependency itself belongs to cutracer's packaging, not to nsys-ai, and is not something this repository can fix. What changes here is that nsys-ai names it instead of failing on it — so `pip install nsys-ai[cutracer]` on Python 3.10 still needs that package installed by hand, and the documentation should not describe the install as frictionless.
