### PR TITLE
test(runner): observe the process tree, and stop racing interpreter startup

### DIFF
--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -2,6 +2,7 @@ import json
 import os
 import sqlite3
 import stat
+import subprocess
 import threading
 import time
 from dataclasses import FrozenInstanceError
@@ -90,11 +91,8 @@ if sys.argv[1] == 'profile':
         output.with_suffix('.child.pid').write_text(str(child.pid))
         time.sleep(0.1)
         sys.exit(17)
-    if mode == 'exit_094':
-        time.sleep(0.94)
-        sys.exit(17)
-    if mode == 'exit_070':
-        time.sleep(0.70)
+    if mode == 'exit_before_deadline':
+        time.sleep(0.5)
         sys.exit(17)
     if mode == 'env':
         ok = (
@@ -607,11 +605,82 @@ def test_capturing_callback_cancellation_prevents_popen(
 
 
 def _process_is_running(pid):
-    try:
-        state = Path(f"/proc/{pid}/stat").read_text().split()[2]
-    except (FileNotFoundError, ProcessLookupError):
-        return False
-    return state != "Z"
+    """True when *pid* names a live, non-zombie process.
+
+    /proc is Linux-only. On macOS every lookup raised FileNotFoundError and this
+    returned False unconditionally, so every ``assert not
+    _process_is_running(...)`` below held without observing anything: the
+    process-tree teardown these tests exist to check was not being checked at
+    all on this platform, and they still read green.
+
+    ``ps -o state=`` answers the same question everywhere -- empty output for a
+    pid that is gone, a leading "Z" for one that has exited but not been
+    reaped.
+    """
+    proc_stat = Path(f"/proc/{pid}/stat")
+    if proc_stat.exists():
+        try:
+            return proc_stat.read_text().split()[2] != "Z"
+        except (FileNotFoundError, ProcessLookupError, IndexError):
+            return False
+    probe = subprocess.run(
+        ["ps", "-o", "state=", "-p", str(pid)], capture_output=True, text=True
+    )
+    state = probe.stdout.strip()
+    return bool(state) and not state.startswith("Z")
+
+
+def _child_pid(tmp_path, timeout=15):
+    """The grandchild's pid, once the fake profiler has recorded it.
+
+    Read eagerly, this raced the fake profiler: it has to start a Python
+    interpreter and then start another one for the child before the file
+    exists, which on a loaded machine takes longer than the fixed delays these
+    tests used to wait. The test then failed reading a file that was never
+    written, which says nothing about the teardown being tested.
+    """
+    path = Path(tmp_path) / "artifacts" / "profile.child.pid"
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            text = path.read_text().strip()
+        except (FileNotFoundError, NotADirectoryError):
+            text = ""
+        if text:
+            return int(text)
+        time.sleep(0.01)
+    raise AssertionError(f"{path} was never written; the fake profiler did not start a child")
+
+
+def _trip_once_child_exists(tmp_path, event, timeout=15):
+    """Trip *event* as soon as the grandchild exists, rather than after a guess.
+
+    A fixed timer was racing two interpreter startups: cancellation regularly
+    arrived before there was any process tree to tear down. Keying off the
+    event the test is actually about removes the race without weakening it --
+    the fake profiler writes the pid and only then begins the window this is
+    meant to land inside.
+    """
+    path = Path(tmp_path) / "artifacts" / "profile.child.pid"
+
+    def _wait():
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if path.exists():
+                break
+            time.sleep(0.01)
+        event.set()
+
+    thread = threading.Thread(target=_wait, daemon=True)
+    thread.start()
+    return thread
+
+
+def _assert_process_exits(pid, timeout=5):
+    deadline = time.monotonic() + timeout
+    while _process_is_running(pid) and time.monotonic() < deadline:
+        time.sleep(0.02)
+    assert not _process_is_running(pid), f"pid {pid} survived teardown"
 
 
 @pytest.mark.parametrize("stop_kind", ["timeout", "cancel"])
@@ -622,7 +691,7 @@ def test_timeout_and_cancellation_kill_the_process_tree(
     cancellation = threading.Event()
     timeout = 1 if stop_kind == "timeout" else None
     if stop_kind == "cancel":
-        threading.Timer(0.15, cancellation.set).start()
+        _trip_once_child_exists(tmp_path, cancellation)
     runner = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys))
 
     result = runner.run(
@@ -632,11 +701,7 @@ def test_timeout_and_cancellation_kill_the_process_tree(
 
     expected = RunStatus.TIMED_OUT if stop_kind == "timeout" else RunStatus.CANCELLED
     assert result.status is expected
-    child_pid = int((tmp_path / "artifacts" / "profile.child.pid").read_text())
-    deadline = time.monotonic() + 2
-    while _process_is_running(child_pid) and time.monotonic() < deadline:
-        time.sleep(0.02)
-    assert not _process_is_running(child_pid)
+    _assert_process_exits(_child_pid(tmp_path))
 
 
 def test_due_cancellation_beats_leader_exit_and_kills_surviving_child(
@@ -645,18 +710,14 @@ def test_due_cancellation_beats_leader_exit_and_kills_surviving_child(
     monkeypatch.setattr("nsys_ai.profile_runner._POLL_SECONDS", 0.25)
     monkeypatch.setattr("nsys_ai.profile_runner._TERMINATION_GRACE_SECONDS", 0.1)
     cancellation = threading.Event()
-    threading.Timer(0.08, cancellation.set).start()
+    _trip_once_child_exists(tmp_path, cancellation)
 
     result = LocalProfileRunner(tmp_path / "artifacts", str(fake_nsys)).run(
         _spec("race_cancel"), cancellation=cancellation
     )
 
     assert result.status is RunStatus.CANCELLED
-    child_pid = int((tmp_path / "artifacts" / "profile.child.pid").read_text())
-    deadline = time.monotonic() + 2
-    while _process_is_running(child_pid) and time.monotonic() < deadline:
-        time.sleep(0.02)
-    assert not _process_is_running(child_pid)
+    _assert_process_exits(_child_pid(tmp_path))
 
 
 def test_leader_exit_always_cleans_surviving_process_group(
@@ -668,20 +729,28 @@ def test_leader_exit_always_cleans_surviving_process_group(
 
     assert result.status is RunStatus.NSYS_FAILED
     assert result.nsys_return_code == 17
-    child_pid = int((tmp_path / "artifacts" / "profile.child.pid").read_text())
-    deadline = time.monotonic() + 2
-    while _process_is_running(child_pid) and time.monotonic() < deadline:
-        time.sleep(0.02)
-    assert not _process_is_running(child_pid)
+    _assert_process_exits(_child_pid(tmp_path))
 
 
-@pytest.mark.parametrize(
-    ("mode", "poll_seconds"),
-    [("exit_094", 2.0), ("exit_070", 5.0)],
-)
+#: The deadline has to clear the fake profiler's sleep by more than the time it
+#: takes to start. The old pairing slept 0.94s against a 1s timeout -- a 60ms
+#: margin that also had to absorb two Python interpreter startups, so on a
+#: loaded machine the run genuinely timed out and the test read TIMED_OUT. The
+#: margin is now a second, which no startup approaches, and the assertion is
+#: unchanged: the deadline still falls well before the poll interval, so a
+#: runner that waited for the next poll instead of noticing the exit would still
+#: time out and fail this.
+#:
+#: RunSpec requires a whole number of seconds, so the margin is bought by
+#: raising the deadline rather than by shaving the sleep, and the poll intervals
+#: move with it to stay clear of the deadline.
+_COMPLETION_TIMEOUT_SECONDS = 2
+
+
+@pytest.mark.parametrize("poll_seconds", [3.0, 6.0])
 @pytest.mark.no_cover
 def test_completion_before_deadline_wins_over_coarse_polling(
-    tmp_path, fake_nsys, monkeypatch, mode, poll_seconds
+    tmp_path, fake_nsys, monkeypatch, poll_seconds
 ):
     # Coverage tracing is deliberately excluded here. This test verifies a
     # sub-second process/deadline race, and tracing both this test and the fake
@@ -692,7 +761,12 @@ def test_completion_before_deadline_wins_over_coarse_polling(
     monkeypatch.delenv("COVERAGE_SOURCE", raising=False)
     monkeypatch.setattr("nsys_ai.profile_runner._POLL_SECONDS", poll_seconds)
 
-    result = _run(tmp_path, fake_nsys, mode, timeout_seconds=1)
+    result = _run(
+        tmp_path,
+        fake_nsys,
+        "exit_before_deadline",
+        timeout_seconds=_COMPLETION_TIMEOUT_SECONDS,
+    )
 
     assert result.status is RunStatus.NSYS_FAILED
     assert result.nsys_return_code == 17
@@ -725,11 +799,7 @@ def test_cancellation_callable_failure_propagates_after_process_tree_cleanup(
             _spec("hang"), cancellation=broken_cancellation
         )
 
-    child_pid = int(pid_path.read_text())
-    deadline = time.monotonic() + 2
-    while _process_is_running(child_pid) and time.monotonic() < deadline:
-        time.sleep(0.02)
-    assert not _process_is_running(child_pid)
+    _assert_process_exits(_child_pid(tmp_path))
 
 
 def test_keyboard_interrupt_from_cancellation_cleans_process_tree(
@@ -748,11 +818,7 @@ def test_keyboard_interrupt_from_cancellation_cleans_process_tree(
             _spec("hang"), cancellation=interrupted_cancellation
         )
 
-    child_pid = int(pid_path.read_text())
-    deadline = time.monotonic() + 2
-    while _process_is_running(child_pid) and time.monotonic() < deadline:
-        time.sleep(0.02)
-    assert not _process_is_running(child_pid)
+    _assert_process_exits(_child_pid(tmp_path))
 
 
 def test_progress_model_is_frozen():


### PR DESCRIPTION
## Summary

Three defects in `tests/test_profile_runner.py`. One of them meant these tests were not testing anything on macOS.

The issue reports the failure as `PermissionError` from signalling a process group — a platform restriction. That is not what happens on `main` today: the failures are a `FileNotFoundError` on the child pid file and a genuine timeout, both races against process startup, and both fixable in the tests.

```
under six-way CPU load
  main:  2 failed, 52 passed   (× 3 runs, every run)
  this:  54 passed             (× 8 runs, every run)

full suite: 2747 passed, 141 skipped, 4 xfailed, 0 failed
```

## Changes

**`_process_is_running` observed nothing on macOS.** It read `/proc/{pid}/stat`; there is no `/proc` here, so every lookup raised `FileNotFoundError` and the helper returned `False` unconditionally. All five `assert not _process_is_running(...)` checks therefore held without looking at anything — the process-tree teardown these tests exist to verify was unverified on this platform, and they read green. Now uses `/proc` where it exists and `ps -o state=` otherwise (empty output for a gone pid, leading `Z` for an unreaped one).

Verified directly: the new helper returns `True` for a live pid and `False` for a killed-and-reaped one, where the old one returned `False` for both. **With real observation the teardown assertions still pass**, so the runner was killing the tree correctly all along — it just was not being checked.

**Cancellation raced interpreter startup.** `threading.Timer(0.15, …)` and `threading.Timer(0.08, …)` fired while the fake profiler still had two Python interpreters to start before recording the child's pid. The timer regularly won, the run was torn down before a process tree existed, and the test failed reading a file nothing had written. Cancellation now trips when the pid file appears, which is the event the timer was approximating. The two tests in this file that already gate on `pid_path.exists()` are precisely the two that never flaked.

**A 60ms margin absorbed process startup.** `exit_094` slept 0.94s against a 1s timeout. Under load the run genuinely exceeded the deadline and reported `TIMED_OUT`. Now 0.5s against a 2s deadline with polls at 3.0/6.0. The assertion is unchanged: the deadline still falls well before the poll interval, so a runner that waited for the next poll rather than noticing the exit would still time out and fail this.

Also adds `_child_pid()` (waits for the file rather than reading it eagerly) and `_assert_process_exits()`, replacing five copies of the same wait loop.

## Backward compatibility

Yes — tests only, no `src/` change.

## Out of scope

The issue's second family, the five `test_profile_reference` validator cases, no longer fails: it was resolved by #572 (`ff3e70a`). Nothing here touches it.

## Test plan

- [x] `pytest tests/test_profile_runner.py` — 54 passed, eight consecutive runs under six-way CPU load; `main` fails 2 on every run under identical load
- [x] `pytest tests/` — 2747 passed, 141 skipped, 4 xfailed, **0 failed** (first fully clean run on this machine)
- [x] New liveness helper verified to distinguish a live pid from a dead one
- [x] `ruff check src/ tests/` clean
- [x] `python -m nsys_ai --help` — CLI loads without error

## Linked issues

Closes #585
