### PR TITLE
fix(skills): require positive evidence before calling regions a pipeline

### DIFF
--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -791,6 +791,19 @@ _PHASE_LABEL_HINTS = (
 )
 
 
+#: A pipeline partitions a model into a few stages: real pipeline-parallel
+#: degrees are single digits, occasionally up to 32. Hundreds of regions are an
+#: annotation of operations or layers, and a recommendation to repartition a
+#: pipeline is not supported by them.
+_MAX_PLAUSIBLE_STAGES = 32
+
+#: The spread has to be worth acting on in absolute terms, not only as a ratio.
+#: The sole gate was ``compute_ms > 0.01`` (10us), so a 0.3ms-against-0.1ms
+#: difference between two trivially small operations cleared the 3x ratio and
+#: was reported as actionable.
+_MIN_IMBALANCE_SPREAD_MS = 1.0
+
+
 def _regions_look_like_repeated_peers(layers: list[dict]) -> bool:
     """True when the regions plausibly name stages of one pipeline.
 
@@ -821,7 +834,34 @@ def _regions_look_like_repeated_peers(layers: list[dict]) -> bool:
     )
     # Any phase label among them is enough: a pipeline's stages are not named
     # "backward", and a mix means the set is not a clean list of peers either.
-    return phase_like == 0
+    if phase_like:
+        return False
+
+    # Reading only the labels made this a denylist, and a denylist fails open:
+    # any annotation style that is not PyTorch's phase naming was taken for a
+    # pipeline by default. On this repository's own fixture that meant 132
+    # regions named "aten::linear, op_id = NNNNNN" -- individual operations --
+    # drew a warning to repartition a pipeline the run may not have.
+    #
+    # Note what is deliberately *not* used to detect that: collapsing trailing
+    # digits would fold "aten::linear, op_id = 1..132" into one name, but it
+    # would equally fold a real "stage_0..stage_7" pipeline into one, rejecting
+    # the very case this is meant to keep.
+    if len(layers) > _MAX_PLAUSIBLE_STAGES:
+        return False
+
+    # A stage spans many kernels; a region wrapping a single kernel is one
+    # operation. Absence of the field is not evidence either way -- callers
+    # legitimately pass rows without it -- so only measured counts vote.
+    measured = [
+        int(count)
+        for count in (r.get("kernel_count") for r in layers)
+        if isinstance(count, (int, float)) and not isinstance(count, bool)
+    ]
+    if measured and sum(1 for c in measured if c <= 1) * 2 > len(measured):
+        return False
+
+    return True
 
 
 def _check_pipeline_imbalance(layer_data: list[dict], threshold_ratio: float = 3.0) -> list[dict]:
@@ -845,6 +885,10 @@ def _check_pipeline_imbalance(layer_data: list[dict], threshold_ratio: float = 3
     ratio = max_compute / min_compute if min_compute > 0 else 0
 
     if ratio < threshold_ratio:
+        return []
+
+    # A ratio with no absolute floor fires on noise.
+    if max_compute - min_compute < _MIN_IMBALANCE_SPREAD_MS:
         return []
 
     # Find the heaviest and lightest layers

--- a/tests/test_root_cause_abstention.py
+++ b/tests/test_root_cause_abstention.py
@@ -174,3 +174,68 @@ def test_nesting_does_not_change_the_verdict():
 
     assert _check_pipeline_imbalance(nested_stages)[0]["pattern"] == "Pipeline Imbalance"
     assert _check_pipeline_imbalance(nested_phases)[0]["pattern"] == "Uneven NVTX Regions"
+
+
+# ── The claim needs positive evidence, and the spread needs a magnitude ──────
+
+
+def test_per_operation_annotations_are_not_a_pipeline():
+    """132 'aten::linear, op_id = N' regions are operations, not stages.
+
+    The label check was a denylist, so anything that was not PyTorch phase
+    naming defaulted to "pipeline stage". This is the repository's own fixture:
+    every region wraps exactly one kernel, which is what an operation looks like
+    and what a stage never does.
+    """
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_pipeline_imbalance
+
+    regions = [
+        {"nvtx_path": f"aten::linear, op_id = {318000 + i}", "kernel_count": 1,
+         "compute_ms": 40.0 if i == 0 else 4.0}
+        for i in range(132)
+    ]
+
+    findings = _check_pipeline_imbalance(regions)
+
+    assert findings[0]["pattern"] == "Uneven NVTX Regions"
+    assert findings[0]["severity"] == "info"
+
+
+def test_a_sub_millisecond_spread_is_not_reported_at_all():
+    """0.3ms against 0.1ms clears a 3x ratio and is still noise.
+
+    The only floor was compute_ms > 10us, so the fixture reported a 4.4x
+    "Pipeline Imbalance" between two operations whose entire difference was
+    0.2ms.
+    """
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_pipeline_imbalance
+
+    assert _check_pipeline_imbalance([
+        {"nvtx_region": "stage_0", "compute_ms": 0.31},
+        {"nvtx_region": "stage_1", "compute_ms": 0.07},
+    ]) == []
+
+
+def test_a_real_pipeline_survives_both_new_guards():
+    """The complement: few stages, each spanning many kernels, a real spread."""
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_pipeline_imbalance
+
+    findings = _check_pipeline_imbalance([
+        {"nvtx_region": f"stage_{i}", "kernel_count": 400, "compute_ms": ms}
+        for i, ms in enumerate([240.0, 80.0, 75.0, 20.0])
+    ])
+
+    assert findings[0]["pattern"] == "Pipeline Imbalance"
+    assert findings[0]["severity"] == "warning"
+
+
+def test_a_missing_kernel_count_is_not_read_as_evidence():
+    """Absence is not a single-kernel region; callers pass rows without it."""
+    from nsys_ai.skills.builtins.root_cause_matcher import _check_pipeline_imbalance
+
+    findings = _check_pipeline_imbalance([
+        {"nvtx_region": f"stage_{i}", "compute_ms": ms}
+        for i, ms in enumerate([240.0, 80.0, 75.0, 20.0])
+    ])
+
+    assert findings[0]["pattern"] == "Pipeline Imbalance"


### PR DESCRIPTION
## Summary

- `_check_pipeline_imbalance` decided whether NVTX regions were pipeline stages with a denylist, which fails open: anything that was not PyTorch phase naming became a "pipeline stage" by default and drew a `warning` to repartition a pipeline the run may not have.
- The ratio test had no absolute floor, so a 0.3ms-against-0.1ms difference between two trivially small operations was reported as actionable.

Both were visible on this repository's own fixture, `tests/fixtures/h100_2gpu_1s.sqlite`:

```
🟡 Pipeline Imbalance
  Evidence: Compute time varies 4.4× across 132 pipeline stages.
            Heaviest: 'aten::linear, op_id = 318126' (0.3ms),
            lightest: 'aten::linear, op_id = 316988' (0.1ms)
  Fix: Rebalance pipeline stage partitioning, ...
```

After this change that finding is gone: the spread is 0.2ms and is not worth reporting under any name.

## Changes

`src/nsys_ai/skills/builtins/root_cause_matcher.py`
- `_regions_look_like_repeated_peers` now requires positive evidence rather than the absence of a phase label:
  - `_MAX_PLAUSIBLE_STAGES = 32` — real pipeline-parallel degrees are single digits; hundreds of regions annotate operations or layers.
  - Regions must span more than one kernel. `nvtx_layer_breakdown` reports `kernel_count: 1` for all 132 fixture regions; a stage never wraps a single kernel. Only *measured* counts vote, so callers passing rows without the field are unaffected.
- `_MIN_IMBALANCE_SPREAD_MS = 1.0` — an absolute floor beneath the existing ratio test.

`tests/test_root_cause_abstention.py` — four tests: the two defects, plus two complement guards (a real pipeline with many kernels, and a missing `kernel_count`).

## Note on the approach

Collapsing trailing digits would also separate operations from stages, and is deliberately **not** used: it folds `op_id = 1..132` into one name, but folds a legitimate `stage_0..stage_7` pipeline into one name just as well — rejecting the case the rule exists to catch. `test_a_real_pipeline_survives_both_new_guards` pins that.

## Backward compatibility

Yes. The `else` branch ("Uneven NVTX Regions", `info`) already existed and is where these cases now land. Sub-millisecond spreads are no longer reported at all.

## Test plan

- [x] Tests added for the new behavior; both defect tests verified to **fail** with the fix reverted and pass with it
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/` — 2738 passed, 141 skipped, 4 xfailed; 2 failed, both the known `test_profile_runner` timing flakes (#585), which fail identically on clean `main`
- [x] `ruff check src/ tests/` clean
- [x] `bandit -r src/ -c pyproject.toml` — no issues identified
- [x] Manually exercised `nsys-ai skill run root_cause_matcher` on the fixture before and after

## Out of scope

The `sync_ms / total_idle_ms` denominator (see #610) and the truncated-gap-count sentence are fixed separately.

## Linked issues

Closes #609
