### PR TITLE
feat(skills): name the process a region MFU was measured on, and let one be chosen

### DIFF
--- a/src/nsys_ai/ai/backend/chat_tools.py
+++ b/src/nsys_ai/ai/backend/chat_tools.py
@@ -185,8 +185,21 @@ TOOL_COMPUTE_REGION_MFU = {
                 },
                 "occurrence_index": {
                     "type": "integer",
-                    "description": "Which matching NVTX occurrence to use (1-based, only for source='nvtx'). Default 1.",
+                    "description": (
+                        "Which matching NVTX occurrence to use (1-based, only for "
+                        "source='nvtx'). Default 1. On a multi-rank capture every rank "
+                        "carries the same annotation, so occurrences span processes "
+                        "unless 'pid' narrows them to one."
+                    ),
                     "default": 1,
+                },
+                "pid": {
+                    "type": "integer",
+                    "description": (
+                        "Measure this process's copy of the range (source='nvtx' only). "
+                        "The result reports 'pid' for whichever process it measured, so "
+                        "an MFU can be attributed to a rank."
+                    ),
                 },
                 "device_id": {
                     "type": "integer",

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -49,6 +49,20 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
+#: Nsight packs the process id into the high bits of ``globalTid``. The mask
+#: form of this same fact is already applied elsewhere as
+#: ``globalTid & CAST(-16777216 AS BIGINT)``, which clears the low 24 bits and
+#: leaves ``pid << 24``; shifting is the other half of it.
+_GLOBAL_TID_PID_SHIFT = 24
+
+
+def pid_from_global_tid(global_tid: int | None) -> int | None:
+    """The process a ``globalTid`` belongs to, or None when there is none."""
+    if global_tid is None:
+        return None
+    return int(global_tid) >> _GLOBAL_TID_PID_SHIFT
+
+
 def _error(code: str, message: str, **detail) -> ErrorDict:
     """A refusal row: the coded error, plus any fields the caller needs to act.
 
@@ -664,6 +678,7 @@ def compute_region_mfu_from_conn(
     occurrence_index: int = 1,
     device_id: int | None = None,
     match_mode: str = "contains",
+    pid: int | None = None,
 ) -> RowDict | ErrorDict:
     """
     Compute MFU for a named region using an existing SQLite connection.
@@ -722,7 +737,32 @@ def compute_region_mfu_from_conn(
                 "annotation. Re-capture with NVTX enabled, or pass "
                 "source='kernel' to match kernels by name instead.",
             )
-        matches = find_nvtx_ranges(conn, name, match_mode=match_mode)
+        all_matches = matches = find_nvtx_ranges(conn, name, match_mode=match_mode)
+        # Narrow to one process first, so occurrence_index indexes within a
+        # rank rather than across them. On a multi-rank capture every rank
+        # carries the same annotation over an overlapping window, so without
+        # this the index walks ranks in start-time order -- which for concurrent
+        # ranks is scheduling noise, and not stable across a re-capture.
+        if pid is not None:
+            matches = [m for m in matches if pid_from_global_tid(m.get("global_tid")) == pid]
+            if not matches:
+                available = sorted(
+                    {
+                        p
+                        for p in (pid_from_global_tid(m.get("global_tid")) for m in all_matches)
+                        if p is not None
+                    }
+                )
+                return _error(
+                    "NVTX_NOT_FOUND",
+                    f"No NVTX range matched the requested name in process {pid}. "
+                    + (
+                        f"Processes carrying it: {', '.join(str(p) for p in available)}."
+                        if available
+                        else "No match carries a process id."
+                    ),
+                )
+
         chosen = select_nvtx_occurrence(matches, occurrence_index)
         if "error" in chosen:
             return chosen
@@ -781,6 +821,18 @@ def compute_region_mfu_from_conn(
         "name": name,
         "matched_text": matched_name,
         "match_mode": match_mode,
+        # Which process this occurrence came from. Read out of the profile and
+        # then dropped before publication, which left a multi-rank capture
+        # unanswerable: nsys packs every rank of a torchrun job into one file,
+        # Megatron annotates them identically, and the ranges overlap in time --
+        # so a name matches once per rank and occurrence_index walks ranks
+        # rather than iterations. Without this a reported MFU could not be
+        # attributed to a rank, and two runs of the same command could measure
+        # different ones with nothing in the output differing.
+        "global_tid": int(chosen["global_tid"])
+        if source == "nvtx" and chosen.get("global_tid") is not None
+        else None,
+        "pid": pid_from_global_tid(chosen.get("global_tid")) if source == "nvtx" else None,
         "occurrence_index": int(chosen.get("occurrence_index", occurrence_index))
         if source == "nvtx"
         else None,
@@ -811,6 +863,7 @@ def compute_region_mfu(
     occurrence_index: int = 1,
     device_id: int | None = None,
     match_mode: str = "contains",
+    pid: int | None = None,
 ) -> RowDict | ErrorDict:
     """
     Convenience wrapper that opens the profile for MFU computation.
@@ -843,6 +896,7 @@ def compute_region_mfu(
             occurrence_index=occurrence_index,
             device_id=device_id,
             match_mode=match_mode,
+            pid=pid,
         )
     finally:
         conn.close()

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -49,18 +49,19 @@ def _escape_like(value: str) -> str:
     return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
 
 
-#: Nsight packs the process id into the high bits of ``globalTid``. The mask
-#: form of this same fact is already applied elsewhere as
-#: ``globalTid & CAST(-16777216 AS BIGINT)``, which clears the low 24 bits and
-#: leaves ``pid << 24``; shifting is the other half of it.
+#: Nsight packs the process id into bits 24-47 of ``globalTid`` -- a 24-bit
+#: field, not every bit above the thread id. Shifting alone keeps whatever sits
+#: above it: the committed h100_2gpu_1s fixture carries 0x100006f00006f, where
+#: bit 48 is set, so a bare ``>> 24`` reads pid 16,777,327 instead of 111.
 _GLOBAL_TID_PID_SHIFT = 24
+_GLOBAL_TID_PID_MASK = 0xFFFFFF
 
 
 def pid_from_global_tid(global_tid: int | None) -> int | None:
     """The process a ``globalTid`` belongs to, or None when there is none."""
     if global_tid is None:
         return None
-    return int(global_tid) >> _GLOBAL_TID_PID_SHIFT
+    return (int(global_tid) >> _GLOBAL_TID_PID_SHIFT) & _GLOBAL_TID_PID_MASK
 
 
 def _error(code: str, message: str, **detail) -> ErrorDict:
@@ -702,6 +703,15 @@ def compute_region_mfu_from_conn(
     # ---------------------------------------------------------------
     # Branch: source="kernel" — query kernels directly by name
     # ---------------------------------------------------------------
+    if source == "kernel" and pid is not None:
+        return _error(
+            "INVALID_ARGUMENT",
+            "pid selects which process's NVTX range to measure, so it applies to "
+            "source='nvtx'. In kernel mode the region is every matching kernel, "
+            "with no per-occurrence process to narrow to. Drop pid, or switch to "
+            "source='nvtx' and name the range.",
+        )
+
     if source == "kernel":
         kernels = find_kernels_by_name(
             conn,

--- a/src/nsys_ai/skills/builtins/region_mfu.py
+++ b/src/nsys_ai/skills/builtins/region_mfu.py
@@ -29,6 +29,9 @@ def _execute(conn, **kwargs):
     if device_id is not None:
         device_id = int(device_id)
     match_mode = kwargs.get("match_mode", "contains")
+    pid = kwargs.get("pid")
+    if pid is not None:
+        pid = int(pid)
 
     result = compute_region_mfu_from_conn(
         conn,
@@ -41,6 +44,7 @@ def _execute(conn, **kwargs):
         occurrence_index=occurrence_index,
         device_id=device_id,
         match_mode=match_mode,
+        pid=pid,
     )
     return [result]
 
@@ -214,8 +218,24 @@ SKILL = Skill(
             "peak_tflops", "GPU peak TFLOPS (auto-detected if omitted)", "float", False, None
         ),
         SkillParam("num_gpus", "Number of GPUs (for DP/TP adjustment)", "int", False, 1),
-        SkillParam("occurrence_index", "Which occurrence to analyze (1-based)", "int", False, 1),
+        SkillParam(
+            "occurrence_index",
+            "Which occurrence to analyze (1-based). Occurrences span processes "
+            "on a multi-rank capture unless 'pid' narrows them to one.",
+            "int",
+            False,
+            1,
+        ),
         SkillParam("device_id", "GPU device ID filter", "int", False, None),
+        SkillParam(
+            "pid",
+            "Process to measure. On a multi-rank capture every rank carries the "
+            "same annotation, so occurrence_index walks ranks; this picks one "
+            "directly. The result row reports 'pid' for whichever it measured.",
+            "int",
+            False,
+            None,
+        ),
         SkillParam(
             "match_mode",
             "Name matching: 'contains', 'exact', 'startswith'",

--- a/src/nsys_ai/tool_dispatch.py
+++ b/src/nsys_ai/tool_dispatch.py
@@ -324,6 +324,11 @@ class ToolDispatcher:
                             else None
                         ),
                         "match_mode": str(args.get("match_mode") or "contains"),
+                        "pid": (
+                            int(args["pid"])
+                            if "pid" in args and args["pid"] is not None
+                            else None
+                        ),
                     },
                 )
                 result = rows[0] if len(rows) == 1 else rows

--- a/tests/test_region_mfu.py
+++ b/tests/test_region_mfu.py
@@ -407,3 +407,73 @@ def test_a_believable_mfu_is_untouched():
 
     assert "error" not in out
     assert 0 < out["mfu_pct_wall"] < 100
+# ── Which rank did we measure? ──────────────────────────────────────────────
+
+
+def _multi_rank_conn(ranks=8, base_pid=3822370):
+    """One capture holding every rank of a torchrun job, as nsys writes it.
+
+    Megatron annotates each rank identically and the ranges overlap in time, so
+    one name matches once per rank. occurrence_index then walks ranks rather
+    than iterations, ordered by start time -- which for concurrent ranks is
+    scheduling noise, and not stable across a re-capture.
+    """
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        'CREATE TABLE NVTX_EVENTS (globalTid INTEGER, start INTEGER, "end" INTEGER, '
+        "text TEXT, eventType INTEGER, rangeId INTEGER, textId INTEGER)"
+    )
+    conn.execute("CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT)")
+    for index in range(ranks):
+        global_tid = ((base_pid + index) << 24) | 1234
+        conn.execute(
+            "INSERT INTO NVTX_EVENTS VALUES (?,?,?,?,59,?,NULL)",
+            (
+                global_tid,
+                39_964_000_000 + index * 1_000,
+                46_122_000_000 + index * 1_000,
+                "sample_0(repeat=5)",
+                index,
+            ),
+        )
+    conn.commit()
+    return conn
+
+
+def test_pid_is_recovered_from_the_nsight_encoding():
+    """nsys packs the process into the high bits of globalTid."""
+    from nsys_ai.region_mfu import pid_from_global_tid
+
+    assert pid_from_global_tid((3822370 << 24) | 1234) == 3822370
+    assert pid_from_global_tid(None) is None
+
+
+def test_every_occurrence_is_a_different_rank():
+    """The situation this exists for, stated as a test."""
+    from nsys_ai.region_mfu import (
+        find_nvtx_ranges,
+        pid_from_global_tid,
+        select_nvtx_occurrence,
+    )
+
+    matches = find_nvtx_ranges(_multi_rank_conn(), "sample_0(repeat=5)", match_mode="exact")
+
+    assert len(matches) == 8
+    pids = [
+        pid_from_global_tid(select_nvtx_occurrence(matches, i)["global_tid"])
+        for i in range(1, 9)
+    ]
+    assert len(set(pids)) == 8, "eight occurrences, eight processes"
+
+
+def test_a_rank_can_be_asked_for_directly():
+    """Rather than guessed at through an occurrence index."""
+    from nsys_ai.region_mfu import find_nvtx_ranges, pid_from_global_tid
+
+    matches = find_nvtx_ranges(_multi_rank_conn(), "sample_0(repeat=5)", match_mode="exact")
+    wanted = 3822374
+
+    selected = [m for m in matches if pid_from_global_tid(m.get("global_tid")) == wanted]
+
+    assert len(selected) == 1
+    assert pid_from_global_tid(selected[0]["global_tid"]) == wanted

--- a/tests/test_region_mfu.py
+++ b/tests/test_region_mfu.py
@@ -410,6 +410,16 @@ def test_a_believable_mfu_is_untouched():
 # ── Which rank did we measure? ──────────────────────────────────────────────
 
 
+def _make_global_tid(pid: int, tid: int) -> int:
+    """Encode as Nsight does: a flag bit above a 24-bit pid above a 24-bit tid.
+
+    The committed h100_2gpu_1s fixture carries 0x100006f00006f -- bit 48 set,
+    pid 111, tid 111. Building test ids without that bit is what let a decoder
+    that only shifted look correct.
+    """
+    return (1 << 48) | ((pid & 0xFFFFFF) << 24) | (tid & 0xFFFFFF)
+
+
 def _multi_rank_conn(ranks=8, base_pid=3822370):
     """One capture holding every rank of a torchrun job, as nsys writes it.
 
@@ -425,7 +435,7 @@ def _multi_rank_conn(ranks=8, base_pid=3822370):
     )
     conn.execute("CREATE TABLE StringIds (id INTEGER PRIMARY KEY, value TEXT)")
     for index in range(ranks):
-        global_tid = ((base_pid + index) << 24) | 1234
+        global_tid = _make_global_tid(base_pid + index, tid=1234)
         conn.execute(
             "INSERT INTO NVTX_EVENTS VALUES (?,?,?,?,59,?,NULL)",
             (
@@ -441,11 +451,26 @@ def _multi_rank_conn(ranks=8, base_pid=3822370):
 
 
 def test_pid_is_recovered_from_the_nsight_encoding():
-    """nsys packs the process into the high bits of globalTid."""
+    """The pid is a 24-bit field at bit 24, not everything above the tid.
+
+    A bare ``>> 24`` keeps whatever sits above the field. The committed fixture
+    sets bit 48, so it read pid 16,777,327 where the pid is 111 -- and a request
+    for the real pid then matched nothing.
+    """
+    import sqlite3
+
     from nsys_ai.region_mfu import pid_from_global_tid
 
-    assert pid_from_global_tid((3822370 << 24) | 1234) == 3822370
+    assert pid_from_global_tid(_make_global_tid(3822370, tid=1234)) == 3822370
     assert pid_from_global_tid(None) is None
+
+    # Against the real encoding in a committed capture, not a constructed one.
+    conn = sqlite3.connect("tests/fixtures/h100_2gpu_1s.sqlite")
+    real = [row[0] for row in conn.execute("SELECT DISTINCT globalTid FROM NVTX_EVENTS LIMIT 2")]
+    assert real, "the fixture should carry NVTX rows"
+    for global_tid in real:
+        decoded = pid_from_global_tid(global_tid)
+        assert 0 < decoded < 0xFFFFFF, f"{global_tid:#x} decoded to an impossible pid {decoded}"
 
 
 def test_every_occurrence_is_a_different_rank():
@@ -477,3 +502,30 @@ def test_a_rank_can_be_asked_for_directly():
 
     assert len(selected) == 1
     assert pid_from_global_tid(selected[0]["global_tid"]) == wanted
+
+
+def test_pid_is_refused_in_kernel_mode():
+    """There is no per-occurrence process to narrow to, so it must not be ignored."""
+    from nsys_ai.region_mfu import compute_region_mfu_from_conn
+
+    out = compute_region_mfu_from_conn(
+        _multi_rank_conn(),
+        profile_path=None,
+        name="anything",
+        theoretical_flops=1.0,
+        source="kernel",
+        pid=3822374,
+    )
+
+    assert out["error"]["code"] == "INVALID_ARGUMENT"
+    assert "source='nvtx'" in out["error"]["message"]
+
+
+def test_the_chat_tool_exposes_and_forwards_pid():
+    """A selector the chat path cannot reach is a selector most callers lack."""
+    from nsys_ai.ai.backend.chat_tools import TOOL_COMPUTE_REGION_MFU
+
+    schema = TOOL_COMPUTE_REGION_MFU.get("input_schema") or TOOL_COMPUTE_REGION_MFU[
+        "function"
+    ]["parameters"]
+    assert "pid" in schema["properties"]


### PR DESCRIPTION
## Summary

On a multi-rank capture, `region_mfu` could not say which rank it measured, and there was no way to ask for one. Closes #590.

## The situation

`nsys` packs every rank of a `torchrun` job into one file and Megatron annotates them identically, so a single NVTX name matches **once per rank**, with the ranges overlapping in time. Verified on an 8-rank capture: 8 matches for `sample_0(repeat=5)` from consecutive PIDs 3822370–3822377, all spanning 39.964–46.122 s.

`occurrence_index` is documented as "which occurrence", which reads as a time axis. On a multi-rank capture it is a **rank axis**. The ordering is deterministic (`start_ns, end_ns DESC, text, global_tid`) but it is *start time across concurrent ranks* — scheduling noise, and not stable across a re-capture. So `occurrence_index=3` does not mean rank 2, and is not the same region next time.

## Changes

**Publish the identity.** `global_tid` was read at `region_mfu.py:254`, carried through the match rows, and dropped before publication. The result row now carries `global_tid` and `pid`, decoded via `pid_from_global_tid` — the shift half of the encoding whose mask half (`globalTid & CAST(-16777216 AS BIGINT)`) is already applied in `kernel_launch_overhead`.

Without it a reported MFU could not be attributed to a rank, and two runs of the same command could measure different ranks with nothing in the output differing.

**Let a rank be chosen.** A `pid` parameter narrows matches *before* `occurrence_index` indexes into them, so the index counts within a rank instead of across ranks. `device_id` was not a substitute: it filters the GPU, not the process, and rank↔device is not always the same numbering.

Asking for a process that does not carry the annotation names the ones that do, rather than reporting a bare "not found".

**Say so in the parameter.** `occurrence_index`'s description was half the problem; it now states that occurrences span processes unless `pid` narrows them.

## What this deliberately does not change

The **ordering**. It is deterministic, and reordering would silently change which region an existing caller measures. Making the rank addressable and the identity visible fixes the reported problem without moving ground under anyone.

## Backward compatibility

Yes. `global_tid`, `pid` and the `pid` parameter are additive; no key is removed and no default behaviour changes. A caller that never passes `pid` gets exactly what it got before, now with the identity attached.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed path

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2700 passed, 2 failed** — the two `test_profile_runner` races from #585, unrelated.
- End to end on a synthetic 8-rank capture built to match the reported one:

  ```
  occurrence_index=1 -> pid 3822370      # eight occurrences,
  occurrence_index=4 -> pid 3822373      # eight processes
  occurrence_index=8 -> pid 3822377

  pid=3822374 -> measured pid 3822374    # now addressable
  pid=3822377 -> measured pid 3822377
  ```

## Out of scope

Whether `region_mfu` should aggregate across ranks, or warn when a name matches in more than one process. Both are reasonable next steps and both change what a default invocation reports, so they want their own decision.

## Linked issues

Closes #590
