### PR TITLE
fix(skills): drive the idle rules from the device figure, not the stream sum

### DIFF
--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -194,8 +194,21 @@ def _execute(conn: sqlite3.Connection, **kwargs):
         gap_threshold = int(kwargs.get("min_gap_ns", 1_000_000))
         large_gaps = [g for g in gap_rows if g.get("gap_ns", 0) > gap_threshold]
         if len(large_gaps) >= 3:
+            # device_idle_ms first, because total_idle_ms is the per-stream sum.
+            # gpu_idle_gaps says so in its own formatter -- "on a multi-stream
+            # profile that overstates the wall-clock lost" -- and prints both for
+            # that reason. Taking the overstating one inflates the denominator of
+            # the synchronisation ratio below, so the rule under-fires on exactly
+            # the profiles that have the most streams to be wrong about.
+            #
+            # The fallback is not decoration: device_idle_ms is None when the
+            # device-level sweep could not run, and absent altogether from the
+            # no-gaps summary.
             total_idle_ms = (
-                gap_summary.get("total_idle_ms", 0)
+                _first_measured(
+                    gap_summary.get("device_idle_ms"),
+                    gap_summary.get("total_idle_ms"),
+                )
                 if gap_summary
                 else sum(g.get("gap_ns", 0) / 1e6 for g in large_gaps)
             )
@@ -710,6 +723,25 @@ def _check_layer_nccl_hotspot(layer_data: list[dict], threshold_pct: float = 40.
                 }
             )
     return findings
+
+
+def _first_measured(*values) -> float:
+    """The first value that is a measurement at all, else 0.0.
+
+    ``None`` means "could not be established" and falls through. Zero does not:
+    a device_idle_ms of 0 says the device was never idle, which is an answer, and
+    falling past it to a per-stream sum would contradict the very measurement
+    being preferred. The caller's threshold already guards against dividing by
+    it.
+    """
+    for value in values:
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            continue
+    return 0.0
 
 
 def _check_pipeline_imbalance(layer_data: list[dict], threshold_ratio: float = 3.0) -> list[dict]:

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -204,15 +204,14 @@ def _execute(conn: sqlite3.Connection, **kwargs):
             # The fallback is not decoration: device_idle_ms is None when the
             # device-level sweep could not run, and absent altogether from the
             # no-gaps summary.
-            total_idle_ms = (
-                _first_measured(
-                    gap_summary.get("device_idle_ms"),
-                    gap_summary.get("total_idle_ms"),
-                )
-                if gap_summary
-                else sum(g.get("gap_ns", 0) / 1e6 for g in large_gaps)
-            )
-            pct = gap_summary.get("pct_of_profile", 0) if gap_summary else 0
+            # The duration and the percentage have to come from the same
+            # measurement. pct_of_profile is total_gap_ns / (span x n_streams) --
+            # normalised per stream, so it pairs with the stream sum. Taking the
+            # device figure for one and leaving the other put two unrelated
+            # quantities in one sentence: "0.0ms of idle time (44.1% of
+            # profile)" on a profile where one stream idled while another kept
+            # the device busy.
+            total_idle_ms, pct = _idle_with_matching_pct(gap_summary, large_gaps)
 
             # Build attribution-aware recommendation
             attr_counts: dict[str, int] = {}
@@ -723,6 +722,30 @@ def _check_layer_nccl_hotspot(layer_data: list[dict], threshold_pct: float = 40.
                 }
             )
     return findings
+
+
+def _idle_with_matching_pct(gap_summary: dict | None, large_gaps: list) -> tuple[float, float]:
+    """Idle duration and its share of the profile, drawn from one measurement.
+
+    Prefers the device-level figure, and recomputes the percentage from the
+    profile span when it does so. Falls back to the per-stream sum and the
+    per-stream percentage together, so the two never describe different things.
+    """
+    if not gap_summary:
+        return sum(g.get("gap_ns", 0) / 1e6 for g in large_gaps), 0.0
+
+    device_idle = gap_summary.get("device_idle_ms")
+    if device_idle is not None:
+        start = gap_summary.get("profile_start_ns")
+        end = gap_summary.get("profile_end_ns")
+        span_ms = (end - start) / 1e6 if start is not None and end is not None else 0
+        pct = round(min(100.0, 100.0 * float(device_idle) / span_ms), 1) if span_ms > 0 else 0.0
+        return float(device_idle), pct
+
+    return (
+        _first_measured(gap_summary.get("total_idle_ms")),
+        float(gap_summary.get("pct_of_profile", 0) or 0),
+    )
 
 
 def _first_measured(*values) -> float:

--- a/tests/test_root_cause_matcher.py
+++ b/tests/test_root_cause_matcher.py
@@ -1,0 +1,52 @@
+"""Rule-level contracts for ``root_cause_matcher``.
+
+The matcher reads other skills' summaries, so its correctness depends on picking
+the right field out of them. That is what these cover: not whether a rule's
+threshold is well chosen, but whether it is applied to the quantity it means.
+"""
+
+# ── Which idle figure drives the rules ──────────────────────────────────────
+
+
+class TestIdleFieldSelection:
+    """``total_idle_ms`` is the per-stream sum; ``device_idle_ms`` is the device.
+
+    ``gpu_idle_gaps`` says so in its own formatter -- "on a multi-stream profile
+    that overstates the wall-clock lost" -- and prints both for that reason. The
+    matcher took the overstating one, which inflates the denominator of the
+    synchronisation ratio and makes the rule under-fire on exactly the profiles
+    with the most streams to be wrong about.
+    """
+
+    @staticmethod
+    def _pick(summary):
+        from nsys_ai.skills.builtins.root_cause_matcher import _first_measured
+
+        return _first_measured(
+            summary.get("device_idle_ms"), summary.get("total_idle_ms")
+        )
+
+    def test_the_device_figure_wins_where_they_disagree(self):
+        """A four-stream profile: the sum is ~4x the wall-clock loss."""
+        assert self._pick({"device_idle_ms": 938.1, "total_idle_ms": 3752.4}) == 938.1
+
+    def test_the_sum_is_used_when_the_device_sweep_could_not_run(self):
+        """device_idle_ms is None there, and None is not a measurement."""
+        assert self._pick({"device_idle_ms": None, "total_idle_ms": 3752.4}) == 3752.4
+
+    def test_a_no_gaps_summary_yields_zero(self):
+        """That shape carries neither field; the caller's guard handles 0."""
+        assert self._pick({"gap_count": 0}) == 0.0
+
+    def test_a_device_that_never_idled_is_not_overridden(self):
+        """0 is an answer, and falling past it would contradict the measurement.
+
+        Streams can sum to thousands of milliseconds of gaps while the device
+        itself was always busy on one of them. Preferring the device figure and
+        then ignoring it when it says zero would be the same bug in reverse.
+        """
+        assert self._pick({"device_idle_ms": 0, "total_idle_ms": 3752.4}) == 0.0
+
+    def test_a_single_stream_profile_is_unchanged(self):
+        """Where they agree, nothing moves -- which is why this went unnoticed."""
+        assert self._pick({"device_idle_ms": 935.4, "total_idle_ms": 935.4}) == 935.4

--- a/tests/test_root_cause_matcher.py
+++ b/tests/test_root_cause_matcher.py
@@ -20,11 +20,9 @@ class TestIdleFieldSelection:
 
     @staticmethod
     def _pick(summary):
-        from nsys_ai.skills.builtins.root_cause_matcher import _first_measured
+        from nsys_ai.skills.builtins.root_cause_matcher import _idle_with_matching_pct
 
-        return _first_measured(
-            summary.get("device_idle_ms"), summary.get("total_idle_ms")
-        )
+        return _idle_with_matching_pct(summary, [])[0]
 
     def test_the_device_figure_wins_where_they_disagree(self):
         """A four-stream profile: the sum is ~4x the wall-clock loss."""
@@ -50,3 +48,52 @@ class TestIdleFieldSelection:
     def test_a_single_stream_profile_is_unchanged(self):
         """Where they agree, nothing moves -- which is why this went unnoticed."""
         assert self._pick({"device_idle_ms": 935.4, "total_idle_ms": 935.4}) == 935.4
+
+
+class TestIdlePercentageMatchesItsDuration:
+    """The duration and the percentage must describe the same measurement.
+
+    ``pct_of_profile`` is ``total_gap_ns / (span x n_streams)`` — normalised per
+    stream, so it belongs with the stream sum. Switching the duration to the
+    device figure and leaving the percentage put two unrelated quantities in one
+    sentence: "0.0ms of idle time (44.1% of profile)" on a profile where one
+    stream idled while another kept the device busy.
+    """
+
+    @staticmethod
+    def _pair(summary):
+        from nsys_ai.skills.builtins.root_cause_matcher import _idle_with_matching_pct
+
+        return _idle_with_matching_pct(summary, [])
+
+    def test_the_device_percentage_is_recomputed_from_the_span(self):
+        ms, pct = self._pair({
+            "device_idle_ms": 250.0, "total_idle_ms": 900.0, "pct_of_profile": 44.1,
+            "profile_start_ns": 0, "profile_end_ns": 1_000_000_000,
+        })
+
+        assert (ms, pct) == (250.0, 25.0)
+
+    def test_a_device_that_never_idled_reports_zero_percent(self):
+        """Not 0.0ms at 44.1%, which is the shape of the bug."""
+        ms, pct = self._pair({
+            "device_idle_ms": 0.0, "total_idle_ms": 900.0, "pct_of_profile": 44.1,
+            "profile_start_ns": 0, "profile_end_ns": 1_000_000_000,
+        })
+
+        assert (ms, pct) == (0.0, 0.0)
+
+    def test_the_stream_figures_are_used_together_as_a_pair(self):
+        """When the device sweep did not run, both come from the stream side."""
+        ms, pct = self._pair({
+            "device_idle_ms": None, "total_idle_ms": 900.0, "pct_of_profile": 44.1,
+        })
+
+        assert (ms, pct) == (900.0, 44.1)
+
+    def test_a_missing_span_does_not_invent_a_percentage(self):
+        """No span, no share — the duration still stands on its own."""
+        ms, pct = self._pair({"device_idle_ms": 250.0, "total_idle_ms": 900.0})
+
+        assert ms == 250.0
+        assert pct == 0.0


### PR DESCRIPTION
Closes #

See the linked issue for the reproduction and the reasoning; the commit message records the design decisions.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean

Full suite run in an isolated worktree; failures are confined to the `test_profile_runner` family tracked in #585, which runs hotter under parallel load.
