### PR TITLE
fix(skills): measure graph launches, which the API filter excluded

### DIFF
--- a/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
+++ b/src/nsys_ai/skills/builtins/kernel_launch_overhead.py
@@ -130,8 +130,25 @@ def _execute(conn, **kwargs):
                 r."end" - r.start AS api_duration_ns
             FROM {runtime_table} r
             JOIN {string_table} s_api ON r.nameId = s_api.id
+            -- cudaGraphLaunch/cuGraphLaunch begin 'cudaGraph'/'cuGraph' and so
+            -- matched neither prefix. Kernels dispatched by a graph replay had
+            -- no runtime row to join to and dropped out before any aggregation:
+            -- absent entirely from the one skill whose subject is dispatch
+            -- cost, on exactly the workloads that dispatch through graphs.
+            --
+            -- api_charge_ns below already charges one API call once across all
+            -- the kernels sharing its correlation id, which is the correction a
+            -- graph replay needs -- it was written for these rows and could not
+            -- engage while they were filtered out.
+            --
+            -- Nsight records these names with an optional version suffix
+            -- ('cudaLaunchKernel_v7000' beside a bare 'cuLaunchKernelEx'), so
+            -- the prefix match covers both spellings. A capture with no graph
+            -- launches matches nothing extra and is unchanged.
             WHERE (s_api.value LIKE 'cudaLaunch%'
-                   OR s_api.value LIKE 'cuLaunch%')
+                   OR s_api.value LIKE 'cuLaunch%'
+                   OR s_api.value LIKE 'cudaGraphLaunch%'
+                   OR s_api.value LIKE 'cuGraphLaunch%')
               AND r."end" >= r.start
         ),
         launch_candidates AS (

--- a/tests/test_cuda_graph.py
+++ b/tests/test_cuda_graph.py
@@ -268,3 +268,68 @@ def test_a_versioned_graph_activity_table_is_resolved():
         "CUPTI_ACTIVITY_KIND_GRAPH_TRACE_V3",
     ):
         assert graph_tables([name]), f"{name} was dropped"
+
+
+def _graph_launch_connection():
+    """A replay whose runtime row is named the way a graph launch really is.
+
+    ``_graph_connection`` names its replay ``cudaLaunchKernel``, so it exercises
+    the charge correction without ever exercising the API filter that decides
+    whether a graph replay is seen at all.
+    """
+    conn = _graph_connection()
+    conn.execute("INSERT INTO StringIds VALUES (20, 'cudaGraphLaunch_v10000')")
+    rows = [
+        (0x100000000, 0, 7, 7, 10_000, 10_005, 1, 2, 101, 42),
+        (0x100000000, 0, 7, 7, 10_020, 10_025, 1, 2, 102, 42),
+        (0x100000000, 0, 7, 7, 10_040, 10_045, 1, 2, 103, 42),
+    ]
+    conn.executemany(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL "
+        "(globalPid, deviceId, streamId, correlationId, start, end, shortName, "
+        "demangledName, graphNodeId, graphId) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.execute(
+        "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (?, ?, ?, ?, ?)",
+        (0x100000007, 7, 8_000, 9_000, 20),
+    )
+    conn.commit()
+    return conn
+
+
+def test_a_graph_replay_is_measured_not_silently_dropped():
+    """cudaGraphLaunch matches neither 'cudaLaunch%' nor 'cuLaunch%'.
+
+    Those kernels had no runtime row to join to and fell out of
+    launch_candidates before any aggregation, so a workload dispatching through
+    CUDA graphs was absent from the skill whose whole subject is dispatch cost.
+    """
+    rows = OVERHEAD.execute_fn(_graph_launch_connection(), min_launches=1, device=0)
+
+    assert rows, "the graph replay produced no rows at all"
+    assert rows[0]["launch_count"] == 3
+    assert rows[0]["graph_id_count"] == 1
+
+
+def test_one_graph_launch_is_charged_once_for_all_its_nodes():
+    """The #569 correction, on rows that can now actually reach it.
+
+    One 1ms cudaGraphLaunch driving three kernel nodes costs 1ms of dispatch,
+    not 3ms: the charge belongs to the call, not to each node it replayed.
+    """
+    rows = OVERHEAD.execute_fn(_graph_launch_connection(), min_launches=1, device=0)
+
+    assert rows[0]["total_api_ms"] == 0.001
+    assert rows[0]["api_calls_charged"] == 1
+
+
+def test_a_capture_without_graph_launches_is_unchanged():
+    """The complement: the widened filter must not alter ordinary captures."""
+    conn = _graph_connection()
+    _insert_graph_replay(conn)
+
+    rows = OVERHEAD.execute_fn(conn, min_launches=1, device=0)
+
+    assert rows[0]["launch_count"] == 2
+    assert rows[0]["total_api_ms"] == 0.001


### PR DESCRIPTION
## Summary

`cudaGraphLaunch` and `cuGraphLaunch` begin `cudaGraph` / `cuGraph`, so they matched neither the `cudaLaunch%` nor the `cuLaunch%` prefix. Kernels dispatched by a graph replay had no runtime row to join to and fell out of `launch_candidates` before any aggregation — absent entirely from the one skill whose subject is dispatch cost, on exactly the workloads that dispatch through graphs.

On `main`, the new fixture produces **no rows at all**:

```
AssertionError: the graph replay produced no rows at all
```

## Changes

`src/nsys_ai/skills/builtins/kernel_launch_overhead.py` — the API filter accepts `cudaGraphLaunch%` and `cuGraphLaunch%`.

`tests/test_cuda_graph.py` — three tests: a replay is measured rather than dropped; one graph launch is charged once across all its nodes; and a capture with no graph launches is unchanged.

## On the uncertainty this issue was filed with

#584 was filed rather than fixed because confirming the recorded `StringIds` value needs a real CUDA-graph capture on a GPU. That uncertainty is about whether the fix **engages**, not whether it is correct:

- The local captures confirm Nsight's naming shape — `cudaLaunchKernel_v7000` beside a bare `cuLaunchKernelEx` — so a prefix match covers the name with or without a version suffix. None of them contains any `%Graph%` API, so the exact spelling still cannot be confirmed here.
- `cudaGraphLaunch` / `cuGraphLaunch` are the documented CUDA runtime and driver entry points.
- A capture with no graph launches matches nothing extra, so the change cannot make anything worse.

Leaving it unfixed means graph replays stay unmeasured indefinitely; applying it costs nothing if the name differs. **Worth a check against a real CUDA-graph capture** to confirm it engages — if the recorded name turns out to differ, the prefix list is one line to extend.

The `api_charge_ns` correction from #569 was written for these rows and could not engage while they were filtered out. The existing fixture names its replay `cudaLaunchKernel`, so it exercised that correction without ever exercising the filter that decides whether a replay is seen at all; the new fixture names it as Nsight does.

## Backward compatibility

Yes. Captures without graph launches are unchanged — pinned by `test_a_capture_without_graph_launches_is_unchanged`.

## Test plan

- [x] Two defect tests verified to **fail** against `main`'s `src` and pass with the fix
- [x] `pytest tests/` — 2756 passed, 141 skipped, 4 xfailed, **0 failed**
- [x] `ruff check src/ tests/` clean

## Linked issues

Closes #584
