### PR TITLE
fix(schema): claim CUDA Graph attribution only where the data supports it

### DIFF
--- a/src/nsys_ai/cuda_graph.py
+++ b/src/nsys_ai/cuda_graph.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 
+from .connection import resolve_table_variant
+
 GRAPH_TABLE_NAMES = (
     "CUDA_GRAPH_EVENTS",
     "CUDA_GRAPH_NODE_EVENTS",
@@ -26,9 +28,23 @@ GRAPH_KERNEL_COLUMNS = {
 
 
 def actual_table(tables: Iterable[str], name: str) -> str | None:
-    """Return the case-preserving table name matching *name*, if present."""
+    """Return the table matching *name*, including a ``_V2``/``_V3`` variant.
+
+    An exact comparison dropped the versioned names Nsight actually writes on
+    newer exports, so a profile carrying ``CUPTI_ACTIVITY_KIND_GRAPH_TRACE_V3``
+    reported no graph metadata at all. Resolution goes through the shared
+    ``resolve_table_variant``, which is what the repository's Nsight table-name
+    contract requires and which already knows that ``_V10`` beats ``_V3``.
+
+    The case-insensitive exact match is kept as the first step, because the
+    shared resolver compares exactly and some callers hand in names whose case
+    came from a different export.
+    """
     wanted = name.lower()
-    return next((table for table in tables if str(table).lower() == wanted), None)
+    exact = next((table for table in tables if str(table).lower() == wanted), None)
+    if exact is not None:
+        return exact
+    return resolve_table_variant({str(t) for t in tables}, name)
 
 
 def actual_columns(columns: Iterable[str]) -> dict[str, str]:
@@ -60,18 +76,37 @@ def kernel_graph_columns(columns: Iterable[str]) -> dict[str, str]:
 
 
 def graph_capability(
-    tables: Iterable[str], kernel_columns: Mapping[str, str]
+    tables: Iterable[str],
+    kernel_columns: Mapping[str, str],
+    *,
+    kernel_rows_present: bool | None = None,
 ) -> dict[str, object]:
     """Describe optional graph support without claiming more than the data.
 
-    ``kernel_attribution`` is true only when kernel rows carry a graph ID.  A
+    ``kernel_attribution`` is true only when kernel rows carry a graph ID. A
     graph metadata table alone is useful for diagnostics, but it cannot be
     joined to kernel timing without inventing an attribution.
+
+    The columns alone are not evidence of that, which is what this used to treat
+    them as. The Parquet cache deliberately synthesises ``NULL AS graph_node_id``
+    for a capture that has none, so downstream SQL does not have to branch — so
+    once cached, a pre-graph profile carries the columns and reported attribution
+    as available. The same profile answered differently before and after its
+    cache was built.
+
+    Nor can the spelling settle it: the cache normalises real graph data to the
+    same snake_case names it synthesises, so ``graph_node_id`` means both things.
+
+    ``kernel_rows_present`` carries the only thing that does settle it — whether
+    a row actually holds a graph id. ``None`` means it could not be established,
+    and attribution is not claimed on a maybe.
     """
     resolved_tables = graph_tables(tables)
+    attribution = bool(kernel_columns) and kernel_rows_present is True
     return {
-        "kernel_attribution": bool(kernel_columns),
+        "kernel_attribution": attribution,
         "kernel_columns": dict(kernel_columns),
+        "kernel_rows_present": kernel_rows_present,
         "tables": resolved_tables,
         "available": bool(kernel_columns or resolved_tables),
     }

--- a/src/nsys_ai/profile.py
+++ b/src/nsys_ai/profile.py
@@ -36,6 +36,9 @@ from nsys_ai.exceptions import (
 )
 from nsys_ai.profile_reference import inspect_local_parquetdir
 
+#: Distinguishes "not probed yet" from a probe that answered None (unknown).
+_UNPROBED = object()
+
 # Regex for safe SQL identifiers (table/column names).
 _SAFE_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
@@ -135,6 +138,7 @@ class NsightSchema:
         self.graph_node_events_table = self._resolve_table("CUDA_GRAPH_NODE_EVENTS")
         self.graph_trace_table = self._resolve_table("CUPTI_ACTIVITY_KIND_GRAPH_TRACE")
         self.kernel_graph_columns: dict[str, str] = {}
+        self._graph_rows_probe: bool | None | object = _UNPROBED
         if self.kernel_table:
             try:
                 self.kernel_graph_columns = kernel_graph_columns(
@@ -296,6 +300,33 @@ class NsightSchema:
                 return t
         return None
 
+    def _graph_rows_present(self) -> bool | None:
+        """True when a kernel row actually carries a graph id; None if unknown.
+
+        Probed rather than inferred from the columns, because the Parquet cache
+        synthesises them for a capture that has none. Lazy and memoised: only a
+        caller asking about graph capability pays for the query, which keeps it
+        off the open path where it would be a scan nobody asked for.
+        """
+        if self._graph_rows_probe is not _UNPROBED:
+            return self._graph_rows_probe
+
+        self._graph_rows_probe = None
+        if self.kernel_table and self.kernel_graph_columns:
+            predicate = " OR ".join(
+                f'"{column}" IS NOT NULL' for column in self.kernel_graph_columns.values()
+            )
+            try:
+                row = self._adapter.execute(
+                    f"SELECT 1 FROM {self.kernel_table} WHERE {predicate} LIMIT 1"  # nosec B608
+                ).fetchone()
+                self._graph_rows_probe = row is not None
+            except DB_ERRORS:
+                # Unknown, not absent. An optional probe must not turn a
+                # readable profile into a failure.
+                self._graph_rows_probe = None
+        return self._graph_rows_probe
+
     @property
     def cuda_graph(self) -> dict[str, object]:
         """Optional CUDA Graph capability visible in this export.
@@ -304,7 +335,11 @@ class NsightSchema:
         not enter :meth:`missing_required_columns`; pre-2026 captures remain
         fully analyzable through the non-graph path.
         """
-        return graph_capability(self.tables, self.kernel_graph_columns)
+        return graph_capability(
+            self.tables,
+            self.kernel_graph_columns,
+            kernel_rows_present=self._graph_rows_present(),
+        )
 
     def _missing_columns(self, table: str, required) -> list[str]:
         try:

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -74,6 +74,7 @@ def _insert_graph_replay(conn):
 
 def test_schema_detects_graph_tables_and_optional_kernel_columns():
     conn = _graph_connection()
+    _insert_graph_replay(conn)          # columns alone are not the claim; rows are
     schema = NsightSchema(conn)
 
     assert schema.kernel_graph_columns == {
@@ -226,3 +227,44 @@ def test_the_arrow_writer_reads_the_sparse_graph_fields():
 
     assert map_tbl.column("graph_node_id").to_pylist() == [None]
     assert map_tbl.column("graph_id").to_pylist() == [None]
+
+
+def test_graph_columns_without_graph_rows_do_not_claim_attribution():
+    """The Parquet cache synthesises these columns for a capture that has none.
+
+    ``_optional_graph_projection`` emits ``NULL AS graph_node_id, NULL AS
+    graph_id`` so downstream SQL need not branch on whether a profile predates
+    graph tracing. Reading that as evidence meant a cached pre-graph profile
+    reported CUDA Graph attribution as available, and the same profile answered
+    differently before and after its cache was built.
+
+    The spelling cannot separate the two either: the cache normalises real graph
+    data to the same snake_case names it synthesises. Only the data settles it.
+    """
+    conn = _graph_connection()          # columns present, no rows inserted
+    schema = NsightSchema(conn)
+
+    capability = schema.cuda_graph
+
+    assert schema.kernel_graph_columns, "the columns are there"
+    assert capability["kernel_attribution"] is False, "but nothing carries a graph id"
+    assert capability["kernel_rows_present"] is False
+    # Still worth reporting: the metadata tables are real and useful to doctor.
+    assert capability["available"] is True
+
+
+def test_a_versioned_graph_activity_table_is_resolved():
+    """Nsight suffixes activity tables _V2/_V3 on newer exports.
+
+    An exact-name comparison dropped them, so a profile carrying
+    CUPTI_ACTIVITY_KIND_GRAPH_TRACE_V3 reported no graph metadata at all. The
+    repository's Nsight table-name contract requires the shared resolver.
+    """
+    from nsys_ai.cuda_graph import graph_tables
+
+    for name in (
+        "CUPTI_ACTIVITY_KIND_GRAPH_TRACE",
+        "CUPTI_ACTIVITY_KIND_GRAPH_TRACE_V2",
+        "CUPTI_ACTIVITY_KIND_GRAPH_TRACE_V3",
+    ):
+        assert graph_tables([name]), f"{name} was dropped"


### PR DESCRIPTION
## Summary

CUDA Graph capability was reported wrong in both directions, so `doctor` and the schema layer misdescribed what a profile can do. Fixes #592.

## 1. It over-claimed

The columns were read as evidence. The Parquet cache deliberately synthesises `NULL AS graph_node_id, NULL AS graph_id` for a capture that has none (`_optional_graph_projection`), so downstream SQL need not branch on whether a profile predates graph tracing. `kernel_graph_columns` then found those names on the cached view:

```
cached columns: ['start', 'end', 'deviceId', 'graph_node_id', 'graph_id']
kernel_attribution -> True          # on a capture with no graph data at all
```

The same profile answered differently before and after its cache was built, which is the sharpest way to see it.

**The spelling cannot separate the two.** My first instinct was that the cache emits snake_case and Nsight emits `graphNodeId`, so the name would tell them apart — but the parquetdir backend normalises *real* graph data to the same snake_case names, so `graph_node_id` means both things. There is no static signal.

So `kernel_attribution` now requires a kernel row that actually carries a graph id. Three states rather than two — carried, absent, unknown — and attribution is not claimed on a maybe. This is what the module's own docstring already said it meant:

> `kernel_attribution` is true only when kernel rows carry a graph ID.

**The probe is lazy and memoised**, deliberately. In `__init__` it would add a scan to every profile open for a question most callers never ask; this way only a reader of `cuda_graph` pays for it.

## 2. It under-claimed

`GRAPH_TABLE_NAMES` was matched by exact name, so a newer export was reported as having no graph metadata:

```
CUPTI_ACTIVITY_KIND_GRAPH_TRACE     -> resolved
CUPTI_ACTIVITY_KIND_GRAPH_TRACE_V2  -> {}
CUPTI_ACTIVITY_KIND_GRAPH_TRACE_V3  -> {}
```

Resolution now goes through `resolve_table_variant`, which is what `CLAUDE.md`'s Nsight table-name contract requires, and which already knows `_V10` beats `_V3`.

## Changes

- `src/nsys_ai/cuda_graph.py` — `actual_table` falls through to the shared resolver; `graph_capability` takes `kernel_rows_present` and publishes it.
- `src/nsys_ai/profile.py` — `NsightSchema._graph_rows_present()`, lazy and memoised, with a sentinel separating "not probed" from "probed, unknown".
- `tests/test_cuda_graph.py` — two new cases, both failing against unfixed source.

## One existing test changed meaning

`test_schema_detects_graph_tables_and_optional_kernel_columns` asserted `kernel_attribution is True` on a fixture with the columns and **no graph rows**. Under the contract above that is `False` — there is nothing to attribute. It now inserts the rows its name implies, and the columns-without-data case is pinned as its own test.

`available` deliberately stays `True` in that state: the metadata tables are real and useful to `doctor`. Only the attribution claim is withdrawn.

## Backward compatibility

`kernel_attribution` becomes `False` for a profile whose graph columns hold nothing — which is the fix, and is what a caller should have been told. `kernel_rows_present` is added. A profile with real graph data is unaffected, and a `_V2`/`_V3` export now reports metadata it previously hid.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2696 passed, 2 failed** — the two `test_profile_runner` races from #585, unrelated.
- `bandit -r src/ -c pyproject.toml` — 0 issues at every severity.

## Linked issues

Closes #592
