### PR TITLE
test(ci): give the skip guard its own profile instead of the environment

### DIFF
--- a/tests/test_ci_coverage.py
+++ b/tests/test_ci_coverage.py
@@ -13,6 +13,7 @@ a new reason means something started skipping that did not before, which is the
 event worth catching.
 """
 
+import os
 import sqlite3
 import subprocess
 import sys
@@ -55,12 +56,28 @@ ACCEPTED_SKIP_REASONS = (
 
 def _collect_skip_reasons() -> list[str]:
     """Run the suite and return each distinct skip reason."""
+    # The subprocess has to see a profile. Without one the profile-backed tests
+    # skip with "No test profile" -- a reason deliberately kept out of
+    # ACCEPTED_SKIP_REASONS by the test below it -- so this guard failed on any
+    # tree where the variable was not exported. That is the ordinary local
+    # state, and running this file on its own is what the contributing
+    # instructions ask for, so the documented gate was red on an unmodified
+    # checkout. A gate that is red by default gets ignored, and this is the one
+    # whose whole purpose is noticing a file going dark.
+    #
+    # CI sets the variable at job level for this same reason. The fixture is
+    # committed and its path is already known here, so default to it rather
+    # than depend on the ambient environment.
+    env = dict(os.environ)
+    if not env.get("NSYS_TEST_PROFILE") and REAL_FIXTURE.is_file():
+        env["NSYS_TEST_PROFILE"] = str(REAL_FIXTURE)
     result = subprocess.run(
         [sys.executable, "-m", "pytest", "tests/", "-q", "-rs", "-p", "no:cacheprovider",
          "--ignore=tests/test_ci_coverage.py"],
         cwd=REPO,
         capture_output=True,
         text=True,
+        env=env,
     )
     reasons = []
     for line in result.stdout.splitlines():
@@ -176,6 +193,30 @@ def test_the_integration_tests_are_no_longer_gated_out_of_ci():
     than quietly returning to the old state.
     """
     assert "No test profile" not in ACCEPTED_SKIP_REASONS
+
+
+def test_ci_hands_the_suite_the_committed_profile():
+    """Defaulting the variable above costs a detection; this restores it.
+
+    While the skip check depended on the ambient environment, a workflow that
+    dropped NSYS_TEST_PROFILE showed up here as "No test profile". Now that the
+    check supplies its own, it stays green whatever the workflow does -- which
+    is what makes the local gate usable, but would let CI's main run lose the
+    variable and silently skip every profile-backed test, the exact regression
+    test_the_integration_tests_are_no_longer_gated_out_of_ci exists to prevent.
+
+    So assert the workflow still hands it over.
+    """
+    ci = (REPO / ".github" / "workflows" / "ci.yml").read_text()
+
+    assert "NSYS_TEST_PROFILE:" in ci, (
+        "ci.yml no longer sets NSYS_TEST_PROFILE, so the profile-backed tests "
+        "skip in CI and the build stays green while covering less."
+    )
+    assert REAL_FIXTURE.name in ci, (
+        f"ci.yml sets NSYS_TEST_PROFILE but not to {REAL_FIXTURE.name}; the "
+        "committed fixture is what makes those tests run in CI."
+    )
 
 
 def test_the_trajectory_suite_is_known_to_run_nowhere():


### PR DESCRIPTION
## Summary

`test_every_skip_has_a_known_reason` failed on a clean checkout whenever `NSYS_TEST_PROFILE` was unset — the ordinary local state, and running this file on its own is what the contributing instructions ask for. The profile-backed tests skip with `"No test profile"`, which is deliberately not an accepted reason, so the guard fired.

A gate that is red by default gets ignored, and this is the one whose stated purpose is noticing a whole file going dark in CI.

## Changes

`tests/test_ci_coverage.py`
- `_collect_skip_reasons` now passes an explicit env to its subprocess, defaulting `NSYS_TEST_PROFILE` to `REAL_FIXTURE` when it is unset. The fixture is committed and its path was already known in this module, so the guard no longer depends on the ambient environment.
- New `test_ci_hands_the_suite_the_committed_profile`, asserting `ci.yml` still sets the variable to the committed fixture.

## Why the second test is not optional

Registering `"No test profile"` in `ACCEPTED_SKIP_REASONS` was the obvious fix and is **not available**: `test_the_integration_tests_are_no_longer_gated_out_of_ci` asserts the opposite on purpose, so that the old gap cannot return quietly. That assertion is correct and is untouched here.

Defaulting the variable instead has a cost that has to be paid back. While the guard depended on the environment, a workflow that dropped `NSYS_TEST_PROFILE` surfaced here as `"No test profile"`. Once the guard supplies its own, it stays green whatever the workflow does — so CI's main run could lose the variable and silently skip every profile-backed test, which is precisely the regression the assertion above exists to prevent. Without the new test, this fix would have widened the hole it was closing.

Verified by deleting the `NSYS_TEST_PROFILE:` line from `ci.yml` and confirming the new test fails with its intended message, then restoring it.

## Backward compatibility

Yes. CI behaviour is unchanged — it already sets the variable at job level, so the new default never applies there.

## Test plan

- [x] `env -u NSYS_TEST_PROFILE pytest tests/test_ci_coverage.py` — 8 passed; fails on `main` under the identical command
- [x] New CI-pinning test verified to fail when the env var is removed from `ci.yml`, and to pass when restored
- [x] `python -m nsys_ai --help` — CLI loads without error
- [x] `ruff check src/ tests/` clean

## Out of scope

The remaining `test_profile_runner` timing flakes (#585) are unrelated and still fail on `main`.

## Linked issues

Closes #615
