### PR TITLE
fix(skills): keep the launch-overhead average numeric when a call fans out

### DIFF
--- a/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
+++ b/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
@@ -194,8 +194,18 @@ def _execute(conn, **kwargs):
             l.device_id,
             COUNT(*) AS launch_count,
             ROUND(SUM(l.api_charge_ns) / 1e6, 3) AS total_api_ms,
-            ROUND(AVG(NULLIF(l.api_charge_ns, 0)) / 1e3, 1) AS avg_api_us,
+            -- COALESCE, because a group can hold no charged launch at all. The
+            -- charge lands on one row per API call, and the grouping is by
+            -- kernel name: a call that fans out to several different kernels --
+            -- which is what a graph replay is -- charges the earliest and leaves
+            -- every other name with nothing but zeros. NULLIF then makes the
+            -- whole group NULL, and both the formatter and the finding builder
+            -- assumed a float, so the skill raised TypeError instead of
+            -- reporting. api_calls_charged is what tells those rows apart from a
+            -- genuinely instant launch.
+            ROUND(COALESCE(AVG(NULLIF(l.api_charge_ns, 0)), 0) / 1e3, 1) AS avg_api_us,
             ROUND(MAX(l.api_charge_ns) / 1e3, 1) AS max_api_us,
+            SUM(CASE WHEN l.api_charge_ns > 0 THEN 1 ELSE 0 END) AS api_calls_charged,
             COUNT(l.queue_duration_ns) AS queue_count,
             ROUND(COALESCE(SUM(l.queue_duration_ns), 0) / 1e6, 3) AS total_queue_ms,
             ROUND(COALESCE(AVG(l.queue_duration_ns), 0) / 1e3, 1) AS avg_queue_us,
@@ -236,7 +246,7 @@ def _format(rows):
         if len(name) > 48:
             name = name[:45] + "..."
         lines.append(
-            f"{name:<50s}  {row['launch_count']:>9d}  {row['avg_api_us']:>11.1f}  "
+            f"{name:<50s}  {row['launch_count']:>9d}  {float(row.get('avg_api_us') or 0.0):>11.1f}  "
             f"{row['avg_queue_us']:>13.1f}  {row['avg_kernel_us']:>14.3f}"
         )
     return "\n".join(lines)
@@ -273,11 +283,12 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 "launch_count": launch_count,
                 "avg_kernel_us": round(avg_kernel_us, 3),
                 "total_kernel_ms": float(row["total_kernel_ms"]),
-                "avg_api_us": float(row["avg_api_us"]),
+                "avg_api_us": float(row.get("avg_api_us") or 0.0),
                 "total_api_ms": float(row["total_api_ms"]),
                 "queue_count": int(row["queue_count"]),
                 "avg_queue_us": float(row["avg_queue_us"]),
                 "total_queue_ms": float(row["total_queue_ms"]),
+                "api_calls_charged": int(row.get("api_calls_charged", 0) or 0),
                 "graph_node_count": int(row.get("graph_node_count", 0) or 0),
                 "graph_id_count": int(row.get("graph_id_count", 0) or 0),
             },
@@ -290,6 +301,7 @@ def _to_findings(rows: list[dict], *, context: dict | None = None) -> list:
                 "queue_count": "count",
                 "avg_queue_us": "microseconds",
                 "total_queue_ms": "ms",
+                "api_calls_charged": "count",
                 "graph_node_count": "count",
                 "graph_id_count": "count",
             },

--- a/tests/test_kernel_launch_overhead.py
+++ b/tests/test_kernel_launch_overhead.py
@@ -393,3 +393,81 @@ def test_skill_is_enrolled_in_evidence_pipeline():
     assert EvidenceBuilder._SKILL_PIPELINE["kernel_launch_overhead"] == (
         "kernel_launch_overhead", {}
     )
+
+
+def _fanout_connection():
+    """One launch API call correlated to two differently-named kernels.
+
+    This is the shape of a CUDA graph replay -- a set of nodes dispatched by one
+    call -- and the shape the api_charge_ns accounting exists to handle.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT);
+        CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME (
+            start INTEGER, "end" INTEGER, correlationId INTEGER,
+            globalTid INTEGER, nameId INTEGER);
+        CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (
+            start INTEGER, "end" INTEGER, deviceId INTEGER, streamId INTEGER,
+            correlationId INTEGER, globalPid INTEGER, demangledName INTEGER,
+            shortName INTEGER, graphNodeId INTEGER, graphId INTEGER);
+        INSERT INTO StringIds VALUES (10,'cudaLaunchKernel'),(20,'gemm_kernel'),(21,'bias_kernel');
+        """
+    )
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (8000, 9000, 7, ?, 10)",
+        (0x100000007,),
+    )
+    for index, (short_name, node_id) in enumerate([(20, 101), (21, 102)]):
+        conn.execute(
+            "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (?,?,0,7,7,?,?,?,?,42)",
+            (10_000 + index * 20, 10_005 + index * 20, 0x100000000, short_name, short_name, node_id),
+        )
+    conn.commit()
+    return conn
+
+
+def test_a_fan_out_to_several_kernel_names_does_not_crash_the_formatter():
+    """The charge lands once; the other names must still render.
+
+    api_charge_ns is assigned to one row per API call while the outer query
+    groups by kernel name, so every name but the earliest holds nothing but
+    zeros. ``AVG(NULLIF(x, 0))`` over an all-zero group is NULL, and both the
+    formatter and the finding builder assumed a float -- ``TypeError:
+    unsupported format string passed to NoneType.__format__``.
+    """
+    conn = _fanout_connection()
+
+    rows = SKILL.execute_fn(conn, min_launches=1, device=0)
+    by_name = {row["kernel_name"]: row for row in rows}
+
+    assert by_name["gemm_kernel"]["avg_api_us"] == 1.0
+    assert by_name["bias_kernel"]["avg_api_us"] == 0.0
+    assert isinstance(SKILL.format_rows(rows), str)
+
+
+def test_a_zero_charge_row_says_it_was_charged_elsewhere():
+    """0.0 alone reads as a free launch, which is the wrong conclusion.
+
+    The dispatch was not cheap for bias_kernel; it was paid once and booked
+    against the kernel that happened to start first. api_calls_charged is what
+    separates the two, so a reader is not left inferring it from a zero.
+    """
+    conn = _fanout_connection()
+
+    by_name = {r["kernel_name"]: r for r in SKILL.execute_fn(conn, min_launches=1, device=0)}
+
+    assert by_name["gemm_kernel"]["api_calls_charged"] == 1
+    assert by_name["bias_kernel"]["api_calls_charged"] == 0
+    assert by_name["bias_kernel"]["total_api_ms"] == 0.0
+
+
+def test_findings_survive_a_zero_charge_row():
+    """to_findings called float() on the same value and raised there too."""
+    conn = _fanout_connection()
+    rows = SKILL.execute_fn(conn, min_launches=1, device=0)
+
+    findings = SKILL.to_findings_fn(rows, context={"profile_id": "p"})
+
+    assert isinstance(findings, list)


### PR DESCRIPTION
## Summary

- `kernel_launch_overhead` raised `TypeError` when one launch API call fanned out to kernels with different names — the shape of a CUDA graph replay, and the shape the `api_charge_ns` accounting exists to handle.
- Fixes #591.

## Changes

**`src/nsys_ai/skills/builtins/kernel_launch_overhead.py`**

`api_charge_ns` is assigned to one row per API call so a dispatch is counted once, but the outer query groups by **kernel name**. A call producing several different kernels charges the earliest and leaves every other name holding only zeros, so `AVG(NULLIF(x, 0))` over that group is `NULL`. Both consumers assumed a float:

- `:239` — `f"{row['avg_api_us']:>11.1f}"`
- `:276` — `float(row["avg_api_us"])`

Three changes:

1. `COALESCE(AVG(NULLIF(...)), 0)` — the crash.
2. **`api_calls_charged`** (new column) — the part worth reviewing. `0.0` on its own is a different wrong answer: it reads as a launch that costs nothing, when the dispatch was paid once and booked against whichever kernel started first. `api_calls_charged` is `1` for the row carrying the charge and `0` for rows charged elsewhere, and is published in the finding with its unit. Without it, fixing the crash would replace a traceback with a plausible wrong number — the failure mode #589 is about, and not one to introduce while fixing something else.
3. Both consumers made null-safe regardless, so a future producer of `None` cannot crash them either.

**`tests/test_kernel_launch_overhead.py`** — three cases over a one-call/two-kernel-name fixture: the formatter survives; the zero row reports `api_calls_charged=0` rather than looking free; `to_findings` survives the same value. The first two fail against unfixed source with the exact `TypeError`.

## Backward compatibility

Yes. `avg_api_us` was `NULL` only in the case that crashed, so nothing that previously worked changes value. `api_calls_charged` is added; no key is removed.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2688 passed, 3 failed**. All three are `test_profile_runner` cases from #585 — that family fails 2 in isolation on this machine and flakes to 4 under full-suite load, so 3 is inside its established range. None are in the changed path.
- Before/after on the reported shape:

  ```
  before:  avg_api_us = [1.0, None]  ->  TypeError in _format
  after:   gemm_kernel  avg_api_us=1.0  api_calls_charged=1
           bias_kernel  avg_api_us=0.0  api_calls_charged=0
  ```

## Out of scope

Whether a per-kernel-name row is the right shape for a replay's dispatch cost at all. Reporting the charge against the replay rather than against one member would be a better model, but it changes the skill's output contract and belongs with #584, which decides whether graph launches reach this code in the first place.

This defect is latent until then: the launch filter excludes `cudaGraphLaunch`, so no real replay currently arrives here. Fixing #584 would expose it immediately, which is the reason to land this first.

## Linked issues

Closes #591
