### PR TITLE
test(runner): trip cancellation on a readable pid, not on the file

### DIFF
--- a/tests/test_profile_runner.py
+++ b/tests/test_profile_runner.py
@@ -664,10 +664,20 @@ def _trip_once_child_exists(tmp_path, event, timeout=15):
     path = Path(tmp_path) / "artifacts" / "profile.child.pid"
 
     def _wait():
+        # Wait for a readable pid, not merely for the file. write_text creates
+        # the file before it writes, so exists() is true while it is still
+        # empty; tripping there let teardown kill the profiler in the gap
+        # before it recorded the pid, and _child_pid -- which does wait for
+        # content -- then spun out its whole timeout and failed a test whose
+        # cleanup had actually worked. A narrower version of the race this
+        # helper exists to remove.
         deadline = time.monotonic() + timeout
         while time.monotonic() < deadline:
-            if path.exists():
-                break
+            try:
+                if path.read_text().strip():
+                    break
+            except (FileNotFoundError, NotADirectoryError):
+                pass
             time.sleep(0.01)
         event.set()
 
@@ -1008,3 +1018,24 @@ def test_teardown_still_stops_at_a_group_that_has_gone(monkeypatch):
     profile_runner.LocalProfileRunner._terminate_process_group(_GoneProcess())
 
     assert _GoneProcess.waited
+
+
+def test_the_cancellation_trigger_waits_for_a_readable_pid(tmp_path):
+    """write_text creates the file before writing, so exists() is not enough.
+
+    Tripping on the bare file let teardown kill the profiler in the gap before
+    it recorded the pid, and _child_pid then spun out its whole timeout on a
+    test whose process cleanup had actually worked.
+    """
+    artifacts = tmp_path / "artifacts"
+    artifacts.mkdir()
+    pid_file = artifacts / "profile.child.pid"
+    pid_file.write_text("")          # created, still empty
+
+    event = threading.Event()
+    _trip_once_child_exists(tmp_path, event, timeout=2)
+
+    assert not event.wait(0.3), "tripped on an empty pid file"
+
+    pid_file.write_text("4321")
+    assert event.wait(2), "did not trip once the pid was readable"


### PR DESCRIPTION
## Summary

`_trip_once_child_exists` triggered cancellation on `path.exists()`. `Path.write_text` creates the file before writing to it, so `exists()` is true while it is still empty:

```
file exists after create, before write : True
contents at that moment                : ''
```

If the fake profiler is descheduled in that gap, cancellation fires, teardown kills it before it records the pid, and `_child_pid` — which correctly waits for parseable content — spins out its full 15s timeout and fails a test whose process cleanup actually worked. A narrower version of the race the helper was added to remove.

## Changes

`tests/test_profile_runner.py` — the trigger now waits for the same condition `_child_pid` waits for: a populated, parseable pid. Adds a test that it does not trip on an empty file and does trip once the pid is readable.

## Backward compatibility

Yes — tests only, no `src/` change.

## Test plan

- [x] New test verified to **fail** with the old `exists()`-only trigger ("tripped on an empty pid file") and pass with the fix
- [x] `pytest tests/` — 2748 passed, 141 skipped, 4 xfailed, **0 failed**
- [x] Three full suites run concurrently produced no flakes
- [x] `ruff check src/ tests/` clean

## Linked issues

Closes #620. Introduced by #617 (`912941d`); found by `codex review`.
