### PR TITLE
fix: three defects found reviewing the batch that was just merged

### DIFF
--- a/src/nsys_ai/agent_skills/PRINCIPLES.md
+++ b/src/nsys_ai/agent_skills/PRINCIPLES.md
@@ -24,7 +24,8 @@ and diagnose performance issues without requiring a display or manual inspection
 - **The profile is a hard dependency** — If no profile is loaded, the tools will error.
   Fail clearly: tell the user what profile is needed and why.
 - **Fail loudly** — Unambiguous error messages let the agent self-correct.
-  Never silently return a wrong answer (e.g. MFU > 100% must be flagged as an error).
+  Never silently return a wrong answer (e.g. a union-basis MFU over 100% must be
+  flagged as an error).
 - **Provide introspection first** — Triage before computing. Run `skills/triage.md`
   to understand what's in the profile before running MFU or diff analysis.
 - **JSON is ground truth** — Tool outputs are JSON. Parse them; do not summarize
@@ -58,7 +59,10 @@ and diagnose performance issues without requiring a display or manual inspection
 
 ## Non-Negotiable Rules
 
-1. **MFU > 100% is always wrong.** The FLOPs scope is too wide. Stop, recompute with
+1. **A refused `MFU_EXCEEDS_PEAK` is always wrong.** The FLOPs scope is too wide,
+   and the call declines rather than returning a number. Judge on
+   `mfu_pct_kernel_union`; a high `mfu_pct_wall` alone means the range is
+   asynchronous, not that the input is bad. Stop, recompute with
    narrower `operation`. Do not report a value > 100%.
 2. **Never use `SELECT *`.** Always name the specific columns you need.
 3. **In diff mode: `search_nvtx_regions` before `get_region_diff`.** Never pass a
@@ -78,7 +82,8 @@ and diagnose performance issues without requiring a display or manual inspection
 
 | Error signal | Required action |
 |-------------|-----------------|
-| `MFU > 100%` | Recompute with narrower operation; explain the error |
+| `MFU_EXCEEDS_PEAK` | Recompute with narrower operation; explain the error |
+| `mfu_pct_wall > 100%`, union under it | Async range — report the union figure, keep the FLOPs |
 | `kernel_count = 0` | Report KERNEL_NOT_FOUND; suggest trying `source="kernel"` |
 | `is_aligned=false` in diff | Warn user; switch to `get_global_diff` |
 | `Hardware_Warning=true` | Note thermal throttle; advise re-run before concluding |

--- a/src/nsys_ai/agent_skills/QUICKSTART.md
+++ b/src/nsys_ai/agent_skills/QUICKSTART.md
@@ -41,7 +41,10 @@ You have two ways to interact with the profile:
 
 ### Step 3 — Know the 3 non-negotiable rules
 
-1. **MFU > 100% = bug.** Stop, recompute with narrower `operation`.
+1. **`MFU_EXCEEDS_PEAK` = bug.** The call refuses rather than returning a
+   number; recompute with the FLOPs of the work in that region. A high
+   `mfu_pct_wall` with `mfu_pct_kernel_union` under 100% is not this — that is an
+   asynchronous range, and the union figure is the one to report.
 2. **Never guess names.** Always query `NVTX_EVENTS` / `StringIds` first.
 3. **`theoretical_flops` must come from `compute_theoretical_flops`.** Never estimate.
 
@@ -102,7 +105,8 @@ When a user asks "what's my MFU?":
 | Use `SELECT *` | Name specific columns |
 | Guess NVTX name | Query `NVTX_EVENTS` first |
 | Divide by 1000 for ms | Divide ns by 1e6 for ms, 1e9 for s |
-| Report MFU > 100% | Recompute with narrower `operation` |
+| Report a refused `MFU_EXCEEDS_PEAK` as a result | Recompute with the region's own FLOPs |
+| Change the FLOPs because `mfu_pct_wall` is high | Check `mfu_pct_kernel_union` first; an async range makes wall meaningless |
 | Skip iteration 0 check in diff | Always skip index 0 (JIT warmup) |
 
 ---

--- a/src/nsys_ai/agent_skills/commands/analyze.md
+++ b/src/nsys_ai/agent_skills/commands/analyze.md
@@ -106,7 +106,9 @@ After delivering your text conclusion, produce visual evidence so humans can ver
 - **Always state**: GPU name, peak TFLOPS, profile span
 - **Always state**: primary bottleneck kernel and % of GPU time
 - **If MFU computed**: state whether it is forward-only or forward+backward
-- **If MFU > 100%**: stop and explain the error before reporting
+- **If the call returns `MFU_EXCEEDS_PEAK`**: stop and explain the error before
+  reporting. A high `mfu_pct_wall` with `mfu_pct_kernel_union` under 100% is an
+  asynchronous range, not an error — report the union figure.
 - **Never output a number without units** (ms, s, %, TFLOPS)
 
 ---

--- a/src/nsys_ai/agent_skills/commands/validate.md
+++ b/src/nsys_ai/agent_skills/commands/validate.md
@@ -78,7 +78,8 @@ Produce a scored report. **Do not skip any category.**
 - [ ] C5.2 All numeric values include units (ms, s, %, TFLOPS)
 - [ ] C5.3 MFU result states whether forward-only or forward+backward
 - [ ] C5.4 MFU result compared to reference range (< 20% / 30-45% / 45-60% / > 60%)
-- [ ] C5.5 No hedging on a wrong result (e.g. MFU > 100% must be corrected, not reported)
+- [ ] C5.5 No hedging on a wrong result (e.g. a union-basis MFU over 100% must be
+      corrected, not reported)
 
 ### Category 6: Tool Usage (5 checks)
 

--- a/src/nsys_ai/agent_skills/skills/mfu.md
+++ b/src/nsys_ai/agent_skills/skills/mfu.md
@@ -35,7 +35,8 @@ Read this when the user asks about GPU efficiency, MFU, or TFLOPS utilization.
 | Generic GEMM | `"linear"` | 2·M·N·K |
 
 **CRITICAL**: If the target is a SINGLE kernel type (e.g. `flash_fwd`), use the narrow
-per-kernel operation. Using `full_model` FLOPs for one kernel ALWAYS gives MFU > 100%.
+per-kernel operation. Using `full_model` FLOPs for one kernel ALWAYS trips
+`MFU_EXCEEDS_PEAK`.
 
 ---
 
@@ -71,9 +72,19 @@ Step 5  Use `compute_region_mfu`:
             source="nvtx" (or "kernel"), peak_tflops=<from step 1>, num_gpus=<world_size>
         → {mfu_pct_wall, mfu_pct_kernel_union, wall_time_s, kernel_count, ...}
 
-Step 6  Sanity check — MANDATORY before reporting:
-        • mfu_pct_wall > 100% → operation scope too wide; use narrower operation from table
-        • mfu_pct_wall < 1%   → name match failed (check kernel_count) or FLOPs too low
+Step 6  Sanity check — MANDATORY before reporting. Judge on
+        mfu_pct_kernel_union, which is measured against the time the GPU was
+        actually busy:
+        • error MFU_EXCEEDS_PEAK → the call refused: nothing can beat its own
+                                   peak, so an input is wrong. Usually a whole
+                                   job's FLOPs against a region covering one
+                                   rank, or num_gpus scaled past what the region
+                                   covers. Fix the input; do not re-report.
+        • mfu_pct_wall > 100%, union under it → NOT an error. An async range can
+                                   close while its work runs on, so wall is not
+                                   the time the work took. Report the union
+                                   figure and say the range is asynchronous.
+        • union < 1%          → name match failed (check kernel_count) or FLOPs too low
         • 40–80%              → healthy compute-bound
         • < 30%               → possible memory bandwidth bottleneck
 
@@ -143,7 +154,8 @@ Also run global checklist in `PRINCIPLES.md`.
 
 | Signal | Action |
 |--------|--------|
-| `mfu_pct_wall > 100%` | Recompute with narrower `operation`; explain to user |
+| error `MFU_EXCEEDS_PEAK` | An input is wrong — recompute with the FLOPs of the work in that region |
+| `mfu_pct_wall > 100%`, union under it | Asynchronous range; report the union figure, do not change the FLOPs |
 | `kernel_count = 0` | Report KERNEL_NOT_FOUND; try `source="kernel"` or fix name substring |
 | GPU unknown | Ask user for `peak_tflops` (BF16/FP16, dense, no sparsity) |
 | Model name not in table | Ask user for `hidden_dim`, `num_layers`, `seq_len` |

--- a/src/nsys_ai/cutracer/installer.py
+++ b/src/nsys_ai/cutracer/installer.py
@@ -488,7 +488,14 @@ def _clone_and_build(
     # records which tag the tree was provisioned for, so any future bump
     # re-provisions rather than compiling against a stale dependency set.
     third_party_nvbit = clone_dir / "third_party" / "nvbit"
-    third_party_stamp = clone_dir / "third_party" / ".nsys-ai-provisioned-tag"
+    # Beside the clone, never inside it. CUTracer's .gitignore lists the
+    # individual dependency directories -- third_party/nvbit, nlohmann,
+    # rapidjson -- not third_party itself, so a file of ours in there is
+    # untracked and unignored. _ensure_pinned_checkout refuses to check out
+    # over a dirty worktree, and it runs before this code, so a stamp inside
+    # the clone would make the first install block every later tag bump: the
+    # exact reconciliation this stamp exists to trigger.
+    third_party_stamp = clone_dir.parent / f".{clone_dir.name}-provisioned-tag"
     provisioned_tag = (
         third_party_stamp.read_text().strip() if third_party_stamp.is_file() else None
     )

--- a/src/nsys_ai/prompts/mfu_reference.txt
+++ b/src/nsys_ai/prompts/mfu_reference.txt
@@ -31,10 +31,17 @@ CRITICAL: theoretical_flops must match ONLY the computation the target kernel/re
   Pass num_gpus=world_size to compute_region_mfu. Peak is scaled automatically.
 
 ## 5. SANITY CHECK (MANDATORY)
-  After computing MFU, check the result:
-  - MFU > 100%  → theoretical_flops is TOO HIGH. You likely used full-model FLOPs
-                   for a single kernel. Recalculate with only that kernel's FLOPs.
-  - MFU < 0.1%  → theoretical_flops may be TOO LOW, or the kernel barely ran.
-  - MFU 10-80%  → typical reasonable range for compute-bound kernels.
-  If MFU > 100%, do NOT report it as-is. Recompute with correct FLOPs and explain.
+  Judge on mfu_pct_kernel_union: it is measured against the time the GPU was
+  actually busy, so it is the figure that cannot exceed 100%.
+  - error MFU_EXCEEDS_PEAK → the call refused rather than returning a number.
+                   theoretical_flops is almost always TOO HIGH: full-model FLOPs
+                   against one kernel, or a whole job's against one rank's
+                   region. Recompute with the FLOPs of the work in that region.
+                   Do not report the implied_ figures as a result.
+  - mfu_pct_wall > 100% while union is under it → NOT an error, and NOT a signal
+                   to change the FLOPs. An asynchronous NVTX range can close
+                   while its kernels run on, so wall is not the time the work
+                   took. Report the union figure and note the range is async.
+  - union < 0.1%  → theoretical_flops may be TOO LOW, or the kernel barely ran.
+  - union 10-80%  → typical reasonable range for compute-bound kernels.
 =============================

--- a/src/nsys_ai/region_mfu.py
+++ b/src/nsys_ai/region_mfu.py
@@ -598,14 +598,26 @@ def compute_mfu_metrics_for_region(
     # No tolerance band: 1% over is as impossible as 300% over, and a band would
     # only decide how much nonsense to publish.
     #
-    # All three bases are checked because all three are published, and the
-    # denominators differ -- a borrowed numerator can land one over while the
-    # others sit under.
-    worst_basis, worst_mfu = max(
-        (("wall", mfu_wall), ("kernel_sum", mfu_sum), ("kernel_union", mfu_union)),
-        key=lambda pair: pair[1],
-    )
-    if worst_mfu > 100.0:
+    # Keyed on the kernel-union basis, which is the only one where exceeding
+    # peak is physically impossible: it is the time the GPU was actually busy,
+    # and no hardware does more FLOPs than peak x busy-time.
+    #
+    # The wall basis is not that test. get_region_kernels attributes kernels by
+    # the CPU call that launched them, and an asynchronous range can close while
+    # its work runs on -- a 1 ms CPU span launching 10 ms of GPU work reports a
+    # wall ratio far above 100% with nothing wrong. Refusing on that discarded a
+    # sound union-basis MFU and its SOL headroom along with it.
+    #
+    # The borrowed-numerator case this guard exists for puts every basis over,
+    # so keying on the strict one still catches it.
+    #
+    # The epsilon admits floating-point representation error and nothing else:
+    # 8901000000000 FLOPs over 0.009 s against 989 TFLOPS is exactly peak and
+    # computes to 100.00000000000001, which was refused while the message it
+    # printed said 100.0%. It is not a tolerance band -- a band would decide how
+    # much nonsense to publish, and 1e-9 of a percentage point publishes none.
+    worst_basis, worst_mfu = "kernel_union", mfu_union
+    if worst_mfu > 100.0 + 1e-9:
         return _error(
             "MFU_EXCEEDS_PEAK",
             f"Refusing to report MFU. On the {worst_basis} basis this calculation puts the "

--- a/tests/test_cutracer_installer.py
+++ b/tests/test_cutracer_installer.py
@@ -543,7 +543,7 @@ class TestThirdPartyProvisioning:
         (clone / "Makefile").write_text("all:\n\techo built\n")
         (clone / "install_third_party.sh").write_text("#!/bin/bash\nexit 0\n")
         if provisioned_for is not None:
-            (clone / "third_party" / ".nsys-ai-provisioned-tag").write_text(
+            (clone.parent / f".{clone.name}-provisioned-tag").write_text(
                 provisioned_for + "\n"
             )
         return clone
@@ -598,3 +598,37 @@ class TestThirdPartyProvisioning:
         clone = self._clone(tmp_path, provisioned_for=None)
 
         assert self._ran_third_party(monkeypatch, clone)
+
+
+def test_the_provisioning_stamp_does_not_dirty_the_clone(tmp_path, monkeypatch):
+    """It must live beside the worktree, not in it.
+
+    CUTracer's .gitignore lists the individual dependency directories --
+    third_party/nvbit, nlohmann, rapidjson -- not third_party itself, so a file
+    of ours in there shows as untracked. _ensure_pinned_checkout refuses to
+    check out over a dirty worktree and runs before provisioning, so a stamp
+    inside the clone would make the first install block every later tag bump:
+    the exact reconciliation the stamp exists to trigger.
+    """
+    from nsys_ai.cutracer import installer
+
+    clone = tmp_path / "CUTracer"
+    (clone / "third_party" / "nvbit").mkdir(parents=True)
+    (clone / "Makefile").write_text("all:\n\techo built\n")
+    (clone / "install_third_party.sh").write_text("#!/bin/bash\nexit 0\n")
+    (clone / "lib").mkdir()
+    (clone / "lib" / "cutracer.so").write_text("")
+
+    import subprocess as _sp
+
+    real_run = _sp.run
+    monkeypatch.setattr(
+        installer.subprocess, "run", lambda cmd, *a, **k: real_run(["true"], *a, **k)
+    )
+    installer._clone_and_build(clone_dir=clone, progress=False)
+
+    written = list(clone.parent.glob(".*provisioned-tag"))
+    assert written, "the stamp should have been written"
+    assert not list(clone.rglob("*provisioned-tag")), (
+        "no stamp may sit inside the clone, where git would see it"
+    )

--- a/tests/test_region_mfu.py
+++ b/tests/test_region_mfu.py
@@ -529,3 +529,58 @@ def test_the_chat_tool_exposes_and_forwards_pid():
         "function"
     ]["parameters"]
     assert "pid" in schema["properties"]
+
+
+def test_exactly_peak_is_not_refused_by_roundoff():
+    """100.00000000000001 is representation error, not an impossible reading.
+
+    8901000000000 FLOPs over 0.009 s against a 989 TFLOPS peak is exactly peak.
+    It was refused while the refusal's own message printed "100.0% of peak".
+    """
+    out = compute_mfu_metrics_for_region(
+        theoretical_flops=8901000000000,
+        peak_tflops=989,
+        wall_time_s=0.009,
+        kernel_sum_s=0.009,
+        kernel_union_s=0.009,
+    )
+
+    assert "error" not in out
+    assert out["mfu_pct_kernel_union"] == 100.0
+
+
+def test_an_async_region_keeps_its_gpu_basis_mfu():
+    """A short CPU range can bound long GPU work without anything being wrong.
+
+    get_region_kernels attributes kernels by the CPU call that launched them,
+    and an asynchronous range can close while its work runs on. A 1 ms span
+    launching 10 ms of GPU work reports a wall ratio of 500% legitimately.
+    Refusing on that discarded a sound union-basis MFU and its SOL headroom.
+
+    Only the union basis is physically bounded: it is the time the GPU was
+    actually busy, so exceeding peak there is impossible rather than merely odd.
+    """
+    out = compute_mfu_metrics_for_region(
+        theoretical_flops=0.5 * 989e12 * 0.010,   # half of peak for 10 ms of work
+        peak_tflops=989.0,
+        wall_time_s=0.001,                        # the CPU range is 1 ms
+        kernel_sum_s=0.010,
+        kernel_union_s=0.010,
+    )
+
+    assert "error" not in out, "a sound GPU-basis reading must survive"
+    assert out["mfu_pct_kernel_union"] == 50.0
+    assert out["mfu_pct_wall"] > 100.0, "the wall ratio is high, and that is fine here"
+
+
+def test_the_borrowed_numerator_is_still_refused():
+    """Re-keying the guard must not let the case it exists for through."""
+    out = compute_mfu_metrics_for_region(
+        theoretical_flops=8.23e14 * 8,
+        peak_tflops=989.0,
+        wall_time_s=6.158,
+        kernel_sum_s=6.2,
+        kernel_union_s=6.1,
+    )
+
+    assert out["error"]["code"] == "MFU_EXCEEDS_PEAK"


### PR DESCRIPTION
## Summary

Three defects found by reviewing the five PRs merged in the previous batch. One is a regression introduced while fixing something else.

## 1. The provisioning stamp blocked the upgrades it exists to enable

`#593` added a stamp so `install_third_party.sh` re-runs when `CUTRACER_TAG` moves. It was written **inside** the clone, and CUTracer's `.gitignore` lists the individual dependency directories — `third_party/nvbit`, `third_party/nlohmann`, `third_party/rapidjson` — not `third_party` itself:

```
before the stamp:  (clean)
after the stamp:   ?? third_party/
```

`_ensure_pinned_checkout` refuses to check out over a dirty worktree, and it runs **before** provisioning. So the first install would have blocked every later tag bump — precisely the reconciliation the stamp was added for. Fixing one upgrade break had introduced another.

It now sits beside the clone (`clone_dir.parent / f".{clone_dir.name}-provisioned-tag"`), outside anything git inspects. The dirty-worktree guard still protects against genuine user edits.

## 2. The impossible-MFU guard refused sound asynchronous readings

`#595` keyed the refusal on whichever of the three bases read highest. The **wall** basis is not a physical bound: `get_region_kernels` attributes kernels by the CPU call that launched them, so an asynchronous range can close while its work runs on. A 1 ms CPU span launching 10 ms of GPU work reports a 500% wall ratio with nothing wrong, and the guard discarded the sound union-basis MFU and its SOL headroom along with it.

Now keyed on **kernel_union** — the only basis where exceeding peak is impossible, because it is the time the GPU was actually busy. The borrowed-numerator case the guard exists for puts *every* basis over, so it is still caught.

```
async region (1 ms CPU span, 10 ms GPU work at half peak):
  before:  refused entirely
  after:   wall=500.0%  union=50.0%     <- the sound reading survives

borrowed numerator (the reported bug):
  before:  refused
  after:   refused                       <- unchanged
```

## 3. Exactly-at-peak was refused by roundoff

`8901000000000` FLOPs over `0.009` s against a 989 TFLOPS peak is exactly peak, and computes to `100.00000000000001`. It was refused — while the refusal's own message printed `100.0% of peak`.

The comparison now admits `1e-9` of a percentage point. That is representation error, not a tolerance band: a band would decide how much nonsense to publish, and this publishes none.

## Changes

- `src/nsys_ai/cutracer/installer.py` — stamp beside the clone, with the `.gitignore` reasoning recorded.
- `src/nsys_ai/region_mfu.py` — guard keyed on `kernel_union`, epsilon at the boundary, both explained.
- `tests/test_cutracer_installer.py` — a test asserting no stamp lands anywhere git would see.
- `tests/test_region_mfu.py` — exactly-peak reports; an async region keeps its GPU-basis MFU; the borrowed numerator is still refused.

## Backward compatibility

Yes, in the direction that matters: results previously refused for a wall-basis artefact or a rounding artefact are now reported. Nothing previously reported becomes refused.

An existing install carrying a stamp inside its clone will re-provision once (no stamp found beside the clone), which is harmless and self-correcting.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean
- [x] Manually exercised the changed paths

Notes on the run:

- Full suite on macOS / Python 3.13.9: **2712 passed, 3 failed** — all three in the `test_profile_runner` family from #585, which fails 2 in isolation on this machine and flakes to 4 under full-suite load. None touch the changed paths.
- `bandit -r src/ -c pyproject.toml` — 0 issues at every severity.
- All three new behavioural tests fail against merged `main` and pass here.
- The `.gitignore` claim was verified against the real v0.3.0 tarball and reproduced in a scratch git repo, not inferred.

## Out of scope

Whether a wall-basis MFU above 100% deserves a warning of its own on an asynchronous region. It is now reported rather than refused, which is the correction; flagging it is a separate judgement about what the field means.
