### PR TITLE
fix(skills): stop pairing a gap count with a total it does not sum to

### DIFF
--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -247,9 +247,27 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                 ),
             )
 
+            # The count and the total are different populations, and "N gaps
+            # ... totaling X" asserted they were one. The count is of gaps above
+            # the threshold; the total is device_idle_ms, which includes every
+            # gap below it. A single-stream profile with three 2ms gaps and a
+            # hundred 0.9ms ones therefore read "3 gaps > 1.0ms detected,
+            # totaling 96.0ms" -- inviting the reader to divide and conclude the
+            # average bubble was 32ms.
+            #
+            # len(large_gaps) was the wrong count for the same sentence anyway:
+            # it counts the detail rows, which gpu_idle_gaps truncates, so the
+            # fixture reported 20 of its actual 56. The summary carries the
+            # real number; fall back to the listed rows only when it does not,
+            # and never let the fallback claim more than it counted.
+            counted = gap_summary.get("gap_count") if gap_summary else None
+            if not isinstance(counted, int) or isinstance(counted, bool):
+                counted = len(large_gaps)
+            counted = max(counted, len(large_gaps))
+
             evidence = (
-                f"{len(large_gaps)} gaps > {gap_threshold / 1e6:.1f}ms detected, "
-                f"totaling {total_idle_ms:.1f}ms of idle time"
+                f"{counted} gaps > {gap_threshold / 1e6:.1f}ms detected; "
+                f"{total_idle_ms:.1f}ms total GPU idle"
             )
             if pct > 0:
                 evidence += f" ({pct}% of profile)"

--- a/tests/test_root_cause_matcher.py
+++ b/tests/test_root_cause_matcher.py
@@ -97,3 +97,68 @@ class TestIdlePercentageMatchesItsDuration:
 
         assert ms == 250.0
         assert pct == 0.0
+
+
+# ── The gap count and the idle total describe the same thing ────────────────
+
+
+class TestGapCountAndIdleTotalAgree:
+    """The evidence sentence used to pair two unrelated populations.
+
+    The count was of gaps above the threshold, the total was ``device_idle_ms``
+    -- every gap including those below it. Stated as "N gaps ... totaling X",
+    a reader divides and gets an average bubble that never occurred.
+    """
+
+    @staticmethod
+    def _evidence(summary, gap_rows):
+        import sqlite3
+        from unittest.mock import patch
+
+        from nsys_ai.skills.builtins import root_cause_matcher as rcm
+
+        def fake(name, conn, **kw):
+            if name == "gpu_idle_gaps":
+                return [summary, *gap_rows]
+            return []
+
+        with patch.object(rcm, "_safe_execute", side_effect=fake):
+            findings = rcm._execute(sqlite3.connect(":memory:"), _skip_device_validation=True)
+        return next(
+            (f["evidence"] for f in findings if f["pattern"] == "GPU Bubbles (Pipeline Stalls)"),
+            "",
+        )
+
+    def test_the_total_is_not_claimed_as_the_sum_of_the_counted_gaps(self):
+        """Three 2ms gaps beside a hundred 0.9ms ones: 6ms, not 96ms."""
+        summary = {
+            "_summary": True, "gap_count": 3, "device_idle_ms": 96.0,
+            "profile_start_ns": 0, "profile_end_ns": 100_000_000,
+        }
+        gaps = [{"gap_ns": 2_000_000, "attribution": {}} for _ in range(3)]
+
+        evidence = self._evidence(summary, gaps)
+
+        assert "totaling 96.0ms" not in evidence, evidence
+        assert "96.0ms total GPU idle" in evidence, evidence
+
+    def test_the_count_comes_from_the_summary_not_the_truncated_rows(self):
+        """gpu_idle_gaps truncates its detail rows; the summary counts them all."""
+        summary = {
+            "_summary": True, "gap_count": 56, "device_idle_ms": 938.1,
+            "profile_start_ns": 0, "profile_end_ns": 960_000_000,
+        }
+        gaps = [{"gap_ns": 5_000_000, "attribution": {}} for _ in range(20)]
+
+        evidence = self._evidence(summary, gaps)
+
+        assert evidence.startswith("56 gaps"), evidence
+
+    def test_a_summary_without_a_count_falls_back_to_the_listed_gaps(self):
+        summary = {
+            "_summary": True, "device_idle_ms": 50.0,
+            "profile_start_ns": 0, "profile_end_ns": 100_000_000,
+        }
+        gaps = [{"gap_ns": 5_000_000, "attribution": {}} for _ in range(4)]
+
+        assert self._evidence(summary, gaps).startswith("4 gaps")


### PR DESCRIPTION
## Summary

- The GPU Bubbles evidence joined a thresholded gap **count** to an unthresholded idle **total** with the word "totaling", asserting the two were the same population.
- Investigating that turned up a second error in the same sentence: the count itself came from the truncated detail rows, not from the summary that knows the real number.

On `tests/fixtures/h100_2gpu_1s.sqlite`:

```
gpu_idle_gaps:  Total: 56 gaps, 935.4ms idle (97.4% of profile)
                Device-level idle: 938.1ms

before:         20 gaps > 1.0ms detected, totaling 938.1ms of idle time (97.7% of profile)
after:          56 gaps > 1.0ms detected; 938.1ms total GPU idle (97.7% of profile)
```

Neither number was right before: 20 is the truncated listing of 56, and 938.1ms is every gap including those under the threshold.

## Changes

`src/nsys_ai/skills/builtins/root_cause_matcher.py`
- Take the gap count from the summary's `gap_count`; fall back to the listed rows only when it is absent, and never let the fallback claim fewer than it counted.
- Report the idle total as what it is (`total GPU idle`) instead of attributing it to the counted gaps.

`tests/test_root_cause_matcher.py` — the two defects, plus a fallback guard for summaries without `gap_count`.

## Deliberately not changed

`codex review` also argued the `sync_ms / total_idle_ms > 0.5` denominator is inflated by sub-threshold idle and makes the rule under-fire. Using `device_idle_ms` there asks "does synchronisation explain most of the GPU's idle wall-clock", which is coherent and is the figure #600 deliberately selected; the error direction is conservative, and there is no user-visible symptom. Changing it would re-litigate that decision, so it is left for a separate call. **Flagging it here for a maintainer's judgment.**

## Backward compatibility

Yes — evidence wording only. No field, threshold, or severity changes.

## Test plan

- [x] Tests added; both defect tests verified to **fail** with the fix reverted and pass with it
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/` — 2738 passed, 141 skipped, 4 xfailed; 1 failed, the known `test_profile_runner` timing flake (#585), which fails identically on clean `main`
- [x] `ruff check src/ tests/` clean

## Linked issues

Closes #610. Follows review of #605.
