### PR TITLE
feat(skills): report how much of the GPU's idle was spent moving data

### DIFF
--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -45,6 +45,19 @@ def _classify_gap_apis(api_names: list[str]) -> tuple[str, str]:
     return "unknown", "Unclassified CUDA API activity"
 
 
+def _in_chunks(cursor, size: int = 10_000):
+    """Yield rows a block at a time, on either backend.
+
+    ``fetchmany`` is the portable call: a sqlite3 cursor is iterable and a
+    DuckDBPyConnection is not, and ``adapter.execute`` can return either.
+    """
+    while True:
+        block = cursor.fetchmany(size)
+        if not block:
+            return
+        yield from block
+
+
 def _copy_wall_ms(adapter, memcpy_tbl, trim_clause, params) -> float | None:
     """Wall time on *device* during which at least one copy was in flight.
 
@@ -63,23 +76,45 @@ def _copy_wall_ms(adapter, memcpy_tbl, trim_clause, params) -> float | None:
     """
     if not memcpy_tbl:
         return None
+    # Overlap, not containment. The kernel predicate this reused is
+    # "start >= trim_start AND end <= trim_end", which drops a transfer that
+    # crosses either edge -- so a copy running 0-20ms reported nothing at all
+    # for a 5-15ms window it occupied end to end. Selected on overlap and
+    # clipped below, so a copy counts for the part inside the window.
+    window = None
+    if trim_clause:
+        window = (int(params[1]), int(params[2]))
+        where = 'WHERE m.deviceId = ? AND m.start < ? AND m."end" > ?'
+        args = [params[0], window[1], window[0]]
+    else:
+        where = "WHERE m.deviceId = ?"
+        args = [params[0]]
     try:
-        rows = adapter.execute(
+        cursor = adapter.execute(
             f'SELECT m.start, m."end" FROM {memcpy_tbl} m '  # nosec B608
-            f"WHERE m.deviceId = ? {trim_clause.replace('k.', 'm.')} "
-            f"ORDER BY m.start",
-            params,
-        ).fetchall()
+            f"{where} ORDER BY m.start",
+            args,
+        )
     except DB_ERRORS:
         return None
-    if not rows:
-        return 0.0
 
+    # fetchmany, not iteration and not fetchall. The merge only ever needs the
+    # interval it is extending, so holding every copy would be memory spent for
+    # nothing -- and this skill is one of the three measured against a heap
+    # ceiling in test_analysis_memory, on profiles where the copy count runs to
+    # millions. Iterating the handle directly does not work: adapter.execute
+    # returns a DuckDBPyConnection on the cached backend, which is not iterable,
+    # while a sqlite3 cursor is. fetchmany is the call both answer to.
     total_ns = 0
     span_start, span_end = None, None
-    for start, end in rows:
+    for start, end in _in_chunks(cursor):
         if start is None or end is None or end <= start:
             continue
+        if window is not None:
+            start = max(int(start), window[0])
+            end = min(int(end), window[1])
+            if end <= start:
+                continue
         if span_start is None:
             span_start, span_end = int(start), int(end)
             continue
@@ -90,7 +125,7 @@ def _copy_wall_ms(adapter, memcpy_tbl, trim_clause, params) -> float | None:
             span_end = max(span_end, int(end))
     if span_start is not None:
         total_ns += span_end - span_start
-    return round(total_ns / 1e6, 2)
+    return round(total_ns / 1e6, 2)  # 0.0 when the table held no rows
 
 
 def _execute(conn: sqlite3.Connection, **kwargs):
@@ -350,8 +385,8 @@ def _format(rows):
         copy_ms = summary.get("copy_ms")
         if copy_ms:
             lines.append(
-                f"  GPU copying:       {copy_ms:.1f}ms — idle above counts kernel "
-                f"absence, so copy time is inside it"
+                f"  GPU copying:       {copy_ms:.1f}ms — measured independently; "
+                f"copies may overlap kernels, so this is not a share of the idle above"
             )
         lines.append(
             f"  Distribution: "

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -45,12 +45,61 @@ def _classify_gap_apis(api_names: list[str]) -> tuple[str, str]:
     return "unknown", "Unclassified CUDA API activity"
 
 
+def _copy_wall_ms(adapter, memcpy_tbl, trim_clause, params) -> float | None:
+    """Wall time on *device* during which at least one copy was in flight.
+
+    Not a subset of idle: a copy can run alongside a kernel, so this can exceed
+    the idle figure it sits beside. It answers "was the GPU moving data", which
+    is the question the idle number cannot.
+
+    The union, not the sum: copies on different streams overlap, and a sum would
+    claim more wall time than the window holds. None when the profile carries no
+    memcpy table, which is not the same as zero copying.
+
+    This exists because "idle" here means "no kernel running", and a reader takes
+    it to mean "the GPU had nothing to do". A window spent moving 253 MB is
+    neither of those, and the two have different fixes -- a stalled input
+    pipeline versus a transfer that wants overlapping or shrinking.
+    """
+    if not memcpy_tbl:
+        return None
+    try:
+        rows = adapter.execute(
+            f'SELECT m.start, m."end" FROM {memcpy_tbl} m '  # nosec B608
+            f"WHERE m.deviceId = ? {trim_clause.replace('k.', 'm.')} "
+            f"ORDER BY m.start",
+            params,
+        ).fetchall()
+    except DB_ERRORS:
+        return None
+    if not rows:
+        return 0.0
+
+    total_ns = 0
+    span_start, span_end = None, None
+    for start, end in rows:
+        if start is None or end is None or end <= start:
+            continue
+        if span_start is None:
+            span_start, span_end = int(start), int(end)
+            continue
+        if int(start) > span_end:
+            total_ns += span_end - span_start
+            span_start, span_end = int(start), int(end)
+        else:
+            span_end = max(span_end, int(end))
+    if span_start is not None:
+        total_ns += span_end - span_start
+    return round(total_ns / 1e6, 2)
+
+
 def _execute(conn: sqlite3.Connection, **kwargs):
     """Execute GPU idle gaps analysis with aggregation and CPU attribution."""
     adapter = wrap_connection(conn)
     tables = adapter.resolve_activity_tables()
     kernel_tbl = tables.get("kernel")
     runtime_tbl = tables.get("runtime")
+    memcpy_tbl = tables.get("memcpy")
     if not kernel_tbl:
         return []
 
@@ -217,6 +266,10 @@ WHERE prev_end IS NOT NULL AND (start - prev_end) > ?"""
         "gap_count": agg.get("gap_count") or 0,
         "total_idle_ms": round(total_gap_ns / 1e6, 2),
         "device_idle_ms": round(device_idle_ms, 2) if device_idle_ms is not None else None,
+        # How much of that "idle" was the GPU moving data. Idle here counts the
+        # absence of a kernel, so a copy-filled window reads as doing nothing.
+        # None means the profile carries no memcpy table, which is not zero.
+        "copy_ms": _copy_wall_ms(adapter, memcpy_tbl, trim_clause, list(trim_params)),
         "pct_of_profile": pct_of_profile,
         "gaps_1_5ms": agg.get("gaps_1_5ms") or 0,
         "gaps_5_50ms": agg.get("gaps_5_50ms") or 0,
@@ -291,6 +344,15 @@ def _format(rows):
         # wall-clock lost, so show what the device itself idled when known.
         if summary.get("device_idle_ms") is not None:
             lines.append(f"  Device-level idle: {summary['device_idle_ms']:.1f}ms")
+        # Idle here counts the absence of a kernel, so a window spent moving data
+        # reads as doing nothing. Naming the copy time separately is what lets a
+        # reader tell a stalled input pipeline from a transfer worth overlapping.
+        copy_ms = summary.get("copy_ms")
+        if copy_ms:
+            lines.append(
+                f"  GPU copying:       {copy_ms:.1f}ms — idle above counts kernel "
+                f"absence, so copy time is inside it"
+            )
         lines.append(
             f"  Distribution: "
             f"{summary['gaps_1_5ms']} × 1-5ms, "

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1237,3 +1237,49 @@ def test_the_table_guard_covers_only_sql_templates():
         f"ACTIVITY_TABLE_PLACEHOLDERS in skills/base.py. Now guarded: "
         f"{sorted(in_templates)}"
     )
+
+
+def test_copy_wall_ms_counts_the_part_inside_the_window():
+    """A transfer crossing a trim edge still copied inside the window.
+
+    The kernel predicate this reused is containment — start >= trim_start AND
+    end <= trim_end — which drops such a transfer entirely, so a copy running
+    0-20 ms reported nothing for a 5-15 ms window it occupied end to end.
+    """
+    import sqlite3
+
+    from nsys_ai.connection import wrap_connection
+    from nsys_ai.skills.builtins.gpu_idle_gaps import _copy_wall_ms
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute('CREATE TABLE CUPTI_ACTIVITY_KIND_MEMCPY (deviceId INT, start INT, "end" INT)')
+    conn.execute("INSERT INTO CUPTI_ACTIVITY_KIND_MEMCPY VALUES (0, 0, 20000000)")
+    conn.commit()
+    adapter = wrap_connection(conn)
+
+    clipped = _copy_wall_ms(
+        adapter,
+        "CUPTI_ACTIVITY_KIND_MEMCPY",
+        "AND k.start >= ? AND k.[end] <= ?",
+        [0, 5_000_000, 15_000_000],
+    )
+    whole = _copy_wall_ms(adapter, "CUPTI_ACTIVITY_KIND_MEMCPY", "", [0])
+
+    assert clipped == 10.0
+    assert whole == 20.0
+
+
+def test_the_copy_line_does_not_claim_to_be_a_share_of_idle():
+    """Copies overlap kernels, so copy time can exceed the idle beside it."""
+    from nsys_ai.skills.builtins.gpu_idle_gaps import _format
+
+    text = _format([
+        # A data row too: with only the summary the formatter takes its
+        # "no significant gaps" path and never reaches the copy line.
+        {"streamId": 7, "gap_ns": 2_000_000, "before_kernel": "k", "attribution": {}},
+        {"_summary": True, "gap_count": 1, "total_idle_ms": 2.0,
+         "device_idle_ms": 2.0, "copy_ms": 20.0, "pct_of_profile": 5.0,
+         "gaps_1_5ms": 1, "gaps_5_50ms": 0, "gaps_gt50ms": 0},
+    ])
+
+    assert "not a share of the idle" in text


### PR DESCRIPTION
Closes #

See the linked issue for the reproduction and the reasoning; the commit message records the design decisions.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean

Full suite run in an isolated worktree; failures are confined to the `test_profile_runner` family tracked in #585, which runs hotter under parallel load.
