### PR TITLE
fix(skills): compute the sync share only against wall-clock idle

### DIFF
--- a/src/nsys_ai/skills/builtins/root_cause_matcher.py
+++ b/src/nsys_ai/skills/builtins/root_cause_matcher.py
@@ -290,7 +290,25 @@ def _execute(conn: sqlite3.Connection, **kwargs):
                 sync_ms = sync_data[0].get("total_sync_wall_ms", 0)
                 sync_density = sync_data[0].get("sync_density_pct", 0)
                 # If sync time accounts for more than half of the idle time, or > 15% of profile:
-                if (total_idle_ms > 0 and sync_ms / total_idle_ms > 0.5) or sync_density > 15.0:
+                # The share needs a wall-clock denominator. total_idle_ms is the
+                # device figure when the device sweep ran and the per-stream sum
+                # when it did not, and the sum exceeds wall-clock idle by roughly
+                # the stream count -- so one profile with one synchronisation
+                # cost answered differently depending on whether that sweep
+                # happened to succeed: 200ms of sync against 270ms of device idle
+                # is 74% and fires, the same 200ms against the 810ms those three
+                # streams summed to is 25% and does not.
+                #
+                # Where the device figure is absent there is no wall-clock idle
+                # to divide by, and bounding the per-stream sum by the profile
+                # span would be inventing one. sync_density_pct is normalised
+                # against the profile and carries the rule there.
+                sync_share = (
+                    sync_ms / total_idle_ms
+                    if device_measured and total_idle_ms > 0
+                    else None
+                )
+                if (sync_share is not None and sync_share > 0.5) or sync_density > 15.0:
                     rec = (
                         "Critical Over-Synchronization Detected. "
                         f"{sync_density:.1f}% of this profile is CPU-blocked by synchronization calls "

--- a/tests/test_root_cause_matcher.py
+++ b/tests/test_root_cause_matcher.py
@@ -210,3 +210,78 @@ class TestTheIdleLabelNamesItsMeasurement:
         })
 
         assert "270.0ms total GPU idle" in evidence, evidence
+
+
+class TestTheSyncShareNeedsAWallClockDenominator:
+    """The over-synchronisation share divided by whichever figure was available.
+
+    ``total_idle_ms`` is the device measurement when the device sweep ran and
+    the per-stream sum when it did not, and the sum exceeds wall-clock idle by
+    roughly the stream count. One profile with one synchronisation cost
+    therefore answered differently depending on whether an unrelated sweep
+    succeeded.
+    """
+
+    SPAN = {"profile_start_ns": 0, "profile_end_ns": 310_000_000}
+
+    @staticmethod
+    def _over_sync(summary, sync_ms, density):
+        import sqlite3
+        from unittest.mock import patch
+
+        from nsys_ai.skills.builtins import root_cause_matcher as rcm
+
+        gaps = [
+            {"gap_ns": 30_000_000, "attribution": {"category": "synchronization"}}
+            for _ in range(9)
+        ]
+
+        def fake(name, conn, **kw):
+            if name == "gpu_idle_gaps":
+                return [summary, *gaps]
+            if name == "sync_cost_analysis":
+                return [{"total_sync_wall_ms": sync_ms, "sync_density_pct": density}]
+            return []
+
+        with patch.object(rcm, "_safe_execute", side_effect=fake):
+            findings = rcm._execute(sqlite3.connect(":memory:"), _skip_device_validation=True)
+        rec = next(
+            (f["recommendation"] for f in findings if f["pattern"].startswith("GPU Bubbles")), ""
+        )
+        return "Critical Over-Synchronization" in rec
+
+    def test_the_stream_sum_is_not_used_as_the_denominator(self):
+        """500ms of sync over a stream sum of 810ms read as a 61% share.
+
+        The numbers are chosen so the two behaviours differ: a smaller sync cost
+        clears neither threshold and would pass whether or not the share is
+        computed, which would make this test prove nothing. Here the old code
+        declares critical over-synchronisation off a ratio whose denominator is
+        three streams' idle added together, and the profile is 310ms long.
+        """
+        assert not self._over_sync(
+            {"_summary": True, "total_idle_ms": 810.0, **self.SPAN}, 500.0, 5.0
+        )
+
+    def test_the_device_figure_still_drives_the_share(self):
+        """Complement guard: a real wall-clock share must still fire.
+
+        200ms of sync against 270ms of device idle is 74%. This holds before and
+        after the change by design -- it guards the fix against over-correcting
+        into silence, rather than demonstrating the defect.
+        """
+        assert self._over_sync(
+            {"_summary": True, "device_idle_ms": 270.0, "total_idle_ms": 810.0, **self.SPAN},
+            200.0,
+            5.0,
+        )
+
+    def test_density_still_carries_the_rule_without_a_device_figure(self):
+        """Complement guard: the share is withheld, the finding is not.
+
+        sync_density_pct is normalised against the profile, so it is unaffected
+        by which idle figure was available and still carries the rule.
+        """
+        assert self._over_sync(
+            {"_summary": True, "total_idle_ms": 810.0, **self.SPAN}, 200.0, 44.7
+        )


### PR DESCRIPTION
## Summary

The over-synchronisation rule divided sync time by `total_idle_ms`, which `_idle_with_matching_pct` returns as the device measurement when the device sweep ran and as the **per-stream sum** when it did not. The sum exceeds wall-clock idle by roughly the stream count, so the rule's sensitivity depended on an implementation detail of a different skill.

One profile — 310ms span, 270ms device idle, 810ms summed across three streams:

```
200ms sync, device figure present : fires      (200/270 = 74%)
200ms sync, device sweep failed   : does not   (200/810 = 25%)
```

Same profile, same synchronisation cost, opposite verdict.

## Changes

`src/nsys_ai/skills/builtins/root_cause_matcher.py` — the share is computed only where the denominator is a wall-clock measurement. Where the device figure is absent there is no wall-clock idle to divide by, and bounding the per-stream sum by the profile span would be inventing one; `sync_density_pct` is normalised against the profile and carries the rule there.

`tests/test_root_cause_matcher.py` — one defect test plus two complement guards.

## A note on the test

My first version of the defect test asserted the 200ms case above and **passed against `main` as well**, because both behaviours decline to fire there — it proved nothing. The committed test uses 500ms against the 810ms sum, where the old code declares critical over-synchronisation off a ratio whose denominator is three streams' idle added together on a 310ms profile. That case fails on `main` and passes with the fix. The two complement guards pass either way by design, and say so in their docstrings.

## Backward compatibility

Behaviour changes only where the device sweep did not run, and only in the direction of withholding a share that could not be computed. The finding itself is unaffected: `sync_density > 15.0` still fires independently.

## Test plan

- [x] Defect test verified to **fail** against `main`'s `src` and pass with the fix
- [x] `pytest tests/` — 2756 passed, 141 skipped, 4 xfailed, **0 failed**
- [x] `ruff check src/ tests/` clean

## Linked issues

Closes #624. Raised by `codex review` against #605, deferred in #613, filed once #619 made the two denominators explicit.
