### PR TITLE
fix(skills): refuse an impossible MFU instead of reporting it

### DIFF
--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -49,8 +49,14 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
-def _error(code: str, message: str) -> ErrorDict:
-    return {"error": {"code": code, "message": message}}
+def _error(code: str, message: str, **detail) -> ErrorDict:
+    """A refusal row: the coded error, plus any fields the caller needs to act.
+
+    ``detail`` sits at row level rather than inside ``error`` so a consumer reads
+    it the way it reads any other column — the same shape ``abstain(reason,
+    **detail)`` uses in the skill layer.
+    """
+    return {"error": {"code": code, "message": message}, **detail}
 
 
 # ---------------------------------------------------------------------------
@@ -566,6 +572,46 @@ def compute_mfu_metrics_for_region(
     mfu_wall = 100.0 * achieved_wall / peak_tflops
     mfu_sum = 100.0 * achieved_sum / peak_tflops
     mfu_union = 100.0 * achieved_union / peak_tflops
+
+    # Hardware cannot exceed its own peak, so an MFU over 100% is not a fast
+    # region -- it is a malformed question, and the numbers below it are
+    # artefacts of the inputs rather than measurements. This is the same refusal
+    # arithmetic_intensity makes (#385), where a 369% reading was published as
+    # "High kernel throughput (likely compute-bound)" with advice to go tune the
+    # kernel. This skill's entire output is MFU and it had no such guard.
+    #
+    # No tolerance band: 1% over is as impossible as 300% over, and a band would
+    # only decide how much nonsense to publish.
+    #
+    # All three bases are checked because all three are published, and the
+    # denominators differ -- a borrowed numerator can land one over while the
+    # others sit under.
+    worst_basis, worst_mfu = max(
+        (("wall", mfu_wall), ("kernel_sum", mfu_sum), ("kernel_union", mfu_union)),
+        key=lambda pair: pair[1],
+    )
+    if worst_mfu > 100.0:
+        return _error(
+            "MFU_EXCEEDS_PEAK",
+            f"Refusing to report MFU. On the {worst_basis} basis this calculation puts the "
+            f"region at {worst_mfu:,.1f}% of peak "
+            f"({peak_tflops:,.1f} TFLOPS), which hardware cannot do, so one of the two inputs "
+            f"is not what the calculation assumes. theoretical_flops="
+            f"{theoretical_flops:.4g} is read as the total FLOPs of the work inside this one "
+            f"region: passing a whole job's FLOPs against a region that measures a single rank, "
+            f"or a per-second rate instead of a total, lands exactly here. Check that first, "
+            f"then peak_tflops and num_gpus -- a peak scaled for more GPUs than the region "
+            f"actually covers is the other way in.",
+            # Prefixed deliberately. These are the repudiated figures, kept
+            # because they are what a caller needs to find their input error --
+            # but a consumer reading mfu_pct_wall must not be handed the very
+            # number this branch exists to refuse.
+            implied_mfu_pct_wall=round(mfu_wall, 2),
+            implied_mfu_pct_kernel_sum=round(mfu_sum, 2),
+            implied_mfu_pct_kernel_union=round(mfu_union, 2),
+            implied_achieved_tflops_wall=round(achieved_wall, 2),
+            peak_tflops=float(peak_tflops),
+        )
 
     return {
         "theoretical_flops": float(theoretical_flops),

--- a/tests/test_region_mfu.py
+++ b/tests/test_region_mfu.py
@@ -95,16 +95,27 @@ def test_get_region_kernels_and_summarize(tmp_path):
         conn.close()
 
 
+#: FLOPs for the fixture's few-millisecond regions, chosen to land near half of
+#: a 989 TFLOPS peak. Every one of these was 1e18, which put the regions between
+#: 10,111% and 101,112,234,580% of peak -- readings the tests asserted as valid
+#: results, so none of them could notice that the skill never refused one.
+_PLAUSIBLE_REGION_FLOPS = 5e8
+
+
 def test_compute_mfu_metrics_for_region():
+    # 50% of a 989 TFLOPS peak over the 10 s below. It was 1e18, which is
+    # 100,000 TFLOPS achieved -- 10,111% MFU -- and the test asserted that as a
+    # valid result. An impossible reading asserted as valid is why #385 could
+    # ship in arithmetic_intensity and why this skill had no guard either.
     out = compute_mfu_metrics_for_region(
-        theoretical_flops=1e18,
+        theoretical_flops=0.5 * 989e12 * 10.0,
         peak_tflops=989.0,
         wall_time_s=10.0,
         kernel_sum_s=10.0,
         kernel_union_s=10.0,
     )
     assert "error" not in out
-    assert out["mfu_pct_wall"] == round(100.0 * ((1e18 / 10.0) / 1e12) / 989.0, 2)
+    assert out["mfu_pct_wall"] == 50.0
 
 
 def test_compute_region_mfu_from_conn_happy_path(tmp_path):
@@ -117,7 +128,7 @@ def test_compute_region_mfu_from_conn_happy_path(tmp_path):
             conn,
             str(db),
             "FlashAttention",
-            theoretical_flops=1e18,
+            theoretical_flops=_PLAUSIBLE_REGION_FLOPS,
             peak_tflops=None,
             occurrence_index=1,
             device_id=0,
@@ -213,7 +224,7 @@ def test_compute_region_mfu_from_conn_textid_schema(tmp_path):
             conn,
             str(db),
             "FlashAttnFwd",
-            theoretical_flops=1e18,
+            theoretical_flops=_PLAUSIBLE_REGION_FLOPS,
             peak_tflops=None,
             occurrence_index=1,
             device_id=0,
@@ -238,7 +249,7 @@ def test_compute_region_mfu_from_conn_multi_gpu(tmp_path):
             conn,
             str(db),
             "FlashAttention",
-            1e18,
+            _PLAUSIBLE_REGION_FLOPS,
             peak_tflops=None,
             num_gpus=1,
             device_id=0,
@@ -247,7 +258,7 @@ def test_compute_region_mfu_from_conn_multi_gpu(tmp_path):
             conn,
             str(db),
             "FlashAttention",
-            1e18,
+            _PLAUSIBLE_REGION_FLOPS,
             peak_tflops=None,
             num_gpus=2,
             device_id=0,
@@ -275,7 +286,7 @@ def test_compute_region_mfu_kernel_mode(tmp_path):
             conn,
             str(db),
             "k_flash",  # matches kernel shortName via StringIds
-            theoretical_flops=1e18,
+            theoretical_flops=_PLAUSIBLE_REGION_FLOPS,
             source="kernel",
             peak_tflops=None,
             device_id=0,
@@ -332,3 +343,67 @@ def test_compute_theoretical_flops_missing_dims():
     result = compute_theoretical_flops("attention", hidden_dim=0, seq_len=0)
     assert "error" in result
     assert result["error"]["code"] == "INVALID_ARGUMENT"
+
+
+# ── An impossible MFU is a malformed question, not a fast region ────────────
+
+
+def _metrics(flops, peak, *, wall=6.158, ksum=6.2, kunion=6.1):
+    return compute_mfu_metrics_for_region(
+        theoretical_flops=flops,
+        peak_tflops=peak,
+        wall_time_s=wall,
+        kernel_sum_s=ksum,
+        kernel_union_s=kunion,
+    )
+
+
+def test_an_mfu_over_one_hundred_percent_is_refused():
+    """Hardware cannot exceed its own peak, so this is an input error.
+
+    The shape that produces it is a borrowed numerator: a FLOP count computed
+    for a whole job handed to a region that measures one rank, or a peak scaled
+    for more GPUs than the region covers. Both are easy on a multi-rank capture.
+
+    arithmetic_intensity already refuses this (#385), where a 369% reading was
+    published as "High kernel throughput (likely compute-bound)" with advice to
+    tune the kernel. This skill's entire output is MFU and it reported 108%.
+    """
+    out = _metrics(8.23e14 * 8, 989.0)
+
+    assert out["error"]["code"] == "MFU_EXCEEDS_PEAK"
+    assert "Refusing to report MFU" in out["error"]["message"]
+
+
+def test_the_refused_figures_do_not_reach_a_consumer_under_their_real_names():
+    """A caller reading mfu_pct_wall must not receive the repudiated number."""
+    out = _metrics(8.23e14 * 8, 989.0)
+
+    for leaked in ("mfu_pct_wall", "mfu_pct_kernel_sum", "mfu_pct_kernel_union"):
+        assert leaked not in out, f"{leaked} survived the refusal"
+    # Kept under a prefix, because they are what shows the caller their mistake.
+    assert out["implied_mfu_pct_wall"] > 100.0
+    assert out["peak_tflops"] == 989.0
+
+
+def test_exactly_peak_still_reports():
+    """100% is achievable, if unlikely. The refusal is for the impossible."""
+    out = _metrics(989e12, 989.0, wall=1.0, ksum=1.0, kunion=1.0)
+
+    assert "error" not in out
+    assert out["mfu_pct_wall"] == 100.0
+
+
+def test_a_one_percent_overshoot_is_refused_too():
+    """No tolerance band: a band only decides how much nonsense to publish."""
+    out = _metrics(989e12 * 1.01, 989.0, wall=1.0, ksum=1.0, kunion=1.0)
+
+    assert out["error"]["code"] == "MFU_EXCEEDS_PEAK"
+
+
+def test_a_believable_mfu_is_untouched():
+    """The guard must not disturb the ordinary case."""
+    out = _metrics(8.23e14, 989.0 * 8)
+
+    assert "error" not in out
+    assert 0 < out["mfu_pct_wall"] < 100


### PR DESCRIPTION
## Summary

- `region_mfu` returned an MFU above 100% as an ordinary result row. That says a region did more FLOPs than the hardware can do, so it is not a measurement — it is a malformed question, and nothing in the output let a caller tell it from a real 8%.
- Fixes #589.

## Changes

**`src/nsys_ai/region_mfu.py`**

`compute_mfu_metrics_for_region` validated that its inputs were positive and then divided, with no check on the result. It now refuses, following the decisions #385 already made for `arithmetic_intensity` rather than inventing new ones:

- **No tolerance band.** 1% over is as impossible as 300% over; a band only decides how much nonsense to publish.
- **The repudiated figures are renamed** — `implied_mfu_pct_wall`, not `mfu_pct_wall`. They are kept because they are what shows a caller their input error, but a consumer reading `rows[0]["mfu_pct_wall"]` must not be handed the number the branch exists to refuse. There is a test for exactly that.
- **All three bases are checked**, since all three are published and a borrowed numerator can put one over while the others sit under.
- **Exactly 100% still reports.** It is achievable, if unlikely; the refusal is for the impossible.

`_error` gained `**detail`, so a refusal can carry those fields at row level — the shape `abstain(reason, **detail)` already uses in the skill layer.

**`tests/test_region_mfu.py`**

Five new cases: refused, figures not leaked under their real names, exactly-peak reports, a one-percent overshoot is refused, an ordinary MFU is untouched. Three fail against unfixed source.

## The part worth reading

Adding the guard broke five existing tests, and that is the finding rather than a problem with the guard.

Every `region_mfu` test passed `theoretical_flops=1e18` against regions of a few microseconds. That is an MFU between **10,111%** and **101,112,234,580%**, asserted as a valid result:

```
assert out["mfu_pct_wall"] == round(100.0 * ((1e18 / 10.0) / 1e12) / 989.0, 2)   # 10111.22
```

None of them could have caught the missing guard, because they were built on precisely the readings it should refuse. This is the lesson #385 already recorded in `test_skills_benchmarks.py`:

> They used to be 1e15, which is 222,222 TFLOPS — 712x an A100's peak, and the skill classified it as good throughput (#385). A test that asserts on an impossible reading cannot notice when the impossible reading is the bug.

The inputs now land near half of peak, and the reason is recorded on the shared constant so the next person does not restore a convenient-but-impossible number.

## Backward compatibility

A calculation that previously returned an impossible MFU now returns a coded refusal instead. That is the fix. Every physically possible result is unchanged — including exactly 100%, which is pinned by a test.

`_error` gaining `**detail` is additive; existing two-argument calls are unaffected.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2691 passed, 2 failed** — the two `test_profile_runner` races from #585, unrelated.
- Before/after on the reported shape (a whole job's FLOPs against one rank's region):

  ```
  before:  mfu_pct_wall = 108.11, returned as a result
  after:   error MFU_EXCEEDS_PEAK, with implied_mfu_pct_wall = 108.11 kept for diagnosis
  ```

## Out of scope

`_sol_headroom_ms` clamps with `min(float(mfu), 100.0)`, which is an existing acknowledgement that MFU could exceed 100 — handled by clamping rather than refusing. With this guard the clamp should be unreachable, but removing it is a separate change and it does no harm as a belt.

## Linked issues

Closes #589
