### PR TITLE
fix(skills): stop reading a distribution off a window too short to have one

### DIFF
--- a/src/nsys_ai/skills/builtins/memory_transfers.py
+++ b/src/nsys_ai/skills/builtins/memory_transfers.py
@@ -44,9 +44,10 @@ ORDER BY total_ms DESC, copyKind ASC""",
 )
 
 
-#: A window shorter than this has no distribution to classify: with two buckets
-#: any "leading portion" is most of the window.
-_MIN_BUCKETS_FOR_SHAPE = 3
+#: A window shorter than this has no distribution to classify: across two
+#: seconds any "leading portion" is most of the window. Measured in elapsed
+#: seconds, not in buckets that happen to carry a transfer.
+_MIN_SECONDS_FOR_SHAPE = 3
 
 #: The leading share of the window that "front-loaded" means. A fraction rather
 #: than a fixed duration, so the same transfer pattern gets the same verdict in a
@@ -68,31 +69,41 @@ def _classify_h2d_pattern(rows: list, kwargs: dict | None = None) -> dict:
     # ratio below is 1.0 by construction and init_heavy wins whatever the data
     # says, so steady per-batch loading in a sub-2s trim was reported as normal
     # weight loading -- the one verdict that tells a reader to stop looking.
-    if len(rows) < _MIN_BUCKETS_FOR_SHAPE:
+    # Elapsed seconds, not row count. The query returns only the seconds that
+    # carried a transfer, so len(rows) is how many buckets have data and says
+    # nothing about how long the window is. Slicing by position then took "the
+    # first quarter of six rows" on buckets [0, 50, 51, 52, 53, 54] and called a
+    # 900 MB spike at second 50 front-loading -- reported, absurdly, as "the
+    # first 51 seconds of a 6-second window" -- which also swallowed the spike
+    # finding that root_cause_matcher consumes.
+    first_second = min(r["second"] for r in rows)
+    last_second = max(r["second"] for r in rows)
+    window_seconds = last_second - first_second + 1
+
+    if window_seconds < _MIN_SECONDS_FOR_SHAPE:
         return {
             "_pattern": True,
             "type": "undetermined",
             "detail": (
-                f"Window covers {len(rows)} second-bucket(s); at least "
-                f"{_MIN_BUCKETS_FOR_SHAPE} are needed to tell a front-loaded "
+                f"Window spans {window_seconds} second-bucket(s); at least "
+                f"{_MIN_SECONDS_FOR_SHAPE} are needed to tell a front-loaded "
                 f"distribution from a steady one. Widen --trim to classify."
             ),
         }
 
     # Init-heavy: the leading portion of the window accounts for >80% of bytes.
-    # Measured as a fraction of the window rather than a fixed two seconds, so
+    # Measured as a fraction of elapsed time rather than a fixed two seconds, so
     # the verdict describes the distribution instead of the window length.
-    lead_buckets = max(1, round(len(rows) * _INIT_LEAD_FRACTION))
-    ordered = sorted(rows, key=lambda r: r["second"])
-    lead_mb = sum(r["total_mb"] for r in ordered[:lead_buckets])
+    lead_seconds = max(1, round(window_seconds * _INIT_LEAD_FRACTION))
+    lead_cutoff = first_second + lead_seconds
+    lead_mb = sum(r["total_mb"] for r in rows if r["second"] < lead_cutoff)
     if lead_mb / total_mb > 0.8:
-        lead_seconds = ordered[lead_buckets - 1]["second"] + 1
         return {
             "_pattern": True,
             "type": "init_heavy",
             "detail": (
                 f"H2D concentrated in the first {lead_seconds} second(s) of a "
-                f"{len(rows)}-second window "
+                f"{window_seconds}-second window "
                 f"({lead_mb:.1f}/{total_mb:.1f} MB = "
                 f"{100 * lead_mb / total_mb:.0f}%). "
                 f"Likely model weight loading — normal behavior."

--- a/src/nsys_ai/skills/builtins/memory_transfers.py
+++ b/src/nsys_ai/skills/builtins/memory_transfers.py
@@ -44,6 +44,16 @@ ORDER BY total_ms DESC, copyKind ASC""",
 )
 
 
+#: A window shorter than this has no distribution to classify: with two buckets
+#: any "leading portion" is most of the window.
+_MIN_BUCKETS_FOR_SHAPE = 3
+
+#: The leading share of the window that "front-loaded" means. A fraction rather
+#: than a fixed duration, so the same transfer pattern gets the same verdict in a
+#: 4-second window and a 40-second one.
+_INIT_LEAD_FRACTION = 0.25
+
+
 def _classify_h2d_pattern(rows: list, kwargs: dict | None = None) -> dict:
     """Classify H2D transfer distribution into init_heavy / spread_out / spike."""
     if not rows:
@@ -53,16 +63,38 @@ def _classify_h2d_pattern(rows: list, kwargs: dict | None = None) -> dict:
     if total_mb <= 0:
         return {"_pattern": True, "type": "none", "detail": "No bytes transferred"}
 
-    # Init-heavy: first 2 seconds account for >80% of total bytes
-    first_2s_mb = sum(r["total_mb"] for r in rows if r["second"] <= 1)
-    if first_2s_mb / total_mb > 0.8:
+    # A window has to be long enough to have a shape before one can be read off
+    # it. With two buckets, "the first two seconds" is the whole window: the
+    # ratio below is 1.0 by construction and init_heavy wins whatever the data
+    # says, so steady per-batch loading in a sub-2s trim was reported as normal
+    # weight loading -- the one verdict that tells a reader to stop looking.
+    if len(rows) < _MIN_BUCKETS_FOR_SHAPE:
+        return {
+            "_pattern": True,
+            "type": "undetermined",
+            "detail": (
+                f"Window covers {len(rows)} second-bucket(s); at least "
+                f"{_MIN_BUCKETS_FOR_SHAPE} are needed to tell a front-loaded "
+                f"distribution from a steady one. Widen --trim to classify."
+            ),
+        }
+
+    # Init-heavy: the leading portion of the window accounts for >80% of bytes.
+    # Measured as a fraction of the window rather than a fixed two seconds, so
+    # the verdict describes the distribution instead of the window length.
+    lead_buckets = max(1, round(len(rows) * _INIT_LEAD_FRACTION))
+    ordered = sorted(rows, key=lambda r: r["second"])
+    lead_mb = sum(r["total_mb"] for r in ordered[:lead_buckets])
+    if lead_mb / total_mb > 0.8:
+        lead_seconds = ordered[lead_buckets - 1]["second"] + 1
         return {
             "_pattern": True,
             "type": "init_heavy",
             "detail": (
-                f"H2D concentrated in first 2 seconds "
-                f"({first_2s_mb:.1f}/{total_mb:.1f} MB = "
-                f"{100 * first_2s_mb / total_mb:.0f}%). "
+                f"H2D concentrated in the first {lead_seconds} second(s) of a "
+                f"{len(rows)}-second window "
+                f"({lead_mb:.1f}/{total_mb:.1f} MB = "
+                f"{100 * lead_mb / total_mb:.0f}%). "
                 f"Likely model weight loading — normal behavior."
             ),
         }

--- a/src/nsys_ai/skills/builtins/memory_transfers.py
+++ b/src/nsys_ai/skills/builtins/memory_transfers.py
@@ -55,6 +55,52 @@ _MIN_SECONDS_FOR_SHAPE = 3
 _INIT_LEAD_FRACTION = 0.25
 
 
+def _observed_seconds(conn, rows: list, kwargs: dict) -> float | None:
+    """Seconds from the first H2D transfer to the end of what was observed.
+
+    The trim window when one was given, otherwise the capture's own span. None
+    when neither can be established, and the caller falls back to the buckets --
+    which is the wrong answer, but a bounded one.
+    """
+    starts = [r.get("window_start") for r in rows if r.get("window_start") is not None]
+    if not starts:
+        return None
+    first_transfer = min(int(s) for s in starts)
+
+    # The last transfer is a floor on how long we watched: we saw it, so
+    # observation reached at least that far. Taking the kernel table's MAX(end)
+    # alone said otherwise wherever copies outlive the last kernel -- on a
+    # fixture with one kernel ending at 1.0s and transfers running to 4.2s it
+    # reported a one-second window and refused to classify a plainly steady
+    # spread.
+    ends = [r.get("window_end") for r in rows if r.get("window_end") is not None]
+    end_ns = max((int(e) for e in ends), default=None)
+
+    trim_end = kwargs.get("trim_end_ns")
+    if trim_end is not None:
+        end_ns = max(int(trim_end), end_ns) if end_ns is not None else int(trim_end)
+    else:
+        try:
+            from nsys_ai.connection import wrap_connection
+
+            adapter = wrap_connection(conn)
+            kernel_tbl = adapter.resolve_activity_tables().get("kernel")
+            if kernel_tbl:
+                row = adapter.execute(
+                    f'SELECT MAX(k."end") FROM {kernel_tbl} k'  # nosec B608
+                ).fetchone()
+                kernel_end = row[0] if row else None
+                if kernel_end is not None:
+                    end_ns = max(int(kernel_end), end_ns) if end_ns is not None else int(kernel_end)
+        except Exception:  # noqa: BLE001 - an optional bound, never a failure
+            pass
+    if end_ns is None:
+        return None
+
+    span_ns = int(end_ns) - first_transfer
+    return max(1.0, span_ns / 1e9) if span_ns > 0 else None
+
+
 def _classify_h2d_pattern(rows: list, kwargs: dict | None = None) -> dict:
     """Classify H2D transfer distribution into init_heavy / spread_out / spike."""
     if not rows:
@@ -78,7 +124,18 @@ def _classify_h2d_pattern(rows: list, kwargs: dict | None = None) -> dict:
     # finding that root_cause_matcher consumes.
     first_second = min(r["second"] for r in rows)
     last_second = max(r["second"] for r in rows)
-    window_seconds = last_second - first_second + 1
+    # How long we watched, not how long transfers ran. Deriving the window from
+    # the buckets makes the commonest init_heavy profile unclassifiable: a
+    # 60-second capture whose weights load in the first two seconds returns
+    # buckets 0 and 1 and nothing else, which reads as a two-second window. And
+    # the advice to widen --trim cannot help, because the rest of the capture
+    # holds no transfers to find.
+    observed_seconds = (kwargs or {}).get("_observed_seconds")
+    window_seconds = (
+        int(observed_seconds)
+        if observed_seconds
+        else last_second - first_second + 1
+    )
 
     if window_seconds < _MIN_SECONDS_FOR_SHAPE:
         return {
@@ -310,7 +367,9 @@ def _execute_h2d_dist(conn, **kwargs):
 
     # Append pattern classification as metadata
     if rows:
-        rows.append(_classify_h2d_pattern(rows, kwargs))
+        rows.append(
+            _classify_h2d_pattern(rows, {**kwargs, "_observed_seconds": _observed_seconds(conn, rows, kwargs)})
+        )
     return rows
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -297,7 +297,9 @@ INSERT INTO CUPTI_ACTIVITY_KIND_MEMCPY VALUES
     -- H2D transfers at second 0 (init-heavy: 4MB)
     (100, 0, 7, 200, 1, 2097152, 7, 2, 100000, 200000),
     (100, 0, 7, 201, 1, 2097152, 7, 2, 300000, 400000),
-    -- H2D transfer at second 2 (small: 0.1MB)
+    -- H2D transfer 2.1 ms in (small: 0.1MB). Note the unit: these timestamps
+    -- are nanoseconds, so every H2D row here falls in bucket 0 and the whole
+    -- seeded span is ~2 ms. The comment used to say "second 2".
     (100, 0, 7, 202, 1, 104858, 7, 2, 2100000, 2200000),
     -- H2D transfer at second 5 (small: 0.1MB)
     (100, 0, 7, 203, 1, 104858, 7, 2, 5100000, 5200000);

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -858,21 +858,25 @@ def test_root_cause_all_patterns_execute(minimal_nsys_conn):
 # ---- V3 Review Feature Tests ------------------------------------------------
 
 
-def test_h2d_distribution_init_heavy_pattern(minimal_nsys_conn):
-    """Seed data has H2D concentrated in second 0 — should classify as init_heavy."""
+def test_h2d_distribution_declines_to_classify_a_millisecond_fixture(minimal_nsys_conn):
+    """The fixture's H2D spans ~2 ms, which has no distribution to read.
+
+    This asserted ``init_heavy`` — "likely model weight loading, normal
+    behavior" — over three transfers 2 milliseconds apart. They all land in
+    bucket 0, so "the first two seconds" was the entire capture and the verdict
+    was structural rather than observed. Two milliseconds is not weight loading,
+    and a test resting on that verdict could not notice the rule never looked at
+    the data.
+    """
     from nsys_ai.skills.registry import get_skill
 
-    skill = get_skill("h2d_distribution")
-    rows = skill.execute(minimal_nsys_conn)
-    # Should have data rows + pattern metadata
+    rows = get_skill("h2d_distribution").execute(minimal_nsys_conn)
+
     assert len(rows) > 0
     pattern = next((r for r in rows if r.get("_pattern")), None)
     assert pattern is not None
-    assert pattern["type"] == "init_heavy"
-    assert (
-        "first 2 seconds" in pattern["detail"].lower()
-        or "concentrated" in pattern["detail"].lower()
-    )
+    assert pattern["type"] == "undetermined"
+    assert "second-bucket" in pattern["detail"]
 
 
 def test_h2d_distribution_format_shows_pattern(minimal_nsys_conn):
@@ -883,7 +887,10 @@ def test_h2d_distribution_format_shows_pattern(minimal_nsys_conn):
     rows = skill.execute(minimal_nsys_conn)
     text = skill.format_rows(rows)
     assert "Pattern:" in text
-    assert "init_heavy" in text
+    # The classification itself, not a particular verdict: this fixture is too
+    # short to have one, and pinning the verdict here is what hid the defect.
+    pattern = next(r for r in rows if r.get("_pattern"))
+    assert pattern["type"] in text
 
 
 def test_gpu_idle_gaps_aggregation(minimal_nsys_conn):
@@ -1283,3 +1290,49 @@ def test_the_copy_line_does_not_claim_to_be_a_share_of_idle():
     ])
 
     assert "not a share of the idle" in text
+
+
+# ── H2D distribution: a window needs a shape before one can be read off it ──
+
+
+def test_h2d_short_window_does_not_claim_weight_loading():
+    """Two buckets make 'the first two seconds' the whole window.
+
+    The ratio was then 1.0 by construction and init_heavy won whatever the data
+    said, so steady per-batch loading in a sub-2s trim was reported as normal
+    weight loading — the one verdict that tells a reader to stop looking.
+    """
+    from nsys_ai.skills.builtins.memory_transfers import _classify_h2d_pattern
+
+    steady = [{"second": 0, "total_mb": 100.0}, {"second": 1, "total_mb": 100.0}]
+
+    result = _classify_h2d_pattern(steady)
+
+    assert result["type"] == "undetermined"
+    assert "at least" in result["detail"]
+
+
+def test_h2d_the_same_pattern_gets_the_same_verdict_at_any_window_length():
+    """The classification must describe the data, not the trim."""
+    from nsys_ai.skills.builtins.memory_transfers import _classify_h2d_pattern
+
+    steady_6 = [{"second": s, "total_mb": 100.0} for s in range(6)]
+    steady_30 = [{"second": s, "total_mb": 100.0} for s in range(30)]
+
+    assert _classify_h2d_pattern(steady_6)["type"] == "spread_out"
+    assert _classify_h2d_pattern(steady_30)["type"] == "spread_out"
+
+
+def test_h2d_front_loading_is_still_recognised():
+    """The heuristic's real job, at two very different window lengths."""
+    from nsys_ai.skills.builtins.memory_transfers import _classify_h2d_pattern
+
+    short = [{"second": 0, "total_mb": 900.0}] + [
+        {"second": s, "total_mb": 5.0} for s in range(1, 8)
+    ]
+    long = [{"second": s, "total_mb": 100.0} for s in range(10)] + [
+        {"second": s, "total_mb": 1.0} for s in range(10, 40)
+    ]
+
+    assert _classify_h2d_pattern(short)["type"] == "init_heavy"
+    assert _classify_h2d_pattern(long)["type"] == "init_heavy"

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1336,3 +1336,34 @@ def test_h2d_front_loading_is_still_recognised():
 
     assert _classify_h2d_pattern(short)["type"] == "init_heavy"
     assert _classify_h2d_pattern(long)["type"] == "init_heavy"
+
+
+def test_h2d_sparse_buckets_do_not_swallow_a_late_spike():
+    """The query returns only seconds that carried a transfer.
+
+    len(rows) is therefore how many buckets have data, not how long the window
+    is. Slicing by position took "the first quarter of six rows" on buckets
+    [0, 50, 51, 52, 53, 54] and called a 900 MB spike at second 50 front-loading
+    — announced as "the first 51 seconds of a 6-second window" — which also
+    swallowed the spike finding root_cause_matcher consumes.
+    """
+    from nsys_ai.skills.builtins.memory_transfers import _classify_h2d_pattern
+
+    sparse = [
+        {"second": s, "total_mb": mb}
+        for s, mb in [(0, 1.0), (50, 900.0), (51, 1.0), (52, 1.0), (53, 1.0), (54, 1.0)]
+    ]
+
+    assert _classify_h2d_pattern(sparse)["type"] == "spike"
+
+
+def test_h2d_the_window_is_measured_in_elapsed_seconds():
+    """Two elapsed seconds have no shape, however many buckets carry data."""
+    from nsys_ai.skills.builtins.memory_transfers import _classify_h2d_pattern
+
+    result = _classify_h2d_pattern(
+        [{"second": 0, "total_mb": 100.0}, {"second": 1, "total_mb": 100.0}]
+    )
+
+    assert result["type"] == "undetermined"
+    assert "spans 2 second-bucket(s)" in result["detail"]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1367,3 +1367,26 @@ def test_h2d_the_window_is_measured_in_elapsed_seconds():
 
     assert result["type"] == "undetermined"
     assert "spans 2 second-bucket(s)" in result["detail"]
+
+
+def test_h2d_weight_loading_in_a_long_capture_is_still_recognised():
+    """The commonest init_heavy profile, and the one the first fix broke.
+
+    A 60-second run whose weights load in the first two seconds produces buckets
+    0 and 1 and nothing after, because the rest of the capture holds no
+    transfers. Deriving the window from the buckets read that as a two-second
+    window and refused to classify it — advising the reader to widen --trim,
+    which cannot help, since there is nothing later to find.
+
+    The same two buckets mean different things depending on how long we watched,
+    so the window comes from the observation bounds and not from the transfers.
+    """
+    from nsys_ai.skills.builtins.memory_transfers import _classify_h2d_pattern
+
+    buckets = [{"second": 0, "total_mb": 900.0}, {"second": 1, "total_mb": 100.0}]
+
+    long_capture = _classify_h2d_pattern(buckets, {"_observed_seconds": 60})
+    short_capture = _classify_h2d_pattern(buckets, {"_observed_seconds": 2})
+
+    assert long_capture["type"] == "init_heavy"
+    assert short_capture["type"] == "undetermined"


### PR DESCRIPTION
Closes #

See the linked issue for the reproduction and the reasoning; the commit message records the design decisions.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean

Full suite run in an isolated worktree; failures are confined to the `test_profile_runner` family tracked in #585, which runs hotter under parallel load.
