### PR TITLE
fix(skills): bound the H2D window by the capture and by the device

### DIFF
--- a/src/nsys_ai/skills/builtins/memory_transfers.py
+++ b/src/nsys_ai/skills/builtins/memory_transfers.py
@@ -58,9 +58,11 @@ _INIT_LEAD_FRACTION = 0.25
 def _observed_seconds(conn, rows: list, kwargs: dict) -> float | None:
     """Seconds from the first H2D transfer to the end of what was observed.
 
-    The trim window when one was given, otherwise the capture's own span. None
-    when neither can be established, and the caller falls back to the buckets --
-    which is the wrong answer, but a bounded one.
+    The capture's own span for the selected device, narrowed to the trim window
+    when one was given -- narrowed, never widened: a requested window is not
+    evidence that anything was watched for that long. None when no bound can be
+    established, and the caller falls back to the buckets -- which is the wrong
+    answer, but a bounded one.
     """
     starts = [r.get("window_start") for r in rows if r.get("window_start") is not None]
     if not starts:
@@ -76,24 +78,35 @@ def _observed_seconds(conn, rows: list, kwargs: dict) -> float | None:
     ends = [r.get("window_end") for r in rows if r.get("window_end") is not None]
     end_ns = max((int(e) for e in ends), default=None)
 
+    # The kernel bound has to be scoped the way the buckets are. This query had
+    # no device predicate while the transfers it is measuring are filtered to
+    # one GPU, so a kernel on another card ending late stretched this card's
+    # window: steady transfers across GPU 0's six seconds classified as
+    # init_heavy because GPU 1 ran until second sixty.
+    try:
+        from nsys_ai.connection import wrap_connection
+
+        adapter = wrap_connection(conn)
+        kernel_tbl = adapter.resolve_activity_tables().get("kernel")
+        if kernel_tbl:
+            device = int(kwargs.get("device", 0) or 0)
+            row = adapter.execute(
+                f'SELECT MAX(k."end") FROM {kernel_tbl} k WHERE k.deviceId = {device}'  # nosec B608
+            ).fetchone()
+            kernel_end = row[0] if row else None
+            if kernel_end is not None:
+                end_ns = max(int(kernel_end), end_ns) if end_ns is not None else int(kernel_end)
+    except Exception:  # noqa: BLE001 - an optional bound, never a failure
+        pass
+
+    # A requested window is not observed time. --trim accepts an endpoint past
+    # the end of the capture and nothing clamps it, so asking for sixty seconds
+    # of a six-second profile put the init lead (a quarter of the window) at
+    # fifteen seconds -- swallowing every transfer and reporting init_heavy for
+    # data that is plainly spread out. Observation stops where the capture does.
     trim_end = kwargs.get("trim_end_ns")
     if trim_end is not None:
-        end_ns = max(int(trim_end), end_ns) if end_ns is not None else int(trim_end)
-    else:
-        try:
-            from nsys_ai.connection import wrap_connection
-
-            adapter = wrap_connection(conn)
-            kernel_tbl = adapter.resolve_activity_tables().get("kernel")
-            if kernel_tbl:
-                row = adapter.execute(
-                    f'SELECT MAX(k."end") FROM {kernel_tbl} k'  # nosec B608
-                ).fetchone()
-                kernel_end = row[0] if row else None
-                if kernel_end is not None:
-                    end_ns = max(int(kernel_end), end_ns) if end_ns is not None else int(kernel_end)
-        except Exception:  # noqa: BLE001 - an optional bound, never a failure
-            pass
+        end_ns = min(int(trim_end), end_ns) if end_ns is not None else int(trim_end)
     if end_ns is None:
         return None
 

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -1390,3 +1390,77 @@ def test_h2d_weight_loading_in_a_long_capture_is_still_recognised():
 
     assert long_capture["type"] == "init_heavy"
     assert short_capture["type"] == "undetermined"
+
+
+# ── The H2D observation window is bounded by the capture, and by the device ──
+
+
+def _kernel_conn(kernels):
+    """A connection whose kernel table holds (deviceId, start, end) rows."""
+    import sqlite3
+
+    conn = sqlite3.connect(":memory:")
+    conn.execute(
+        'CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL('
+        'globalPid INTEGER, deviceId INTEGER, streamId INTEGER, correlationId INTEGER,'
+        'start INTEGER, "end" INTEGER, shortName INTEGER, demangledName INTEGER)'
+    )
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL "
+        "(globalPid, deviceId, streamId, correlationId, start, end, shortName, demangledName) "
+        "VALUES (0, ?, 7, 1, ?, ?, 1, 1)",
+        kernels,
+    )
+    conn.commit()
+    return conn
+
+
+def _steady_buckets(seconds):
+    """One 100MB transfer per second, for `seconds` seconds."""
+    return [
+        {"second": s, "total_mb": 100.0,
+         "window_start": s * 1_000_000_000, "window_end": s * 1_000_000_000 + 1_000_000}
+        for s in range(seconds)
+    ]
+
+
+def test_a_trim_window_past_the_capture_does_not_become_observed_time():
+    """--trim accepts an endpoint beyond the capture and nothing clamped it.
+
+    With the init lead at a quarter of the window, asking for 60s of a 6s
+    profile puts the lead at 15s -- swallowing every transfer and reporting
+    init_heavy for data that is plainly spread out.
+    """
+    from nsys_ai.skills.builtins.memory_transfers import _observed_seconds
+
+    conn = _kernel_conn([(0, 0, 6_000_000_000)])
+    rows = _steady_buckets(6)
+
+    untrimmed = _observed_seconds(conn, rows, {"device": 0})
+    trimmed = _observed_seconds(conn, rows, {"device": 0, "trim_end_ns": 60_000_000_000})
+
+    assert untrimmed == trimmed, f"{untrimmed} != {trimmed}"
+    assert trimmed < 10
+
+
+def test_a_kernel_on_another_device_does_not_stretch_this_one_s_window():
+    """The buckets are filtered to one GPU; the bound has to be too."""
+    from nsys_ai.skills.builtins.memory_transfers import _observed_seconds
+
+    rows = _steady_buckets(6)
+    alone = _observed_seconds(_kernel_conn([(0, 0, 6_000_000_000)]), rows, {"device": 0})
+    with_peer = _observed_seconds(
+        _kernel_conn([(0, 0, 6_000_000_000), (1, 0, 60_000_000_000)]), rows, {"device": 0}
+    )
+
+    assert alone == with_peer, f"GPU 1 changed GPU 0's window: {alone} -> {with_peer}"
+
+
+def test_a_trim_window_inside_the_capture_is_still_honoured():
+    """The complement: narrowing is the point, so a real trim must still apply."""
+    from nsys_ai.skills.builtins.memory_transfers import _observed_seconds
+
+    conn = _kernel_conn([(0, 0, 60_000_000_000)])
+    rows = _steady_buckets(6)
+
+    assert _observed_seconds(conn, rows, {"device": 0, "trim_end_ns": 6_000_000_000}) < 10


### PR DESCRIPTION
## Summary

`_observed_seconds` gates H2D shape classification, and two of its bounds described something other than what was observed. Both inflate the window, and with `_INIT_LEAD_FRACTION = 0.25` an inflated window swallows every transfer into the init lead — flipping `spread_out` to `init_heavy` and suppressing the matcher's `Continuous H2D Transfers` warning.

**1. A requested trim window is not observed time.** `--trim` accepts an endpoint past the end of the capture and nothing clamped it, so 60s of a 6s profile put the lead at 15s.

```
6s capture, 100MB/s steady   ->  spread_out   (correct)
same data, --trim 0 60       ->  init_heavy   (wrong)
```

**2. The kernel bound was not device-scoped.** `SELECT MAX(k."end") FROM {kernel_table} k` had no device predicate, while the transfer buckets it measures are filtered to one GPU. A kernel on GPU 1 ending at 60s stretched GPU 0's window.

## Changes

`src/nsys_ai/skills/builtins/memory_transfers.py`
- The kernel bound carries `WHERE k.deviceId = {device}`, matching how the skill's own transfer queries are scoped.
- The trim window now `min`s against the capture bound instead of replacing it: it narrows the observed span, never widens it.
- Docstring updated to state the new contract.

`tests/test_skills.py` — the two defects, plus a complement guard that a trim *inside* the capture is still honoured (narrowing is the point).

## Backward compatibility

Yes. A trim inside the capture behaves exactly as before; only windows extending past the capture, and multi-GPU profiles, change — in both cases toward the classification the untrimmed/single-device data already produced.

## Test plan

- [x] Tests added; both defect tests verified to **fail** with the fix reverted and pass with it
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `pytest tests/` — 2736 passed, 141 skipped, 4 xfailed; 3 failed, all the known `test_profile_runner` timing flakes (#585), which fail identically on clean `main`
- [x] `ruff check src/ tests/` clean
- [x] `bandit` clean — the new predicate is an `int()`-coerced device id, and the query keeps its `# nosec B608`

## Linked issues

Closes #611. Both bounds were introduced by #606 (merged as 35cd2bb); found by `codex review` of that batch.
