### PR TITLE
fix(skills): say which idle measurement the evidence is quoting

### DIFF
--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -265,9 +265,22 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                 counted = len(large_gaps)
             counted = max(counted, len(large_gaps))
 
+            # Say which measurement this is. _idle_with_matching_pct returns the
+            # device figure when the sweep ran and the per-stream sum when it
+            # did not, and calling both "total GPU idle" made the fallback claim
+            # the device: three streams idling concurrently summed to 810.0ms of
+            # "total GPU idle" on a profile 310ms long. The percentage does not
+            # give it away either, because the per-stream figure travels with
+            # the per-stream percentage. That overstatement is the one #600
+            # removed from the number; this keeps it out of the label.
+            device_measured = (
+                bool(gap_summary) and gap_summary.get("device_idle_ms") is not None
+            )
+            idle_label = "total GPU idle" if device_measured else "idle summed across streams"
+
             evidence = (
                 f"{counted} gaps > {gap_threshold / 1e6:.1f}ms detected; "
-                f"{total_idle_ms:.1f}ms total GPU idle"
+                f"{total_idle_ms:.1f}ms {idle_label}"
             )
             if pct > 0:
                 evidence += f" ({pct}% of profile)"

--- a/tests/test_root_cause_matcher.py
+++ b/tests/test_root_cause_matcher.py
@@ -162,3 +162,51 @@ class TestGapCountAndIdleTotalAgree:
         gaps = [{"gap_ns": 5_000_000, "attribution": {}} for _ in range(4)]
 
         assert self._evidence(summary, gaps).startswith("4 gaps")
+
+
+class TestTheIdleLabelNamesItsMeasurement:
+    """The evidence must not call the per-stream sum device-wide idle.
+
+    _idle_with_matching_pct returns the device figure when the sweep ran and the
+    per-stream sum when it did not. Labelling both "total GPU idle" let three
+    concurrently-idling streams report 810.0ms of it on a 310ms profile -- the
+    overstatement #600 removed from the number, back in the label. The
+    percentage does not expose it, because the per-stream figure travels with
+    the per-stream percentage.
+    """
+
+    @staticmethod
+    def _evidence(summary):
+        import sqlite3
+        from unittest.mock import patch
+
+        from nsys_ai.skills.builtins import root_cause_matcher as rcm
+
+        gaps = [{"gap_ns": 90_000_000, "attribution": {}} for _ in range(9)]
+
+        def fake(name, conn, **kw):
+            return [summary, *gaps] if name == "gpu_idle_gaps" else []
+
+        with patch.object(rcm, "_safe_execute", side_effect=fake):
+            findings = rcm._execute(sqlite3.connect(":memory:"), _skip_device_validation=True)
+        return next(
+            (f["evidence"] for f in findings if f["pattern"].startswith("GPU Bubbles")), ""
+        )
+
+    def test_the_stream_sum_is_not_called_device_idle(self):
+        """810ms of idle cannot be "GPU idle" on a 310ms profile."""
+        evidence = self._evidence({
+            "_summary": True, "total_idle_ms": 810.0, "pct_of_profile": 87.1,
+            "profile_start_ns": 0, "profile_end_ns": 310_000_000,
+        })
+
+        assert "810.0ms total GPU idle" not in evidence, evidence
+        assert "summed across streams" in evidence, evidence
+
+    def test_the_device_measurement_keeps_the_device_wording(self):
+        evidence = self._evidence({
+            "_summary": True, "device_idle_ms": 270.0, "total_idle_ms": 810.0,
+            "profile_start_ns": 0, "profile_end_ns": 310_000_000,
+        })
+
+        assert "270.0ms total GPU idle" in evidence, evidence


### PR DESCRIPTION
## Summary

`_idle_with_matching_pct` returns the device figure when the device sweep ran and the per-stream sum when it did not. #613 labelled both unconditionally as `total GPU idle`, so the fallback made a device-wide claim about a per-stream aggregate:

```
before:  9 gaps > 1.0ms detected; 810.0ms total GPU idle (87.1% of profile)
after:   9 gaps > 1.0ms detected; 810.0ms idle summed across streams (87.1% of profile)
```

The profile's entire span is **310ms**. Three streams idling concurrently sum to 810ms; the device was idle for 270ms. Nothing in the old sentence looked wrong, because the per-stream figure travels with the per-stream percentage, which stays self-consistent.

This is the overstatement #600 set out to remove — "on a multi-stream profile that overstates the wall-clock lost" — reintroduced in the label rather than in the number.

## Changes

`src/nsys_ai/skills/builtins/root_cause_matcher.py` — the caller checks whether `device_idle_ms` was a measurement and labels the fallback accordingly. The helper's two-value return is unchanged, so its existing contract tests are untouched.

`tests/test_root_cause_matcher.py` — both directions: the stream sum is not called device idle, and a real device measurement keeps the device wording.

## Backward compatibility

Yes — evidence wording only, and only on the fallback path.

## Test plan

- [x] Defect test verified to **fail** against `main`'s `src` and pass with the fix
- [x] `pytest tests/` — 2749 passed, 141 skipped, 4 xfailed, **0 failed**
- [x] `ruff check src/ tests/` clean

## Linked issues

Closes #619. Introduced by #613 (`79c88cf`); found by `codex review`.
