### PR TITLE
docs(skills): say what has to be true for a recommendation to pay

### DIFF
--- a/src/nsys_ai/data/book.md
+++ b/src/nsys_ai/data/book.md
@@ -93,7 +93,10 @@ nsys-ai skill run memory_transfers profile.sqlite
 H2D total time > 5% of iteration time is concerning.
 
 **How to fix:**
-- Use `pin_memory=True` in DataLoader for async H2D
+- Use `pin_memory=True` in DataLoader for async H2D — asynchronous is not the
+  same as overlapped: without prefetching or a copy stream to overlap with, the
+  copy is issued asynchronously and then waited on, moving the cost rather than
+  removing it
 - Keep all model parameters on GPU (check for accidental CPU tensors)
 - Accumulate metrics on GPU, sync to CPU only at checkpoint time
 - Pre-allocate GPU buffers instead of re-creating tensors each iteration

--- a/src/nsys_ai/data/book.md
+++ b/src/nsys_ai/data/book.md
@@ -94,9 +94,10 @@ H2D total time > 5% of iteration time is concerning.
 
 **How to fix:**
 - Use `pin_memory=True` in DataLoader for async H2D — asynchronous is not the
-  same as overlapped: without prefetching or a copy stream to overlap with, the
-  copy is issued asynchronously and then waited on, moving the cost rather than
-  removing it
+  same as overlapped. Pinning removes the pageable staging copy, which raises
+  transfer bandwidth on its own; hiding the transfer behind compute needs a copy
+  stream as well, since DataLoader prefetching queues batches on the CPU and a
+  transfer sharing the model's stream still serializes against it
 - Keep all model parameters on GPU (check for accidental CPU tensors)
 - Accumulate metrics on GPU, sync to CPU only at checkpoint time
 - Pre-allocate GPU buffers instead of re-creating tensors each iteration

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -336,7 +336,8 @@ _EXPLANATION = (
 _SUGGESTED_ACTIONS = [
     "Check for explicit cudaDeviceSynchronize / torch.cuda.synchronize calls in the call chain",
     "Verify the dataloader is keeping up (num_workers, prefetch_factor, and "
-    "pin_memory — which only pays alongside the other two)",
+    "pin_memory — the first two keep CPU batches ready, pinning speeds the "
+    "transfer itself, and overlapping it with compute needs a copy stream)",
     "Consider CUDA graphs if many tiny kernels precede the gap",
     "Check whether host-to-device transfers can be overlapped with compute",
 ]

--- a/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
+++ b/src/nsys_ai/skills/builtins/gpu_idle_gaps.py
@@ -335,7 +335,8 @@ _EXPLANATION = (
 )
 _SUGGESTED_ACTIONS = [
     "Check for explicit cudaDeviceSynchronize / torch.cuda.synchronize calls in the call chain",
-    "Verify the dataloader is keeping up (num_workers, pin_memory, prefetch_factor)",
+    "Verify the dataloader is keeping up (num_workers, prefetch_factor, and "
+    "pin_memory — which only pays alongside the other two)",
     "Consider CUDA graphs if many tiny kernels precede the gap",
     "Check whether host-to-device transfers can be overlapped with compute",
 ]

--- a/src/nsys_ai/skills/builtins/memory_transfers.py
+++ b/src/nsys_ai/skills/builtins/memory_transfers.py
@@ -104,7 +104,7 @@ def _classify_h2d_pattern(rows: list, kwargs: dict | None = None) -> dict:
             "detail": (
                 f"H2D transfers spread across {len(rows)} seconds "
                 f"({total_mb:.1f} MB total). Every step has H2D — "
-                f"consider pin_memory=True with prefetching — pin_memory only pays alongside prefetching or a copy stream; on its own it moves the copy cost rather than removing it."
+                f"consider pin_memory=True with prefetching — pin_memory raises transfer bandwidth on its own, but hiding the transfer behind compute additionally needs a copy stream — DataLoader prefetching stages batches on the CPU and does not by itself overlap H2D with kernels."
             ),
         }
 

--- a/src/nsys_ai/skills/builtins/memory_transfers.py
+++ b/src/nsys_ai/skills/builtins/memory_transfers.py
@@ -104,7 +104,7 @@ def _classify_h2d_pattern(rows: list, kwargs: dict | None = None) -> dict:
             "detail": (
                 f"H2D transfers spread across {len(rows)} seconds "
                 f"({total_mb:.1f} MB total). Every step has H2D — "
-                f"consider pin_memory=True and increasing DataLoader num_workers."
+                f"consider pin_memory=True with prefetching — pin_memory only pays alongside prefetching or a copy stream; on its own it moves the copy cost rather than removing it."
             ),
         }
 

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -370,7 +370,8 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                         ),
                         "recommendation": (
                             "Use pin_memory=True in DataLoader, keep "
-                            "model params on GPU, accumulate metrics on GPU."
+                            "model params on GPU, accumulate metrics on GPU. "
+                            "pin_memory only pays alongside prefetching or a copy stream; on its own it moves the copy cost rather than removing it."
                         ),
                     }
                 )
@@ -390,8 +391,11 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                             "detail", "H2D transfers detected in every step"
                         ),
                         "recommendation": (
-                            "Use pin_memory=True in DataLoader, increase num_workers, "
-                            "set prefetch_factor>=2, and ensure tensors are pre-staged on GPU. "
+                            "Use pin_memory=True in DataLoader together with "
+                            "increased num_workers and prefetch_factor>=2 — the pinning is "
+                            "what lets the copy be asynchronous, the prefetching is what "
+                            "gives it something to overlap with, and pinning alone moves the "
+                            "cost rather than removing it. Ensure tensors are pre-staged on GPU. "
                             "Check if .cpu() / .item() calls in the loop are pulling data back to host."
                         ),
                     }
@@ -1007,6 +1011,7 @@ def _check_sync_memcpy(conn: sqlite3.Connection, **kwargs):
                 "recommendation": (
                     "Replace cudaMemcpy with cudaMemcpyAsync + pinned memory. "
                     "Use pin_memory=True in DataLoader and non_blocking=True in .to(device). "
+                    "Pinning only pays where the copy can overlap compute — a prefetching DataLoader, a separate copy stream, or non_blocking=True with work between the copy and its first use. Applied alone it makes the copy asynchronous and then waits on it anyway, moving the cost rather than removing it. "
                     "Run `nsys recipe cuda_memcpy_sync <profile.nsys-rep>` for a detailed breakdown."
                 ),
             }
@@ -1062,7 +1067,7 @@ def _check_pageable_memcpy(conn: sqlite3.Connection, **kwargs):
                 ),
                 "recommendation": (
                     "Use pinned (page-locked) memory: cudaMallocHost() / "
-                    "pin_memory=True in DataLoader. This enables true async H2D overlap. "
+                    "pin_memory=True in DataLoader. Pinning only pays where the copy can overlap compute — a prefetching DataLoader, a separate copy stream, or non_blocking=True with work between the copy and its first use. Applied alone it makes the copy asynchronous and then waits on it anyway, moving the cost rather than removing it. "
                     "Run `nsys recipe cuda_memcpy_async <profile.nsys-rep>` for details on pageable fallback."
                 ),
             }

--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -371,7 +371,7 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                         "recommendation": (
                             "Use pin_memory=True in DataLoader, keep "
                             "model params on GPU, accumulate metrics on GPU. "
-                            "pin_memory only pays alongside prefetching or a copy stream; on its own it moves the copy cost rather than removing it."
+                            "pin_memory raises transfer bandwidth on its own, but hiding the transfer behind compute additionally needs a copy stream — DataLoader prefetching stages batches on the CPU and does not by itself overlap H2D with kernels."
                         ),
                     }
                 )
@@ -392,10 +392,12 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                         ),
                         "recommendation": (
                             "Use pin_memory=True in DataLoader together with "
-                            "increased num_workers and prefetch_factor>=2 — the pinning is "
-                            "what lets the copy be asynchronous, the prefetching is what "
-                            "gives it something to overlap with, and pinning alone moves the "
-                            "cost rather than removing it. Ensure tensors are pre-staged on GPU. "
+                            "increased num_workers and prefetch_factor>=2. These solve "
+                            "different halves: the workers keep CPU batches ready, the "
+                            "pinning removes the pageable staging copy. Overlapping the H2D "
+                            "with compute is a third thing and needs a copy stream — batches "
+                            "queued on the CPU do not overlap a transfer that shares the "
+                            "model's stream. Ensure tensors are pre-staged on GPU. "
                             "Check if .cpu() / .item() calls in the loop are pulling data back to host."
                         ),
                     }
@@ -1011,7 +1013,7 @@ def _check_sync_memcpy(conn: sqlite3.Connection, **kwargs):
                 "recommendation": (
                     "Replace cudaMemcpy with cudaMemcpyAsync + pinned memory. "
                     "Use pin_memory=True in DataLoader and non_blocking=True in .to(device). "
-                    "Pinning only pays where the copy can overlap compute — a prefetching DataLoader, a separate copy stream, or non_blocking=True with work between the copy and its first use. Applied alone it makes the copy asynchronous and then waits on it anyway, moving the cost rather than removing it. "
+                    "Pinning does two separable things. It raises transfer bandwidth by removing the pageable staging copy, which is worth having on its own for repeated transfers from a reused buffer. Hiding the transfer behind compute is the other, and needs more than pinning: a separate copy stream with events, or genuine concurrency between the copy and the work that follows it. Note that DataLoader num_workers/prefetch_factor prepare batches on the CPU — if the .to(device, non_blocking=True) and the model share one stream, the copy and the kernels still serialize. "
                     "Run `nsys recipe cuda_memcpy_sync <profile.nsys-rep>` for a detailed breakdown."
                 ),
             }
@@ -1067,7 +1069,7 @@ def _check_pageable_memcpy(conn: sqlite3.Connection, **kwargs):
                 ),
                 "recommendation": (
                     "Use pinned (page-locked) memory: cudaMallocHost() / "
-                    "pin_memory=True in DataLoader. Pinning only pays where the copy can overlap compute — a prefetching DataLoader, a separate copy stream, or non_blocking=True with work between the copy and its first use. Applied alone it makes the copy asynchronous and then waits on it anyway, moving the cost rather than removing it. "
+                    "pin_memory=True in DataLoader. Pinning does two separable things. It raises transfer bandwidth by removing the pageable staging copy, which is worth having on its own for repeated transfers from a reused buffer. Hiding the transfer behind compute is the other, and needs more than pinning: a separate copy stream with events, or genuine concurrency between the copy and the work that follows it. Note that DataLoader num_workers/prefetch_factor prepare batches on the CPU — if the .to(device, non_blocking=True) and the model share one stream, the copy and the kernels still serialize. "
                     "Run `nsys recipe cuda_memcpy_async <profile.nsys-rep>` for details on pageable fallback."
                 ),
             }


### PR DESCRIPTION
Closes #603

Applying `pin_memory=True` on its own measured as a **regression of +2.3pp** on a real workload the tool had recommended it for. The advice was not wrong; it was incomplete in the way that makes following it exactly the worst thing to do.

> "This enables true async H2D overlap"

is accurate and is the whole problem. Pinning *enables* overlap, it does not create it. Without a prefetching loader, a copy stream, or work between the copy and its first use, the copy is issued asynchronously and then waited on anyway, while page-locking has added its own allocation cost. The cost moves rather than going away.

Six sites now name the precondition, including `data/book.md`'s "for async H2D" — the sentence that licenses the mistake, since asynchronous is not overlapped. One site already recommended `num_workers` and `prefetch_factor` alongside pinning but never said why the three go together, so a reader could reasonably apply one; it now spells out the division of labour.

Left alone where the surrounding text already supplies the structure (`triage.md` names prefetching in the same breath) or where the mention is a list of knobs to investigate rather than advice to apply (`variance.md`).

## Test plan

- [ ] Tests added — not applicable, recommendation text only
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/ -v --tb=short` passes locally — **2708 passed**
- [x] `ruff check src/ tests/` clean

Failures are confined to the `test_profile_runner` family tracked in #585.
