### PR TITLE
fix(skills): claim a pipeline only where the regions look like one

### DIFF
--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -773,6 +773,48 @@ def _first_measured(*values) -> float:
     return 0.0
 
 
+#: NVTX labels that name a phase of one iteration rather than a stage of a
+#: pipeline. Phases differ in cost by design, so a spread across them is not an
+#: imbalance to correct.
+_PHASE_LABEL_HINTS = (
+    "forward",
+    "backward",
+    "optimizer",
+    "optim",
+    "data",
+    "dataload",
+    "loss",
+    "zero_grad",
+    "step",
+    "eval",
+    "validation",
+)
+
+
+def _regions_look_like_repeated_peers(layers: list[dict]) -> bool:
+    """True when the regions plausibly name stages of one pipeline.
+
+    Deliberately conservative, and deliberately not clever. There is no field
+    saying what an NVTX annotation means, so this reads the only signal actually
+    present: a label that names a phase of an iteration is not a pipeline stage,
+    however uneven its cost. Anything else is left to the caller's existing
+    threshold.
+
+    Getting this wrong in the permissive direction restores the old behaviour for
+    that profile -- a recommendation to rebalance -- so the cost of a miss is the
+    status quo, not a new failure.
+    """
+    labels = [
+        str(r.get("nvtx_path") or r.get("nvtx_region") or "").lower() for r in layers
+    ]
+    phase_like = sum(
+        1 for label in labels if any(hint in label for hint in _PHASE_LABEL_HINTS)
+    )
+    # Any phase label among them is enough: a pipeline's stages are not named
+    # "backward", and a mix means the set is not a clean list of peers either.
+    return phase_like == 0
+
+
 def _check_pipeline_imbalance(layer_data: list[dict], threshold_ratio: float = 3.0) -> list[dict]:
     """Detect compute time imbalance across NVTX layers.
 
@@ -803,20 +845,47 @@ def _check_pipeline_imbalance(layer_data: list[dict], threshold_ratio: float = 3
     heaviest_label = heaviest.get("nvtx_path") or heaviest.get("nvtx_region", "?")
     lightest_label = lightest.get("nvtx_path") or lightest.get("nvtx_region", "?")
 
+    # What this compared were NVTX regions, which are whatever the annotator
+    # named. Only some captures annotate pipeline stages; the common PyTorch
+    # style is per-phase -- forward, backward, optimizer, data_load -- and those
+    # are *supposed* to differ. Reporting a 120x spread between 'backward' and
+    # 'data_load' as a pipeline to rebalance is a diagnosis the evidence does not
+    # support, on a run that may have no pipeline parallelism at all.
+    #
+    # Repetition is what separates the two: pipeline stages recur with similar
+    # shape across iterations, phases of one iteration do not. Where the regions
+    # do not look like repeated peers, the spread is still worth reporting -- it
+    # is true -- but as an observation about NVTX regions rather than as advice
+    # about partitioning.
+    looks_like_stages = _regions_look_like_repeated_peers(compute_layers)
+    if looks_like_stages:
+        recommendation = (
+            "Rebalance pipeline stage partitioning, "
+            "or investigate if the heavy layer has suboptimal kernel configuration "
+            "(e.g. too many small kernels, poor tiling)."
+        )
+        evidence_noun = "pipeline stages"
+    else:
+        recommendation = (
+            "These are NVTX regions, not necessarily pipeline stages — a phase "
+            "annotation (forward / backward / optimizer) is expected to vary this "
+            "way and needs no rebalancing. Check what the annotations mark before "
+            "acting: if they are pipeline stages, rebalance the partitioning; if "
+            "they are phases, investigate the heaviest one on its own merits."
+        )
+        evidence_noun = "NVTX regions"
+
     return [
         {
-            "pattern": "Pipeline Imbalance",
-            "severity": "warning",
+            "pattern": "Pipeline Imbalance" if looks_like_stages else "Uneven NVTX Regions",
+            "severity": "warning" if looks_like_stages else "info",
             "evidence": (
-                f"Compute time varies {ratio:.1f}× across layers. "
+                f"Compute time varies {ratio:.1f}× across {len(compute_layers)} "
+                f"{evidence_noun}. "
                 f"Heaviest: '{heaviest_label}' ({heaviest['compute_ms']:.1f}ms), "
                 f"lightest: '{lightest_label}' ({lightest['compute_ms']:.1f}ms)"
             ),
-            "recommendation": (
-                "Rebalance pipeline stage partitioning, "
-                "or investigate if the heavy layer has suboptimal kernel configuration "
-                "(e.g. too many small kernels, poor tiling)."
-            ),
+            "recommendation": recommendation,
         }
     ]
 

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -804,8 +804,17 @@ def _regions_look_like_repeated_peers(layers: list[dict]) -> bool:
     that profile -- a recommendation to rebalance -- so the cost of a miss is the
     status quo, not a new failure.
     """
+    # The region's own label, not its ancestry. nvtx_layer_breakdown returns
+    # full hierarchical paths, so sibling stages nested under a "train_step"
+    # parent all carry "step" in their path and were read as phases -- the
+    # warning was suppressed because an enclosing annotation existed, which is
+    # the opposite of what the enclosing annotation tells you.
     labels = [
-        str(r.get("nvtx_path") or r.get("nvtx_region") or "").lower() for r in layers
+        str(r.get("nvtx_path") or r.get("nvtx_region") or "")
+        .rsplit(">", 1)[-1]
+        .strip()
+        .lower()
+        for r in layers
     ]
     phase_like = sum(
         1 for label in labels if any(hint in label for hint in _PHASE_LABEL_HINTS)

--- a/tests/test_root_cause_abstention.py
+++ b/tests/test_root_cause_abstention.py
@@ -97,3 +97,58 @@ def test_matcher_reports_no_layer_findings_without_annotation(conn):
         assert "layer" not in str(f.get("pattern", "")).lower(), (
             f"layer-attributed cause on an unannotated profile: {f}"
         )
+
+
+# ── Pipeline Imbalance only claims a pipeline where one is plausible ────────
+
+
+def test_phase_annotations_are_not_reported_as_a_pipeline_to_rebalance():
+    """forward / backward / optimizer / data_load differ by design.
+
+    The check compared whatever nvtx_layer_breakdown returned and called the
+    spread "Pipeline Imbalance", recommending stage repartitioning — on a
+    single-GPU run that may have no pipeline parallelism at all. backward taking
+    120x data_load is what a healthy iteration looks like.
+    """
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_pipeline_imbalance
+
+    findings = _check_pipeline_imbalance([
+        {"nvtx_region": "forward", "compute_ms": 120.0},
+        {"nvtx_region": "backward", "compute_ms": 240.0},
+        {"nvtx_region": "optimizer", "compute_ms": 15.0},
+        {"nvtx_region": "data_load", "compute_ms": 2.0},
+    ])
+
+    assert len(findings) == 1
+    assert findings[0]["pattern"] == "Uneven NVTX Regions"
+    assert findings[0]["severity"] == "info"
+    assert "not necessarily pipeline stages" in findings[0]["recommendation"]
+    # The measurement is still reported; it is true and worth seeing.
+    assert "120.0×" in findings[0]["evidence"]
+
+
+def test_stage_like_regions_keep_the_rebalancing_advice():
+    """Where the regions do look like peers, the original finding stands."""
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_pipeline_imbalance
+
+    findings = _check_pipeline_imbalance([
+        {"nvtx_region": f"stage_{i}", "compute_ms": ms}
+        for i, ms in enumerate([240.0, 80.0, 75.0, 20.0])
+    ])
+
+    assert findings[0]["pattern"] == "Pipeline Imbalance"
+    assert findings[0]["severity"] == "warning"
+    assert "Rebalance pipeline stage partitioning" in findings[0]["recommendation"]
+
+
+def test_a_single_phase_label_is_enough_to_withhold_the_claim():
+    """A mixed set is not a clean list of peers either."""
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_pipeline_imbalance
+
+    findings = _check_pipeline_imbalance([
+        {"nvtx_region": "stage_0", "compute_ms": 240.0},
+        {"nvtx_region": "stage_1", "compute_ms": 80.0},
+        {"nvtx_region": "backward", "compute_ms": 20.0},
+    ])
+
+    assert findings[0]["pattern"] == "Uneven NVTX Regions"

--- a/tests/test_root_cause_abstention.py
+++ b/tests/test_root_cause_abstention.py
@@ -152,3 +152,25 @@ def test_a_single_phase_label_is_enough_to_withhold_the_claim():
     ])
 
     assert findings[0]["pattern"] == "Uneven NVTX Regions"
+
+
+def test_nesting_does_not_change_the_verdict():
+    """nvtx_layer_breakdown returns full paths, so ancestors are in the label.
+
+    Sibling stages under a 'train_step' parent all carry "step" in their path
+    and were read as phases — the warning suppressed because an enclosing
+    annotation existed, which is the opposite of what that annotation says.
+    """
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_pipeline_imbalance
+
+    nested_stages = [
+        {"nvtx_path": f"train_step > stage_{i}", "compute_ms": ms}
+        for i, ms in enumerate([240.0, 80.0, 75.0, 20.0])
+    ]
+    nested_phases = [
+        {"nvtx_path": f"iteration > {name}", "compute_ms": ms}
+        for name, ms in [("forward", 120.0), ("backward", 240.0), ("data_load", 2.0)]
+    ]
+
+    assert _check_pipeline_imbalance(nested_stages)[0]["pattern"] == "Pipeline Imbalance"
+    assert _check_pipeline_imbalance(nested_phases)[0]["pattern"] == "Uneven NVTX Regions"


### PR DESCRIPTION
Closes #

See the linked issue for the reproduction and the reasoning; the commit message records the design decisions.

## Test plan

- [x] Tests added or updated for the new behavior
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally
- [x] `ruff check src/ tests/` clean

Full suite run in an isolated worktree; failures are confined to the `test_profile_runner` family tracked in #585, which runs hotter under parallel load.
